### PR TITLE
Document the current BlitzForge getting-started workflow

### DIFF
--- a/docs/start.md
+++ b/docs/start.md
@@ -1,13 +1,79 @@
 <!-- body { color:black background-color:white } a:link{ color:#0070FF } a:visited{ color:#0070FF } --> RealmCrafter: Community Edition Documentation
 
-Warning: It is assumed at this point that you have a basic knowledge of the Blitz3D/BlitzPlus programming languages. If not, you should refer to the Blitz documentation and community for help in learning the language.
+# Getting Started
 
-Realm Crafter is essentially split into two seperate programs -- the client and the server. When you compile the code you must open _Client.bb_ (the client) in Blitz3D and _Server.bb_ in BlitzPlus. These two files are the ones present in the root folder of your project. All files in the \\Modules folder (which make up most of the code) are used as Include files by _Client.bb_ and _Server.bb_.
+This page is the contributor-oriented quick start for the current RCCE source tree. It assumes you already have some familiarity with the Blitz language family and want to build, test, or inspect the engine source itself.
 
-Tips and tricks:
+## Current architecture
 
-*   Running the client in debug mode will automatically use windowed graphics
-*   In this mode it is possible to run multiple clients on a single PC
-*   The server runs extremely slowly in debug mode, use it as little as possible
-*   In the code, abilities are usually referred to as spells, and zones as areas
-*   Add more here as I think of them
+RCCE is no longer built as a split Blitz3D/BlitzPlus project. The repository now builds through the vendored [BlitzForge](../compiler/BlitzForge) toolchain:
+
+*   `src/Client.bb` builds the game client
+*   `src/Server.bb` builds the game server
+*   `src/GUE.bb` builds the Game Unified Editor
+*   `src/Project Manager.bb` builds the launcher used to open and run projects
+*   `src/Modules/` contains the shared include files used by those entry points
+
+The default sample game content lives under [`data/`](../data), and the compiled outputs are written to [`bin/`](../bin) plus the root-level `Project Manager` executable.
+
+## Clone the repository
+
+```bash
+git clone --recurse-submodules https://github.com/RydeTec/rcce2.git
+cd rcce2
+```
+
+If you already cloned without submodules:
+
+```bash
+git submodule update --init --recursive
+```
+
+## Build from source
+
+### Windows
+
+Use the repository entrypoint scripts from the repo root:
+
+```bat
+compile.bat            :: build engine + tools
+compile.bat -b         :: also rebuild BlitzForge first
+publish.bat            :: produce a redistributable release
+```
+
+`compile.bat` invokes BlitzForge to build `Server.exe`, `Client.exe`, `GUE.exe`, `Project Manager.exe`, and every tool source under `src\Tools`.
+
+### macOS (Apple Silicon) / Linux
+
+Use the shell-script equivalents from the repo root:
+
+```bash
+./scripts/bootstrap_macos.sh    # one-time setup on macOS
+./compile.sh                    # build engine + tools
+./compile.sh -b                 # also rebuild BlitzForge first
+./publish.sh                    # produce a redistributable release
+```
+
+macOS support is currently alpha because the underlying BlitzForge runtime is still incomplete there. Treat the macOS path as a development and feedback surface, not a production release target.
+
+## Run tests
+
+The tracked tests live under [`src/Tests`](../src/Tests).
+
+*   Windows: `test.bat`
+*   macOS / Linux: `./test.sh`
+
+Both runners compile each `*.bb` file in `src/Tests` with BlitzForge test mode. They are the expected pre-commit validation surface for focused source changes.
+
+## Launch the tools
+
+After a successful build:
+
+*   Open `Project Manager.exe` on Windows or `Project Manager` on macOS to launch the sample project, run the server, or run the client.
+*   The main editor and support tools are emitted under [`bin/`](../bin) and [`bin/tools/`](../bin/tools).
+
+## Useful orientation notes
+
+*   Running the client in debug mode uses a windowed display, which makes multi-client local testing easier.
+*   Server-side gameplay code often refers to abilities as spells and zones as areas.
+*   If you are inspecting gameplay or content behavior, look in `data/Server Data/Scripts` alongside the engine sources in `src/`.


### PR DESCRIPTION
## Non-technical summary

The contributor getting-started page was still telling people to build RCCE by opening `Client.bb` in Blitz3D and `Server.bb` in BlitzPlus from the project root. That has not matched the real repository for a while now. This PR rewrites `docs/start.md` so the first onboarding page points contributors at the workflow the repo actually ships today: clone with submodules, build through BlitzForge, run the repository test entrypoints, and launch the built tools from the generated outputs.

This matters now because the README and the codebase have already moved to the current BlitzForge-based build flow, so `docs/start.md` had become an implementation-facing lie for anyone following the docs instead of the README.

## Technical summary

- replace the legacy Blitz3D/BlitzPlus split-build explanation in `docs/start.md` with the current RCCE entry points in `src/`
- document the real repository build scripts on both platforms: `compile.bat` / `publish.bat` on Windows and `./scripts/bootstrap_macos.sh` / `./compile.sh` / `./publish.sh` on macOS
- document the tracked test surface as `src/Tests` via `test.bat` and `./test.sh`
- add current orientation notes about generated outputs, Project Manager, and where gameplay/content contributors should look in the tree
- keep the scope tightly on `docs/start.md`; no code, scripts, or README changes

Relevant intent and evidence:
- `ReadMe.md` already presents the current BlitzForge-based source-build workflow
- `compile.bat`, `compile.sh`, `publish.bat`, `publish.sh`, `test.bat`, `test.sh`, and `scripts/bootstrap_macos.sh` all exist in the live tree and are the actual entrypoints this page should describe
- the previous `docs/start.md` content still described the older dual-compiler model and root-level `Client.bb` / `Server.bb` layout, which no longer matches the repository

Tests / verification:
- `git diff --check`
- static verification that every path and script named in `docs/start.md` exists in the checkout
- direct comparison of the rewritten instructions against `ReadMe.md`, `compile.bat`, `compile.sh`, `test.bat`, and `test.sh`

Breaking changes:
- none; documentation-only

## Additional notes

Trade-off: I kept this increment focused on the getting-started page only. I did not also update `docs/index.md` or broader documentation navigation because there is already open docs work on the macOS source-build surface, and this PR is intentionally avoiding that overlap.

Deferred follow-up: other module and contributor docs may still contain older assumptions, but this fixes the most user-facing onboarding page first.

Remaining gap versus the fuller vision: the docs now better reflect the current build/test workflow, but macOS runtime support remains alpha and broader documentation modernization is still ongoing.