### PR TITLE
security: server tier-1 exploits + auth hardening (Track G, round 2)

### DIFF
--- a/src/Modules/AccountsServer.bb
+++ b/src/Modules/AccountsServer.bb
@@ -35,6 +35,64 @@ Function FindAccountByListID.Account(ListID)
 
 End Function
 
+; Per-source login-attempt throttle. Each entry tracks one peer's recent
+; failure count and the millisecond timestamp of the first counted failure.
+; When failures cross the threshold within the window, further P_VerifyAccount
+; attempts from that peer are refused (with a "N" reply so the response
+; doesn't betray why) until the window expires. A successful login resets
+; the counter for that peer.
+Const LoginAttemptMaxFailures = 5
+Const LoginAttemptWindowMs    = 60000 ; 60 seconds
+
+Type LoginAttempt
+	Field FromID%
+	Field Failures%
+	Field WindowStart%
+End Type
+
+Function LoginAttemptFind.LoginAttempt(FromID)
+	For LA.LoginAttempt = Each LoginAttempt
+		If LA\FromID = FromID Then Return LA
+	Next
+	Return Null
+End Function
+
+; Returns True if a fresh P_VerifyAccount from FromID should be processed.
+; False if the source has tripped the failure threshold within the window.
+Function LoginAttemptOk%(FromID)
+	LA.LoginAttempt = LoginAttemptFind(FromID)
+	If LA = Null Then Return True
+	; Window expired — let the next failure record reset it.
+	If MilliSecs() - LA\WindowStart >= LoginAttemptWindowMs Then Return True
+	If LA\Failures < LoginAttemptMaxFailures Then Return True
+	Return False
+End Function
+
+; Record the outcome of a login attempt. Success resets the source's count;
+; failure increments it (creating a fresh entry / opening a new window if
+; the previous one expired).
+Function LoginAttemptRecord(FromID, Success)
+	LA.LoginAttempt = LoginAttemptFind(FromID)
+	If Success
+		If LA <> Null Then Delete LA
+		Return
+	EndIf
+	If LA = Null
+		LA = New LoginAttempt
+		LA\FromID = FromID
+		LA\WindowStart = MilliSecs()
+		LA\Failures = 1
+		Return
+	EndIf
+	; Reset window if the previous one closed.
+	If MilliSecs() - LA\WindowStart >= LoginAttemptWindowMs
+		LA\WindowStart = MilliSecs()
+		LA\Failures = 1
+		Return
+	EndIf
+	LA\Failures = LA\Failures + 1
+End Function
+
 ; Returns True iff some live character on this account has its RNID matching
 ; the requester's connection — i.e. the requester is the currently-logged-in
 ; session for this account.

--- a/src/Modules/AccountsServer.bb
+++ b/src/Modules/AccountsServer.bb
@@ -35,6 +35,25 @@ Function FindAccountByListID.Account(ListID)
 
 End Function
 
+; Returns True iff some live character on this account has its RNID matching
+; the requester's connection — i.e. the requester is the currently-logged-in
+; session for this account.
+;
+; Used to gate destructive account ops (ChangePassword, DeleteCharacter) so
+; a replayed packet with the (broken-MD5) hash can't take over an account
+; or destroy its characters unless the attacker is *also* currently holding
+; the session.
+Function RequesterOwnsAccountSession%(A.Account, FromID)
+	If A = Null Then Return False
+	If FromID < 1 Then Return False
+	For i = 0 To 9
+		If A\Character[i] <> Null
+			If A\Character[i]\RNID = FromID Then Return True
+		EndIf
+	Next
+	Return False
+End Function
+
 ; Builds the display string used in the Accounts list box.
 ; LoggedOn matches Account\LoggedOn semantics: -1 means logged out, anything
 ; greater than or equal to 0 indicates an active character index.

--- a/src/Modules/RCEnet.bb
+++ b/src/Modules/RCEnet.bb
@@ -29,27 +29,49 @@ End Function
 
 Function RCE_CreateMessages()
 	If (RCE_MoveToFirstMessage() <> 0)
-	
+
 		Repeat
-			M.RCE_Message = New RCE_Message
-			M\Connection = RCE_GetMessageConnection()
-			M\FromID = M\Connection
-			M\MessageType = RCE_GetMessageType()
-			
-			Length% = RCE_MessageLength()
-			If (Length > 0)
-				MessageData= CreateBank(Length)
-				RCE_GetMessageData(MessageData)
-				; Copy the data	
-				For i = 0 To Length - 1
-					M\MessageData$ = M\MessageData$ + Chr$(PeekByte(MessageData, i))
-				Next
-				FreeBank(MessageData)
+			Local incomingType% = RCE_GetMessageType()
+			Local incomingConn% = RCE_GetMessageConnection()
+
+			; Reject "local-only" sentinel types if they arrive over the network.
+			; RCE_PlayerTimedOut / PlayerHasLeft / PlayerKicked are supposed to be
+			; synthesized by the network library when it detects a disconnect on
+			; *this* host; the message handlers act on them as authoritative and
+			; (in the kicked case) take the target RNID straight out of the
+			; payload. Without this guard any connected peer can spoof a
+			; PlayerKicked message and disconnect any other player — see
+			; ServerNet.bb P_PlayerKicked handler.
+			If incomingType% >= RCE_PlayerTimedOut And incomingType% <= RCE_PlayerKicked And incomingConn% <> 0
+				; Drain the payload so the underlying queue advances, but do
+				; NOT create an RCE_Message for the handlers to act on.
+				Length% = RCE_MessageLength()
+				If Length > 0
+					MessageData = CreateBank(Length)
+					RCE_GetMessageData(MessageData)
+					FreeBank(MessageData)
+				EndIf
+			Else
+				M.RCE_Message = New RCE_Message
+				M\Connection = incomingConn%
+				M\FromID = M\Connection
+				M\MessageType = incomingType%
+
+				Length% = RCE_MessageLength()
+				If (Length > 0)
+					MessageData= CreateBank(Length)
+					RCE_GetMessageData(MessageData)
+					; Copy the data
+					For i = 0 To Length - 1
+						M\MessageData$ = M\MessageData$ + Chr$(PeekByte(MessageData, i))
+					Next
+					FreeBank(MessageData)
+				EndIf
 			EndIf
-			
-		Until RCE_AreMoreMessage() = 0 	
-	EndIf	
-End Function 
+
+		Until RCE_AreMoreMessage() = 0
+	EndIf
+End Function
 
 ; Conversions
 Function RCE_IntFromStr(Dat$)

--- a/src/Modules/Scripting.bb
+++ b/src/Modules/Scripting.bb
@@ -71,6 +71,22 @@ Type ScriptInstance
 	Field Thread%
 End Type
 
+; Returns True if the given ScriptInstance is currently waiting on behalf of
+; the actor whose runtime ID is the supplied wire FromID. Used by the
+; P_Dialog / P_ProgressBar / P_ScriptInput handlers to confirm that the
+; reply came from the player the script is actually addressed to.
+;
+; Without this check, ScriptInstance handles (4-byte int) were brute-
+; forceable: any connected peer could pick another player's live script and
+; answer its dialog/progress/input prompt, hijacking quest flow, loot
+; assignments, or NPC choices the other player was making.
+Function ScriptHandleBelongsTo(S.ScriptInstance, FromID)
+	If S = Null Then Return False
+	Local Sender.ActorInstance = FindActorInstanceFromRNID(FromID)
+	If Sender = Null Then Return False
+	Return S\AI = Handle(Sender)
+End Function
+
 ; Maps a script and places it on the execution stack
 Function RunScript(SS.ScriptSource, Func$, AI.ActorInstance, AIContext.ActorInstance, Param$ = "")
 	; This function maps the module to the execution context in preperation to being run

--- a/src/Modules/Scripting.bb
+++ b/src/Modules/Scripting.bb
@@ -50,6 +50,14 @@ Type ThreadScript
 	Field AI.ActorInstance
 	Field AIContext.ActorInstance
 	Field Param$
+	; Privileged scripts are allowed to invoke admin-only BVM commands
+	; (BanPlayer, KickPlayer, GiveItem, Warp, SetGold, SetActorLevel, etc).
+	; Default 0; the chat `/script` command and any explicit ThreadScript
+	; call from a code path that has already verified GM status set this
+	; to 1. NPC scripts triggered by player interaction (Examine, Trade,
+	; RightClick, ItemUse) MUST stay non-privileged so they can't be used
+	; to ban/kick the clicker.
+	Field Privileged%
 End Type
 
 Type ScriptInstance
@@ -61,14 +69,18 @@ Type ScriptInstance
 	Field Param$
 
 	Field Persistent%
-	
+
 	Field Waiting%
 	Field WaitStart%, WaitTime%
 	Field WaitHour%, WaitMinute%
 	Field WaitResult$
-	
+
 	Field Ended%
 	Field Thread%
+
+	; Propagated from the ThreadScript that spawned this instance.
+	; See BVM_RequirePrivileged().
+	Field Privileged%
 End Type
 
 ; Returns True if the given ScriptInstance is currently waiting on behalf of
@@ -88,7 +100,7 @@ Function ScriptHandleBelongsTo(S.ScriptInstance, FromID)
 End Function
 
 ; Maps a script and places it on the execution stack
-Function RunScript(SS.ScriptSource, Func$, AI.ActorInstance, AIContext.ActorInstance, Param$ = "")
+Function RunScript(SS.ScriptSource, Func$, AI.ActorInstance, AIContext.ActorInstance, Param$ = "", Privileged% = 0)
 	; This function maps the module to the execution context in preperation to being run
 		If BVM_FindFunction(SS\hModule, Func$) <> -1
 			S.ScriptInstance = New ScriptInstance
@@ -98,6 +110,7 @@ Function RunScript(SS.ScriptSource, Func$, AI.ActorInstance, AIContext.ActorInst
 			S\AIContext = Handle(AIContext.ActorInstance)
 			S\Param = Param
 			S\Thread = -1 ;Every script gets one pass through the VM before being threaded
+			S\Privileged = Privileged%
 			BVM_MapModule(S\hContext, SS\hModule)
 			Local hEntryPoint% = BVM_FindEntryPoint(S\hContext, SS\hModule, Func$)
 			BVM_SelectContext(S\hContext)
@@ -111,7 +124,7 @@ Function RunScript(SS.ScriptSource, Func$, AI.ActorInstance, AIContext.ActorInst
 		EndIf
 End Function
 
-Function ThreadScript(Name$, Func$, Actor%, CActor%, Param$ = "")
+Function ThreadScript(Name$, Func$, Actor%, CActor%, Param$ = "", Privileged% = 0)
 	; This function only adds the scripts to the ScriptInstance type and maps the module
 	Local Found = False
 	AI.ActorInstance = Object.ActorInstance(Actor)
@@ -130,6 +143,7 @@ Function ThreadScript(Name$, Func$, Actor%, CActor%, Param$ = "")
 		TS\AI.ActorInstance = AI.ActorInstance
 		TS\AIContext.ActorInstance = AIContext.ActorInstance
 		TS\Param$ = Param$
+		TS\Privileged = Privileged%
 	Else
 		 WriteLog(Mainlog, "Script " + Name$ + " does not exist.")
 	EndIf
@@ -140,7 +154,7 @@ Function UpdateScripts()
 	If Pass = 0 Then Pass = Order()
 	; Handle threaded scripts
 	For TS.ThreadScript = Each ThreadScript
-		RunScript(TS\SS.ScriptSource, TS\Func$, TS\AI.ActorInstance, TS\AIContext.ActorInstance, TS\Param$)
+		RunScript(TS\SS.ScriptSource, TS\Func$, TS\AI.ActorInstance, TS\AIContext.ActorInstance, TS\Param$, TS\Privileged)
 		Delete TS
 	Next
 

--- a/src/Modules/ScriptingCommands.bb
+++ b/src/Modules/ScriptingCommands.bb
@@ -159,14 +159,20 @@ Function BVM_ACTORINTRIGGER%(Param1%, Param2%)
 	Actor.ActorInstance = Object.ActorInstance(Param1%)
 	If Actor <> Null
 		TriggerID = Param2%
-		AInstance.AreaInstance = Object.AreaInstance(Actor\ServerArea)
-		If Len(AInstance\Area\TriggerScript$[TriggerID]) > 0
-			Size# = AInstance\Area\TriggerSize#[TriggerID] * AInstance\Area\TriggerSize#[TriggerID]
-			DistX# = Abs(Actor\X# - AInstance\Area\TriggerX#[TriggerID])
-			DistY# = Abs(Actor\Y# - AInstance\Area\TriggerY#[TriggerID])
-			DistZ# = Abs(Actor\Z# - AInstance\Area\TriggerZ#[TriggerID])
-			Dist# = (DistX# * DistX#) + (DistY# * DistY#) + (DistZ# * DistZ#)
-			If Dist# < Size# Then Result% = 1
+		; TriggerScript$/TriggerSize#/etc. are Dim'd 0..149 on AreaInstance.
+		; Reject any out-of-range index from the script before indexing.
+		If TriggerID >= 0 And TriggerID <= 149
+			AInstance.AreaInstance = Object.AreaInstance(Actor\ServerArea)
+			If AInstance <> Null
+				If Len(AInstance\Area\TriggerScript$[TriggerID]) > 0
+					Size# = AInstance\Area\TriggerSize#[TriggerID] * AInstance\Area\TriggerSize#[TriggerID]
+					DistX# = Abs(Actor\X# - AInstance\Area\TriggerX#[TriggerID])
+					DistY# = Abs(Actor\Y# - AInstance\Area\TriggerY#[TriggerID])
+					DistZ# = Abs(Actor\Z# - AInstance\Area\TriggerZ#[TriggerID])
+					Dist# = (DistX# * DistX#) + (DistY# * DistY#) + (DistZ# * DistZ#)
+					If Dist# < Size# Then Result% = 1
+				EndIf
+			EndIf
 		EndIf
 	EndIf
 Return Result%
@@ -2477,13 +2483,20 @@ Function BVM_SETWAITKILL(Param1%, Param2%, Param3%)
 	SI.ScriptInstance = Object.ScriptInstance(hSI%)
 	If Actor <> Null
 		KillActor = Param2%
-		If ActorList(KillActor) <> Null
-			PS.PausedScript = New PausedScript
-			PS\S = SI
-			PS\Reason = 2
-			PS\ReasonActor = Actor
-			PS\ReasonKillActor = ActorList(KillActor)
-			PS\ReasonAmount = Param3%
+		; ActorList is Dim'd 0..65535. A script supplying a negative or
+		; out-of-range KillActor (BVM Param2 is signed-int from the bytecode)
+		; would index outside the Dim — Blitz3D doesn't bounds-check Dim
+		; accesses and writes through the resulting wild pointer, so this
+		; corrupts adjacent globals and crashes the server unpredictably.
+		If KillActor >= 0 And KillActor <= 65535
+			If ActorList(KillActor) <> Null
+				PS.PausedScript = New PausedScript
+				PS\S = SI
+				PS\Reason = 2
+				PS\ReasonActor = Actor
+				PS\ReasonKillActor = ActorList(KillActor)
+				PS\ReasonAmount = Param3%
+			EndIf
 		EndIf
 	EndIf
 End Function

--- a/src/Modules/ScriptingCommands.bb
+++ b/src/Modules/ScriptingCommands.bb
@@ -53,6 +53,7 @@ Function BVM_THREADEXECUTE(Name$, Func$, AI%=0, AIContext%=0, Param$ = "")
 End Function
 
 Function BVM_SAVESTATE()
+	If Not BVM_RequirePrivileged() Then Return
 	WriteLog(MainLog, "SaveState running...")
 	SaveAccounts()
 	WriteLog(MainLog, "Saved accounts...")
@@ -112,7 +113,24 @@ Function BVM_PLAYERISBANNED%(Param%)
 Return Result%
 End Function
 
+; Returns True iff the currently-executing script was spawned via a code
+; path that has already verified the caller is a GM. Used to gate
+; admin-only BVM commands (Ban/Kick/Warp/GiveItem/SetGold/SetActorLevel).
+;
+; Without this gate, any NPC's Examine / Trade / RightClick / ItemUse
+; script ran with the clicker's actor handle and could invoke BanPlayer
+; on the clicker. The only GM check in the entire scripting surface was
+; the chat `/script` command itself.
+Function BVM_RequirePrivileged%()
+	SI.ScriptInstance = Object.ScriptInstance(hSI)
+	If SI = Null Then Return False
+	If SI\Privileged <> 0 Then Return True
+	BVM_ScriptLog("Privileged BVM call refused from non-privileged script: " + SI\Name)
+	Return False
+End Function
+
 Function BVM_BANPLAYER(Param%)
+	If Not BVM_RequirePrivileged() Then Return
 	Actor.ActorInstance = Object.ActorInstance(Param)
 	If Actor <> Null
 		A.Account = Object.Account(Actor\Account)
@@ -121,6 +139,7 @@ Function BVM_BANPLAYER(Param%)
 End Function
 
 Function BVM_KICKPLAYER(Param%)
+	If Not BVM_RequirePrivileged() Then Return
 	Actor.ActorInstance = Object.ActorInstance(Param%)
 	If Actor <> Null
 			DataAux$ = RCE_StrFromInt(Actor\RNID)
@@ -368,6 +387,7 @@ Function BVM_KILLACTOR(Param1%, Param2%=0)
 End Function
 
 Function BVM_CHANGEACTOR(Param1%, Param2%)
+	If Not BVM_RequirePrivileged() Then Return
 	Local Success% = False
 	ID% = Param2
 	
@@ -1561,6 +1581,7 @@ Return Result%
 End Function
 
 Function BVM_WARP(Param1%, Param2$, Param3$, Param4%=0)
+	If Not BVM_RequirePrivileged() Then Return
 	Actor.ActorInstance = Object.ActorInstance(Param1%)
 	If Actor <> Null
 		Name$ = Upper$(Param2$)
@@ -1628,6 +1649,7 @@ Return Result%
 End Function
 
 Function BVM_SETACTORLEVEL(Param1%, Param2%)
+	If Not BVM_RequirePrivileged() Then Return
 	Actor.ActorInstance = Object.ActorInstance(Param1%)
 	If Actor <> Null
 		Actor\XP = 0
@@ -2069,6 +2091,7 @@ End Function
 
 
 Function BVM_SETGOLD(Param1%, Param2%)
+	If Not BVM_RequirePrivileged() Then Return
 	Actor.ActorInstance = Object.ActorInstance(Param1%)
 	If Actor <> Null
 		Amount = Param2%
@@ -2235,6 +2258,7 @@ Return Result$
 End Function
 
 Function BVM_GIVEITEM(Param1%, Param2$, Param3%=1)
+	If Not BVM_RequirePrivileged() Then Return
 	Actor.ActorInstance = Object.ActorInstance(Param1%)
 	If Actor <> Null
 		ItemName$ = Upper$(Param2$)

--- a/src/Modules/ServerNet.bb
+++ b/src/Modules/ServerNet.bb
@@ -1847,18 +1847,31 @@ Function UpdateNetwork()
 				; Non-MySQL version
 				Else*/
 
+					; Rate-limit failed verifications. Without this the lack of any
+					; throttle made dictionary / credential-stuffing attacks free,
+					; and the distinct "N/P/B/L" replies advertised whether each
+					; username existed (and whether it was banned or already on).
+					; LoginAttemptOk() returns False once the configured threshold
+					; for this source has been crossed; we send the same "N" reply
+					; as for an unknown account so the response itself doesn't
+					; betray why the attempt failed under attack.
+					If Not LoginAttemptOk(M\FromID)
+						RCE_Send(Host, M\FromID, P_VerifyAccount, "N", True)
+					Else
 					; Find account
 					Exists = False
 					For A.Account = Each Account
 						If Upper$(A\User$) = Upper$(Username$)
 							; Account is already logged in
 							If A\LoggedOn <> -1
+								LoginAttemptRecord(M\FromID, False)
 								RCE_Send(Host, M\FromID, P_VerifyAccount, "L", True)
 							Else
 								Offset = 2 + UsernameLen
 								PwdLen = RCE_IntFromStr(Mid$(M\MessageData$, Offset, 1))
 								; If password is correct, send back character list
 								If A\Pass$ = Mid$(M\MessageData$, Offset + 1, PwdLen) And A\IsBanned = False
+									LoginAttemptRecord(M\FromID, True)
 									Pa$ = "Y"
 									For i = 0 To 9
 										If A\Character[i] <> Null
@@ -1871,6 +1884,7 @@ Function UpdateNetwork()
 									RCE_Send(Host, M\FromID, P_VerifyAccount, Pa$, True)
 								; Otherwise return password failure
 								Else
+									LoginAttemptRecord(M\FromID, False)
 									If A\IsBanned = False
 										RCE_Send(Host, M\FromID, P_VerifyAccount, "P", True)
 									Else
@@ -1883,7 +1897,11 @@ Function UpdateNetwork()
 						EndIf
 					Next
 					; If account was not found, return failure
-					If Exists = False Then RCE_Send(Host, M\FromID, P_VerifyAccount, "N", True)
+					If Exists = False
+						LoginAttemptRecord(M\FromID, False)
+						RCE_Send(Host, M\FromID, P_VerifyAccount, "N", True)
+					EndIf
+					EndIf
 				//EndIf
 
 			; Change account password request

--- a/src/Modules/ServerNet.bb
+++ b/src/Modules/ServerNet.bb
@@ -983,9 +983,9 @@ Function UpdateNetwork()
 			Case P_ProgressBar
 				If Left$(M\MessageData$, 1) = "C"
 					S.ScriptInstance = Object.ScriptInstance(RCE_IntFromStr(Mid$(M\MessageData$, 2, 4)))
-					If S <> Null
+					If S <> Null And ScriptHandleBelongsTo(S, M\FromID)
 						S\WaitResult$ = Str$(RCE_IntFromStr(Mid$(M\MessageData$, 6)))
-					Else
+					ElseIf S = Null
 						RCE_Send(Host, M\FromID, P_ProgressBar, "D" + Mid$(M\MessageData$, 6), True)
 					EndIf
 				EndIf
@@ -996,25 +996,25 @@ Function UpdateNetwork()
 					; New dialog created
 					Case "N"
 						S.ScriptInstance = Object.ScriptInstance(RCE_IntFromStr(Mid$(M\MessageData$, 2, 4)))
-						If S <> Null
+						If S <> Null And ScriptHandleBelongsTo(S, M\FromID)
 							S\WaitResult$ = Str$(RCE_IntFromStr(Mid$(M\MessageData$, 6)))
-						Else
+						ElseIf S = Null
 							RCE_Send(Host, M\FromID, P_Dialog, "C" + Mid$(M\MessageData$, 6), True)
 						EndIf
 					; Dialog text received
 					Case "T"
 						S.ScriptInstance = Object.ScriptInstance(RCE_IntFromStr(Mid$(M\MessageData$, 2, 4)))
-						If S <> Null Then S\WaitResult$ = "0"
+						If S <> Null And ScriptHandleBelongsTo(S, M\FromID) Then S\WaitResult$ = "0"
 					; Dialog option picked
 					Case "O"
 						S.ScriptInstance = Object.ScriptInstance(RCE_IntFromStr(Mid$(M\MessageData$, 2, 4)))
-						If S <> Null Then S\WaitResult$ = RCE_IntFromStr(Mid$(M\MessageData$, 6, 1))
+						If S <> Null And ScriptHandleBelongsTo(S, M\FromID) Then S\WaitResult$ = RCE_IntFromStr(Mid$(M\MessageData$, 6, 1))
 				End Select
 
 			; Text input reply
 			Case P_ScriptInput
 				S.ScriptInstance = Object.ScriptInstance(RCE_IntFromStr(Mid$(M\MessageData$, 1, 4)))
-				If S <> Null Then S\WaitResult$ = Mid$(M\MessageData$, 5)
+				If S <> Null And ScriptHandleBelongsTo(S, M\FromID) Then S\WaitResult$ = Mid$(M\MessageData$, 5)
 
 			; A player ate an item
 			Case P_EatItem

--- a/src/Modules/ServerNet.bb
+++ b/src/Modules/ServerNet.bb
@@ -1578,7 +1578,7 @@ Function UpdateNetwork()
 							Offset = Offset + 1 + PwdLen
 							Number = Asc(Mid$(M\MessageData$, Offset, 1))
 
-							If Number > -1 And Number < 10
+							If Number > -1 And Number < 10 And A\Character[Number] <> Null
 								; Set his status to in game and put him in his area
 								SetLoginStatus(A, Number)
 								A\Character[Number]\RNID = M\FromID

--- a/src/Modules/ServerNet.bb
+++ b/src/Modules/ServerNet.bb
@@ -273,7 +273,11 @@ Function UpdateNetwork()
 								If A\IsDM = True
 									Name$ = Trim$(Split$(Params$, 1, ","))
 									Func$ = Trim$(Split$(Params$, 2, ","))
-									ThreadScript(Name$, Func$, Handle(AI), 0)
+									; Privileged=1: this code path has verified
+									; the invoker is a GM, so the spawned script
+									; is allowed to call Ban/Kick/Warp/etc. via
+									; BVM_RequirePrivileged().
+									ThreadScript(Name$, Func$, Handle(AI), 0, "", 1)
 								EndIf
 							Case LanguageString$(LS_SCMe)
 								Pa$ = Chr$(252) + "* " + AI\Name$ + " " + Params$

--- a/src/Modules/ServerNet.bb
+++ b/src/Modules/ServerNet.bb
@@ -1896,8 +1896,12 @@ Function UpdateNetwork()
 					If Upper$(A\User$) = Upper$(Username$)
 						Offset = 2 + UsernameLen
 						PwdLen = RCE_IntFromStr(Mid$(M\MessageData$, Offset, 1))
-						; If password is correct, change it to the new one
-						If A\Pass$ = Mid$(M\MessageData$, Offset + 1, PwdLen)
+						; If password is correct AND the requester is the currently-
+						; logged-in session for this account, change it. Without
+						; the session check, a captured/replayed P_ChangePassword
+						; lets any party with the (broken-MD5) hash steal the
+						; account permanently.
+						If A\Pass$ = Mid$(M\MessageData$, Offset + 1, PwdLen) And RequesterOwnsAccountSession(A, M\FromID)
 							Offset = 2 + PwdLen
 							PwdLen = RCE_IntFromStr(Mid$(M\MessageData$, Offset, 1))
 							A\Pass$ = Mid$(M\MessageData$, Offset + 1, PwdLen)
@@ -2155,8 +2159,12 @@ Function UpdateNetwork()
 					If Upper$(A\User$) = Upper$(Username$)
 						Offset = 2 + UsernameLen
 						PwdLen = RCE_IntFromStr(Mid$(M\MessageData$, Offset, 1))
-						; If password is correct
-						If A\Pass$ = Mid$(M\MessageData$, Offset + 1, PwdLen)
+						; If password is correct AND the requester is the
+						; currently-logged-in session for this account.
+						; A replayed P_DeleteCharacter would otherwise let
+						; anyone with the hash permanently destroy character
+						; slots on the account.
+						If A\Pass$ = Mid$(M\MessageData$, Offset + 1, PwdLen) And RequesterOwnsAccountSession(A, M\FromID)
 							Offset = Offset + 1 + PwdLen
 							Number = Asc(Mid$(M\MessageData$, Offset, 1))
 							If Number > -1 And Number < 10

--- a/src/Modules/ServerNet.bb
+++ b/src/Modules/ServerNet.bb
@@ -1620,7 +1620,10 @@ Function UpdateNetwork()
 				Next
 		        ; If account was not found or was already logged on, return failure
 		        If Exists = False Then RCE_Send(Host, M\FromID, P_StartGame, "N", True)
-				If (M\FromID = 2) Stop
+				; (removed) `If (M\FromID = 2) Stop` — a leftover debug trap that
+				; halted the entire server process the first time the peer whose
+				; RakNet connection ID is 2 sent P_StartGame. Trivial remote DoS
+				; for the second connecting client.
 
 			; Fetch update files list request
 			Case P_FetchUpdateFiles ; :)

--- a/src/Tests/Modules/AccountsServerTest.bb
+++ b/src/Tests/Modules/AccountsServerTest.bb
@@ -3,6 +3,7 @@ EnableGC
 
 Type ActorInstance
 	Field Account
+	Field RNID
 End Type
 
 Type QuestLog


### PR DESCRIPTION
## Track G — Server tier-1 exploits + auth hardening

Closes the round-2 Tier 1 findings: trivially-reachable remote DoS, mass disconnect, cross-player script hijack, BVM array OOB, account-takeover replay vectors, and login enumeration.

### Commits
- **Remove `Stop` debug trap from P_StartGame** — `If (M\FromID = 2) Stop` halted the server when the second-connecting peer logged in. Leftover from local debugging.
- **Reject spoofed RCE_PlayerKicked / TimedOut / HasLeft from the wire** — local-only sentinel types 200–202 used to flow through `RCE_CreateMessages` unchecked; the P_PlayerKicked handler took the target RNID from the payload and ran full disconnect cleanup. Any peer could evict any other player. Gate on Connection != 0 (legitimate locally-synthesized kicks come from destination=0 / Connection=0).
- **Bind script wait/resume handles to the sending actor** — `P_Dialog` / `P_ProgressBar` / `P_ScriptInput` looked up the ScriptInstance from a 32-bit handle on the wire with no check that the handle belonged to the sender. Added `ScriptHandleBelongsTo(S, FromID)` in Scripting.bb and gated all five sites.
- **Bound BVM_SETWAITKILL and BVM_ACTORINTRIGGER array indices** — `ActorList(unbounded)` and `TriggerScript$[unbounded]` writes/reads from a script were unchecked. Blitz3D doesn't bounds-check Dim, so a malicious or buggy script corrupted memory.
- **Null-guard P_StartGame character slot** — `Number > -1 And Number < 10` validated the range but not the slot's occupancy; an empty slot null-dereferenced `A\Character[Number]\RNID = …`.
- **Gate dangerous BVM commands behind a privilege flag** — `Ban/Kick/GiveItem/Warp/SetGold/SetActorLevel/ChangeActor/SaveState` ran on whoever the script picked. NPC scripts invoked from `P_Examine` / `P_Trade` / `P_RightClick` / item use pass `Handle(clicker)` — an NPC's script could BanPlayer the clicker. Add `Privileged%` field to ThreadScript and ScriptInstance, default 0; only the chat `/script` command (already GM-gated) sets it. `BVM_RequirePrivileged()` checks the current SI's flag.
- **Require active session for P_ChangePassword / P_DeleteCharacter** — handlers checked only the hash. Added `RequesterOwnsAccountSession(A, FromID)` so a captured-and-replayed packet can't take over an account unless the attacker also currently holds the session.
- **Rate-limit P_VerifyAccount** — 5 failures per 60s per source, uniform "N" reply once throttled (legitimate UX preserved until threshold). Doesn't fix the underlying replay (needs challenge/response protocol).
- **Add RNID field to AccountsServerTest ActorInstance stub** — RequesterOwnsAccountSession reads it.

### Test plan
- [x] compile.bat (Server, Client, GUE, Project Manager, all tools)
- [x] test.bat (40+ cases pass)

### Known limitations (separate work)
- MD5 password hash is still replayable from a sniffed login packet (no nonce). Closed downstream paths but the upstream vector requires coordinated client+server protocol changes.
- `Encrypt$` (Caesar cipher on the recovery email) untouched — protocol change to remove would break existing clients.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
