### PR TITLE
Fix NPC respawns after server unlock

### DIFF
--- a/src/Modules/SpawnTracking.bb
+++ b/src/Modules/SpawnTracking.bb
@@ -1,0 +1,25 @@
+; Rebuilds AreaInstance\Spawned[] from the live ActorInstance list.
+;
+; This is primarily used when the server lock/unlock cycle leaves stale spawn
+; occupancy behind after actors were cleaned up through a non-death path. By
+; reconstructing the counts from current actors, normal spawn scheduling can
+; repopulate any missing NPCs instead of treating those slots as permanently
+; full.
+Function SyncAreaSpawnCounts()
+
+	For AInstance.AreaInstance = Each AreaInstance
+		For i = 0 To 999
+			AInstance\Spawned[i] = 0
+		Next
+	Next
+
+	For AI.ActorInstance = Each ActorInstance
+		If AI\SourceSP > -1
+			AInstance.AreaInstance = Object.AreaInstance(AI\ServerArea)
+			If AInstance <> Null
+				AInstance\Spawned[AI\SourceSP] = AInstance\Spawned[AI\SourceSP] + 1
+			EndIf
+		EndIf
+	Next
+
+End Function

--- a/src/Server.bb
+++ b/src/Server.bb
@@ -24,6 +24,7 @@ Include "Modules\briskvm.bb"
 Include "Modules\Actors.bb"               ; Actors module
 Include "Modules\Inventories.bb"          ; Inventory module
 Include "Modules\ServerAreas.bb"          ; Areas module
+Include "Modules\SpawnTracking.bb"        ; Spawn bookkeeping helpers
 Include "Modules\Scripting.bb"            ; Script language module
 Include "Modules\Logging.bb"              ; Logging module
 Include "Modules\AccountsServer.bb"       ; Accounts server module
@@ -498,6 +499,10 @@ Repeat
 					HideGadget Updates\LockLabel
 					SetGadgetText Updates\LockButton, "Lock Updates Server"
 					SetPanelImage(Updates\ImageBox, CurrentDir() + "Data\Server Data\GreenLight.bmp")
+
+					; Rebuild spawn occupancy from the actors that actually survived the
+					; lock cycle so stale counts cannot block future respawns.
+					SyncAreaSpawnCounts()
 
 					; Reload files list
 					Delete Each UpdateFile

--- a/src/Tests/Modules/SpawnTrackingTest.bb
+++ b/src/Tests/Modules/SpawnTrackingTest.bb
@@ -1,0 +1,60 @@
+Strict
+EnableGC
+
+Type ActorInstance
+	Field SourceSP, ServerArea
+End Type
+
+Type Area
+End Type
+
+Type AreaInstance
+	Field Area.Area
+	Field SpawnLast[999], Spawned[999]
+End Type
+
+Include "Modules\SpawnTracking.bb"
+
+Test testSyncAreaSpawnCountsRebuildsOccupancyFromLiveActors()
+	Local area.Area = New Area()
+
+	Local firstZone.AreaInstance = New AreaInstance()
+	firstZone\Area = area
+	firstZone\Spawned[4] = 9
+
+	Local secondZone.AreaInstance = New AreaInstance()
+	secondZone\Area = area
+	secondZone\Spawned[2] = 7
+	secondZone\Spawned[9] = 3
+
+	Local actorOne.ActorInstance = New ActorInstance()
+	actorOne\SourceSP = 4
+	actorOne\ServerArea = Handle(firstZone)
+
+	Local actorTwo.ActorInstance = New ActorInstance()
+	actorTwo\SourceSP = 4
+	actorTwo\ServerArea = Handle(firstZone)
+
+	Local actorThree.ActorInstance = New ActorInstance()
+	actorThree\SourceSP = 2
+	actorThree\ServerArea = Handle(secondZone)
+
+	Local ignored.ActorInstance = New ActorInstance()
+	ignored\SourceSP = -1
+	ignored\ServerArea = Handle(secondZone)
+
+	Local detached.ActorInstance = New ActorInstance()
+	detached\SourceSP = 1
+	detached\ServerArea = 0
+
+	SyncAreaSpawnCounts()
+
+	Assert(firstZone\Spawned[4] = 2)
+	Assert(secondZone\Spawned[2] = 1)
+	Assert(firstZone\Spawned[0] = 0)
+	Assert(secondZone\Spawned[9] = 0)
+
+	Delete Each ActorInstance
+	Delete Each AreaInstance
+	Delete Each Area
+End Test


### PR DESCRIPTION
## Non-technical summary
- Fixes a server reliability issue where relocking and unlocking could leave NPC spawn slots looking occupied even after the actors were gone.
- This matters now because it blocks the server from naturally repopulating areas after an unlock cycle, which matches the behavior reported in issue #39.
- After this change, the server rebuilds spawn occupancy from the actors that actually still exist before it starts accepting players again.

## Technical summary
- Added `src/Modules/SpawnTracking.bb` with `SyncAreaSpawnCounts()`, a small helper that reconstructs each `AreaInstance\Spawned[]` array from live `ActorInstance` data.
- Wired that helper into the unlock path in `src/Server.bb` immediately before the update file list is reloaded and the host socket is reopened.
- Added `src/Tests/Modules/SpawnTrackingTest.bb` to pin the bookkeeping behavior for stale counts, detached actors, and multiple zones.
- Validation performed:
  - `git diff --check`
  - compile-only check of `src/Tests/Modules/SpawnTrackingTest.bb` with the existing sibling BlitzForge `blitzcc`
  - compile-only check of `src/Server.bb` with the existing sibling BlitzForge `blitzcc`
- Breaking changes: none intended.

## Additional notes
- I kept the scope on spawn bookkeeping recovery during the unlock cycle rather than changing broader actor-lifecycle semantics.
- Full `./test.sh` execution was not available in this worktree because the pinned `compiler/BlitzForge` submodule currently fails to build on this machine (`windows.h` include and missing `std::clog`/`std::endl` qualification in the bundled C++ sources), and native test execution on `macos-arm64` is still stubbed.
- Existing Blitz tests in this repo also still use older `New Type` syntax that the current sibling `blitzcc` rejects, so I limited live validation to compile-only proof for the touched surfaces.