### PR TITLE
Refactor: extract Accounts list-entry formatting helper

### DIFF
--- a/docs/modules/accountsserver.md
+++ b/docs/modules/accountsserver.md
@@ -14,6 +14,8 @@ This module contains the following types:
 
 This module contains the following functions:  
 
+*   [FindAccountByListID](#FFindAccountByListID)
+*   [FormatAccountListEntry](#FFormatAccountListEntry)
 *   [SetLoginStatus](#FSetLoginStatus)
 *   [SetAccountDMStatus](#FSetAccountDMStatus)
 *   [SetAccountBanStatus](#FSetAccountBanStatus)
@@ -63,6 +65,40 @@ This type represents a player character's current action bar settings. It contai
   
   
 
+**FindAccountByListID.Account(ListID)**  
+  
+Return value: The matching [Account](#TAccount) object, or Null if no account has the supplied ListID.  
+  
+Parameters:  
+
+*   _ListID_ - The list-box index of the desired account, as returned by `SelectedGadgetItem(Accounts\List)`
+
+  
+This function looks up the [Account](#TAccount) currently displayed at the given row of the server's Accounts list box. It is used by the GM, ban, and delete buttons on the Accounts window to resolve the selected row to the underlying account. It returns Null for any negative ListID and for any positive ListID that does not match an existing account, so callers can safely guard against an empty selection.
+
+  
+  
+  
+
+**FormatAccountListEntry$(IsDM, IsBanned, LoggedOn, User$, Email$)**  
+  
+Return value: The display string used by the server's Accounts list box for the given account state.  
+  
+Parameters:  
+
+*   _IsDM_ - True/False flag for whether the account is flagged as GM
+*   _IsBanned_ - True/False flag for whether the account is banned
+*   _LoggedOn_ - The account's login status: -1 for logged out, or a character ID (0-9) when a character is logged in
+*   _User$_ - The account's username
+*   _Email$_ - The account's email address
+
+  
+This is a pure helper function used by [SetLoginStatus](#FSetLoginStatus) and [LoadAccounts](#FLoadAccounts) to build the user-visible row text shown for each account. The format is `[*] [[BAN]][[GM]] User  (Email)`, where the leading `*` marker indicates the account is currently logged in, `[BAN]` indicates a banned account, and `[GM]` indicates a GM account. Markers are omitted when their corresponding flag is unset.
+
+  
+  
+  
+
 **SetLoginStatus(A.Account, Status)**  
   
 Return value: None  
@@ -73,7 +109,7 @@ Parameters:
 *   _Status_ - The new status
 
   
-This function sets an account's login status. The value of the Status parameter should be -1 to mean that the account is logged out, or otherwise a character ID (from 0 to 9) specifying which character has been logged in on the account. The server's Accounts window is updated to show the new status.
+This function sets an account's login status. The value of the Status parameter should be -1 to mean that the account is logged out, or otherwise a character ID (from 0 to 9) specifying which character has been logged in on the account. The server's Accounts window is updated to show the new status (see [FormatAccountListEntry](#FFormatAccountListEntry) for the row format).
 
   
   

--- a/src/Modules/AccountsServer.bb
+++ b/src/Modules/AccountsServer.bb
@@ -35,39 +35,26 @@ Function FindAccountByListID.Account(ListID)
 
 End Function
 
+; Builds the display string used in the Accounts list box.
+; LoggedOn matches Account\LoggedOn semantics: -1 means logged out, anything
+; greater than or equal to 0 indicates an active character index.
+Function FormatAccountListEntry$(IsDM, IsBanned, LoggedOn, User$, Email$)
+
+	Local Prefix$ = ""
+	If LoggedOn > -1 Then Prefix$ = "* "
+	If IsBanned Then Prefix$ = Prefix$ + "[BAN]"
+	If IsDM Then Prefix$ = Prefix$ + "[GM]"
+	If Len(Prefix$) > 0 And Right$(Prefix$, 1) <> " " Then Prefix$ = Prefix$ + " "
+
+	Return Prefix$ + User$ + "  (" + Email$ + ")"
+
+End Function
+
 ; Alters the logged in status of an account
 Function SetLoginStatus(A.Account, Status)
 
 	A\LoggedOn = Status
-	If Status > -1
-		If A\IsDM = False
-			If A\IsBanned = False
-				ModifyGadgetItem Accounts\List, A\ListID, "* " + A\User$ + "  (" + A\Email$ + ")"
-			Else
-				ModifyGadgetItem Accounts\List, A\ListID, "* [BAN] " + A\User$ + "  (" + A\Email$ + ")"
-			EndIf
-		Else
-			If A\IsBanned = False
-				ModifyGadgetItem Accounts\List, A\ListID, "* [GM] " + A\User$ + "  (" + A\Email$ + ")"
-			Else
-				ModifyGadgetItem Accounts\List, A\ListID, "* [BAN][GM] " + A\User$ + "  (" + A\Email$ + ")"
-			EndIf
-		EndIf
-	Else
-		If A\IsDM = False
-			If A\IsBanned = False
-				ModifyGadgetItem Accounts\List, A\ListID, A\User$ + "  (" + A\Email$ + ")"
-			Else
-				ModifyGadgetItem Accounts\List, A\ListID, "[BAN] " + A\User$ + "  (" + A\Email$ + ")"
-			EndIf
-		Else
-			If A\IsBanned = False
-				ModifyGadgetItem Accounts\List, A\ListID, "[GM] " + A\User$ + "  (" + A\Email$ + ")"
-			Else
-				ModifyGadgetItem Accounts\List, A\ListID, "[BAN][GM] " + A\User$ + "  (" + A\Email$ + ")"
-			EndIf
-		EndIf
-	EndIf
+	ModifyGadgetItem Accounts\List, A\ListID, FormatAccountListEntry$(A\IsDM, A\IsBanned, A\LoggedOn, A\User$, A\Email$)
 
 End Function
 
@@ -198,22 +185,9 @@ Function LoadAccounts()
 			A\IsBanned = ReadByte(F)
 			A\Ignore$ = ReadString$(F)
 			A\LoggedOn = -1
-			If A\IsDM = False
-				If A\IsBanned = False
-					AddListBoxItem Accounts\List, A\User$ + "  (" + A\Email$ + ")"
-				Else
-					AddListBoxItem Accounts\List, "[BAN] " + A\User$ + "  (" + A\Email$ + ")"
-					Accounts\TotalBanned = Accounts\TotalBanned + 1
-				EndIf
-			Else
-				If A\IsBanned = False
-					AddListBoxItem Accounts\List, "[GM] " + A\User$ + "  (" + A\Email$ + ")"
-				Else
-					AddListBoxItem Accounts\List, "[BAN][GM] " + A\User$ + "  (" + A\Email$ + ")"
-					Accounts\TotalBanned = Accounts\TotalBanned + 1
-				EndIf
-				Accounts\TotalDMs = Accounts\TotalDMs + 1
-			EndIf
+			AddListBoxItem Accounts\List, FormatAccountListEntry$(A\IsDM, A\IsBanned, A\LoggedOn, A\User$, A\Email$)
+			If A\IsBanned Then Accounts\TotalBanned = Accounts\TotalBanned + 1
+			If A\IsDM Then Accounts\TotalDMs = Accounts\TotalDMs + 1
 			A\ListID = CountGadgetItems(Accounts\List) - 1
 			Chars = ReadByte(F)
 			For i = 1 To Chars

--- a/src/Tests/Modules/AccountsServerTest.bb
+++ b/src/Tests/Modules/AccountsServerTest.bb
@@ -52,3 +52,41 @@ Test testFindAccountByListIDReturnsNullForInvalidSelection()
 
 	Delete Each Account
 End Test
+
+; FormatAccountListEntry$ should produce the exact display strings the
+; Accounts list box has historically used for each combination of GM,
+; banned, and logged-on status. These tests pin the format so that future
+; refactors of SetLoginStatus / LoadAccounts cannot drift the user-visible
+; output without being noticed.
+
+Test testFormatAccountListEntryLoggedOutPlainAccount()
+	Assert(FormatAccountListEntry$(False, False, -1, "alice", "alice@example.com") = "alice  (alice@example.com)")
+End Test
+
+Test testFormatAccountListEntryLoggedOutBanned()
+	Assert(FormatAccountListEntry$(False, True, -1, "alice", "alice@example.com") = "[BAN] alice  (alice@example.com)")
+End Test
+
+Test testFormatAccountListEntryLoggedOutGM()
+	Assert(FormatAccountListEntry$(True, False, -1, "alice", "alice@example.com") = "[GM] alice  (alice@example.com)")
+End Test
+
+Test testFormatAccountListEntryLoggedOutBannedGM()
+	Assert(FormatAccountListEntry$(True, True, -1, "alice", "alice@example.com") = "[BAN][GM] alice  (alice@example.com)")
+End Test
+
+Test testFormatAccountListEntryLoggedInPlainAccount()
+	Assert(FormatAccountListEntry$(False, False, 0, "alice", "alice@example.com") = "* alice  (alice@example.com)")
+End Test
+
+Test testFormatAccountListEntryLoggedInBanned()
+	Assert(FormatAccountListEntry$(False, True, 3, "alice", "alice@example.com") = "* [BAN] alice  (alice@example.com)")
+End Test
+
+Test testFormatAccountListEntryLoggedInGM()
+	Assert(FormatAccountListEntry$(True, False, 9, "alice", "alice@example.com") = "* [GM] alice  (alice@example.com)")
+End Test
+
+Test testFormatAccountListEntryLoggedInBannedGM()
+	Assert(FormatAccountListEntry$(True, True, 5, "alice", "alice@example.com") = "* [BAN][GM] alice  (alice@example.com)")
+End Test


### PR DESCRIPTION
## Summary

The server's Accounts list box has eight possible row formats covering combinations of (logged-on, GM, banned). Today that 4-way nested format is duplicated as two separate branches in `SetLoginStatus` (eight `ModifyGadgetItem` calls) and `LoadAccounts` (four `AddListBoxItem` calls), with no test coverage pinning the exact strings. Any tweak to a marker had to land in both places without drifting.

This change extracts a single pure `FormatAccountListEntry$()` helper that produces the exact same eight strings, replaces both call sites with a single call to the helper, and adds eight pin tests that lock in the historical format. Documentation is updated to cover the new helper plus the recently-added `FindAccountByListID` (which had been previously undocumented).

The system after this change: a single source of truth for Accounts row formatting, exhaustive unit coverage of that source of truth, and discoverability via the module reference.

## Technical summary

- `src/Modules/AccountsServer.bb`
  - Added pure helper `FormatAccountListEntry$(IsDM, IsBanned, LoggedOn, User$, Email$)` that returns the exact display string the Accounts list box has historically used. The helper is UI-free, so it is directly testable.
  - `SetLoginStatus` collapses from a 4-way nested `If` into a single `ModifyGadgetItem` call through the helper.
  - `LoadAccounts` collapses the same 4-way nested `If` into a single `AddListBoxItem` call, and hoists the `TotalDMs` / `TotalBanned` increments out into two flat guarded statements (matching the pattern already used by `SetAccountDMStatus` / `SetAccountBanStatus`).
- `src/Tests/Modules/AccountsServerTest.bb`
  - Added eight pin tests covering every (`IsDM`, `IsBanned`, `LoggedOn` ∈ {-1, ≥0}) combination. Tests use only primitive arguments, so they have no UI dependency.
- `docs/modules/accountsserver.md`
  - Added function-index entries and per-function sections for `FindAccountByListID` (originally added in #52) and `FormatAccountListEntry`.
  - `SetLoginStatus` now cross-links to `FormatAccountListEntry` so the row format is discoverable from the mutator.

### Behavior preservation

All eight historical row formats are preserved exactly:

| LoggedOn | IsDM | IsBanned | Output (with `User=alice`, `Email=alice@example.com`) |
|----------|------|----------|--------------------------------------------------------|
| -1 (off) | F    | F        | `alice  (alice@example.com)`                           |
| -1 (off) | F    | T        | `[BAN] alice  (alice@example.com)`                     |
| -1 (off) | T    | F        | `[GM] alice  (alice@example.com)`                      |
| -1 (off) | T    | T        | `[BAN][GM] alice  (alice@example.com)`                 |
| ≥0 (on)  | F    | F        | `* alice  (alice@example.com)`                         |
| ≥0 (on)  | F    | T        | `* [BAN] alice  (alice@example.com)`                   |
| ≥0 (on)  | T    | F        | `* [GM] alice  (alice@example.com)`                    |
| ≥0 (on)  | T    | T        | `* [BAN][GM] alice  (alice@example.com)`               |

Each row is asserted by a dedicated pin test.

### Verification performed

- `blitzcc -c -t -target macos-arm64 /tmp/_format_probe.bb` (helper + tests in isolation): exit 0.
- `blitzcc -c -target host -w src src/Server.bb` (full Server build, host target): exit 0.
- `blitzcc -c -target macos-arm64 -w src src/Server.bb` (full Server build, macOS-arm64 target): exit 0 (compat warnings for unrelated dylibs only).
- Existing macOS-arm64 parser issue at `AccountsServerTest.bb:26` (`New Account` without parens, pre-existing from #52) is intentionally untouched here so this PR stays a pure refactor; the new tests use primitives and don't rely on `New`.

### Breaking changes

None. This is a behavior-preserving refactor.

## Additional notes

- The `LoadAccounts` change incidentally simplifies the totals math: previously the `TotalBanned` / `TotalDMs` increments were tucked inside the formatting branches in a way that mirrored the format conditionals; now they're flat `If` statements on the underlying flags, which is consistent with the rest of the module and matches `SetAccountDMStatus` / `SetAccountBanStatus`.
- `FormatAccountListEntry$` is intentionally pure (no `Accounts\` reads, no `Mod*Gadget*` calls), which makes the format trivially unit-testable; the test file mocks for `ActorInstance`, `QuestLog`, `WriteActorInstance`, `ReadActorInstance`, `FreeActorInstance` (already present from #52) are sufficient to include the module without additional UI scaffolding.
- Out of scope (intentionally deferred): the `LoadAccounts` -> `RemoveGadgetItem` deletion path in `Server.bb` still does manual ListID re-numbering via `After A`, which assumes linked-list order matches list-box order. That's a separate correctness concern that doesn't belong in a refactor PR.