### PR TITLE
[ENHANCE] Add right-click context menu

### DIFF
--- a/data/Server Data/Scripts/Click_Trainer.rsl
+++ b/data/Server Data/Scripts/Click_Trainer.rsl
@@ -24,3 +24,7 @@ Function Main()
    	EndIf
 
 End Function
+
+Function Examine()
+	Output(Actor(), "This trainer can teach you the fireball skill")
+End Function

--- a/data/Server Data/Scripts/Default.rsl
+++ b/data/Server Data/Scripts/Default.rsl
@@ -1,0 +1,17 @@
+Using "RC_Core.rcm"
+; Default server script
+; You may alter this script however you like
+; This script is used in some instances where no other script is specified or able to be run
+
+Function Main()
+	Return
+
+End Function
+
+Function Examine()
+    Player = Actor()
+	Target = ContextActor()
+
+	Output(Actor(), "This is a " + Name(Target))
+End Function
+

--- a/src/Modules/Interface3D.bb
+++ b/src/Modules/Interface3D.bb
@@ -1,3 +1,8 @@
+Global WContextMenu = 0
+Global BInteract = 0
+Global BAttack = 0
+Global BExamine = 0
+
 ; Alphabetically sorted list of abilities
 Dim KnownSpellSort(999)
 
@@ -608,6 +613,56 @@ Function UpdateInterface()
 		If CamDist# > 50.0 Then CamDist# = 50.0
 	EndIf
 
