### PR TITLE
Fix Gubbin Tool save targeting for edited meshes

### DIFF
--- a/src/Tools/Gubbin Tool.bb
+++ b/src/Tools/Gubbin Tool.bb
@@ -113,7 +113,7 @@ Global PreviewPitch#, PreviewYaw#, PreviewDistance# = 30.0
 SetActor()
 UpdatePreviewCam()
 Global TempPosX#, TempPosY#, TempPosZ#, TempScale#
-Global gubbinID,meshID
+Global gubbinID
 
 ; Delta timing
 Dim DeltaBuffer(5)
@@ -154,8 +154,7 @@ Repeat
 								MeshNames$(Result) = Name$ + Chr$(0)
 								SetMeshOffset(Result, LoadedMeshX#(SelectedMeshID), LoadedMeshY#(SelectedMeshID), LoadedMeshZ#(SelectedMeshID))
 								SetMeshScale(Result, LoadedMeshScales#(SelectedMeshID))
-								SaveRotation()
-								SetGubbinMesh(Result)
+								SaveRotation(Result)
 							EndIf
 						EndIf
 					EndIf
@@ -225,7 +224,6 @@ Repeat
 						If Right$(Upper$(Name$), 3) <> "B3D"
 							FUI_CustomMessageBox("Rotation changes cannot be saved for this mesh format!", "Warning", MB_OK)
 						EndIf
-						meshID = ID
 					EndIf
 				EndIf
 
@@ -782,7 +780,7 @@ Function SaveAll()
 	If PreviewMesh <> 0
 		SetMeshOffset(SelectedMeshID, TempPosX#, TempPosY#, TempPosZ#)
 		SetMeshScale(SelectedMeshID, TempScale#)
-		SaveRotation()
+		SaveRotation(SelectedMeshID)
 		AppTitle("Realm Crafter Gubbin Tool")
 		ChangesSaved = True
 	EndIf
@@ -790,14 +788,14 @@ Function SaveAll()
 End Function
 
 ; Updates the B3D file of the current mesh with its rotation
-Function SaveRotation()
+Function SaveRotation(TargetMeshID)
 
 	Local TName$ = ""
 	Local Name$ = ""
 	Local isEncrypted = False
 	
 	If PreviewMesh <> 0
-		Name$ = EditorMeshName$(SelectedMeshID)
+		Name$ = EditorMeshName$(TargetMeshID)
 		If Right$(Upper$(Name$), 3) = "B3D" Then
 			If Right$(Upper$(Name$), 5) = ".EB3D" Then
 				TName$ = Name$
@@ -892,7 +890,7 @@ Function SaveRotation()
 	
 ; REMOVE FOR DECRYPT SIREDBLOOD SAYS MUHAHAHA #######################
 	
-	Name$ = EditorMeshName$(SelectedMeshID)
+	Name$ = EditorMeshName$(TargetMeshID)
 	
 	If TName$ <> "" And isEncrypted Then
 		EncryptMesh("Data\Meshes\" + Name$)
@@ -901,7 +899,7 @@ Function SaveRotation()
 
 ;#####################################################################
 
-	SetGubbinMesh(meshID)
+	SetGubbinMesh(TargetMeshID)
 
 End Function
 


### PR DESCRIPTION
## Non-technical summary
This fixes a Gubbin Tool save-path bug where saving or duplicating an adjusted mesh could apply the rotation update to the wrong mesh identity. That matters now because issue #43 reports that using the tool can leave the edited model unusable instead of preserving the change.

After this change, the tool persists rotation back into the mesh the user is actually editing or duplicating, then reloads that same mesh in the preview instead of jumping through a stale global mesh id.

## Technical summary
- removed the stale `meshID` global from `src/Tools/Gubbin Tool.bb`
- changed `SaveRotation` to accept an explicit target mesh id instead of implicitly using whichever mesh id was last stored elsewhere
- updated the normal save path to call `SaveRotation(SelectedMeshID)` so rotation persistence stays aligned with the currently edited mesh
- updated the duplicate flow to call `SaveRotation(Result)` so copied meshes receive the preview rotation instead of writing back into the source mesh
- kept the scope local to the Gubbin Tool save/duplicate flow; no engine, runtime, or data-format behavior changed

### Tests / verification
- `git diff --check`
- static inspection of the save and duplicate call paths in `src/Tools/Gubbin Tool.bb`
- compile-time verification was not possible in this worktree because `compiler/BlitzForge/bin/blitzcc` is not present

### Breaking changes
- none

## Additional notes
The remaining gap to fully closing issue #43 is runtime confirmation in a built Gubbin Tool session, ideally by saving both an existing mesh and a duplicated mesh and then reopening the result in the media viewer. I kept this run scoped to the clear save-targeting bug rather than broadening into unrelated mesh-format or tool UI changes.