### PR TITLE
[FIX] Wire up the macOS build path the README quickstart promises

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,6 +40,21 @@ bin/GUE.exe
 
 bin/Server.exe
 
+# macOS / Linux engine outputs (compile.sh)
+bin/Client
+bin/GUE
+bin/Server
+bin/tools/Gubbin Tool
+bin/tools/RC Architect
+bin/tools/RC Caves Editor
+bin/tools/RC Rock Editor
+bin/tools/RC Terrain Editor
+bin/tools/RC Tree Editor
+
+# Match the no-extension Project Manager binary that compile.sh emits at the
+# repo root on macOS / Linux.
+/Project Manager
+
 data/Logs/
 
 data/RCTE/RCTE_SAVED/

--- a/compile.sh
+++ b/compile.sh
@@ -1,0 +1,136 @@
+#!/usr/bin/env bash
+# RCCE2 build entry point for macOS / Linux. Mirrors compile.bat.
+#
+# Mac/Linux uses the BlitzForge `blitzcc` Mach-O / ELF binary at
+# `compiler/BlitzForge/bin/blitzcc`. macOS support in BlitzForge is alpha and
+# coverage of the engine sources is incomplete — see ReadMe.md for current
+# status.
+set -euo pipefail
+
+ROOTDIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+BLITZPATH="${ROOTDIR}/compiler/BlitzForge"
+
+TOOLCHAIN=0
+RCCETOOLS=1
+RCCE=1
+
+usage() {
+  cat <<'EOF'
+RCCE2 Compiler Script
+
+Usage: compile.sh [flags]
+
+  -t | --skip-tools     Skip compilation of the RCCE2 tool applications in src/Tools
+  -b | --blitz          Compile the BlitzForge toolchain
+  -e | --skip-engine    Skip compilation of the RCCE2 engine itself in src
+  -h | --help           Show this help
+EOF
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    -b|--blitz) TOOLCHAIN=1 ;;
+    -t|--skip-tools) RCCETOOLS=0 ;;
+    -e|--skip-engine) RCCE=0 ;;
+    -h|--help) usage; exit 0 ;;
+    *) echo "Unknown flag: $1" >&2; usage; exit 1 ;;
+  esac
+  shift
+done
+
+# Resolve which blitzcc binary to invoke — Mach-O/ELF on Unix, .exe fallback so
+# this also works under WSL or Git Bash on Windows.
+resolve_blitzcc() {
+  local unix="${BLITZPATH}/bin/blitzcc"
+  local win="${BLITZPATH}/bin/blitzcc.exe"
+  if [[ -x "${unix}" ]]; then
+    echo "${unix}"
+  elif [[ -f "${win}" ]]; then
+    echo "${win}"
+  else
+    echo ""
+  fi
+}
+
+if [[ "${TOOLCHAIN}" -eq 1 ]]; then
+  echo "Compiling BlitzForge Toolchain..."
+  if [[ ! -d "${BLITZPATH}/.git" ]]; then
+    (cd "${ROOTDIR}" && git submodule update --init --recursive) \
+      || { echo "Failed to initialize submodules." >&2; exit 1; }
+  fi
+  if [[ ! -x "${BLITZPATH}/compile.sh" ]]; then
+    echo "BlitzForge compile.sh not found at ${BLITZPATH}/compile.sh." >&2
+    echo "The pinned BlitzForge commit may predate macOS/Linux build support." >&2
+    exit 1
+  fi
+  "${BLITZPATH}/compile.sh"
+fi
+
+if [[ "${RCCE}" -eq 1 || "${RCCETOOLS}" -eq 1 ]]; then
+  BLITZCC="$(resolve_blitzcc)"
+  if [[ -z "${BLITZCC}" ]]; then
+    echo "${BLITZPATH}/bin/blitzcc not found!" >&2
+    echo "Compile source with ./compile.sh -b, or download binaries from" >&2
+    echo "  https://github.com/RydeTec/blitz-forge/releases" >&2
+    exit 1
+  fi
+fi
+
+# Drop the .ico flag on macOS until BlitzForge supports native icon embedding.
+# See https://github.com/RydeTec/blitz-forge — fix/custom-exe-icons.
+ICON_FLAG=()
+if [[ "$(uname -s)" != "Darwin" && -f "${ROOTDIR}/res/Icon.ico" ]]; then
+  ICON_FLAG=(-n "${ROOTDIR}/res/Icon.ico")
+fi
+
+# Match compile.bat output names on macOS: drop the .exe extension so that
+# `Project Manager` (no suffix) launches as the README documents.
+EXE_SUFFIX=""
+if [[ "$(uname -s)" != "Darwin" ]]; then
+  EXE_SUFFIX=".exe"
+fi
+
+if [[ "${RCCE}" -eq 1 ]]; then
+  echo "Compiling RealmCrafter CE Engine..."
+  mkdir -p "${ROOTDIR}/bin"
+  cd "${ROOTDIR}/src"
+
+  "${BLITZCC}" -o "${ROOTDIR}/bin/Server${EXE_SUFFIX}" \
+    "${ROOTDIR}/src/Server.bb"
+  "${BLITZCC}" -o "${ROOTDIR}/Project Manager${EXE_SUFFIX}" "${ICON_FLAG[@]}" \
+    "${ROOTDIR}/src/Project Manager.bb"
+  "${BLITZCC}" -o "${ROOTDIR}/bin/GUE${EXE_SUFFIX}" "${ICON_FLAG[@]}" \
+    "${ROOTDIR}/src/GUE.bb"
+  "${BLITZCC}" -o "${ROOTDIR}/bin/Client${EXE_SUFFIX}" "${ICON_FLAG[@]}" \
+    "${ROOTDIR}/src/Client.bb"
+fi
+
+if [[ "${RCCETOOLS}" -eq 1 ]]; then
+  echo "Compiling RealmCrafter CE Tools..."
+  mkdir -p "${ROOTDIR}/bin/tools"
+
+  if [[ -d "${ROOTDIR}/src/Tools" ]]; then
+    TOOLSDIR="${ROOTDIR}/src/Tools"
+  elif [[ -d "${ROOTDIR}/src/tools" ]]; then
+    TOOLSDIR="${ROOTDIR}/src/tools"
+  else
+    echo "Tools directory not found. Expected src/Tools or src/tools." >&2
+    exit 1
+  fi
+
+  cd "${TOOLSDIR}"
+  shopt -s nullglob nocaseglob
+  tool_count=0
+  for f in *.bb; do
+    name="${f%.*}"
+    "${BLITZCC}" -o "${ROOTDIR}/bin/tools/${name}${EXE_SUFFIX}" \
+      "${ICON_FLAG[@]}" -w "${ROOTDIR}/src" "${TOOLSDIR}/${f}"
+    tool_count=$((tool_count + 1))
+  done
+  shopt -u nullglob nocaseglob
+  if [[ "${tool_count}" -eq 0 ]]; then
+    echo "No tools found in ${TOOLSDIR}." >&2
+  fi
+fi
+
+cd "${ROOTDIR}"

