### PR TITLE
strict: declare BMINI/BCLOSE, bump BlitzForge submodule (Track C)

### DIFF
--- a/src/Project Manager.bb
+++ b/src/Project Manager.bb
@@ -322,6 +322,11 @@ local M_SWH = FUI_MenuItem(M_Help, "Spell Wizard Help")
 local M_HF = FUI_MenuItem(M_Help, "Help File")
 
 ;Function Buttons
+; Buttons disabled; preserve the global symbols so the (dead) Case BMINI /
+; Case BCLOSE branches below still compile under Strict mode. Both will
+; remain 0, so the Cases never match a real gadget event.
+Global BMINI = 0
+Global BCLOSE = 0
 ;BMINI = FUI_Button(WMain, 509, 1, 18, 18, "_")
 ;BCLOSE = FUI_Button(WMain, 529, 1, 18, 18, "X")
 


### PR DESCRIPTION
﻿## Track C — Strict-on-reads, declare BMINI/BCLOSE

Reopened after the original PR (#71) auto-closed when its base branch (`tools/sigil-cleanup`) was deleted on merge of Track F. Same content, retargeted at develop and rebased.

Picks up the now-merged Track C BlitzForge changes (Strict-on-reads enforcement) via submodule pointer bump, plus declares `BMINI`/`BCLOSE` globals adjacent to the commented button creation so the existing dead-code `Case` blocks still compile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)