### PR TITLE
server: stability fixes — div-by-zero, iterator UB, log caching (Track E)

### DIFF
--- a/src/Modules/AccountsServer.bb
+++ b/src/Modules/AccountsServer.bb
@@ -192,7 +192,16 @@ Function LoadAccounts()
 			Chars = ReadByte(F)
 			For i = 1 To Chars
 				A\Character[i - 1] = ReadActorInstance(F)
-				A\Character[i - 1]\Account = Handle(A)
+				; Previously this dereferenced A\Character[i - 1]\Account
+				; before the Null cleanup below; a corrupted/partial
+				; Accounts.dat (server crash mid-save, manual edit) crashed
+				; every subsequent server startup. Skip the Account-link and
+				; per-character allocations on a Null read; we still need to
+				; consume the trailing QuestLog + ActionBar bytes from the
+				; stream so following characters parse correctly.
+				If A\Character[i - 1] <> Null
+					A\Character[i - 1]\Account = Handle(A)
+				EndIf
 				A\QuestLog[i - 1] = New QuestLog
 				For j = 0 To 499
 					A\QuestLog[i - 1]\EntryName$[j] = ReadString$(F)

--- a/src/Modules/GameServer.bb
+++ b/src/Modules/GameServer.bb
@@ -71,13 +71,20 @@ Function GiveXP(A.ActorInstance, XP, IgnoreParty = 0)
 					If Party\Player[i]\ServerArea = A\ServerArea Then Members = Members + 1
 				EndIf
 			Next
-			PartyXP = XP / Members
-			For i = 0 To 7
-				If Party\Player[i] <> Null And Party\Player[i] <> A
-					If Party\Player[i]\ServerArea = A\ServerArea Then GiveXP(Party\Player[i], PartyXP, True)
-				EndIf
-			Next
-			XP = PartyXP + (XP Mod Party\Members)
+			; Skip the share path entirely if no in-area members were
+			; counted. Previously `XP / Members` and `XP Mod Party\Members`
+			; could fire with Members or Party\Members = 0 (everyone in the
+			; party in different zones, or a desynced party state), crashing
+			; the server on every kill that yielded XP.
+			If Members > 0 And Party\Members > 0
+				PartyXP = XP / Members
+				For i = 0 To 7
+					If Party\Player[i] <> Null And Party\Player[i] <> A
+						If Party\Player[i]\ServerArea = A\ServerArea Then GiveXP(Party\Player[i], PartyXP, True)
+					EndIf
+				Next
+				XP = PartyXP + (XP Mod Party\Members)
+			EndIf
 		EndIf
 	EndIf
 
@@ -928,7 +935,15 @@ Function UpdateActorInstances(Broadcast)
 								XDist# = Abs(A2\X# - A2\DestX#)
 								ZDist# = Abs(A2\Z# - A2\DestZ#)
 								DoneDist# = (XDist# * XDist#) + (ZDist# * ZDist#)
-								YPos# = A2\Y# + ((AInstance\Area\WaypointY#[A2\CurrentWaypoint] - A2\Y#) * (DoneDist# / TotalDist#))
+								; Avoid divide-by-zero when the waypoint coincides with the
+								; previous origin (single-waypoint patrol or a config error
+								; that left OldX/Z == DestX/Z). Fall back to the actor's
+								; current Y rather than crashing the periodic broadcast.
+								If TotalDist# > 0.0
+									YPos# = A2\Y# + ((AInstance\Area\WaypointY#[A2\CurrentWaypoint] - A2\Y#) * (DoneDist# / TotalDist#))
+								Else
+									YPos# = A2\Y#
+								EndIf
 							Else
 								YPos# = A2\Y#
 							EndIf

