### PR TITLE
Make build scripts cwd-independent and propagate failures

### DIFF
--- a/compile.bat
+++ b/compile.bat
@@ -5,7 +5,10 @@ set TOOLCHAIN=0
 set RCCETOOLS=1
 set RCCE=1
 
-set ROOTDIR=%CD%
+set "ROOTDIR=%~dp0"
+if "%ROOTDIR:~-1%"=="\" set "ROOTDIR=%ROOTDIR:~0,-1%"
+
+set "BLITZPATH=%ROOTDIR%\compiler\BlitzForge"
 
 :parse_args
 if "%1"=="" goto end_args
@@ -36,7 +39,7 @@ goto parse_args
 :help_text
 echo RCCE2 Compiler Script
 echo.
-echo -t ^| --skip-tools     Skip compilation of the RCCE2 tool applications in \src\tools
+echo -t ^| --skip-tools     Skip compilation of the RCCE2 tool applications in \src\Tools
 echo -b ^| --blitz          Compile the BlitzForge toolchain
 echo -e ^| --skip-engine    Skip compilation of the RCCE2 engine itself in \src
 endlocal
@@ -46,54 +49,69 @@ exit /b
 
 if %TOOLCHAIN%==1 (
     echo Compiling BlitzForge Toolchain...
-    call %ROOTDIR%\scripts\submodules_init.bat
-    call %ROOTDIR%\compiler\BlitzForge\scripts\msbuild_init.bat
+    call "%ROOTDIR%\scripts\submodules_init.bat" || (
+        echo Failed to initialize submodules.
+        endlocal
+        exit /b 1
+    )
+    call "%BLITZPATH%\scripts\msbuild_init.bat"
 
-    cd %ROOTDIR%
+    cd /d "%ROOTDIR%"
 
-    call %ROOTDIR%\compiler\BlitzForge\scripts\msbuild_blitzforge.bat
+    call "%BLITZPATH%\scripts\msbuild_blitzforge.bat"
 )
 
 if %RCCE%==1 (
-    IF NOT EXIST "%ROOTDIR%\compiler\BlitzForge\bin\blitzcc.exe" (
-        echo "%ROOTDIR%\compiler\BlitzForge\bin\blitzcc.exe not found!"
+    if not exist "%BLITZPATH%\bin\blitzcc.exe" (
+        echo "%BLITZPATH%\bin\blitzcc.exe not found!"
         echo "Compile source or download binaries from https://github.com/RydeTec/blitz-forge/releases"
-        exit 1;
+        endlocal
+        exit /b 1
     )
 
     echo Compiling RealmCrafter CE Engine...
 
-    cd %ROOTDIR%\src
+    cd /d "%ROOTDIR%\src"
 
-    set BLITZPATH=%ROOTDIR%\compiler\BlitzForge
-
-    "!BLITZPATH!\bin\blitzcc.exe" -o "%ROOTDIR%\bin\Server.exe" "%ROOTDIR%\src\Server.bb"
-    "!BLITZPATH!\bin\blitzcc.exe" -o "%ROOTDIR%\Project Manager.exe" -n "%ROOTDIR%\res\Icon.ico" "%ROOTDIR%\src\Project Manager.bb"
-    "!BLITZPATH!\bin\blitzcc.exe" -o "%ROOTDIR%\bin\GUE.exe" -n "%ROOTDIR%\res\Icon.ico" "%ROOTDIR%\src\GUE.bb"
-    "!BLITZPATH!\bin\blitzcc.exe" -o "%ROOTDIR%\bin\Client.exe" -n "%ROOTDIR%\res\Icon.ico" "%ROOTDIR%\src\Client.bb"
+    "%BLITZPATH%\bin\blitzcc.exe" -o "%ROOTDIR%\bin\Server.exe" "%ROOTDIR%\src\Server.bb" || (cd /d "%ROOTDIR%" & endlocal & exit /b 1)
+    "%BLITZPATH%\bin\blitzcc.exe" -o "%ROOTDIR%\Project Manager.exe" -n "%ROOTDIR%\res\Icon.ico" "%ROOTDIR%\src\Project Manager.bb" || (cd /d "%ROOTDIR%" & endlocal & exit /b 1)
+    "%BLITZPATH%\bin\blitzcc.exe" -o "%ROOTDIR%\bin\GUE.exe" -n "%ROOTDIR%\res\Icon.ico" "%ROOTDIR%\src\GUE.bb" || (cd /d "%ROOTDIR%" & endlocal & exit /b 1)
+    "%BLITZPATH%\bin\blitzcc.exe" -o "%ROOTDIR%\bin\Client.exe" -n "%ROOTDIR%\res\Icon.ico" "%ROOTDIR%\src\Client.bb" || (cd /d "%ROOTDIR%" & endlocal & exit /b 1)
 )
 
 if %RCCETOOLS%==1 (
-    IF NOT EXIST "%ROOTDIR%\compiler\BlitzForge\bin\blitzcc.exe" (
-        echo "%ROOTDIR%\compiler\BlitzForge\bin\blitzcc.exe not found!"
+    if not exist "%BLITZPATH%\bin\blitzcc.exe" (
+        echo "%BLITZPATH%\bin\blitzcc.exe not found!"
         echo "Compile source or download binaries from https://github.com/RydeTec/blitz-forge/releases"
-        exit 1;
+        endlocal
+        exit /b 1
     )
-    
+
     echo Compiling RealmCrafter CE Tools...
 
     if not exist "%ROOTDIR%\bin\tools" (
         mkdir "%ROOTDIR%\bin\tools"
     )
 
-    cd %ROOTDIR%\src\tools
+    set "TOOLSDIR="
+    if exist "%ROOTDIR%\src\Tools" (
+        set "TOOLSDIR=%ROOTDIR%\src\Tools"
+    ) else if exist "%ROOTDIR%\src\tools" (
+        set "TOOLSDIR=%ROOTDIR%\src\tools"
+    )
 
-    set "BLITZPATH=%ROOTDIR%\compiler\BlitzForge"
+    if not defined TOOLSDIR (
+        echo Tools directory not found. Expected src\Tools or src\tools.
+        endlocal
+        exit /b 1
+    )
+
+    cd /d "!TOOLSDIR!"
 
     for %%f in (*.bb) do (
-        "!BLITZPATH!\bin\blitzcc.exe" -o "%ROOTDIR%\bin\tools\%%~nf.exe" -n "%ROOTDIR%\res\Icon.ico" -w "%ROOTDIR%\src" "%ROOTDIR%\src\tools\%%~nf.bb"
+        "%BLITZPATH%\bin\blitzcc.exe" -o "%ROOTDIR%\bin\tools\%%~nf.exe" -n "%ROOTDIR%\res\Icon.ico" -w "%ROOTDIR%\src" "!TOOLSDIR!\%%~nf.bb" || (cd /d "%ROOTDIR%" & endlocal & exit /b 1)
     )
 )
 
-cd %ROOTDIR%
+cd /d "%ROOTDIR%"
 endlocal

--- a/publish.bat
+++ b/publish.bat
@@ -1,11 +1,16 @@
 @echo off
 setlocal
 
-set ROOTDIR=%CD%
+set "ROOTDIR=%~dp0"
+if "%ROOTDIR:~-1%"=="\" set "ROOTDIR=%ROOTDIR:~0,-1%"
 
-call .\compile.bat
+call "%ROOTDIR%\compile.bat" || (
+    echo Compilation failed; aborting publish.
+    endlocal
+    exit /b 1
+)
 
-cd %ROOTDIR%
+cd /d "%ROOTDIR%"
 
 if exist "%ROOTDIR%\release" rmdir /S /Q "%ROOTDIR%\release"
 

--- a/scripts/compiler.bat
+++ b/scripts/compiler.bat
@@ -1,29 +1,32 @@
 @echo off
-setlocal
+setlocal EnableDelayedExpansion
 
-set ROOTDIR=%1
-set BLITZPATH=%ROOTDIR%\compiler\%2
-set SRCPATH=%3
-set SRCFILE=%4
+set "ROOTDIR=%~1"
+set "COMPILERNAME=%~2"
+set "SRCPATH=%~3"
+set "SRCFILE=%~4"
 
-IF NOT EXIST "%ROOTDIR%\compiler\BlitzForge\bin\blitzcc.exe" (
-    echo "%ROOTDIR%\compiler\BlitzForge\bin\blitzcc.exe not found!"
+set "BLITZPATH=%ROOTDIR%\compiler\%COMPILERNAME%"
+
+if not exist "%BLITZPATH%\bin\blitzcc.exe" (
+    echo "%BLITZPATH%\bin\blitzcc.exe not found!"
     echo "Compile source or download binaries from https://github.com/RydeTec/blitz-forge/releases"
-    exit 1;
+    endlocal
+    exit /b 1
 )
 
-cd %SRCPATH%
+cd /d "%SRCPATH%"
 
-:: Shift the arguments so %1 now refers to what %2 was originally, etc.
+:: Shift past the first four positional arguments so %1 now refers to the first
+:: trailing flag (e.g. -c, -d, -d -t).
 shift
 shift
 shift
 shift
 
-:: Initialize an empty string to collect the remaining arguments
+:: Collect any remaining trailing flags into ARGS verbatim.
 set "ARGS="
 
-:: Loop through the remaining arguments and append them to ARGS
 :loop
 if "%~1"=="" goto endloop
 set "ARGS=%ARGS% %1"
@@ -32,9 +35,9 @@ goto loop
 
 :endloop
 
-:: Now ARGS contains all the arguments except for the first one
-"%BLITZPATH%\bin\blitzcc.exe" %ARGS% -w "%ROOTDIR%\src" %SRCFILE%
+"%BLITZPATH%\bin\blitzcc.exe"%ARGS% -w "%ROOTDIR%\src" "%SRCFILE%"
+set "EXITCODE=%ERRORLEVEL%"
 
-cd %ROOTDIR%
+cd /d "%ROOTDIR%"
 
-endlocal
+endlocal & exit /b %EXITCODE%

--- a/scripts/submodules_init.bat
+++ b/scripts/submodules_init.bat
@@ -1,13 +1,27 @@
 @echo off
-setlocal
+setlocal EnableDelayedExpansion
 
-set ROOTDIR=%CD%
-set BLITZPATH=%ROOTDIR%\compiler\BlitzForge
+:: Anchor on the script's own location so this works regardless of cwd.
+:: %~dp0 resolves to ...\rcce2\scripts\, so step up one directory for ROOTDIR.
+set "SCRIPTDIR=%~dp0"
+if "%SCRIPTDIR:~-1%"=="\" set "SCRIPTDIR=%SCRIPTDIR:~0,-1%"
+for %%I in ("%SCRIPTDIR%\..") do set "ROOTDIR=%%~fI"
 
-REM Check if the submodule directory exists and is not empty
-IF NOT EXIST "%BLITZPATH%\.git" (
-    echo "BlitzForge not found, initializing and updating..."
+set "BLITZPATH=%ROOTDIR%\compiler\BlitzForge"
+
+REM Check if the submodule directory exists and is initialized.
+if not exist "%BLITZPATH%\.git" (
+    echo BlitzForge not found, initializing and updating submodules...
+    pushd "%ROOTDIR%" >nul
     git submodule update --init --recursive
+    set "GITRC=!ERRORLEVEL!"
+    popd >nul
+    if not "!GITRC!"=="0" (
+        echo Failed to initialize submodules ^(exit code !GITRC!^).
+        endlocal
+        exit /b 1
+    )
 )
 
 endlocal
+exit /b 0


### PR DESCRIPTION
## Summary

Following the pattern established for `test.bat` in #51, this PR hardens
the rest of the Windows build pipeline so it works regardless of where
the scripts are invoked from. The previous scripts silently misbehaved
when called from any directory other than the repo root, which affected
git hooks, CI runners, IDE tasks, and any path containing spaces. They
also dropped the exit code on the floor so a failed engine build would
not stop the rest of the script (or cause `publish.bat` to abort), and
used the no-op syntax `exit 1;` which does not actually return 1 on
modern Windows.

After this change, `compile.bat`, `publish.bat`, `scripts/compiler.bat`,
and `scripts/submodules_init.bat` consistently:

- anchor on `%~dp0` instead of `%CD%` (or strip quotes from positional
  args via `%~N`), so cwd no longer matters
- quote all paths and use `cd /d` so spaces and cross-drive invocations
  work
- use `exit /b N` instead of the broken `exit 1;`
- propagate non-zero exit codes from sub-commands so failures surface to
  the caller

## Details

### `compile.bat`
- Anchor `ROOTDIR` on `%~dp0` (script location), trimming the trailing
  backslash, and define `BLITZPATH` once at the top.
- Quote all paths and switch to `cd /d "..."` for invocations.
- Replace the broken `exit 1;` with `exit /b 1` and `endlocal` first.
- Detect `src\Tools` vs `src\tools` the same way `test.bat` handles
  `src\Tests` vs `src\tests`, and store the resolved path in `TOOLSDIR`.
- Use `||` after each `blitzcc.exe` invocation and after the
  `submodules_init.bat` call so the script aborts and returns 1 on the
  first failure instead of running to completion with an arbitrary
  ERRORLEVEL.
- Update the help text to reflect the actual `\src\Tools` casing.

### `publish.bat`
- Anchor `ROOTDIR` on `%~dp0`.
- Quote the embedded `call .\compile.bat` and abort with `exit /b 1` on
  failure so a broken build no longer silently produces a partial
  release.

### `scripts/compiler.bat`
- Read positional arguments via `%~1`..`%~4` so quoted workspace paths
  passed by the VS Code task (which contain spaces in real-world
  installs) no longer corrupt derived variables like `BLITZPATH`.
- `cd /d` for the source directory, capture `ERRORLEVEL` of the
  `blitzcc.exe` invocation into `EXITCODE`, then propagate it through
  `endlocal & exit /b %EXITCODE%`.
- Replace `exit 1;` with `exit /b 1`.

### `scripts/submodules_init.bat`
- Derive `ROOTDIR` from the script's own location (`%~dp0\..`) instead
  of `%CD%`, and `pushd` into it before running `git submodule update`
  so the script works when called from anywhere (including from
  `compile.bat -b` invoked outside the repo root).
- Capture `ERRORLEVEL` via delayed expansion and surface a non-zero exit
  code when submodule initialization fails, which is what the new
  `compile.bat` short-circuit relies on.

## Manual Test Notes

Because these are Windows `.bat` scripts and the work was done on
macOS, automated execution wasn't possible from this branch. The
changes are mechanical mirrors of the patterns merged in #51 for
`test.bat`, plus standard `cmd.exe` idioms (`%~dp0`, `cd /d`, quoted
paths, `exit /b`).

Suggested manual smoke on Windows:

1. From the repo root: `compile.bat -t -e` (no engine, no tools) — should
   no-op cleanly with exit code 0.
2. From a parent directory: `rcce2\compile.bat -t -e` — should still
   work.
3. From a path with spaces: copy/clone the repo to e.g.
   `C:\Users\name\My Repos\rcce2`, then `compile.bat -t -e` — should
   still work.
4. With BlitzForge submodule deleted: `compile.bat -b -t -e` — should
   re-initialize submodules and propagate any git failure as a non-zero
   exit code instead of charging ahead.
5. Force a `blitzcc.exe` failure (e.g. by syntax error in `Server.bb`)
   and run `publish.bat` — should stop with exit code 1 and not produce
   a partial `release\` directory.

## Additional Notes

- No source / runtime code changes; this is strictly build-script
  hardening.
- Behavior change worth flagging: `compile.bat` now stops on the first
  blitzcc failure (previously it ran all four engine invocations and
  then all tools regardless of failures, returning whichever
  ERRORLEVEL the last command happened to set). This is a deliberate
  reliability improvement aligned with the goal that script exit codes
  reflect build success.
- `extras/vscode-blitz-forge/compile.bat` was intentionally left
  untouched — it's an extension build script, not part of the main
  pipeline.

Generated as a single coherent developer-experience increment per the
RCCE engineering guardrails.