+	; Update context menu if it exists
+	If WContextMenu <> 0
+		If PlayerTarget > 0
+			AI.ActorInstance = Object.ActorInstance(PlayerTarget)
+			; Handle Interact button
+			If GY_ButtonHit(BInteract)
+				If AI <> Null
+					If EntityDistance#(AI\CollisionEN, Me\CollisionEN) < InteractRange
+						RCE_Send(Connection, PeerToHost, P_RightClick, RCE_StrFromInt$(AI\RuntimeID, 2), True)
+					else
+						SetDestination(Me, EntityX#(AI\CollisionEN), EntityZ#(AI\CollisionEN), EntityY#(AI\CollisionEN))
+						Me\IsRunning = True
+						If Me\Mount <> Null Then Me\Mount\IsRunning = True
+					EndIf
+				EndIf
+				GY_FreeGadget(WContextMenu)
+				WContextMenu = 0
+			EndIf
+			
+			; Handle Attack button
+			If GY_ButtonHit(BAttack)
+				If AI <> Null
+					SetDestination(Me, EntityX#(AI\CollisionEN), EntityZ#(AI\CollisionEN), EntityY#(AI\CollisionEN))
+					Me\IsRunning = True
+					If Me\Mount <> Null Then Me\Mount\IsRunning = True
+					AttackTarget = True
+				EndIf
+				GY_FreeGadget(WContextMenu)
+				WContextMenu = 0
+			EndIf
+			
+			; Handle Examine button
+			If GY_ButtonHit(BExamine)
+				If AI <> Null
+					RCE_Send(Connection, PeerToHost, P_Examine, RCE_StrFromInt$(AI\RuntimeID, 2), True)
+				EndIf
+				GY_FreeGadget(WContextMenu)
+				WContextMenu = 0
+			EndIf
+			
+			; Close menu if clicked outside
+			If MouseHit(1) And GY_MouseOverGadget = False
+				GY_FreeGadget(WContextMenu)
+				WContextMenu = 0
+			EndIf
+		else 
+			WContextMenu = 0
+		EndIf
+	EndIf
+
 	; Update these buttons if the mouse is not over a dialog or the action bar
 	If GY_MouseOverGadget = False And GY_MouseY# < 0.85 And (CurrentSeq(Me) >= Anim_LookRound Or Animating(Me\EN) = False) And InDialog = False And SMemorising = 0
 		; Talk to button down, remember the time (so we ignore presses which take more than 500ms)
@@ -717,14 +772,27 @@ Function UpdateInterface()
 					Else
 						If CharInteractVisible
 							UpdateCharInteractionWindow()
-						ElseIf CharInteract = Null
+						Else
 							CreateCharInteractionWindow(AI)
-							;CysisLibs Outline
-							;Outline ActorSelectEN
 						EndIf
-						If AI\FactionRatings[Me\HomeFaction] > 99 And EntityDistance#(AI\CollisionEN, Me\CollisionEN) < InteractRange
-							RCE_Send(Connection, PeerToHost, P_RightClick, RCE_StrFromInt$(AI\RuntimeID, 2), True)
+						; Create context menu
+						WContextMenu = GY_CreateWindowInter("Actions", GY_MouseX#, GY_MouseY#, 0.1, 0.08, True, True, False, CreateTexture(2, 2))
+						
+						; Interact button
+						Local interactLabel$ = "Interact"
+						If EntityDistance#(AI\CollisionEN, Me\CollisionEN) > InteractRange
+							interactLabel$ = "Move To"
 						EndIf
+						BInteract = GY_CreateButton(WContextMenu, 0.0, 0.0, 1.0, 0.33, interactLabel$, False, 255, 255, 255, LoadTexture("Data\Textures\GUI\ToolTip.png"))
+						
+						; Attack button (only if target is attackable)
+						If AI\Actor\Aggressiveness < 3 And Me\FactionRatings[AI\HomeFaction] <= 150
+							BAttack = GY_CreateButton(WContextMenu, 0.0, 0.33, 1.0, 0.33, "Attack", False, 255, 255, 255, LoadTexture("Data\Textures\GUI\ToolTip.png"))
+						EndIf
+						
+						; Examine button
+						BExamine = GY_CreateButton(WContextMenu, 0.0, 0.66, 1.0, 0.33, "Examine", False, 255, 255, 255, LoadTexture("Data\Textures\GUI\ToolTip.png"))
+						
 						AttackTarget = False
 					EndIf
 					;HideEntity(ClickMarkerEN) ;{@@@~}

--- a/src/Modules/Packets.bb
+++ b/src/Modules/Packets.bb
@@ -53,3 +53,4 @@ Const P_ProgressBar        = 51
 Const P_BubbleMessage      = 52
 Const P_ScriptInput        = 53
 Const P_KickedPlayer       = 60
+Const P_Examine            = 61

--- a/src/Modules/ServerNet.bb
+++ b/src/Modules/ServerNet.bb
@@ -1130,6 +1130,26 @@ Function UpdateNetwork()
 						EndIf
 					EndIf
 				EndIf
+			
+			Case P_Examine
+				AI.ActorInstance = FindActorInstanceFromRNID(M\FromID)
+				If AI <> Null And Len(M\MessageData$) = 2
+					A2.ActorInstance = RuntimeIDList(RCE_IntFromStr(M\MessageData$))
+					If A2\Script$ <> ""
+						Running = False
+						
+						For Si.ScriptInstance = Each ScriptInstance
+							If Si\Name = A2\Script
+								If Si\AI = Handle(AI) And Si\AIContext = Handle(A2) Then Running = True : Exit
+							EndIf
+						Next
+						If Running = False
+							ThreadScript(A2\Script$, "Examine", Handle(AI), Handle(A2))
+						EndIf
+					Else
+						ThreadScript("Default", "Examine", Handle(AI), Handle(A2))
+					EndIf
+				EndIf
 
 			; A player has attacked something
 			Case P_AttackActor


### PR DESCRIPTION
This PR adds a context menu that pops up when you right-click (or whatever you have mapped to select) an actor. If you are to far to interact with the actor the first option is "Move To" which will move your character towards the actor. If you are in Interact range the first option is "Interact". Clicking this will run the actors `Main` function in their script. If the actor can be attacked there will be an "Attack" option next. And lastly there is a new "Examine" option which when clicked will run the `Examine` function of the actors script. If the actor has no script a new `Default.rsl` script will run it's "Examine" script.

![Client 2025-01-21 05-41-52_697](https://github.com/user-attachments/assets/add54e0c-051e-44f2-a013-4d7c5915ab3c)
