### PR TITLE
Fix #34 GUE window resize responsiveness

### DIFF
--- a/src/Modules/F-UI.bb
+++ b/src/Modules/F-UI.bb
@@ -37,6 +37,8 @@
 
 ;Strict
 
+Include "Modules\Helpers\FUIResizeMetrics.bb"
+
 ;#Region ---------- Types ----------------------
 Type CHOOSEFONT
 	
@@ -1315,6 +1317,7 @@ Function FUI_ResizeApp( W, H )
 	app\OldH = app\H
 	app\W = W
 	app\H = H
+	FUI_UpdateProjection()
 	
 	;Normal window border
 	If (FUI_API_GetWindowLong( app\hWnd,-16 ) And $40000) = $40000
@@ -1331,6 +1334,24 @@ Function FUI_ResizeApp( W, H )
 	FreeBank bnkRECT
 	bnkRECT = Null
 	
+End Function
+
+; Rebuild the GUI projection after any window size change so pointer picking
+; and layout scaling stay aligned with the resized client area.
+Function FUI_UpdateProjection()
+	If app = Null Or app\Cam = Null Or app\Pivot = Null
+		Return
+	EndIf
+	If app\W <= 0 Or app\H <= 0
+		Return
+	EndIf
+
+	app\Aspect = FUI_WindowAspect#(app\W, app\H)
+	app\Scale = FUI_WindowScale#(app\W)
+
+	CameraViewport app\Cam, 0, 0, app\W, app\H
+	PositionEntity app\Pivot,-1.0, app\Aspect, 1.0
+	ScaleEntity app\Pivot, app\Scale,-app\Scale,-app\Scale
 End Function
 
 Function FUI_CenterApp(  )
@@ -16640,8 +16661,6 @@ Function FUI_Initialise( W, H, D, M, Resizable=False, Border=True, Caption$="", 
 	MoveEntity	(app\Cam, 0, 0, -500)
 	
 	app\Pivot		= CreatePivot( app\Cam )
-	app\Aspect		= Float( H ) / W
-	app\Scale		= 2.0 / W
 	
 	app\currentFont	= New Font
 	;Fixed camera bug in zone editor cysis145
@@ -16651,8 +16670,7 @@ Function FUI_Initialise( W, H, D, M, Resizable=False, Border=True, Caption$="", 
 	ClearTextureFilters
 	AmbientLight 255, 255, 255
 	
-	PositionEntity app\Pivot,-1.0, app\Aspect, 1.0
-	ScaleEntity app\Pivot, app\Scale,-app\Scale,-app\Scale
+	FUI_UpdateProjection()
 	
 	app\A = 255
 	app\A2 = 255
@@ -16766,8 +16784,11 @@ Function FUI_Update( Idle = False )
 			winCH = PeekInt( bnkRECT, 12 ) - PeekInt( bnkRECT, 4 )
 	
 			If winCW <> app\W Or winCH <> app\H
+				app\OldW = app\W
+				app\OldH = app\H
 				app\W = winCW
 				app\H = winCH
+				FUI_UpdateProjection()
 			EndIf
 			
 			FreeBank bnkRECT

--- a/src/Modules/Helpers/FUIResizeMetrics.bb
+++ b/src/Modules/Helpers/FUIResizeMetrics.bb
@@ -1,0 +1,18 @@
+; Shared resize math for F-UI surfaces. Keep this pure so the resize
+; projection contract can be covered by the lightweight test harness.
+
+Function FUI_WindowAspect#(width%, height%)
+	If width <= 0
+		Return 0.0
+	EndIf
+
+	Return Float(height) / Float(width)
+End Function
+
+Function FUI_WindowScale#(width%)
+	If width <= 0
+		Return 0.0
+	EndIf
+
+	Return 2.0 / Float(width)
+End Function

--- a/src/Tests/Helpers/FUIResizeMetricsTest.bb
+++ b/src/Tests/Helpers/FUIResizeMetricsTest.bb
@@ -1,0 +1,19 @@
+Strict
+EnableGC
+
+Include "Modules\Helpers\FUIResizeMetrics.bb"
+
+Test testFUIWindowAspectTracksWindowRatio()
+	Local aspect# = FUI_WindowAspect#(1600, 900)
+	Assert(aspect > 0.56 And aspect < 0.57)
+End Test
+
+Test testFUIWindowScaleTracksWindowWidth()
+	Local scale# = FUI_WindowScale#(1280)
+	Assert(scale > 0.0015 And scale < 0.0016)
+End Test
+
+Test testFUIWindowMetricsGuardZeroWidth()
+	Assert(FUI_WindowAspect#(0, 900) = 0.0)
+	Assert(FUI_WindowScale#(0) = 0.0)
+End Test


### PR DESCRIPTION
## Non-technical summary
This restores the GUE resize path so the editor stays aligned with the resized window instead of leaving the interface and pointer mapping out of sync. It matters now because issue #34 is a user-visible regression in a core editor workflow, and the fix stays narrowly focused on the shared resize seam rather than broad GUE cleanup.

## Technical summary
- add a small `FUIResizeMetrics` helper that computes the window aspect and GUI scale used by F-UI projection math
- update `src/Modules/F-UI.bb` to rebuild the camera viewport and pivot transform during initialisation and whenever the app window size changes
- cover the resize-metric contract with a focused Blitz test in `src/Tests/Helpers/FUIResizeMetricsTest.bb`
- preserve the existing editor layout logic; this change only repairs the shared projection refresh that keeps input and rendered widgets aligned after a resize

## Additional notes
- Validation in this macOS environment is compile-oriented: `git diff --check`, compile-only `-c -t` for the new resize-metrics test, and compile-only `-c` for `src/GUE.bb` and `src/Project Manager.bb`
- Full local test execution is still blocked by the current BlitzForge macOS arm64 stub runtime, and a full compile-only sweep also hits a pre-existing failure in `src/Tests/Modules/AccountsServerTest.bb` (`New must call constructor`)
- The clean worktree could not build its own vendored BlitzForge compiler because the pinned submodule state still fails on macOS (`windows.h` dependency in BlitzForge sources), so validation used the already-built local `blitzcc` binary from the main repo checkout against this worktree's sources
