### PR TITLE
Fix test workflow path consistency

### DIFF
--- a/ReadMe.md
+++ b/ReadMe.md
@@ -45,7 +45,7 @@ If you are familiar with the Blitz programming language you can help make improv
 
 ##### Tests
 
-You could also help writing tests in blitz as well. All tests should live under the [src\Tests](src\Tests) folder and you can run all tests by running the `test.bat` script. Tests are run before every git commit locally and must pass for your commit to succeed.
+You could also help writing tests in blitz as well. All tests should live under the [src/Tests](src/Tests) folder and you can run all tests by running the `test.bat` script. Tests are run before every git commit locally and must pass for your commit to succeed.
 
 #### C++
 

--- a/test.bat
+++ b/test.bat
@@ -1,24 +1,38 @@
 @echo off
 setlocal
 
-set ROOTDIR=%CD%
+set "ROOTDIR=%~dp0"
+if "%ROOTDIR:~-1%"=="\" set "ROOTDIR=%ROOTDIR:~0,-1%"
 
-IF NOT EXIST "%ROOTDIR%\compiler\BlitzForge\bin\blitzcc.exe" (
-    echo "%ROOTDIR%\compiler\BlitzForge\bin\blitzcc.exe not found!"
-    echo "Compile source or download binaries from https://github.com/RydeTec/blitz-forge/releases"
-    exit 1;
+set "BLITZPATH=%ROOTDIR%\compiler\BlitzForge"
+set "TESTDIR="
+
+if exist "%ROOTDIR%\src\Tests" (
+    set "TESTDIR=%ROOTDIR%\src\Tests"
+) else if exist "%ROOTDIR%\src\tests" (
+    set "TESTDIR=%ROOTDIR%\src\tests"
 )
 
-cd %ROOTDIR%\src\tests
+if not exist "%BLITZPATH%\bin\blitzcc.exe" (
+    echo "%BLITZPATH%\bin\blitzcc.exe not found!"
+    echo "Compile source or download binaries from https://github.com/RydeTec/blitz-forge/releases"
+    exit /b 1
+)
 
-set BLITZPATH=%ROOTDIR%\compiler\BlitzForge
+if not defined TESTDIR (
+    echo "Test directory not found. Expected src\Tests or src\tests."
+    exit /b 1
+)
+
+cd /d "%TESTDIR%"
+
 set FAILED=0
 
 for /R %%f in (*.bb) do (
     "%BLITZPATH%\bin\blitzcc.exe" -t -w "%ROOTDIR%\src" "%%f" || (echo "%%f failed at least one test" && SET FAILED=1)
 )
 
-cd %ROOTDIR%
+cd /d "%ROOTDIR%"
 
 if %FAILED% == 1 (
     echo "Tests failed"


### PR DESCRIPTION
## Non-technical summary
This fixes the repository's test entrypoint so it points at the real test directory and works when invoked outside the repo root. It matters now because contributors are explicitly told to use `test.bat`, and the previous path handling could break on case-sensitive filesystems or when launched from another working directory.

After this change, the documented test location matches the codebase and the batch runner fails more clearly if the Blitz compiler or test directory is missing.

## Technical summary
- update `test.bat` to derive the repository root from the script location instead of `%CD%`
- resolve the canonical `src\Tests` directory first, with a fallback to `src\tests` for compatibility
- replace the ambiguous `exit 1;` failure path with `exit /b 1`
- use `cd /d` so the script can switch drives safely when changing directories
- correct the contributor documentation link in `ReadMe.md` from `src\Tests` to `src/Tests`

Relevant intent:
- the repository's contributor guide says Blitz tests live under `src/Tests` and should be runnable through `test.bat`
- the tracked tree currently contains `src/Tests/...`, while the old script hardcoded `src\tests`

Tests and verification:
- `git diff --check`
- static verification that Git tracks `src/Tests/...`
- direct execution of `test.bat` was not possible in this macOS environment because `cmd.exe` is not installed

Breaking changes:
- none intended

## Additional notes
Trade-offs:
- I kept the change tightly scoped to the test entrypoint and contributor docs rather than broadening into hook portability or CI changes.

Deferred follow-up:
- if the project wants first-class non-Windows contributor support, the next step would be adding a cross-platform test wrapper instead of relying only on `test.bat`.

Remaining gap:
- the repo still has a Windows-first test execution surface; this change only removes one concrete path/cwd mismatch inside that existing workflow.