--- a/publish.sh
+++ b/publish.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+# RCCE2 release packager for macOS / Linux. Mirrors publish.bat.
+# Builds the engine + tools, then copies runtime payloads into release/ for
+# distribution. Forwards extra arguments to compile.sh so callers can pass
+# `--blitz`, `--skip-tools`, etc.
+set -euo pipefail
+
+ROOTDIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+RELEASE_DIR="${ROOTDIR}/release"
+
+"${ROOTDIR}/compile.sh" "$@"
+
+cd "${ROOTDIR}"
+
+rm -rf "${RELEASE_DIR}"
+mkdir -p "${RELEASE_DIR}"
+
+rsync -a "${ROOTDIR}/bin/" "${RELEASE_DIR}/bin/"
+if [[ -f "${ROOTDIR}/bin/ReShade.ini.example" && ! -f "${RELEASE_DIR}/bin/ReShade.ini" ]]; then
+  cp "${ROOTDIR}/bin/ReShade.ini.example" "${RELEASE_DIR}/bin/ReShade.ini"
+fi
+
+# Copy the freshly compiled Project Manager binary alongside the bin tree, so
+# users can launch it directly from the release root just like the Windows
+# zip layout.
+if [[ -f "${ROOTDIR}/Project Manager.exe" ]]; then
+  cp "${ROOTDIR}/Project Manager.exe" "${RELEASE_DIR}/"
+fi
+if [[ -f "${ROOTDIR}/Project Manager" ]]; then
+  cp "${ROOTDIR}/Project Manager" "${RELEASE_DIR}/"
+fi
+
+for dir in data res docs; do
+  if [[ -d "${ROOTDIR}/${dir}" ]]; then
+    rsync -a "${ROOTDIR}/${dir}/" "${RELEASE_DIR}/${dir}/"
+  fi
+done
+
+if [[ -d "${ROOTDIR}/extras/Freemake" ]]; then
+  mkdir -p "${RELEASE_DIR}/extras/Freemake"
+  rsync -a "${ROOTDIR}/extras/Freemake/" "${RELEASE_DIR}/extras/Freemake/"
+fi
+
+rm -f "${RELEASE_DIR}/res/Recent.dat"
+
+# Generate the macOS build notes the README points users to. Only emitted on
+# macOS so we don't lie about a Mach-O build on other hosts.
+if [[ "$(uname -s)" == "Darwin" ]]; then
+  arch="$(uname -m)"
+  cat > "${RELEASE_DIR}/MACOS_NOTES.txt" <<EOF
+This release was produced on macOS ${arch} via ./publish.sh.
+
+macOS support is alpha — the BlitzForge runtime/linker path is incomplete and
+many engine features are not yet wired up. Use this build for development and
+feedback only; do not rely on it for shipping a game. Compatibility diagnostics
+written by blitzcc -compat-report (when generated separately) live under
+release/compat/*.compat.txt.
+EOF
+fi

--- a/scripts/bootstrap_macos.sh
+++ b/scripts/bootstrap_macos.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+# One-time toolchain setup for building RCCE2 on macOS (Apple Silicon).
+#
+# This is a thin wrapper that:
+#   1. Initializes git submodules (so the BlitzForge submodule is populated).
+#   2. Runs BlitzForge's own bootstrap_macos.sh to install Homebrew packages
+#      required to build blitzcc + runtime/linker dylibs from source.
+#
+# After this script succeeds, run `./compile.sh -b` from the rcce2 root to
+# build BlitzForge, then `./compile.sh` to build the engine and tools.
+set -euo pipefail
+
+if [[ "$(uname -s)" != "Darwin" ]]; then
+  echo "bootstrap_macos.sh is intended for macOS hosts." >&2
+  exit 1
+fi
+
+SCRIPTDIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOTDIR="$(cd "${SCRIPTDIR}/.." && pwd)"
+BLITZPATH="${ROOTDIR}/compiler/BlitzForge"
+
+if [[ ! -d "${BLITZPATH}/.git" || ! -f "${BLITZPATH}/ReadMe.md" ]]; then
+  echo "BlitzForge submodule missing — initializing submodules..."
+  (cd "${ROOTDIR}" && git submodule update --init --recursive)
+fi
+
+if [[ ! -x "${BLITZPATH}/scripts/bootstrap_macos.sh" ]]; then
+  echo "BlitzForge macOS bootstrap not found at ${BLITZPATH}/scripts/bootstrap_macos.sh." >&2
+  echo "The pinned BlitzForge commit may predate macOS support." >&2
+  exit 1
+fi
+
+"${BLITZPATH}/scripts/bootstrap_macos.sh"
+
+echo
+echo "Toolchain ready. Next steps:"
+echo "  ./compile.sh -b   # build BlitzForge (blitzcc + runtime/linker)"
+echo "  ./compile.sh      # build the RCCE2 engine and tools"

--- a/test.sh
+++ b/test.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+# RCCE2 test runner for macOS / Linux. Mirrors test.bat.
+# Compiles every test source in src/Tests with `blitzcc -t`. Any failure marks
+# the run as failed but the loop continues so you see every broken test in one
+# pass.
+set -uo pipefail
+
+ROOTDIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+BLITZPATH="${ROOTDIR}/compiler/BlitzForge"
+
+if [[ -d "${ROOTDIR}/src/Tests" ]]; then
+  TESTDIR="${ROOTDIR}/src/Tests"
+elif [[ -d "${ROOTDIR}/src/tests" ]]; then
+  TESTDIR="${ROOTDIR}/src/tests"
+else
+  echo "Test directory not found. Expected src/Tests or src/tests." >&2
+  exit 1
+fi
+
+BLITZCC_UNIX="${BLITZPATH}/bin/blitzcc"
+BLITZCC_WIN="${BLITZPATH}/bin/blitzcc.exe"
+if [[ -x "${BLITZCC_UNIX}" ]]; then
+  BLITZCC="${BLITZCC_UNIX}"
+elif [[ -f "${BLITZCC_WIN}" ]]; then
+  BLITZCC="${BLITZCC_WIN}"
+else
+  echo "${BLITZPATH}/bin/blitzcc not found!" >&2
+  echo "Compile source with ./compile.sh -b, or download binaries from" >&2
+  echo "  https://github.com/RydeTec/blitz-forge/releases" >&2
+  exit 1
+fi
+
+cd "${TESTDIR}"
+
+FAILED=0
+while IFS= read -r -d '' f; do
+  if ! "${BLITZCC}" -t -w "${ROOTDIR}/src" "${f}"; then
+    echo "\"${f}\" failed at least one test"
+    FAILED=1
+  fi
+done < <(find "${TESTDIR}" -type f -name '*.bb' -print0)
+
+cd "${ROOTDIR}"
+
+if [[ "${FAILED}" -eq 1 ]]; then
+  echo "Tests failed"
+  exit 1
+fi
+
+echo "Tests passed"


### PR DESCRIPTION
## Non-technical summary

When PR #55 (the README marketing rewrite) shipped, it added a macOS Quick Start section that tells contributors to run:

```bash
./scripts/bootstrap_macos.sh
./compile.sh
./publish.sh
```

None of those files exist in `rcce2`. Mac contributors who follow the README literally hit `no such file or directory` at the very first line. The Windows `.bat` siblings ship; the Mac equivalents never did. To make matters worse, the `compiler/BlitzForge` submodule was still pinned to a commit that predates BlitzForge's macOS port, so even a hypothetical `compile.sh` had no Mach-O `blitzcc` to call into.

This PR wires up the path the README already promises:

- New `compile.sh`, `test.sh`, `publish.sh` at the repo root, mirroring the existing `.bat` flag surface (`-b`, `-e`, `-t`).
- New `scripts/bootstrap_macos.sh` that initializes submodules and delegates to BlitzForge's own Homebrew-based bootstrap.
- The BlitzForge submodule pointer bumps from `bfdad53` (2025-01-30, Windows-only) to develop HEAD `e8d86c4`, which contains the macOS arm64 port and the cross-platform CMake build.
- A small `.gitignore` extension covers the no-extension binaries (`bin/Server`, `bin/Client`, `bin/GUE`, the named `bin/tools/*` outputs, `/Project Manager`) that `compile.sh` emits on Unix hosts.
- `publish.sh` writes `release/MACOS_NOTES.txt` on Darwin so the README link to that file is no longer dead after a publish.

After this PR, macOS contributors can finally run the commands the README told them to run a week ago. The existing alpha disclosure (added by PR #56) remains accurate and is the right place for users to learn what currently does and does not work end-to-end.

## Technical summary

### Submodule bump (`0f023d8`)

`compiler/BlitzForge`: `bfdad53` → `e8d86c4`. The intervening commits are macOS-additive (ARM64 codegen, host abstraction, CMake build, macOS runtime backend, macOS bootstrap script) plus an `ObjectType` class-name lookup fix and Windows CI compatibility fixes that were validated by BlitzForge's CI on Windows. The Windows path is unaffected.

### Build scripts (`43e5d5b`)

| Script | Mirrors | Notes |
|---|---|---|
| `compile.sh` | `compile.bat` | Same flag surface (`-h`, `-b`/`--blitz`, `-t`/`--skip-tools`, `-e`/`--skip-engine`). Resolves `blitzcc` (prefers Mach-O/ELF, falls back to `.exe` for WSL/Git Bash). On macOS drops the `.exe` suffix from outputs (matching the existing pre-built `Project Manager` binary) and skips `-n icon.ico` until BlitzForge's macOS icon support lands. `-b` chains BlitzForge's own `compile.sh`. |
| `test.sh` | `test.bat` | Iterates every `src/Tests/**/*.bb` under `blitzcc -t -w src`. Exits non-zero on any failure. |
| `publish.sh` | `publish.bat` | Builds via `compile.sh "$@"` so callers can forward flags. Rsyncs `bin/`, `data/`, `res/`, `docs/`, and the Project Manager binary (with or without `.exe`) into `release/`. On macOS also writes `release/MACOS_NOTES.txt`. |
| `scripts/bootstrap_macos.sh` | (no Windows equivalent — `.bat` users have a working toolchain by default) | Initializes submodules if missing, then runs `compiler/BlitzForge/scripts/bootstrap_macos.sh` for Homebrew dependencies. Refuses to run on non-Darwin. |

### Gitignore additions

```
bin/Client
bin/GUE
bin/Server
bin/tools/Gubbin Tool
bin/tools/RC Architect
bin/tools/RC Caves Editor
bin/tools/RC Rock Editor
bin/tools/RC Terrain Editor
bin/tools/RC Tree Editor
/Project Manager
```

These are the precise outputs the new `compile.sh` emits on Unix hosts. Existing tracked content under `bin/tools/<dir>/` is untouched (the patterns target top-level files only).

## Verification performed

- `bash -n` syntax check on every new script.
- `./compile.sh -h` renders the help; `./compile.sh --invalid` rejects unknown flags with exit 1.
- `./compile.sh -e -t` (no-op) succeeds with exit 0.
- `./compile.sh` with no `blitzcc` present → clear error pointing to `./compile.sh -b` or the BlitzForge releases page, exit 1.
- `./compile.sh` with `blitzcc` present → script invokes the compiler correctly; the run fails today at the linker step with the upstream BlitzForge alpha message `Blitz Linker Error: Executable image creation is only implemented for Windows PE targets in the legacy linker`. The script wrapper itself is wired correctly upstream of that gap and will work without modification once BlitzForge's macOS linker lands.
- `./test.sh` runs end-to-end on macOS: blitzcc executes assembled code in-process during test mode, so tests actually run (and surface real failures) on Mac today.

## Trade-offs and follow-up

- BlitzForge's macOS linker still cannot produce Mach-O executables, so the engine build will fail at `Server.bb` until that lands. The alpha disclosure already in the README covers this expectation. This PR is deliberately scoped to the wiring layer; fixing the linker belongs in BlitzForge.
- The icon flag (`-n res/Icon.ico`) is silently skipped on macOS because BlitzForge does not yet embed icons there (work in flight on `blitz-forge#fix/custom-exe-icons`). Re-enable conditionally once that lands.
- No GitHub Actions workflow added for the new shell scripts; rcce2 has no `.github/workflows/` today. Adding macOS CI to exercise these scripts is a separate, dedicated increment.
- This PR does not touch `docs/start.md` or `docs/index.md`, both of which still describe the legacy Blitz3D / BlitzPlus dual-compiler workflow. That is a separate documentation-improvement increment.

## Test plan for reviewers

- [ ] Confirm submodule pointer matches BlitzForge develop HEAD: `git ls-tree HEAD compiler/BlitzForge` → `e8d86c47f6e1742067e9485eb2f91f77431199f2`.
- [ ] On Windows: existing `compile.bat`, `test.bat`, `publish.bat` continue to work unchanged (this PR adds new files; no existing files are modified except `.gitignore`).
- [ ] On macOS:
  - [ ] `./scripts/bootstrap_macos.sh` succeeds (or errors clearly if Homebrew is missing).
  - [ ] `./compile.sh -b` builds BlitzForge from source.
  - [ ] `./compile.sh -e -t` is a clean no-op.
  - [ ] `./compile.sh -h` shows the help.
  - [ ] `./test.sh` runs every `src/Tests/**/*.bb` (failures expected today; the run itself completes).