### PR TITLE
tools: sigil + small-correctness cleanup (Track F)

### DIFF
--- a/src/Client.bb
+++ b/src/Client.bb
@@ -211,27 +211,14 @@ Repeat
 
 	; Render game
 	CameraProjMode(GY_Cam, 0)
-		
-	;Adding FastExt settings to options menu Cysis145
-	F = ReadFile("Data\Options.dat")
-		Width = ReadShort(F)
-		Height = ReadShort(F)
-		Depth = ReadByte(F)
-		AA = ReadByte(F)
-		DefaultVolume# = ReadFloat#(F)
-		GrassEnabled = ReadByte(F)
-		AnisotropyLevel = ReadByte(F)
-		FullScreen = ReadByte(F)
-		VSync = ReadByte(F)
-		Bloom = ReadByte(F)
-		Rays = ReadByte(F)
-		AWater = ReadByte(F)
-		ShadowC = ReadByte(F)
-		ShadowQ = ReadByte(F)
-		ShadowR = ReadByte(F)		
-	CloseFile(F)
-	
-	
+
+	; Options are loaded once at startup by LoadGame() in ClientLoaders.bb.
+	; A previous version of this block re-read Data\Options.dat every frame
+	; just to refresh ShadowC/ShadowQ/ShadowR/etc. — a needless file
+	; open/read/close on the hot render path. Any in-game settings dialog
+	; that mutates these globals is responsible for re-running LoadGame()
+	; (or equivalent) when the user applies changes.
+
 ;&&&&&&&&&&&&&&&&& Reflective water	terrier
 	RenderWater(Cam)
 

--- a/src/Modules/Graphics/UI/BPWrapper.bb
+++ b/src/Modules/Graphics/UI/BPWrapper.bb
@@ -133,8 +133,11 @@ Function GadgetHeight(parent%)
 End Function
 
 Function AddTextAreaText(parent%, text$)
-    Local current_text = FUI_SendMessage(parent, M_GETTEXT)
-    FUI_SendMessage(parent, M_SETTEXT, current_text + text$)
+    ; M_GETTEXT returns a string; the local must carry the $ sigil or Blitz
+    ; quietly receives the int form (0) and the concatenation becomes
+    ; "0" + text$, wiping any existing textarea contents.
+    Local current_text$ = FUI_SendMessage(parent, M_GETTEXT)
+    FUI_SendMessage(parent, M_SETTEXT, current_text$ + text$)
 End Function
 
 Function GadgetGroup(parent%)

--- a/src/Modules/Graphics/UI/Components/Component.bb
+++ b/src/Modules/Graphics/UI/Components/Component.bb
@@ -10,9 +10,9 @@ Type Component
     Field pos.PositionTrait
     Field scale.ScaleTrait
 
-    Method create.Component(componentType$, id$=0)
-        self\id = new IdentifierTrait(id)
-        
+    Method create.Component(componentType$, id$="")
+        self\id = new IdentifierTrait(id$)
+
         self\componentType = componentType
 
         return self

--- a/src/Modules/IO/Image.bb
+++ b/src/Modules/IO/Image.bb
@@ -23,8 +23,15 @@ Type Image.File
     End Method
 
     Method unload()
-        FreeImage(self\img)
-        self\loaded = false
+        ; Guard against unload-before-load (or double unload). Without it,
+        ; FreeImage runs on a stale or zero BBImage handle. Clearing img
+        ; afterwards also prevents a second unload from re-freeing the same
+        ; handle if the BBImage slot is recycled.
+        If self\loaded
+            FreeImage(self\img)
+            self\img = Null
+            self\loaded = false
+        End If
     End Method
 
     Method setDefault(uri$)

--- a/src/Modules/Project Manager/RecentProjects.bb
+++ b/src/Modules/Project Manager/RecentProjects.bb
@@ -18,7 +18,7 @@ Function RecentProjectsFindByRootDir%(recentProjects.BBList, rootDir$)
 
     For i = 0 To count
         Local prj.Project = ListAt(recentProjects, i)
-        If NormalizeProjectRoot$(prj\rootDir) = normalizedRoot Then Return i
+        If NormalizeProjectRoot$(prj\rootDir) = normalizedRoot$ Then Return i
     Next
 
     Return -1

--- a/src/Modules/Traits/IdentifierTrait.bb
+++ b/src/Modules/Traits/IdentifierTrait.bb
@@ -5,11 +5,11 @@ Include "Modules\Helpers\Random.bb"
 Type IdentifierTrait
     Field id$
 
-    Method create.IdentifierTrait(id$=0)
-        If (NOT id)
+    Method create.IdentifierTrait(id$="")
+        If (id$ = "")
             self\id = Random::i() + "-" + Random::i() + "-" + Random::i()
         Else
-            self\id = id
+            self\id = id$
         End If
 
         return self

--- a/src/Project Manager.bb
+++ b/src/Project Manager.bb
@@ -182,9 +182,9 @@ Type ProjectManager.RCCEApp
 
 		for i = 0 to 9
 			Local dir$ = File::readLine(self\recentProjectFile)
-			if (dir = "") Then Exit
+			if (dir$ = "") Then Exit
 			Local prj.Project = new Project(dir$)
-			if (NOT Project::verify(prj)) 
+			if (NOT Project::verify(prj))
 				delete prj
 			else
 				ListAdd(self\recentProjectList, prj)