--- a/src/Modules/GameServer.bb
+++ b/src/Modules/GameServer.bb
@@ -963,10 +963,16 @@ End Function
 ; Changes the area of an actor instance
 Function SetArea(A.ActorInstance, Ar.Area, Instance, Waypoint = -1, Portal = 0, X# = 0, Y# = 0, Z# = 0)
 
-	; Check instance exists
-	If Ar\Instances[Instance] = Null
+	; Check instance exists. The bounds check has to come BEFORE the
+	; Instances[] access — without it, a GM typing `/warp Area, 9999`
+	; indexed past the 100-slot Instances array (declared 0..99) and
+	; crashed the server before any Null check could run.
+	If Instance < 0 Or Instance > 99
+		WriteLog(MainLog, "Error: Cannot put actor into instance #" + Str$(Instance) + " of " + Ar\Name$ + " — instance index out of range")
 		Instance = 0
+	ElseIf Ar\Instances[Instance] = Null
 		WriteLog(MainLog, "Error: Cannot put actor into instance #" + Str$(Instance) + " of " + Ar\Name$ + " as the instance does not exist")
+		Instance = 0
 	EndIf
 	
 	;set flag to ignore standard updates until client has notified us that it has completed the move

--- a/src/Modules/GameServer.bb
+++ b/src/Modules/GameServer.bb
@@ -100,6 +100,31 @@ Function GiveXP(A.ActorInstance, XP, IgnoreParty = 0)
 End Function
 
 ; Kills off an actor instance
+; Deferred-kill queue. KillActor can FreeActorInstance(A), and when KillActor
+; is invoked from inside `For AI.ActorInstance = Each ActorInstance` (e.g.
+; water-damage death in UpdateActorInstances), freeing the current iterator
+; leaves Blitz's For-Each next-pointer pointing into freed memory. The
+; iteration sites use DeferKillActor instead, then call ProcessPendingKills
+; after the loop completes.
+Type PendingKill
+	Field Actor.ActorInstance
+	Field Killer.ActorInstance
+End Type
+
+Function DeferKillActor(A.ActorInstance, Killer.ActorInstance)
+	If A = Null Then Return
+	PK.PendingKill = New PendingKill
+	PK\Actor = A
+	PK\Killer = Killer
+End Function
+
+Function ProcessPendingKills()
+	For PK.PendingKill = Each PendingKill
+		If PK\Actor <> Null Then KillActor(PK\Actor, PK\Killer)
+	Next
+	Delete Each PendingKill
+End Function
+
 Function KillActor(A.ActorInstance, Killer.ActorInstance)
 
 	; Tell players in the same area if it was an AI actor dying
@@ -671,7 +696,11 @@ Function UpdateActorInstances(Broadcast)
 							UpdateAttribute(AI, HealthStat, AI\Attributes\Value[HealthStat] - 1)
 							If AI\Attributes\Value[HealthStat] <= 0
 								AI\Attributes\Value[HealthStat] = 0
-								KillActor(AI, Null)
+								; AI is the current For-Each iterator — defer the
+								; actual KillActor (which FreeActorInstance's an AI)
+								; until after the loop. See DeferKillActor /
+								; ProcessPendingKills.
+								DeferKillActor(AI, Null)
 							EndIf
 						EndIf
 						If AI\RNID > 0
@@ -686,7 +715,8 @@ Function UpdateActorInstances(Broadcast)
 						UpdateAttribute(AI, HealthStat, AI\Attributes\Value[HealthStat] - Damage)
 						If AI\Attributes\Value[HealthStat] <= 0
 							AI\Attributes\Value[HealthStat] = 0
-							KillActor(AI, Null)
+							; Same iterator-during-iteration hazard — defer.
+							DeferKillActor(AI, Null)
 						EndIf
 					EndIf
 				EndIf
@@ -878,6 +908,12 @@ Function UpdateActorInstances(Broadcast)
 			EndIf
 		EndIf
 	Next
+
+	; Process any kills deferred from the loop above (water-damage NPC
+	; deaths). Doing it here means the For-Each next-pointers stayed valid
+	; throughout the iteration; the actual FreeActorInstance(A) happens
+	; now, while no iteration is active.
+	ProcessPendingKills()
 
 ;****************************************************************
 ;****************************************************************

--- a/src/Modules/Logging.bb
+++ b/src/Modules/Logging.bb
@@ -2,6 +2,12 @@ Type LogFile
 	Field File
 End Type
 
+; Cached debug-log handle. WriteLog used to call StartLog+StopLog every
+; entry under LogMode>0, which opens, writes one line, and closes the
+; DEBUG log per call — a serious IO load. Hold the handle for the life
+; of the process instead. 0 = not yet opened, -1 = open failed (don't retry).
+Global DebugLogHandle = 0
+
 ; Starts a log and returns the handle
 Function StartLog(Logname$, Append = True)
 
@@ -27,14 +33,17 @@ Function WriteLog(LogHandle, Dat$, Timestamp = True, Datestamp = False)
 	If Timestamp = True Then Dat$ = "[" + LSet$(CurrentTime$(), 8) + "]  " + Dat$
 	If Datestamp = True Then Dat$ = "[" + LSet$(CurrentDate$(), 11) + "]  " + Dat$
 
-	WriteLine(LogHandle, Dat$)
+	If LogHandle <> 0 Then WriteLine(LogHandle, Dat$)
 
 	if LogMode > 0
 		DebugLog Dat$
 
-		LOG = StartLog("DEBUG")
-		WriteLine(LOG, Dat$)
-		StopLog(LOG)
+		; Reuse a cached DEBUG log handle. -1 means a previous StartLog
+		; failed (e.g. disk full, Data\Logs read-only) — don't keep
+		; retrying every WriteLog call. 0 means we haven't tried yet.
+		If DebugLogHandle = 0 Then DebugLogHandle = StartLog("DEBUG")
+		If DebugLogHandle = 0 Then DebugLogHandle = -1
+		If DebugLogHandle > 0 Then WriteLine(DebugLogHandle, Dat$)
 	EndIf
 
 End Function
@@ -51,6 +60,11 @@ End Function
 
 ; Closes all open log files
 Function CloseAllLogs()
+
+	If DebugLogHandle > 0
+		CloseFile(DebugLogHandle)
+		DebugLogHandle = 0
+	EndIf
 
 	For L.LogFile = Each LogFile
 		CloseFile(L\File)

--- a/src/Modules/ServerNet.bb
+++ b/src/Modules/ServerNet.bb
@@ -1492,9 +1492,24 @@ Function UpdateNetwork()
 					EndIf
 					AI\RuntimeID = -1
 					AI\IsTrading = 0
+					; Mark-and-sweep to avoid deleting the current iterator.
+					; The original loop called FreeItemInstance(II) while II
+					; was still the For-Each cursor; Blitz then used II's
+					; freed next pointer for the following iteration,
+					; intermittently skipping items or crashing the server
+					; on logout. First pass tags candidates; we then sweep
+					; via a fresh enumeration that never reaches a tagged
+					; item by its own next pointer.
 					For II.ItemInstance = Each ItemInstance
-						If II\AssignTo = AI And II\Assignment > 0 Then FreeItemInstance(II)
+						If II\AssignTo = AI And II\Assignment > 0 Then II\Assignment = -1
 					Next
+					Local IINext.ItemInstance = Null
+					II.ItemInstance = First ItemInstance
+					While II <> Null
+						IINext = After II
+						If II\Assignment = -1 And II\AssignTo = AI Then FreeItemInstance(II)
+						II = IINext
+					Wend
 					
 					; Remove from server display
 					If AInstance <> Null

--- a/src/Modules/SpawnTracking.bb
+++ b/src/Modules/SpawnTracking.bb
@@ -14,7 +14,11 @@ Function SyncAreaSpawnCounts()
 	Next
 
 	For AI.ActorInstance = Each ActorInstance
-		If AI\SourceSP > -1
+		; Upper-bound SourceSP against the Spawned[] array (declared 0..999).
+		; Legacy saves or a script bug can leave an actor with an out-of-range
+		; SourceSP; before this guard the resync wrote past the end of the
+		; AreaInstance struct, corrupting adjacent fields.
+		If AI\SourceSP > -1 And AI\SourceSP <= 999
 			AInstance.AreaInstance = Object.AreaInstance(AI\ServerArea)
 			If AInstance <> Null
 				AInstance\Spawned[AI\SourceSP] = AInstance\Spawned[AI\SourceSP] + 1


### PR DESCRIPTION
﻿## Track E — Server stability fixes

Reopened after the original PR (#72) auto-closed when its base branch (`security/server-packet-hardening`) was deleted on merge of Track A. Same content, retargeted at develop and rebased.

Stability bugs flagged by the audit that aren't direct exploits but cause crashes / silent corruption / data loss under unusual but reachable conditions:

- **Divide-by-zero guards + partial-character-load null check** — `GiveXP` party-share, flying-NPC waypoint Y interpolation, `AccountsServer.LoadAccounts` null-deref on partial data.
- **Bound /warp Instance, cap SpawnTracking SourceSP, cache DEBUG log** — `SetArea` array bounds-check ordering; `SyncAreaSpawnCounts` upper bound; `WriteLog` no longer reopens DEBUG log every entry.
- **Defer KillActor and FreeItemInstance out of iteration loops** — water-damage NPC death and logout item cleanup were deleting their own `For Each` cursor; introduce a `PendingKill` queue and a mark-and-sweep on the logout side.

🤖 Generated with [Claude Code](https://claude.com/claude-code)