### PR TITLE
Fix GUE media imports from absolute paths

### DIFF
--- a/src/GUE.bb
+++ b/src/GUE.bb
@@ -10,6 +10,7 @@ ChangeDir RootDir$
 
 Include "Modules\RCEnet.bb"
 Include "Modules\Media.bb"
+Include "Modules\MediaImport.bb"
 Include "Modules\MediaDialogs.bb"
 Include "Modules\Projectiles.bb"
 Include "Modules\Language.bb"
@@ -6288,29 +6289,18 @@ Cls
 						If (Flags And 1) <> False Then IsAnim = True Else IsAnim = False
 						IsEncrypted = False
 
-						; Remove trailing slash
-						If Right$(App\CurrentFile$, 1) = "\"
-							App\CurrentFile$ = Left$(App\CurrentFile$, Len(App\CurrentFile$) - 1)
-						EndIf
+						App\CurrentFile$ = MediaImportTrimTrailingSlash$(App\CurrentFile$)
+						Filename$ = MediaImportRelativePath$(App\CurrentFile$, "Data\Meshes\", CurrentDir$(), MediaFolder$)
 
 						; Copy file/folder if required
-						If Instr(App\CurrentFile$, "Data\Meshes\") = 0 ;TODO: If RootDir is changed this may break
-							Filename$ = App\CurrentFile$
-							If MediaFolder$ <> "" Then Filename$ = MediaFolder$ + "\" + Filename$
-							For i = Len(App\CurrentFile$) To 1 Step -1
-								If Mid$(App\CurrentFile$, i, 1) = "\" Or Mid$(App\CurrentFile$, i, 1) = "/"
-									Filename$ = Mid$(App\CurrentFile$, i + 1)
-									If MediaFolder$ <> "" Then Filename$ = MediaFolder$ + "\" + Filename$
-									Exit
-								EndIf
-							Next
-							If FileType(App\CurrentFile$) = 1
-								CopyFile(CurrentDir$() + App\CurrentFile$, CurrentDir$() + "Data\Meshes\" + Filename$)
-							ElseIf FileType(App\CurrentFile$) = 2
-								CopyTree(CurrentDir$() + App\CurrentFile$, CurrentDir$() + "Data\Meshes\" + Filename$)
+						If MediaImportShouldCopy(App\CurrentFile$, "Data\Meshes\", CurrentDir$())
+							Local sourcePath$ = MediaImportSourcePath$(App\CurrentFile$, CurrentDir$())
+							Local destinationPath$ = MediaImportSourcePath$("Data\Meshes\" + Filename$, CurrentDir$())
+							If FileType(sourcePath$) = 1
+								CopyFile(sourcePath$, destinationPath$)
+							ElseIf FileType(sourcePath$) = 2
+								CopyTree(sourcePath$, destinationPath$)
 							EndIf
-						Else
-							Filename$ = Right$(App\CurrentFile$, Len(App\CurrentFile$) - Len("Data\Meshes\")) ;TODO: If RootDir is changed this may break
 						EndIf
 
 						; Single file
@@ -6333,29 +6323,18 @@ Cls
 						; Get extra options
 						Flags = TextureDialog()
 
-						; Remove trailing slash
-						If Right$(App\CurrentFile$, 1) = "\"
-							App\CurrentFile$ = Left$(App\CurrentFile$, Len(App\CurrentFile$) - 1)
-						EndIf
+						App\CurrentFile$ = MediaImportTrimTrailingSlash$(App\CurrentFile$)
+						Filename$ = MediaImportRelativePath$(App\CurrentFile$, "Data\Textures\", CurrentDir$(), MediaFolder$)
 
 						; Copy file/folder if required
-						If Instr(App\CurrentFile$, "Data\Textures\") = 0 ;TODO: If RootDir is changed this may break
-							Filename$ = App\CurrentFile$
-							If MediaFolder$ <> "" Then Filename$ = MediaFolder$ + "\" + Filename$
-							For i = Len(App\CurrentFile$) To 1 Step -1
-								If Mid$(App\CurrentFile$, i, 1) = "\" Or Mid$(App\CurrentFile$, i, 1) = "/"
-									Filename$ = Mid$(App\CurrentFile$, i + 1)
-									If MediaFolder$ <> "" Then Filename$ = MediaFolder$ + "\" + Filename$
-									Exit
-								EndIf
-							Next
-							If FileType(App\CurrentFile$) = 1
-								CopyFile(CurrentDir$() + App\CurrentFile$, CurrentDir$() + "Data\Textures\" + Filename$)
-							ElseIf FileType(App\CurrentFile$) = 2
-								CopyTree(CurrentDir$() + App\CurrentFile$, CurrentDir$() + "Data\Textures\" + Filename$)
+						If MediaImportShouldCopy(App\CurrentFile$, "Data\Textures\", CurrentDir$())
+							Local sourcePath$ = MediaImportSourcePath$(App\CurrentFile$, CurrentDir$())
+							Local destinationPath$ = MediaImportSourcePath$("Data\Textures\" + Filename$, CurrentDir$())
+							If FileType(sourcePath$) = 1
+								CopyFile(sourcePath$, destinationPath$)
+							ElseIf FileType(sourcePath$) = 2
+								CopyTree(sourcePath$, destinationPath$)
 							EndIf
-						Else
-							Filename$ = Right$(App\CurrentFile$, Len(App\CurrentFile$) - Len("Data\Textures\")) ;TODO: If RootDir is changed this may break
 						EndIf
 
 						; Single file
@@ -6379,29 +6358,18 @@ Cls
 						; Get extra options
 						Is3D = SoundDialog()
 
-						; Remove trailing slash
-						If Right$(App\CurrentFile$, 1) = "\"
-							App\CurrentFile$ = Left$(App\CurrentFile$, Len(App\CurrentFile$) - 1)
-						EndIf
+						App\CurrentFile$ = MediaImportTrimTrailingSlash$(App\CurrentFile$)
+						Filename$ = MediaImportRelativePath$(App\CurrentFile$, "Data\Sounds\", CurrentDir$(), MediaFolder$)
 
 						; Copy file/folder if required
-						If Instr(App\CurrentFile$, "Data\Sounds\") = 0 ;TODO: If RootDir is changed this may break
-							Filename$ = App\CurrentFile$
-							If MediaFolder$ <> "" Then Filename$ = MediaFolder$ + "\" + Filename$
-							For i = Len(App\CurrentFile$) To 1 Step -1
-								If Mid$(App\CurrentFile$, i, 1) = "\" Or Mid$(App\CurrentFile$, i, 1) = "/"
-									Filename$ = Mid$(App\CurrentFile$, i + 1)
-									If MediaFolder$ <> "" Then Filename$ = MediaFolder$ + "\" + Filename$
-									Exit
-								EndIf
-							Next
-							If FileType(App\CurrentFile$) = 1
-								CopyFile(CurrentDir$() + App\CurrentFile$, CurrentDir$() + "Data\Sounds\" + Filename$)
-							ElseIf FileType(App\CurrentFile$) = 2
-								CopyTree(CurrentDir$() + App\CurrentFile$, CurrentDir$() + "Data\Sounds\" + Filename$)
+						If MediaImportShouldCopy(App\CurrentFile$, "Data\Sounds\", CurrentDir$())
+							Local sourcePath$ = MediaImportSourcePath$(App\CurrentFile$, CurrentDir$())
+							Local destinationPath$ = MediaImportSourcePath$("Data\Sounds\" + Filename$, CurrentDir$())
+							If FileType(sourcePath$) = 1
+								CopyFile(sourcePath$, destinationPath$)
+							ElseIf FileType(sourcePath$) = 2
+								CopyTree(sourcePath$, destinationPath$)
 							EndIf
-						Else
-							Filename$ = Right$(App\CurrentFile$, Len(App\CurrentFile$) - Len("Data\Sounds\")) ;TODO: If RootDir is changed this may break
 						EndIf
 
 						; Single file
@@ -6424,29 +6392,18 @@ Cls
 					Result = FUI_CustomOpenDialog("Choose file to add...", "Data\Music\", FileTypes$, False, True)
 					If Result = True
 
-						; Remove trailing slash
-						If Right$(App\CurrentFile$, 1) = "\"
-							App\CurrentFile$ = Left$(App\CurrentFile$, Len(App\CurrentFile$) - 1)
-						EndIf
+						App\CurrentFile$ = MediaImportTrimTrailingSlash$(App\CurrentFile$)
+						Filename$ = MediaImportRelativePath$(App\CurrentFile$, "Data\Music\", CurrentDir$(), MediaFolder$)
 
 						; Copy file/folder if required
-						If Instr(App\CurrentFile$, "Data\Music\") = 0 ;TODO: If RootDir is changed this may break
-							Filename$ = App\CurrentFile$
-							If MediaFolder$ <> "" Then Filename$ = MediaFolder$ + "\" + Filename$
-							For i = Len(App\CurrentFile$) To 1 Step -1
-								If Mid$(App\CurrentFile$, i, 1) = "\" Or Mid$(App\CurrentFile$, i, 1) = "/"
-									Filename$ = Mid$(App\CurrentFile$, i + 1)
-									If MediaFolder$ <> "" Then Filename$ = MediaFolder$ + "\" + Filename$
-									Exit
-								EndIf
-							Next
-							If FileType(App\CurrentFile$) = 1
-								CopyFile(CurrentDir$() + App\CurrentFile$, CurrentDir$() + "Data\Music\" + Filename$)
-							ElseIf FileType(App\CurrentFile$) = 2
-								CopyTree(CurrentDir$() + App\CurrentFile$, CurrentDir$() + "Data\Music\" + Filename$)
+						If MediaImportShouldCopy(App\CurrentFile$, "Data\Music\", CurrentDir$())
+							Local sourcePath$ = MediaImportSourcePath$(App\CurrentFile$, CurrentDir$())
+							Local destinationPath$ = MediaImportSourcePath$("Data\Music\" + Filename$, CurrentDir$())
+							If FileType(sourcePath$) = 1
+								CopyFile(sourcePath$, destinationPath$)
+							ElseIf FileType(sourcePath$) = 2
+								CopyTree(sourcePath$, destinationPath$)
 							EndIf
-						Else
-							Filename$ = Right$(App\CurrentFile$, Len(App\CurrentFile$) - Len("Data\Music\")) ;TODO: If RootDir is changed this may break
 						EndIf
 
 						; Single file

--- a/src/Modules/MediaImport.bb
+++ b/src/Modules/MediaImport.bb
@@ -1,0 +1,82 @@
+Strict
+
+Function MediaImportNormalizeSlashes$(path$)
+	Local normalized$ = ""
+	For i = 1 To Len(path$)
+		Local ch$ = Mid$(path$, i, 1)
+		If ch$ = "/" Then ch$ = "\"
+		normalized$ = normalized$ + ch$
+	Next
+	Return normalized$
+End Function
+
+Function MediaImportTrimTrailingSlash$(path$)
+	path$ = MediaImportNormalizeSlashes$(path$)
+	While Len(path$) > 0
+		Local ch$ = Mid$(path$, Len(path$), 1)
+		If ch$ <> "\" Then Exit
+		path$ = Left$(path$, Len(path$) - 1)
+	Wend
+	Return path$
+End Function
+
+Function MediaImportEnsureTrailingSlash$(path$)
+	path$ = MediaImportNormalizeSlashes$(path$)
+	If Right$(path$, 1) <> "\" Then path$ = path$ + "\"
+	Return path$
+End Function
+
+Function MediaImportIsAbsolute%(path$)
+	path$ = MediaImportNormalizeSlashes$(path$)
+	If Len(path$) >= 2 And Mid$(path$, 2, 1) = ":" Then Return True
+	If Left$(path$, 2) = "\\" Then Return True
+	Return False
+End Function
+
+Function MediaImportHasPrefix%(path$, prefix$)
+	If Len(path$) < Len(prefix$) Then Return False
+	Return Lower$(Left$(path$, Len(prefix$))) = Lower$(prefix$)
+End Function
+
+Function MediaImportFileName$(path$)
+	path$ = MediaImportTrimTrailingSlash$(path$)
+	For i = Len(path$) To 1 Step -1
+		Local ch$ = Mid$(path$, i, 1)
+		If ch$ = "\" Or ch$ = "/" Then Return Mid$(path$, i + 1)
+	Next
+	Return path$
+End Function
+
+Function MediaImportSourcePath$(path$, currentDir$)
+	path$ = MediaImportTrimTrailingSlash$(path$)
+	If MediaImportIsAbsolute(path$) Then Return path$
+	Return MediaImportEnsureTrailingSlash$(currentDir$) + path$
+End Function
+
+Function MediaImportShouldCopy%(path$, mediaRoot$, currentDir$)
+	path$ = MediaImportTrimTrailingSlash$(path$)
+	Local relativeRoot$ = MediaImportEnsureTrailingSlash$(mediaRoot$)
+	Local absoluteRoot$ = MediaImportSourcePath$(relativeRoot$, currentDir$)
+	If MediaImportHasPrefix(path$, relativeRoot$) Then Return False
+	If MediaImportHasPrefix(path$, absoluteRoot$) Then Return False
+	Return True
+End Function
+
+Function MediaImportRelativePath$(path$, mediaRoot$, currentDir$, mediaFolder$ = "")
+	path$ = MediaImportTrimTrailingSlash$(path$)
+	Local relativeRoot$ = MediaImportEnsureTrailingSlash$(mediaRoot$)
+	Local absoluteRoot$ = MediaImportSourcePath$(relativeRoot$, currentDir$)
+
+	If MediaImportHasPrefix(path$, relativeRoot$)
+		Return Mid$(path$, Len(relativeRoot$) + 1)
+	EndIf
+
+	If MediaImportHasPrefix(path$, absoluteRoot$)
+		Return Mid$(path$, Len(absoluteRoot$) + 1)
+	EndIf
+
+	Local filename$ = MediaImportFileName$(path$)
+	Local folder$ = MediaImportTrimTrailingSlash$(mediaFolder$)
+	If folder$ <> "" Then filename$ = folder$ + "\" + filename$
+	Return filename$
+End Function

--- a/src/Tests/Modules/MediaImportTest.bb
+++ b/src/Tests/Modules/MediaImportTest.bb
@@ -1,0 +1,25 @@
+Strict
+EnableGC
+
+Include "Modules\MediaImport.bb"
+
+Test testMediaImportTreatsProjectRelativeSelectionAsExistingMedia()
+	Assert(MediaImportShouldCopy("Data\Textures\GUI\Button.png", "Data\Textures\", "C:\RCCE") = False)
+	Assert(MediaImportRelativePath$("Data\Textures\GUI\Button.png", "Data\Textures\", "C:\RCCE") = "GUI\Button.png")
+End Test
+
+Test testMediaImportTreatsAbsoluteProjectSelectionAsExistingMedia()
+	Assert(MediaImportShouldCopy("C:/RCCE/Data/Textures/GUI/Button.png", "Data\Textures\", "C:\RCCE") = False)
+	Assert(MediaImportRelativePath$("C:/RCCE/Data/Textures/GUI/Button.png", "Data\Textures\", "C:\RCCE") = "GUI\Button.png")
+End Test
+
+Test testMediaImportKeepsAbsoluteSourcePathsForExternalSelections()
+	Assert(MediaImportShouldCopy("D:/Downloads/Button.png", "Data\Textures\", "C:\RCCE") = True)
+	Assert(MediaImportSourcePath$("D:/Downloads/Button.png", "C:\RCCE") = "D:\Downloads\Button.png")
+	Assert(MediaImportRelativePath$("D:/Downloads/Button.png", "Data\Textures\", "C:\RCCE", "GUI") = "GUI\Button.png")
+End Test
+
+Test testMediaImportUsesFolderNameForExternalFolderSelections()
+	Assert(MediaImportRelativePath$("D:\Downloads\Creatures\", "Data\Meshes\", "C:\RCCE") = "Creatures")
+	Assert(MediaImportSourcePath$("Data\Meshes\Creatures\", "C:\RCCE") = "C:\RCCE\Data\Meshes\Creatures")
+End Test


### PR DESCRIPTION
## Non-technical summary
This fixes a reliability bug in the GUE media import flow. Adding meshes, textures, sounds, or music now correctly recognizes files that are already inside the current project's `Data/...` tree even when the file dialog returns an absolute path, and it still copies truly external selections into the chosen media folder.

This matters now because the existing code was slicing paths with hardcoded `Data\\...` offsets, which could mis-handle absolute selections and produce the wrong imported filename. After this change, project-local picks resolve to the expected relative media path instead of being treated like arbitrary external files.

## Technical summary
- added [`src/Modules/MediaImport.bb`](https://github.com/RydeTec/rcce2/blob/fix/gue-media-import-paths/src/Modules/MediaImport.bb) to centralize slash normalization, absolute-vs-relative detection, project-root matching, and relative media-path extraction
- added [`src/Tests/Modules/MediaImportTest.bb`](https://github.com/RydeTec/rcce2/blob/fix/gue-media-import-paths/src/Tests/Modules/MediaImportTest.bb) to pin behavior for project-relative selections, absolute project-local selections, external absolute paths, and external folder imports
- updated [`src/GUE.bb`](https://github.com/RydeTec/rcce2/blob/fix/gue-media-import-paths/src/GUE.bb) so mesh, texture, sound, and music imports all use the shared helper instead of duplicated string slicing
- preserved the existing external-copy behavior while fixing the path-resolution boundary that decides whether a selection is already inside `Data\\Meshes`, `Data\\Textures`, `Data\\Sounds`, or `Data\\Music`
- no breaking changes intended

### Validation
- `git diff --check`
- attempted `./compiler/BlitzForge/compile.sh`, but the pinned BlitzForge submodule failed on this macOS host before producing `compiler/BlitzForge/bin/blitzcc` (`windows.h` / `_declspec` / `std::clog` build errors in the dependency)
- because `blitzcc` was not produced, `./test.sh` could not be run in this environment

## Additional notes
Trade-off: I kept the fix scoped to the GUE media-add flow instead of widening it into a repo-wide path-policy refactor.

Deferred follow-up: once the pinned BlitzForge macOS build is healthy again, the new Blitz test should be compiled as part of the normal `./test.sh` sweep to convert this from static proof plus targeted test coverage into compiler-backed validation.

Remaining gap: this change does not alter runtime media loading or Project Manager publishing behavior; it only fixes the import-path boundary in GUE.
