### PR TITLE
[HOTFIX] Fix importing assets into GUE

### DIFF
--- a/src/GUE.bb
+++ b/src/GUE.bb
@@ -6340,7 +6340,6 @@ Cls
 
 						; Copy file/folder if required
 						If Instr(App\CurrentFile$, "Data\Textures\") = 0 ;TODO: If RootDir is changed this may break
-						If Instr(App\CurrentFile$, "Data\Textures\") = 0 ;TODO: If RootDir is changed this may break
 							Filename$ = App\CurrentFile$
 							If MediaFolder$ <> "" Then Filename$ = MediaFolder$ + "\" + Filename$
 							For i = Len(App\CurrentFile$) To 1 Step -1

--- a/src/GUE.bb
+++ b/src/GUE.bb
@@ -6313,10 +6313,6 @@ Cls
 							Filename$ = Left$(Filename$, Len(Filename$) - 1)
 						EndIf
 
-						; Remove trailing slash
-						If Right$(Filename$, 1) = "\"
-							Filename$ = Left$(Filename$, Len(Filename$) - 1)
-						EndIf
 
 						; Single file
 						If FileType("Data\Meshes\" + Filename$) = 1
@@ -6448,6 +6444,11 @@ Cls
 							EndIf
 						Else
 							Filename$ = Right$(App\CurrentFile$, Len(App\CurrentFile$) - Len("Data\Music\")) ;TODO: If RootDir is changed this may break
+						EndIf
+
+							; Remove trailing slash
+						If Right$(Filename$, 1) = "\"
+							Filename$ = Left$(Filename$, Len(Filename$) - 1)
 						EndIf
 
 						; Single file

--- a/src/GUE.bb
+++ b/src/GUE.bb
@@ -6334,7 +6334,7 @@ Cls
 						Flags = TextureDialog()
 
 						; Copy file/folder if required
-						If Instr(App\CurrentFile$, CurrentDir$() + "Data\Textures\") = 0 ;TODO: If RootDir is changed this may break
+						If Instr(App\CurrentFile$, "Data\Textures\") = 0 ;TODO: If RootDir is changed this may break
 							Filename$ = App\CurrentFile$
 							If MediaFolder$ <> "" Then Filename$ = MediaFolder$ + "\" + Filename$
 							For i = Len(App\CurrentFile$) To 1 Step -1
@@ -6350,7 +6350,7 @@ Cls
 								CopyTree(App\CurrentFile$, "Data\Textures\" + Filename$)
 							EndIf
 						Else
-							Filename$ = Right$(App\CurrentFile$, Len(App\CurrentFile$) - Len(CurrentDir$() + "Data\Textures\")) ;TODO: If RootDir is changed this may break
+							Filename$ = Right$(App\CurrentFile$, Len(App\CurrentFile$) - Len("Data\Textures\")) ;TODO: If RootDir is changed this may break
 						EndIf
 
 						; Single file
@@ -6375,7 +6375,7 @@ Cls
 						Is3D = SoundDialog()
 
 						; Copy file/folder if required
-						If Instr(App\CurrentFile$, CurrentDir$() + "Data\Sounds\") = 0 ;TODO: If RootDir is changed this may break
+						If Instr(App\CurrentFile$, "Data\Sounds\") = 0 ;TODO: If RootDir is changed this may break
 							Filename$ = App\CurrentFile$
 							If MediaFolder$ <> "" Then Filename$ = MediaFolder$ + "\" + Filename$
 							For i = Len(App\CurrentFile$) To 1 Step -1
@@ -6391,7 +6391,7 @@ Cls
 								CopyTree(App\CurrentFile$, "Data\Sounds\" + Filename$)
 							EndIf
 						Else
-							Filename$ = Right$(App\CurrentFile$, Len(App\CurrentFile$) - Len(CurrentDir$() + "Data\Sounds\")) ;TODO: If RootDir is changed this may break
+							Filename$ = Right$(App\CurrentFile$, Len(App\CurrentFile$) - Len("Data\Sounds\")) ;TODO: If RootDir is changed this may break
 						EndIf
 
 						; Single file
@@ -6415,7 +6415,7 @@ Cls
 					If Result = True
 
 						; Copy file/folder if required
-						If Instr(App\CurrentFile$, CurrentDir$() + "Data\Music\") = 0 ;TODO: If RootDir is changed this may break
+						If Instr(App\CurrentFile$, "Data\Music\") = 0 ;TODO: If RootDir is changed this may break
 							Filename$ = App\CurrentFile$
 							If MediaFolder$ <> "" Then Filename$ = MediaFolder$ + "\" + Filename$
 							For i = Len(App\CurrentFile$) To 1 Step -1
@@ -6431,7 +6431,7 @@ Cls
 								CopyTree(App\CurrentFile$, "Data\Music\" + Filename$)
 							EndIf
 						Else
-							Filename$ = Right$(App\CurrentFile$, Len(App\CurrentFile$) - Len(CurrentDir$() + "Data\Music\")) ;TODO: If RootDir is changed this may break
+							Filename$ = Right$(App\CurrentFile$, Len(App\CurrentFile$) - Len("Data\Music\")) ;TODO: If RootDir is changed this may break
 						EndIf
 
 						; Single file

--- a/src/GUE.bb
+++ b/src/GUE.bb
@@ -6289,7 +6289,7 @@ Cls
 						IsEncrypted = False
 
 						; Copy file/folder if required
-						If Instr(App\CurrentFile$, CurrentDir$() + "Data\Meshes\") = 0 ;TODO: If RootDir is changed this may break
+						If Instr(App\CurrentFile$, "Data\Meshes\") = 0 ;TODO: If RootDir is changed this may break
 							Filename$ = App\CurrentFile$
 							If MediaFolder$ <> "" Then Filename$ = MediaFolder$ + "\" + Filename$
 							For i = Len(App\CurrentFile$) To 1 Step -1
@@ -6305,7 +6305,12 @@ Cls
 								CopyTree(App\CurrentFile$, "Data\Meshes\" + Filename$)
 							EndIf
 						Else
-							Filename$ = Right$(App\CurrentFile$, Len(App\CurrentFile$) - Len(CurrentDir$() + "Data\Meshes\")) ;TODO: If RootDir is changed this may break
+							Filename$ = Right$(App\CurrentFile$, Len(App\CurrentFile$) - Len("Data\Meshes\")) ;TODO: If RootDir is changed this may break
+						EndIf
+
+						; Remove trailing slash
+						If Right$(Filename$, 1) = "\"
+							Filename$ = Left$(Filename$, Len(Filename$) - 1)
 						EndIf
 
 						; Single file

--- a/src/GUE.bb
+++ b/src/GUE.bb
@@ -6404,7 +6404,6 @@ Cls
 						If Right$(Filename$, 1) = "\"
 							Filename$ = Left$(Filename$, Len(Filename$) - 1)
 						EndIf
-						
 
 						; Single file
 						If FileType("Data\Sounds\" + Filename$) = 1

--- a/src/GUE.bb
+++ b/src/GUE.bb
@@ -6313,6 +6313,11 @@ Cls
 							Filename$ = Left$(Filename$, Len(Filename$) - 1)
 						EndIf
 
+						; Remove trailing slash
+						If Right$(Filename$, 1) = "\"
+							Filename$ = Left$(Filename$, Len(Filename$) - 1)
+						EndIf
+
 						; Single file
 						If FileType("Data\Meshes\" + Filename$) = 1
 							AddMeshToManager(Filename$, IsAnim, IsEncrypted)
@@ -6334,7 +6339,7 @@ Cls
 						Flags = TextureDialog()
 
 						; Copy file/folder if required
-						If Instr(App\CurrentFile$, CurrentDir$() + "Data\Textures\") = 0 ;TODO: If RootDir is changed this may break
+						If Instr(App\CurrentFile$, "Data\Textures\") = 0 ;TODO: If RootDir is changed this may break
 							Filename$ = App\CurrentFile$
 							If MediaFolder$ <> "" Then Filename$ = MediaFolder$ + "\" + Filename$
 							For i = Len(App\CurrentFile$) To 1 Step -1
@@ -6350,7 +6355,12 @@ Cls
 								CopyTree(App\CurrentFile$, "Data\Textures\" + Filename$)
 							EndIf
 						Else
-							Filename$ = Right$(App\CurrentFile$, Len(App\CurrentFile$) - Len(CurrentDir$() + "Data\Textures\")) ;TODO: If RootDir is changed this may break
+							Filename$ = Right$(App\CurrentFile$, Len(App\CurrentFile$) - Len("Data\Textures\")) ;TODO: If RootDir is changed this may break
+						EndIf
+
+						; Remove trailing slash
+						If Right$(Filename$, 1) = "\"
+							Filename$ = Left$(Filename$, Len(Filename$) - 1)
 						EndIf
 
 						; Single file
@@ -6375,7 +6385,7 @@ Cls
 						Is3D = SoundDialog()
 
 						; Copy file/folder if required
-						If Instr(App\CurrentFile$, CurrentDir$() + "Data\Sounds\") = 0 ;TODO: If RootDir is changed this may break
+						If Instr(App\CurrentFile$, "Data\Sounds\") = 0 ;TODO: If RootDir is changed this may break
 							Filename$ = App\CurrentFile$
 							If MediaFolder$ <> "" Then Filename$ = MediaFolder$ + "\" + Filename$
 							For i = Len(App\CurrentFile$) To 1 Step -1
@@ -6391,8 +6401,14 @@ Cls
 								CopyTree(App\CurrentFile$, "Data\Sounds\" + Filename$)
 							EndIf
 						Else
-							Filename$ = Right$(App\CurrentFile$, Len(App\CurrentFile$) - Len(CurrentDir$() + "Data\Sounds\")) ;TODO: If RootDir is changed this may break
+							Filename$ = Right$(App\CurrentFile$, Len(App\CurrentFile$) - Len("Data\Sounds\")) ;TODO: If RootDir is changed this may break
 						EndIf
+
+						; Remove trailing slash
+						If Right$(Filename$, 1) = "\"
+							Filename$ = Left$(Filename$, Len(Filename$) - 1)
+						EndIf
+						
 
 						; Single file
 						If FileType("Data\Sounds\" + Filename$) = 1
@@ -6415,7 +6431,7 @@ Cls
 					If Result = True
 
 						; Copy file/folder if required
-						If Instr(App\CurrentFile$, CurrentDir$() + "Data\Music\") = 0 ;TODO: If RootDir is changed this may break
+						If Instr(App\CurrentFile$, "Data\Music\") = 0 ;TODO: If RootDir is changed this may break
 							Filename$ = App\CurrentFile$
 							If MediaFolder$ <> "" Then Filename$ = MediaFolder$ + "\" + Filename$
 							For i = Len(App\CurrentFile$) To 1 Step -1
@@ -6431,7 +6447,7 @@ Cls
 								CopyTree(App\CurrentFile$, "Data\Music\" + Filename$)
 							EndIf
 						Else
-							Filename$ = Right$(App\CurrentFile$, Len(App\CurrentFile$) - Len(CurrentDir$() + "Data\Music\")) ;TODO: If RootDir is changed this may break
+							Filename$ = Right$(App\CurrentFile$, Len(App\CurrentFile$) - Len("Data\Music\")) ;TODO: If RootDir is changed this may break
 						EndIf
 
 						; Single file

--- a/src/GUE.bb
+++ b/src/GUE.bb
@@ -6288,6 +6288,11 @@ Cls
 						If (Flags And 1) <> False Then IsAnim = True Else IsAnim = False
 						IsEncrypted = False
 
+						; Remove trailing slash
+						If Right$(Filename$, 1) = "\"
+							Filename$ = Left$(Filename$, Len(Filename$) - 1)
+						EndIf
+
 						; Copy file/folder if required
 						If Instr(App\CurrentFile$, "Data\Meshes\") = 0 ;TODO: If RootDir is changed this may break
 							Filename$ = App\CurrentFile$
@@ -6300,19 +6305,13 @@ Cls
 								EndIf
 							Next
 							If FileType(App\CurrentFile$) = 1
-								CopyFile(App\CurrentFile$, "Data\Meshes\" + Filename$)
+								CopyFile(CurrentDir$() + App\CurrentFile$, CurrentDir$() + "Data\Meshes\" + Filename$)
 							ElseIf FileType(App\CurrentFile$) = 2
-								CopyTree(App\CurrentFile$, "Data\Meshes\" + Filename$)
+								CopyTree(CurrentDir$() + App\CurrentFile$, CurrentDir$() + "Data\Meshes\" + Filename$)
 							EndIf
 						Else
 							Filename$ = Right$(App\CurrentFile$, Len(App\CurrentFile$) - Len("Data\Meshes\")) ;TODO: If RootDir is changed this may break
 						EndIf
-
-						; Remove trailing slash
-						If Right$(Filename$, 1) = "\"
-							Filename$ = Left$(Filename$, Len(Filename$) - 1)
-						EndIf
-
 
 						; Single file
 						If FileType("Data\Meshes\" + Filename$) = 1
@@ -6334,6 +6333,12 @@ Cls
 						; Get extra options
 						Flags = TextureDialog()
 
+						; Remove trailing slash
+						If Right$(App\CurrentFile$, 1) = "\"
+							DebugLog "Trailing slash found"
+							App\CurrentFile$ = Left$(App\CurrentFile$, Len(App\CurrentFile$) - 1)
+						EndIf
+
 						; Copy file/folder if required
 						If Instr(App\CurrentFile$, "Data\Textures\") = 0 ;TODO: If RootDir is changed this may break
 							Filename$ = App\CurrentFile$
@@ -6346,17 +6351,12 @@ Cls
 								EndIf
 							Next
 							If FileType(App\CurrentFile$) = 1
-								CopyFile(App\CurrentFile$, "Data\Textures\" + Filename$)
+								CopyFile(CurrentDir$() + App\CurrentFile$, CurrentDir$() + "Data\Textures\" + Filename$)
 							ElseIf FileType(App\CurrentFile$) = 2
-								CopyTree(App\CurrentFile$, "Data\Textures\" + Filename$)
+								CopyTree(CurrentDir$() + App\CurrentFile$, CurrentDir$() + "Data\Textures\" + Filename$)
 							EndIf
 						Else
 							Filename$ = Right$(App\CurrentFile$, Len(App\CurrentFile$) - Len("Data\Textures\")) ;TODO: If RootDir is changed this may break
-						EndIf
-
-						; Remove trailing slash
-						If Right$(Filename$, 1) = "\"
-							Filename$ = Left$(Filename$, Len(Filename$) - 1)
 						EndIf
 
 						; Single file
@@ -6380,6 +6380,11 @@ Cls
 						; Get extra options
 						Is3D = SoundDialog()
 
+						; Remove trailing slash
+						If Right$(Filename$, 1) = "\"
+							Filename$ = Left$(Filename$, Len(Filename$) - 1)
+						EndIf
+
 						; Copy file/folder if required
 						If Instr(App\CurrentFile$, "Data\Sounds\") = 0 ;TODO: If RootDir is changed this may break
 							Filename$ = App\CurrentFile$
@@ -6392,17 +6397,12 @@ Cls
 								EndIf
 							Next
 							If FileType(App\CurrentFile$) = 1
-								CopyFile(App\CurrentFile$, "Data\Sounds\" + Filename$)
+								CopyFile(CurrentDir$() + App\CurrentFile$, CurrentDir$() + "Data\Sounds\" + Filename$)
 							ElseIf FileType(App\CurrentFile$) = 2
-								CopyTree(App\CurrentFile$, "Data\Sounds\" + Filename$)
+								CopyTree(CurrentDir$() + App\CurrentFile$, CurrentDir$() + "Data\Sounds\" + Filename$)
 							EndIf
 						Else
 							Filename$ = Right$(App\CurrentFile$, Len(App\CurrentFile$) - Len("Data\Sounds\")) ;TODO: If RootDir is changed this may break
-						EndIf
-
-						; Remove trailing slash
-						If Right$(Filename$, 1) = "\"
-							Filename$ = Left$(Filename$, Len(Filename$) - 1)
 						EndIf
 
 						; Single file
@@ -6425,6 +6425,11 @@ Cls
 					Result = FUI_CustomOpenDialog("Choose file to add...", "Data\Music\", FileTypes$, False, True)
 					If Result = True
 
+						; Remove trailing slash
+						If Right$(Filename$, 1) = "\"
+							Filename$ = Left$(Filename$, Len(Filename$) - 1)
+						EndIf
+
 						; Copy file/folder if required
 						If Instr(App\CurrentFile$, "Data\Music\") = 0 ;TODO: If RootDir is changed this may break
 							Filename$ = App\CurrentFile$
@@ -6437,17 +6442,12 @@ Cls
 								EndIf
 							Next
 							If FileType(App\CurrentFile$) = 1
-								CopyFile(App\CurrentFile$, "Data\Music\" + Filename$)
+								CopyFile(CurrentDir$() + App\CurrentFile$, CurrentDir$() + "Data\Music\" + Filename$)
 							ElseIf FileType(App\CurrentFile$) = 2
-								CopyTree(App\CurrentFile$, "Data\Music\" + Filename$)
+								CopyTree(CurrentDir$() + App\CurrentFile$, CurrentDir$() + "Data\Music\" + Filename$)
 							EndIf
 						Else
 							Filename$ = Right$(App\CurrentFile$, Len(App\CurrentFile$) - Len("Data\Music\")) ;TODO: If RootDir is changed this may break
-						EndIf
-
-							; Remove trailing slash
-						If Right$(Filename$, 1) = "\"
-							Filename$ = Left$(Filename$, Len(Filename$) - 1)
 						EndIf
 
 						; Single file

--- a/src/GUE.bb
+++ b/src/GUE.bb
@@ -6289,8 +6289,8 @@ Cls
 						IsEncrypted = False
 
 						; Remove trailing slash
-						If Right$(Filename$, 1) = "\"
-							Filename$ = Left$(Filename$, Len(Filename$) - 1)
+						If Right$(App\CurrentFile$, 1) = "\"
+							App\CurrentFile$ = Left$(App\CurrentFile$, Len(App\CurrentFile$) - 1)
 						EndIf
 
 						; Copy file/folder if required
@@ -6335,7 +6335,6 @@ Cls
 
 						; Remove trailing slash
 						If Right$(App\CurrentFile$, 1) = "\"
-							DebugLog "Trailing slash found"
 							App\CurrentFile$ = Left$(App\CurrentFile$, Len(App\CurrentFile$) - 1)
 						EndIf
 
@@ -6381,8 +6380,8 @@ Cls
 						Is3D = SoundDialog()
 
 						; Remove trailing slash
-						If Right$(Filename$, 1) = "\"
-							Filename$ = Left$(Filename$, Len(Filename$) - 1)
+						If Right$(App\CurrentFile$, 1) = "\"
+							App\CurrentFile$ = Left$(App\CurrentFile$, Len(App\CurrentFile$) - 1)
 						EndIf
 
 						; Copy file/folder if required
@@ -6426,8 +6425,8 @@ Cls
 					If Result = True
 
 						; Remove trailing slash
-						If Right$(Filename$, 1) = "\"
-							Filename$ = Left$(Filename$, Len(Filename$) - 1)
+						If Right$(App\CurrentFile$, 1) = "\"
+							App\CurrentFile$ = Left$(App\CurrentFile$, Len(App\CurrentFile$) - 1)
 						EndIf
 
 						; Copy file/folder if required


### PR DESCRIPTION
With issue #27 there was a bug when attempting to import assets into the GUE. The code assumed the CurrentDir was appended to the app/CurrentFile so the filename ended up getting complete truncated. There was also a trailing slash left in the folder name.