### PR TITLE
[DOCS] Reconcile macOS arm64 README claims with BlitzForge alpha status

### DIFF
--- a/ReadMe.md
+++ b/ReadMe.md
@@ -20,7 +20,7 @@ RCCE picks up where the original RealmCrafter left off — modernized, cross-pla
 [![Discussions](https://img.shields.io/github/discussions/RydeTec/rcce2)](https://github.com/RydeTec/rcce2/discussions)
 
 [![Platform: Windows](https://img.shields.io/badge/Windows-x64-0078D4?logo=windows&logoColor=white)](https://github.com/RydeTec/rcce2/releases)
-[![Platform: macOS](https://img.shields.io/badge/macOS-Apple%20Silicon-000000?logo=apple&logoColor=white)](release/MACOS_NOTES.txt)
+[![Platform: macOS](https://img.shields.io/badge/macOS-Apple%20Silicon%20(alpha)-orange?logo=apple&logoColor=white)](release/MACOS_NOTES.txt)
 [![Engine: BlitzForge](https://img.shields.io/badge/Engine-BlitzForge-ff6a00)](compiler/BlitzForge)
 
 </div>
@@ -45,7 +45,7 @@ RealmCrafter was one of the earliest tools that let solo developers and small te
 | | Original RealmCrafter | RCCE |
 |---|---|---|
 | Status | Abandoned | **Actively maintained** |
-| Platforms | Windows only | **Windows + macOS (Apple Silicon)** |
+| Platforms | Windows only | **Windows (stable) + macOS Apple Silicon (alpha)** |
 | Compiler | Closed-source Blitz3D | **[BlitzForge](compiler/BlitzForge) — open-source fork with ARM64 codegen** |
 | Tooling | Frozen | Modern VS Code extension, native IDEs, CI |
 | License model | Proprietary | Community / open development |
@@ -73,7 +73,7 @@ RealmCrafter was one of the earliest tools that let solo developers and small te
 3. Launch **Project Manager** (`Project Manager.exe` on Windows, `Project Manager` on macOS).
 4. Open the bundled sample project, hit **Run Server**, then **Run Client**.
 
-> **macOS users:** RCCE ships native Apple Silicon binaries. See [`release/MACOS_NOTES.txt`](release/MACOS_NOTES.txt) for compatibility notes on the Win32-emulating layer used for legacy DLL-style modules.
+> **macOS users — alpha.** RCCE produces native Apple Silicon binaries via [BlitzForge's macOS port](compiler/BlitzForge#macos-apple-silicon--alpha), which is currently **alpha**: the runtime path is incomplete, many language and standard-library features are not yet wired up, and breakage is expected. Use the macOS build for development and feedback, not for shipping a game. See [`release/MACOS_NOTES.txt`](release/MACOS_NOTES.txt) for current compatibility notes.
 
 ### Build from source
 
@@ -133,9 +133,10 @@ rcce2/
 
 ## Roadmap highlights
 
-- ✅ macOS arm64 native runtime (Mach-O, no Wine/Rosetta)
-- ✅ ARM64 code generation in BlitzForge
 - ✅ Cross-platform build scripts (`compile.sh`, `publish.sh`, `bootstrap_macos.sh`)
+- ✅ ARM64 code generation in BlitzForge
+- 🚧 macOS arm64 native runtime (Mach-O, no Wine/Rosetta) — **alpha**, not production-ready
+- 🔄 Filling in the macOS runtime to reach feature parity with the Windows runtime
 - 🔄 Continued modernization of the rendering and audio backends
 - 🔄 Documentation overhaul
 - 🔮 Linux runtime (community interest tracked in [Discussions](https://github.com/RydeTec/rcce2/discussions))


### PR DESCRIPTION
## Context

PR #55 (the README marketing rewrite) shipped to `develop` with macOS Apple Silicon support presented as a stable, production-ready platform alongside Windows. While #55 was in flight, BlitzForge `develop` landed [PR #25 (the macOS arm64 native port)](https://github.com/RydeTec/blitz-forge/pull/25) with an explicit alpha disclosure in *its* README:

> **Status: alpha. Not stable. Expect breakage.**
>
> Native macOS arm64 support is under active development. The compiler (`blitzcc`) builds and can target `macos-arm64`, but the runtime execution path is incomplete and many language and standard-library features are not yet wired up. **Do not rely on it for shipping work.**

RCCE's macOS path goes through BlitzForge's compiler, so by transitive dependency RCCE's macOS support is at most as stable as BlitzForge's — i.e. alpha. The current `develop` README overstates that. This PR closes the gap.

The companion PR in BlitzForge applying the matching change to its own README is RydeTec/blitz-forge#26.

## What changed

This PR touches only `ReadMe.md`:

- **Hero badge:** `Apple Silicon` → `Apple Silicon (alpha)`, repainted orange so the alpha status is visible at a glance.
- **Why RCCE comparison table:** `Windows + macOS (Apple Silicon)` → `Windows (stable) + macOS Apple Silicon (alpha)`.
- **macOS users callout:** reframed from a confident "RCCE ships native Apple Silicon binaries" to an explicit alpha disclosure that links into BlitzForge's own alpha section, calls out incomplete runtime coverage, and recommends "use for development and feedback, not for shipping a game."
- **Roadmap:** the macOS native runtime is moved from "shipped" (green check) to "in progress" with explicit "alpha, not production-ready" labeling, and a new item is added for filling in the macOS runtime to reach feature parity with Windows.

The Windows path is unchanged and remains the stable, production target.

## Why this is a separate PR

PR #55 was already squash-merged into `develop` before this honesty reconciliation could be folded into it. Rather than reopen #55, this is a small, targeted follow-up that's easy to review on its own.

## Test plan

- [ ] Render `ReadMe.md` on the GitHub web UI for the PR branch and confirm:
  - [ ] The macOS badge now shows `(alpha)` and renders orange.
  - [ ] The `[BlitzForge's macOS port]` link in the macOS users callout resolves to the alpha section in the BlitzForge submodule README (after BlitzForge#26 merges, that anchor will exist; until then the link points to a section that doesn't yet live on master — which is still informative).
  - [ ] Roadmap renders with the construction emoji and "alpha" label.
- [ ] Confirm no other content drift versus current `develop`.

## Follow-ups

- Once the macOS runtime reaches feature parity, remove the alpha disclosure across both READMEs in a single coordinated PR.