### PR TITLE
[ENHANCE] Dismiss current target if target details window closed

### DIFF
--- a/src/Modules/Interface3D.bb
+++ b/src/Modules/Interface3D.bb
@@ -1100,6 +1100,7 @@ Function UpdateInterface()
 			CharInteract = Null
 			GY_FreeGadget(WCharInteract)
 			CharInteractVisible = False
+			PlayerTarget = 0
 		; Window still open
 		Else
 			; Change target


### PR DESCRIPTION
This PR makes a change where if you dismiss the window of a target showing the details of the target like their current health it will also dismiss the target itself.