### PR TITLE
strict: bump BlitzForge for Strict-on-reads, declare BMINI/BCLOSE (Track C)

### DIFF
--- a/src/Project Manager.bb
+++ b/src/Project Manager.bb
@@ -322,6 +322,11 @@ local M_SWH = FUI_MenuItem(M_Help, "Spell Wizard Help")
 local M_HF = FUI_MenuItem(M_Help, "Help File")
 
 ;Function Buttons
+; Buttons disabled; preserve the global symbols so the (dead) Case BMINI /
+; Case BCLOSE branches below still compile under Strict mode. Both will
+; remain 0, so the Cases never match a real gadget event.
+Global BMINI = 0
+Global BCLOSE = 0
 ;BMINI = FUI_Button(WMain, 509, 1, 18, 18, "_")
 ;BCLOSE = FUI_Button(WMain, 529, 1, 18, 18, "X")
 


### PR DESCRIPTION
## Track C — Bump BlitzForge for Strict-on-reads, declare BMINI/BCLOSE

Picks up [blitz-forge `strict/enforce-on-reads`](https://github.com/RydeTec/blitz-forge/pull/new/strict/enforce-on-reads): undeclared identifiers in read context now raise a compile error under `Strict` instead of silently auto-declaring a new int.

Across the whole rcce2 source tree there were only two reads that the new enforcement catches: `Case BMINI` and `Case BCLOSE` in Project Manager.bb, both pointing at button declarations that are commented out (the dead-code situation predates this change). Declared as `Global BMINI = 0` / `Global BCLOSE = 0` adjacent to the commented button creation — keeps the same dead-code semantics (both stay 0, the `Case` blocks never match a real gadget event) while satisfying Strict.

**This PR targets `tools/sigil-cleanup`** — Track F fixes the user-code sigil bugs that *would* have been compile errors after this change. Landing Track C without Track F would be a noisier rollout.

**Requires the BlitzForge submodule PR to land first.**

### Test plan

- [x] rcce2 builds against the bumped submodule
- [x] rcce2 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)
