### PR TITLE
Fix server account actions targeting the wrong selection

### DIFF
--- a/src/Modules/AccountsServer.bb
+++ b/src/Modules/AccountsServer.bb
@@ -23,6 +23,18 @@ Type ActionBarData
 End Type
 Global Accounts.AccountsWindow
 
+Function FindAccountByListID.Account(ListID)
+
+	If ListID < 0 Then Return Null
+
+	For A.Account = Each Account
+		If A\ListID = ListID Then Return A
+	Next
+
+	Return Null
+
+End Function
+
 ; Alters the logged in status of an account
 Function SetLoginStatus(A.Account, Status)
 

--- a/src/Server.bb
+++ b/src/Server.bb
@@ -411,16 +411,14 @@ Repeat
 				WriteLog(ChatLog, "** Log flushed **", True, True)
 			; Toggle DM status
 			Case Accounts\DMButton
-				A.Account = First Account
-				For i = 2 To SelectedGadgetItem(Accounts\List) : A = After A : Next
+				A.Account = FindAccountByListID(SelectedGadgetItem(Accounts\List))
 				If A <> Null
 					SetAccountDMStatus(A, Not A\IsDM)
 					WriteLog(MainLog, "Toggled DM Status: " + A\User$ + " it is now " + Str(A\IsDM))
 				EndIf
 			; Toggle ban status
 			Case Accounts\BanButton
-				A.Account = First Account
-				For i = 2 To SelectedGadgetItem(Accounts\List) : A = After A : Next
+				A.Account = FindAccountByListID(SelectedGadgetItem(Accounts\List))
 				If A <> Null
 					SetAccountBanStatus(A, Not A\IsBanned)
 					WriteLog(MainLog, "Toggled Ban Status: " + A\User$ + " it is now " + Str(A\IsBanned))
@@ -428,8 +426,7 @@ Repeat
 			; Remove account
 			Case Accounts\DeleteButton
 				If Confirm("Really remove account?") = True
-					A.Account = First Account
-					For i = 2 To SelectedGadgetItem(Accounts\List) : A = After A : Next
+					A.Account = FindAccountByListID(SelectedGadgetItem(Accounts\List))
 					If A <> Null
 						; Remove from counters
 						Accounts\TotalAccounts = Accounts\TotalAccounts - 1

--- a/src/Tests/Modules/AccountsServerTest.bb
+++ b/src/Tests/Modules/AccountsServerTest.bb
@@ -1,0 +1,54 @@
+Strict
+EnableGC
+
+Type ActorInstance
+	Field Account
+End Type
+
+Type QuestLog
+	Field EntryName$[499]
+	Field EntryStatus$[499]
+End Type
+
+Function WriteActorInstance(F, A.ActorInstance)
+End Function
+
+Function ReadActorInstance.ActorInstance(F)
+	Return Null
+End Function
+
+Function FreeActorInstance(A.ActorInstance)
+End Function
+
+Include "Modules\AccountsServer.bb"
+
+Test testFindAccountByListIDReturnsMatchingAccount()
+	Local firstAccount.Account = New Account
+	firstAccount\User$ = "first"
+	firstAccount\ListID = 0
+
+	Local secondAccount.Account = New Account
+	secondAccount\User$ = "second"
+	secondAccount\ListID = 1
+
+	Local thirdAccount.Account = New Account
+	thirdAccount\User$ = "third"
+	thirdAccount\ListID = 2
+
+	Local found.Account = FindAccountByListID(1)
+	Assert(found = secondAccount)
+	Assert(found\User$ = "second")
+
+	Delete Each Account
+End Test
+
+Test testFindAccountByListIDReturnsNullForInvalidSelection()
+	Local firstAccount.Account = New Account
+	firstAccount\User$ = "first"
+	firstAccount\ListID = 0
+
+	Assert(FindAccountByListID(-1) = Null)
+	Assert(FindAccountByListID(7) = Null)
+
+	Delete Each Account
+End Test


### PR DESCRIPTION
## Non-technical summary
The Server Accounts window can act on the wrong account when you toggle GM status, ban/unban, or delete a row. This change makes those actions follow the account that is actually selected in the list, so account administration behaves predictably again.

This matters now because issue #48 reports GM toggling as broken in the live server UI, and the same selection bug also affected the adjacent ban and delete actions.

Fixes #48.

## Technical summary
- added `FindAccountByListID` in `src/Modules/AccountsServer.bb` so account-window actions resolve the selected `Account` by its maintained `ListID` instead of walking the linked list by position
- updated the Server Accounts window handlers in `src/Server.bb` to use that lookup for GM toggle, ban toggle, and delete
- added `src/Tests/Modules/AccountsServerTest.bb` with focused coverage for valid and invalid list-ID lookup behavior

## Additional notes
Trade-off: this PR keeps scope on selection targeting only. It does not change when account edits are persisted to disk beyond the existing delete flow.

Validation: added a regression test, but I could not execute `test.bat` in this macOS environment because `cmd.exe` is unavailable and this checkout does not contain a runnable `compiler/BlitzForge/bin/blitzcc.exe`.

Remaining gap: if maintainers want these account-admin actions to persist immediately rather than on the existing save points, that should be a separate follow-up increment.