--- a/src/Tools/RC Architect.BB
+++ b/src/Tools/RC Architect.BB
@@ -1039,8 +1039,14 @@ Case GUI_MENUFILE_SAVE
      tFile = FUI_SaveDialog( "Save architect map", "Data\ARCHITECT\Saves\", "ACT Map (*.act)|*.act")
  	 If tFile = True Then
      savemap$=APP\CURRENTFILE
-       If savemap$<>"" Then 
-	   If Instr( Lower$(savemap$), "act", 1 ) > 1 Then
+       If savemap$<>"" Then
+       ; Only treat the filename as already having an extension when ".act"
+       ; is at the end. The previous Instr-based check matched the substring
+       ; "act" anywhere in the path, so e.g. "practice", "factory", or any
+       ; folder named "act" caused savework() to receive a name without the
+       ; expected ".act" suffix and the resulting file was unreadable to
+       ; the loader.
+	   If Right$( Lower$(savemap$), 4 ) = ".act" Then
                         DebugLog "saving : "+savemap$
 						savework (savemap$)
 						Else

--- a/src/Tools/RC Caves Editor.BB
+++ b/src/Tools/RC Caves Editor.BB
@@ -2157,13 +2157,18 @@ For e.Event = Each event
                Return  
                EndIf
        If Right$(rd$,4)<> ".b3d" Then rd$=rd$+".b3d"
-       If FileType(CurrentDir()+"Data\RCCAVES\"+rd$)=1 Then 
+       If FileType(CurrentDir()+"Data\RCCAVES\"+rd$)=1 Then
             FCheck=Fui_Confirm("Overwrite File?","Yes","No")
-            If Fcheck=1 Then  SAVEWORK(rd$) 
+            If Fcheck=1 Then  SAVEWORK(rd$)
     	    ChangeDir thispath$
         Else
-		  SAVEWORK(rd$) 
-       EndIf         
+		  SAVEWORK(rd$)
+		  ; Mirror the file-existed branch above so the new-file path also
+		  ; ends back at the app working directory. SAVEWORK can chdir into
+		  ; Data\RCCAVES; without this restore the next file op uses that as
+		  ; the relative root and silently mis-resolves.
+		  ChangeDir thispath$
+       EndIf
        EndIf
 ;-----------------
        Case GUI_MENUFILE_OPEN

--- a/src/Tools/RC Terrain Editor.bb
+++ b/src/Tools/RC Terrain Editor.bb
@@ -2578,7 +2578,7 @@ vrty# = (VertexY(S,aaa) + VertexY(S,aaa1) + VertexY(S,aaa2) + VertexY(S,aaa3)) *
 If H1 > H2 Or MinSlope > MaxSlope Then Goto skip_continue
 
 ;Slopeval#=dp#;Abs(VertexNZ(S,AAA)*1.1)
-If slopeval#=<0 Then slopeval=0.1
+If slopeval#=<0 Then slopeval#=0.1
  If vrty#=>h1# And vrty#=<h2# Then 
  If minslope#<=slopeval# And maxslope#>=slopeval# Then
   bringup 1,0,ax,az


### PR DESCRIPTION
## Track F — Tools/UI cleanup

Sigil + small-correctness bugs across modules, tools, and one UI helper. Each commit is one logical fix.

### Commits

- **RecentProjects / Project Manager missing-sigil string comparisons** — `RecentProjectsFindByRootDir` compared a string against `normalizedRoot` (no `$`, separate int variable always 0), so Find always returned -1 and the recent-projects list never dedup'd. Project Manager's `loadRecentProjects` had the same pattern on `dir`, so the early-exit on blank lines never fired and trailing blanks became phantom Projects.
- **`IdentifierTrait.create` honors caller-supplied id** — declared `id$=0` and tested `If (NOT id)` which read the int alias (always 0 → True), so every caller got a random GUID. Switch defaults to `""` and read the sigil explicitly. Component constructor had the same pattern.
- **RC Terrain `slopeval` int/float mismatch** — `If slopeval#=<0 Then slopeval=0.1` clamped the int alias to 0 (truncated); subsequent compares kept reading the still-negative float. Near-flat terrain brushes silently no-op'd.
- **RC Architect extension match** — `Instr(savemap$, "act", 1) > 1` matched substring anywhere, so `practice.map`, `factory_v2`, etc. skipped the `.act` append and the loader couldn't open the result. Switch to `Right$(...,4) = ".act"`.
- **RC Caves Editor save dialog CWD restore** — file-existed branch restored `thispath$` after SAVEWORK; new-file branch didn't, so the CWD ended up wherever `SAVEWORK` left it.
- **Client per-frame `Data\Options.dat` read** — Client's render loop opened, read, and closed `Data\Options.dat` every frame just to refresh shadow flags. `LoadGame()` in `ClientLoaders.bb` already reads them at startup; removed the redundant hot-path IO.
- **`Image::unload` guard + null-out** — `FreeImage(self\img)` ran unconditionally; an unload-before-load or double-unload freed a stale or zero BBImage handle.
- **`BPWrapper.AddTextAreaText` sigil** — `Local current_text = FUI_SendMessage(M_GETTEXT)` captured the int form of a string return, then concatenation produced `"0" + text$` and wiped the existing textarea contents.

### Test plan

- [x] All four rcce2 binaries (Server, Project Manager, GUE, Client) + 6 tools build clean
- [x] rcce2 test suite passes (39 cases)
- [ ] Manual smoke test of Project Manager recent-projects (verify dedup works, no phantom entries)
- [ ] Manual smoke test of RC Architect save (verify `.act` appended when missing, kept when present)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
