### PR TITLE
Refresh the module reference landing page

### DIFF
--- a/docs/reference.md
+++ b/docs/reference.md
@@ -1,132 +1,166 @@
-<!-- body { color:black background-color:white } a:link{ color:#0070FF } a:visited{ color:#0070FF } --> RealmCrafter: Community Edition Documentation
+# Module Reference
 
-The following is a list of all the modules used by Realm Crafter, followed by a list of which modules are used by the client and the server. Click any module name to see the full documentation for its code.
+This page is the reference landing map for the documented RCCE modules under
+[`docs/modules/`](modules/). Use it together with the live application
+entrypoints in [`src/Client.bb`](../src/Client.bb),
+[`src/Server.bb`](../src/Server.bb), [`src/GUE.bb`](../src/GUE.bb), and
+[`src/Project Manager.bb`](../src/Project%20Manager.bb) when you are tracing a
+runtime path through the current source tree.
 
-**List of all modules:**
+Not every source module has a matching reference page yet. This index covers
+the modules that already have docs and calls out the largest undocumented
+surfaces so the page reflects the real repository state.
 
-*   [AccountsServer](modules/accountsserver.md)  
-    Contains functions to create and manage user accounts on the server, and the accounts window.
-*   [GameServer](modules/gameserver.md)  
-    Contains functions to update the state of all game logic on the server, and to create and manage the server game window.
-*   [UpdatesServer](modules/updatesserver.md)  
-    Contains functions to create and manage the server updates window, and to load update files information from disk.
-*   [Actors](modules/actors.md)  
-    Contains functions to create, update, save, and delete actor templates and instances, which are the people - both human and AI controlled - of the game world.
-*   [Actors3D](modules/actors3d.md)  
-    Contains functions relating to the creation, management and deletion of all client side 3D rendering data for actor instances.
-*   [Animations](modules/animations.md)  
-    Contains functions to load animation set data, apply it to actors, and save it back to disk.
-*   [CharacterEditorLoader](modules/charactereditorloader.md)  
-    Contains the function to load special 3D rendering data for actors created using the Character Editor tool.
-*   [ClientAreas](modules/clientareas.md)  
-    Contains functions to load, save, and delete client side zone data.
-*   [ClientCombat](modules/clientcombat.md)  
-    Contains functions to load combat settings, update the combat interface, perform combat animations on actor instances, and display combat damage.
-*   [ClientLoaders](modules/clientloaders.md)  
-    Contains functions to load client side data, such as host names, game options, sky spheres and the user interface.
-*   [ClientNet](modules/clientnet.md)  
-    Contains the function to connect to the server, and the function to process all received network messages and send player updates to the server.
-*   [Environment](modules/environment.md)  
-    Contains functions to load, save, and manage game environment settings, such as the time of day and weather.
-*   [Environment3D](modules/environment3d.md)  
-    Contains functions to load and update 3D rendering data for the game environment, such as rain/snow, suns, and 3D weather sound effects.
-*   [Gooey](modules/gooey.md)  
-    Custom resolution independent user interface library, used for most of the in-game interface.
-*   [Gooey\_3D\_Text](modules/gooey_3d_text.md)  
-    Contains functions to render text in a 3D environment for the Gooey module (see above).
-*   [Interface](modules/interface.md)  
-    Contains functions to load and save positioning data for the in-game interface and other related settings.
-*   [Interface3D](modules/interface3d.md)  
-    Contains functions to load and update the actual in-game interface components, and to manage all player input.
-*   [Inventories](modules/inventories.md)  
-    Contains functions to manage the inventories of actor instances.
-*   [Items](modules/items.md)  
-    Contains functions to load, save, and manage the items which actor instances can carry and use in the game.
-*   [Language](modules/language.md)  
-    Loads and provides access to all string constants from a text file, to assist localisation of Realm Crafter games.
-*   [Logging](modules/logging.md)  
-    Contains functions to create and write to log files.
-*   [MainMenu](modules/mainmenu.md)  
-    Runs the main menu on client startup.
-*   [MD5](modules/md5.md)  
-    Contains a function to return the MD5 checksum of a string.
-*   [Media](modules/media.md)  
-    Contains functions to manage the media databases, which contain information about mesh, texture, sound and music files.
-*   [MediaDialogs](modules/mediadialogs.md)  
-    Provides a set of standard dialogs to allow the user to choose files from the media databases in a FUI application.
-*   [MySQL](modules/mysql.md)  
-    Provides MySQL functionality for the server.
-*   [Packets](modules/packets.md)  
-    Contains a set of constants defining the various packet types for network messages.
-*   [Projectiles](modules/projectiles.md)  
-    Contains functions to load, save, and update projectiles and projectile settings.
-*   [Projectiles3D](modules/projectiles3d.md)  
-    Contains functions to create and update client side 3D rendering data for projectile instances.
-*   [Radar](modules/radar.md)  
-    Contains functions to create and update the in-game mini-map.
-*   [RCTrees](modules/rctrees.md)  
-    Contains functions to load and update trees created in the Tree Editor tool.
-*   [RottNet](modules/rottnet.md)  
-    This is the network library used by Realm Crafter, which sets up and manages network connections, and sends/receives all network messages.
-*   [RottParticles](modules/rottparticles.md)  
-    Contains functions to create, load, save, and update 3D particle effects.
-*   [Scripting](modules/scripting.md)  
-    The scripting interpreter which loads and runs user-created scripts on the server.
-*   [ServerAreas](modules/serverareas.md)  
-    Contains functions to load, save, and delete server side zone data. It also contains a function to update the current weather in a zone.
-*   [ServerNet](modules/servernet.md)  
-    Processes all received network messages and sends updates to all connected clients.
-*   [Spells](modules/spells.md)  
-    Contains functions to create, load, and save ability data. Abilities are scripted powers which can be used by actor instances.
+## How To Read The Current Tree
 
-  
+- The client currently includes [`ClientAreas_FE.bb`](../src/Modules/ClientAreas_FE.bb);
+  the matching reference page is [`modules/clientareas.md`](modules/clientareas.md).
+- The server and editor share a large slice of gameplay/content modules, but the
+  server also owns authority, persistence, and account/update flows.
+- Project Manager now lives on newer framework, graphics, IO, and component
+  modules that do not yet have dedicated reference pages under `docs/modules/`.
 
-**Module usage:**
+## Application Map
 
-*   **Server**
+### Client
 
-*   RottNet
-*   Environment
-*   Items
-*   Projectiles
-*   Spells
-*   Actors
-*   Inventories
-*   ServerAreas
-*   Scripting
-*   Logging
-*   AccountsServer
-*   GameServer
-*   UpdatesServer
-*   Packets
-*   ServerNet
-*   MySQL
+- Startup and resource loading:
+  [`ClientLoaders`](modules/clientloaders.md), [`MainMenu`](modules/mainmenu.md),
+  [`Media`](modules/media.md), [`Language`](modules/language.md),
+  [`Logging`](modules/logging.md)
+- World and rendering:
+  [`ClientAreas`](modules/clientareas.md), [`Environment`](modules/environment.md),
+  [`Environment3D`](modules/environment3d.md), [`Actors`](modules/actors.md),
+  [`Actors3D`](modules/actors3d.md), [`Animations`](modules/animations.md),
+  [`Projectiles3D`](modules/projectiles3d.md),
+  [`RottParticles`](modules/rottparticles.md), [`Radar`](modules/radar.md)
+- Gameplay and interface:
+  [`Items`](modules/items.md), [`Inventories`](modules/inventories.md),
+  [`Spells`](modules/spells.md), [`ClientCombat`](modules/clientcombat.md),
+  [`Interface`](modules/interface.md), [`Interface3D`](modules/interface3d.md),
+  [`Gooey`](modules/gooey.md),
+  [`Gooey_3D_Text`](modules/gooey_3d_text.md),
+  [`CharacterEditorLoader`](modules/charactereditorloader.md)
+- Networking:
+  [`RottNet`](modules/rottnet.md), [`ClientNet`](modules/clientnet.md),
+  [`Packets`](modules/packets.md), [`MD5`](modules/md5.md)
 
-*   **Client**
+### Server
 
-*   Language
-*   RottParticles
-*   RottNet
-*   Media
-*   Environment
-*   Environment3D
-*   Animations
-*   Spells
-*   Items
-*   Inventories
-*   Actors
-*   Actors3D
-*   ClientCombat
-*   Interface
-*   Interface3D
-*   Radar
-*   RCTrees
-*   ClientAreas
-*   Logging
-*   ClientLoaders
-*   ClientNet
-*   MainMenu
-*   Packets
-*   Gooey
-*   MD5
-*   Projectiles3D
+- Core game state:
+  [`Actors`](modules/actors.md), [`Items`](modules/items.md),
+  [`Inventories`](modules/inventories.md), [`Spells`](modules/spells.md),
+  [`Projectiles`](modules/projectiles.md),
+  [`Environment`](modules/environment.md), [`ServerAreas`](modules/serverareas.md)
+- Scripting, networking, and persistence:
+  [`Scripting`](modules/scripting.md), [`RottNet`](modules/rottnet.md),
+  [`ServerNet`](modules/servernet.md), [`Packets`](modules/packets.md),
+  [`MySQL`](modules/mysql.md), [`Logging`](modules/logging.md),
+  [`Language`](modules/language.md)
+- Server-only control surfaces:
+  [`AccountsServer`](modules/accountsserver.md),
+  [`GameServer`](modules/gameserver.md),
+  [`UpdatesServer`](modules/updatesserver.md)
+
+### GUE Editor
+
+- Content databases and pickers:
+  [`Media`](modules/media.md), [`MediaDialogs`](modules/mediadialogs.md),
+  [`Items`](modules/items.md), [`Inventories`](modules/inventories.md),
+  [`Animations`](modules/animations.md), [`Spells`](modules/spells.md)
+- World and content editing:
+  [`Actors`](modules/actors.md), [`Actors3D`](modules/actors3d.md),
+  [`CharacterEditorLoader`](modules/charactereditorloader.md),
+  [`Environment`](modules/environment.md), [`Interface`](modules/interface.md),
+  [`ClientAreas`](modules/clientareas.md), [`ServerAreas`](modules/serverareas.md),
+  [`Projectiles`](modules/projectiles.md), [`RCTrees`](modules/rctrees.md),
+  [`RottParticles`](modules/rottparticles.md)
+- Shared runtime plumbing:
+  [`Language`](modules/language.md), [`RottNet`](modules/rottnet.md),
+  [`Packets`](modules/packets.md), [`Logging`](modules/logging.md)
+
+### Project Manager
+
+Project Manager is part of the live source tree, but its current implementation
+leans on framework, graphics, IO, and UI-component modules that do not yet have
+matching pages in [`docs/modules/`](modules/). For now, start with
+[`src/Project Manager.bb`](../src/Project%20Manager.bb) and the contributor
+workflow in [`start.md`](start.md).
+
+## Documented Module Index
+
+### World, Gameplay, And Content
+
+- [`Actors`](modules/actors.md) - actor templates and live actor instances
+- [`Actors3D`](modules/actors3d.md) - client-side actor rendering state
+- [`Animations`](modules/animations.md) - animation set loading and save flows
+- [`CharacterEditorLoader`](modules/charactereditorloader.md) - character editor
+  render data loading
+- [`ClientAreas`](modules/clientareas.md) - client-side area loading and save
+  flows
+- [`ClientCombat`](modules/clientcombat.md) - combat UI updates and combat
+  animation/display logic
+- [`Environment`](modules/environment.md) - world time, weather, and other
+  environment settings
+- [`Environment3D`](modules/environment3d.md) - 3D weather, suns, and other
+  client presentation for the environment
+- [`Inventories`](modules/inventories.md) - inventory ownership and item storage
+- [`Items`](modules/items.md) - item templates and persistence
+- [`Projectiles`](modules/projectiles.md) - projectile definitions and server
+  updates
+- [`Projectiles3D`](modules/projectiles3d.md) - client-side projectile
+  rendering
+- [`Radar`](modules/radar.md) - minimap creation and updates
+- [`RCTrees`](modules/rctrees.md) - tree assets built by the tree editor
+- [`RottParticles`](modules/rottparticles.md) - 3D particle effect assets and
+  runtime behavior
+- [`ServerAreas`](modules/serverareas.md) - server-side area data and weather
+- [`Spells`](modules/spells.md) - ability definitions and related data
+
+### Interface, Assets, And Client Support
+
+- [`ClientLoaders`](modules/clientloaders.md) - client startup data loading
+- [`Gooey`](modules/gooey.md) - resolution-independent in-game UI framework
+- [`Gooey_3D_Text`](modules/gooey_3d_text.md) - 3D text support for Gooey
+- [`Interface`](modules/interface.md) - saved interface layout/settings data
+- [`Interface3D`](modules/interface3d.md) - live in-game interface widgets and
+  player input handling
+- [`Language`](modules/language.md) - localized string loading and lookup
+- [`MainMenu`](modules/mainmenu.md) - client startup menu flow
+- [`Media`](modules/media.md) - mesh, texture, sound, and music database access
+- [`MediaDialogs`](modules/mediadialogs.md) - standard media selection dialogs
+
+### Networking, Services, And Server Control
+
+- [`AccountsServer`](modules/accountsserver.md) - account creation and account
+  management windows
+- [`ClientNet`](modules/clientnet.md) - client message handling and outbound
+  updates
+- [`GameServer`](modules/gameserver.md) - server-side game logic update loop and
+  server window management
+- [`Logging`](modules/logging.md) - log creation and log writing
+- [`MD5`](modules/md5.md) - MD5 checksum helper used by password flows
+- [`MySQL`](modules/mysql.md) - MySQL integration points
+- [`Packets`](modules/packets.md) - network packet type constants
+- [`RottNet`](modules/rottnet.md) - low-level networking library
+- [`Scripting`](modules/scripting.md) - gameplay script interpreter
+- [`ServerNet`](modules/servernet.md) - server message processing and broadcast
+  flows
+- [`UpdatesServer`](modules/updatesserver.md) - update file metadata and update
+  distribution window
+
+## Current Gaps
+
+These source-tree surfaces are part of the live code but still lack dedicated
+reference pages here:
+
+- Project Manager framework and component modules under
+  [`src/Modules/Framework/`](../src/Modules/Framework/) and
+  [`src/Modules/Graphics/`](../src/Modules/Graphics/)
+- Server helpers such as [`SpawnTracking.bb`](../src/Modules/SpawnTracking.bb)
+- Client/editor helpers such as [`F-UI.bb`](../src/Modules/F-UI.bb),
+  [`FastExt.bb`](../src/Modules/FastExt.bb), and
+  [`ShadowsSimple.bb`](../src/Modules/ShadowsSimple.bb)
+
+When you need those areas today, read the source entrypoint plus the
+corresponding module files directly.


### PR DESCRIPTION
## Non-technical summary
- Replaced the legacy `docs/reference.md` dump with a current reference landing page for the live RCCE source tree.
- The docs now show where the documented modules fit into Client, Server, and GUE, and they stop implying that undocumented Project Manager/framework surfaces are already covered.
- This matters now because `docs/reference.md` is a top-level entry from both the README and docs index, so stale structure there makes contributor orientation harder right after the onboarding refresh.

## Technical summary
- Rewrote `docs/reference.md` around the current application entrypoints in `src/Client.bb`, `src/Server.bb`, `src/GUE.bb`, and `src/Project Manager.bb`.
- Added an application map for Client, Server, GUE, and Project Manager that reflects the documented module surface used by the live tree.
- Added a normalized-name note for `ClientAreas_FE.bb` -> `docs/modules/clientareas.md` so the page matches current source naming.
- Replaced the old flat list with grouped module indexes for gameplay/content, interface/assets, and networking/services.
- Added an explicit `Current Gaps` section covering still-undocumented framework, graphics, and helper modules instead of leaving that missing coverage implicit.
- Validation: `git diff --check` plus a local markdown-link resolution check for every repository-local link in `docs/reference.md`.
- Breaking changes: none.

## Additional notes
- Trade-off: this keeps the increment bounded to the docs landing page instead of widening into rewriting the individual module pages.
- Follow-up intentionally deferred: dedicated reference pages for Project Manager/framework modules, `SpawnTracking.bb`, and other currently source-only helpers.
- Remaining gap: the repo still has undocumented runtime/framework modules; this PR makes that gap visible and navigable, but it does not close it.
