### PR TITLE
Document the actual macOS source-build path

### DIFF
--- a/ReadMe.md
+++ b/ReadMe.md
@@ -20,7 +20,7 @@ RCCE picks up where the original RealmCrafter left off — modernized, cross-pla
 [![Discussions](https://img.shields.io/github/discussions/RydeTec/rcce2)](https://github.com/RydeTec/rcce2/discussions)
 
 [![Platform: Windows](https://img.shields.io/badge/Windows-x64-0078D4?logo=windows&logoColor=white)](https://github.com/RydeTec/rcce2/releases)
-[![Platform: macOS](https://img.shields.io/badge/macOS-Apple%20Silicon%20(alpha)-orange?logo=apple&logoColor=white)](release/MACOS_NOTES.txt)
+[![Platform: macOS](https://img.shields.io/badge/macOS-Apple%20Silicon%20(alpha)-orange?logo=apple&logoColor=white)](docs/macos-apple-silicon.md)
 [![Engine: BlitzForge](https://img.shields.io/badge/Engine-BlitzForge-ff6a00)](compiler/BlitzForge)
 
 </div>
@@ -73,7 +73,7 @@ RealmCrafter was one of the earliest tools that let solo developers and small te
 3. Launch **Project Manager** (`Project Manager.exe` on Windows, `Project Manager` on macOS).
 4. Open the bundled sample project, hit **Run Server**, then **Run Client**.
 
-> **macOS users — alpha.** RCCE produces native Apple Silicon binaries via [BlitzForge's macOS port](compiler/BlitzForge#macos-apple-silicon--alpha), which is currently **alpha**: the runtime path is incomplete, many language and standard-library features are not yet wired up, and breakage is expected. Use the macOS build for development and feedback, not for shipping a game. See [`release/MACOS_NOTES.txt`](release/MACOS_NOTES.txt) for current compatibility notes.
+> **macOS users — alpha.** RCCE produces native Apple Silicon binaries via [BlitzForge's macOS port](compiler/BlitzForge#macos-apple-silicon--alpha), which is currently **alpha**: the runtime path is incomplete, many language and standard-library features are not yet wired up, and breakage is expected. Use the macOS build for development and feedback, not for shipping a game. See [macOS Apple Silicon notes](docs/macos-apple-silicon.md) for the current source-build flow and compatibility caveats.
 
 ### Build from source
 
@@ -100,7 +100,9 @@ publish.bat            :: produce a redistributable release
 
 ```bash
 ./scripts/bootstrap_macos.sh    # one-time toolchain setup
+./compile.sh -b                 # build BlitzForge (blitzcc + runtime/linker)
 ./compile.sh                    # build engine + tools
+./test.sh                       # compile the Blitz test suite
 ./publish.sh                    # produce a redistributable release
 ```
 
@@ -124,6 +126,7 @@ rcce2/
 ## Documentation
 
 - **[Getting Started](docs/start.md)** — your first project
+- **[macOS Apple Silicon Notes](docs/macos-apple-silicon.md)** — source-build steps, release notes, and alpha caveats
 - **[Module Reference](docs/reference.md)** — engine APIs
 - **[Format Reference](docs/formats.md)** — file formats and conventions
 - **[RealmCrafter Wiki](https://realmcrafter.fandom.com/)** — legacy gameplay and editor docs

--- a/docs/index.md
+++ b/docs/index.md
@@ -5,4 +5,5 @@ This is the index page for the RealmCrafter: Community Edition source code docum
   
 
 *   [Getting Started](start.md)
+*   [macOS Apple Silicon Notes](macos-apple-silicon.md)
 *   [Module Reference](reference.md)

--- a/docs/macos-apple-silicon.md
+++ b/docs/macos-apple-silicon.md
@@ -1,0 +1,67 @@
+<!-- body { color:black background-color:white } a:link{ color:#0070FF } a:visited{ color:#0070FF } -->
+
+# macOS Apple Silicon Notes
+
+RCCE can produce native Apple Silicon binaries through the vendored
+[BlitzForge](../compiler/BlitzForge) toolchain, but the macOS runtime remains
+alpha. Expect missing language/runtime coverage and editor/runtime breakage.
+Use the macOS port for development and feedback, not for shipping a game.
+
+## Build from source
+
+Start from a fresh clone with submodules:
+
+```bash
+git clone --recurse-submodules https://github.com/RydeTec/rcce2.git
+cd rcce2
+```
+
+If the submodules were not populated during clone:
+
+```bash
+git submodule update --init --recursive
+```
+
+Install the Homebrew/toolchain prerequisites that BlitzForge needs:
+
+```bash
+./scripts/bootstrap_macos.sh
+```
+
+That bootstrap script does not compile BlitzForge for you. Build the toolchain
+first so `compiler/BlitzForge/bin/blitzcc` exists, then build RCCE itself:
+
+```bash
+./compile.sh -b
+./compile.sh
+```
+
+Recommended follow-up checks:
+
+```bash
+./test.sh
+./publish.sh
+```
+
+`./publish.sh` rebuilds the engine/tools, creates the `release/` directory, and
+generates `release/MACOS_NOTES.txt` inside the packaged output. That generated
+text file is release-bundle metadata, not a tracked source file in this
+repository.
+
+## What to expect
+
+- The first `./compile.sh -b` run builds BlitzForge itself and can take a while.
+- `./compile.sh` expects a working `compiler/BlitzForge/bin/blitzcc`; without
+  it, the script exits and points you back to `./compile.sh -b`.
+- `./test.sh` compiles the Blitz test suite from `src/Tests`; it is the best
+  built-in source-level confidence check before packaging.
+- `./publish.sh` is the path that emits the release-bundle `MACOS_NOTES.txt`
+  file mentioned in older README text and release artifacts.
+
+## Current compatibility position
+
+- Native Apple Silicon support is alpha.
+- The runtime/linker path is still incomplete.
+- Many engine behaviors are not yet at Windows parity.
+- Failures on fresh builds should be treated as bugs, not as proof the macOS
+  path is production-ready.


### PR DESCRIPTION
## Summary
The macOS source-build docs now match the scripts that actually ship in the repo, so fresh-clone contributors are pointed through the full Apple Silicon bootstrap flow instead of stopping before BlitzForge is built.

## Details
- replace the README's broken `release/MACOS_NOTES.txt` repo link with a tracked macOS Apple Silicon notes page
- document the required `./compile.sh -b` step before `./compile.sh`, matching `scripts/bootstrap_macos.sh` and the current build scripts
- add the tracked notes page to the docs index and README documentation section
- clarify that `release/MACOS_NOTES.txt` is generated by `./publish.sh` inside packaged output rather than existing as a tracked source file

## Manual Test Notes
- compared the updated README commands against `scripts/bootstrap_macos.sh`, `compile.sh`, `test.sh`, and `publish.sh`
- verified the new markdown targets exist in the repository and removed the stale repo-path link to a generated artifact

## Additional Notes
- This is documentation-only and intentionally does not change the macOS build/runtime behavior itself.
- The remaining gap is runtime parity: the docs now describe the live alpha flow more accurately, but the macOS runtime is still incomplete by design.