### PR TITLE
server: VM error containment, script caps, NaN clamps, name bounds (Track I)

### DIFF
--- a/src/Modules/AccountsServer.bb
+++ b/src/Modules/AccountsServer.bb
@@ -35,6 +35,64 @@ Function FindAccountByListID.Account(ListID)
 
 End Function
 
+; Per-source login-attempt throttle. Each entry tracks one peer's recent
+; failure count and the millisecond timestamp of the first counted failure.
+; When failures cross the threshold within the window, further P_VerifyAccount
+; attempts from that peer are refused (with a "N" reply so the response
+; doesn't betray why) until the window expires. A successful login resets
+; the counter for that peer.
+Const LoginAttemptMaxFailures = 5
+Const LoginAttemptWindowMs    = 60000 ; 60 seconds
+
+Type LoginAttempt
+	Field FromID%
+	Field Failures%
+	Field WindowStart%
+End Type
+
+Function LoginAttemptFind.LoginAttempt(FromID)
+	For LA.LoginAttempt = Each LoginAttempt
+		If LA\FromID = FromID Then Return LA
+	Next
+	Return Null
+End Function
+
+; Returns True if a fresh P_VerifyAccount from FromID should be processed.
+; False if the source has tripped the failure threshold within the window.
+Function LoginAttemptOk%(FromID)
+	LA.LoginAttempt = LoginAttemptFind(FromID)
+	If LA = Null Then Return True
+	; Window expired — let the next failure record reset it.
+	If MilliSecs() - LA\WindowStart >= LoginAttemptWindowMs Then Return True
+	If LA\Failures < LoginAttemptMaxFailures Then Return True
+	Return False
+End Function
+
+; Record the outcome of a login attempt. Success resets the source's count;
+; failure increments it (creating a fresh entry / opening a new window if
+; the previous one expired).
+Function LoginAttemptRecord(FromID, Success)
+	LA.LoginAttempt = LoginAttemptFind(FromID)
+	If Success
+		If LA <> Null Then Delete LA
+		Return
+	EndIf
+	If LA = Null
+		LA = New LoginAttempt
+		LA\FromID = FromID
+		LA\WindowStart = MilliSecs()
+		LA\Failures = 1
+		Return
+	EndIf
+	; Reset window if the previous one closed.
+	If MilliSecs() - LA\WindowStart >= LoginAttemptWindowMs
+		LA\WindowStart = MilliSecs()
+		LA\Failures = 1
+		Return
+	EndIf
+	LA\Failures = LA\Failures + 1
+End Function
+
 ; Returns True iff some live character on this account has its RNID matching
 ; the requester's connection — i.e. the requester is the currently-logged-in
 ; session for this account.

--- a/src/Modules/AccountsServer.bb
+++ b/src/Modules/AccountsServer.bb
@@ -35,6 +35,25 @@ Function FindAccountByListID.Account(ListID)
 
 End Function
 
+; Returns True iff some live character on this account has its RNID matching
+; the requester's connection — i.e. the requester is the currently-logged-in
+; session for this account.
+;
+; Used to gate destructive account ops (ChangePassword, DeleteCharacter) so
+; a replayed packet with the (broken-MD5) hash can't take over an account
+; or destroy its characters unless the attacker is *also* currently holding
+; the session.
+Function RequesterOwnsAccountSession%(A.Account, FromID)
+	If A = Null Then Return False
+	If FromID < 1 Then Return False
+	For i = 0 To 9
+		If A\Character[i] <> Null
+			If A\Character[i]\RNID = FromID Then Return True
+		EndIf
+	Next
+	Return False
+End Function
+
 ; Builds the display string used in the Accounts list box.
 ; LoggedOn matches Account\LoggedOn semantics: -1 means logged out, anything
 ; greater than or equal to 0 indicates an active character index.

--- a/src/Modules/GameServer.bb
+++ b/src/Modules/GameServer.bb
@@ -151,8 +151,13 @@ Function KillActor(A.ActorInstance, Killer.ActorInstance)
 		GiveXP(Killer, XP)
 	EndIf
 
-	; Continue any paused scripts waiting for this event
-	For PS.PausedScript = Each PausedScript
+	; Continue any paused scripts waiting for this event. After-cursor walk:
+	; the body Deletes PS, which would corrupt a For-Each cursor on the
+	; next iteration step if two WaitKill scripts resume in the same kill.
+	Local PS.PausedScript = First PausedScript
+	Local PSNext.PausedScript = Null
+	While PS <> Null
+		PSNext = After PS
 		If PS\Reason = 2
 			If PS\ReasonActor = Killer And PS\ReasonKillActor = A\Actor
 				PS\ReasonCount = PS\ReasonCount + 1
@@ -162,7 +167,8 @@ Function KillActor(A.ActorInstance, Killer.ActorInstance)
 				EndIf
 			EndIf
 		EndIf
-	Next
+		PS = PSNext
+	Wend
 
 	; Human death
 	If A\RNID > 0

--- a/src/Modules/Projectiles3D.bb
+++ b/src/Modules/Projectiles3D.bb
@@ -59,10 +59,17 @@ Function CreateProjectile(Source.ActorInstance, Target.ActorInstance, MeshID, Ho
 
 End Function
 
-; Updates all projectile instances
+; Updates all projectile instances. After-cursor walk: the destroy branch
+; calls FreeProjectileInstance(P) which Deletes P; a For-Each cursor would
+; then read the freed projectile's next pointer on the following step and
+; either skip the next projectile or crash. Two projectiles arriving at
+; their targets in the same frame is the typical reproducer.
 Function UpdateProjectiles()
 
-	For P.ProjectileInstance = Each ProjectileInstance
+	Local P.ProjectileInstance = First ProjectileInstance
+	Local PNext.ProjectileInstance = Null
+	While P <> Null
+		PNext = After P
 		; Move
 		If P\Target <> Null
 			P\TargetX# = EntityX#(P\Target\CollisionEN)
@@ -77,7 +84,8 @@ Function UpdateProjectiles()
 		If EntityDistance#(P\EN, GPP) < 2.0
 			FreeProjectileInstance(P)
 		EndIf
-	Next
+		P = PNext
+	Wend
 
 End Function
 

--- a/src/Modules/RCEnet.bb
+++ b/src/Modules/RCEnet.bb
@@ -107,3 +107,24 @@ Function RCE_FloatFromStr#(Dat$)
   Next
   Return PeekFloat#(RCE_ConvertBank, 0)
 End Function
+
+; Clamp a world coordinate to a sane range. NaN compares false against any
+; bound so it always falls through to the explicit 0 reset; Inf/large
+; magnitudes get pulled to the limit. Used before persisting / broadcasting
+; player-supplied position floats so a single crafted packet can't poison
+; dropped-item / scenery / actor positions with NaN that subsequently
+; corrupts every receiver's spatial code.
+Const WorldCoordMax# = 100000.0
+Function ClampWorldCoord#(v#)
+  If v# > -WorldCoordMax# And v# < WorldCoordMax# Then Return v#
+  Return 0.0
+End Function
+
+; Sane bounds for non-position floats coming off the wire (e.g. UI dims).
+; Same NaN-via-comparison trick; range is intentionally permissive so the
+; only thing rejected is NaN/Inf/extreme magnitudes.
+Const FloatSanityMax# = 1000000000.0
+Function ClampSaneFloat#(v#)
+  If v# > -FloatSanityMax# And v# < FloatSanityMax# Then Return v#
+  Return 0.0
+End Function

--- a/src/Modules/RCEnet.bb
+++ b/src/Modules/RCEnet.bb
@@ -29,27 +29,49 @@ End Function
 
 Function RCE_CreateMessages()
 	If (RCE_MoveToFirstMessage() <> 0)
-	
+
 		Repeat
-			M.RCE_Message = New RCE_Message
-			M\Connection = RCE_GetMessageConnection()
-			M\FromID = M\Connection
-			M\MessageType = RCE_GetMessageType()
-			
-			Length% = RCE_MessageLength()
-			If (Length > 0)
-				MessageData= CreateBank(Length)
-				RCE_GetMessageData(MessageData)
-				; Copy the data	
-				For i = 0 To Length - 1
-					M\MessageData$ = M\MessageData$ + Chr$(PeekByte(MessageData, i))
-				Next
-				FreeBank(MessageData)
+			Local incomingType% = RCE_GetMessageType()
+			Local incomingConn% = RCE_GetMessageConnection()
+
+			; Reject "local-only" sentinel types if they arrive over the network.
+			; RCE_PlayerTimedOut / PlayerHasLeft / PlayerKicked are supposed to be
+			; synthesized by the network library when it detects a disconnect on
+			; *this* host; the message handlers act on them as authoritative and
+			; (in the kicked case) take the target RNID straight out of the
+			; payload. Without this guard any connected peer can spoof a
+			; PlayerKicked message and disconnect any other player — see
+			; ServerNet.bb P_PlayerKicked handler.
+			If incomingType% >= RCE_PlayerTimedOut And incomingType% <= RCE_PlayerKicked And incomingConn% <> 0
+				; Drain the payload so the underlying queue advances, but do
+				; NOT create an RCE_Message for the handlers to act on.
+				Length% = RCE_MessageLength()
+				If Length > 0
+					MessageData = CreateBank(Length)
+					RCE_GetMessageData(MessageData)
+					FreeBank(MessageData)
+				EndIf
+			Else
+				M.RCE_Message = New RCE_Message
+				M\Connection = incomingConn%
+				M\FromID = M\Connection
+				M\MessageType = incomingType%
+
+				Length% = RCE_MessageLength()
+				If (Length > 0)
+					MessageData= CreateBank(Length)
+					RCE_GetMessageData(MessageData)
+					; Copy the data
+					For i = 0 To Length - 1
+						M\MessageData$ = M\MessageData$ + Chr$(PeekByte(MessageData, i))
+					Next
+					FreeBank(MessageData)
+				EndIf
 			EndIf
-			
-		Until RCE_AreMoreMessage() = 0 	
-	EndIf	
-End Function 
+
+		Until RCE_AreMoreMessage() = 0
+	EndIf
+End Function
 
 ; Conversions
 Function RCE_IntFromStr(Dat$)

--- a/src/Modules/RottParticles.bb
+++ b/src/Modules/RottParticles.bb
@@ -77,8 +77,14 @@ End Type
 ; Updates all emitters
 Function RP_Update(Delta# = 1.0)
 
-	; Update emitters
-	For E.RP_Emitter = Each RP_Emitter
+	; Update emitters. After-cursor walk: the KillMode branch invokes
+	; RP_FreeEmitter, which Deletes E mid-iteration; if two emitters
+	; finish their kill phase in the same frame, a For-Each cursor walks
+	; the freed Type instance's next pointer.
+	Local E.RP_Emitter = First RP_Emitter
+	Local ENext.RP_Emitter = Null
+	While E <> Null
+		ENext = After E
 		; Move mesh to new handle position - leaving them at 0, 0, 0 works but may work against Blitz's entity culling
 		PositionEntity E\MeshEN, EntityX#(E\EmitterEN, True), EntityY#(E\EmitterEN, True), EntityZ#(E\EmitterEN, True)
 
@@ -104,7 +110,8 @@ Function RP_Update(Delta# = 1.0)
 		Else
 			If E\ActiveParticles = 0 Then HideEntity E\MeshEN
 		EndIf
-	Next
+		E = ENext
+	Wend
 
 	; Update particles
 	For P.RP_Particle = Each RP_Particle
@@ -1378,11 +1385,18 @@ Function RP_FreeEmitter(ID, FreeConfig = False, FreeTex = False)
 
 End Function
 
-; Frees every emitter, particle and configuration
+; Frees every emitter, particle and configuration. After-cursor walk —
+; RP_FreeEmitter Deletes E. The original For-Each pattern read the freed
+; instance's next pointer for the following step (typical trigger: zone
+; change with multiple active emitters).
 Function RP_Clear(Configs = True, Textures = True)
 
-	For E.RP_Emitter = Each RP_Emitter
+	Local E.RP_Emitter = First RP_Emitter
+	Local ENext.RP_Emitter = Null
+	While E <> Null
+		ENext = After E
 		RP_FreeEmitter(E\EmitterEN, Configs, Textures)
-	Next
+		E = ENext
+	Wend
 
 End Function

--- a/src/Modules/Scripting.bb
+++ b/src/Modules/Scripting.bb
@@ -71,6 +71,22 @@ Type ScriptInstance
 	Field Thread%
 End Type
 
+; Returns True if the given ScriptInstance is currently waiting on behalf of
+; the actor whose runtime ID is the supplied wire FromID. Used by the
+; P_Dialog / P_ProgressBar / P_ScriptInput handlers to confirm that the
+; reply came from the player the script is actually addressed to.
+;
+; Without this check, ScriptInstance handles (4-byte int) were brute-
+; forceable: any connected peer could pick another player's live script and
+; answer its dialog/progress/input prompt, hijacking quest flow, loot
+; assignments, or NPC choices the other player was making.
+Function ScriptHandleBelongsTo(S.ScriptInstance, FromID)
+	If S = Null Then Return False
+	Local Sender.ActorInstance = FindActorInstanceFromRNID(FromID)
+	If Sender = Null Then Return False
+	Return S\AI = Handle(Sender)
+End Function
+
 ; Maps a script and places it on the execution stack
 Function RunScript(SS.ScriptSource, Func$, AI.ActorInstance, AIContext.ActorInstance, Param$ = "")
 	; This function maps the module to the execution context in preperation to being run

--- a/src/Modules/Scripting.bb
+++ b/src/Modules/Scripting.bb
@@ -124,11 +124,29 @@ Function RunScript(SS.ScriptSource, Func$, AI.ActorInstance, AIContext.ActorInst
 		EndIf
 End Function
 
+; Soft cap on simultaneously-pending script work. The threader (Order())
+; can scale across this without missing scheduling deadlines, but if a
+; runaway script keeps ThreadScript-ing itself we want to refuse rather
+; than allocate ScriptInstance forever. Tune up if legitimate workloads
+; ever bump the ceiling.
+Const ScriptPendingMax = 2048
+
 Function ThreadScript(Name$, Func$, Actor%, CActor%, Param$ = "", Privileged% = 0)
 	; This function only adds the scripts to the ScriptInstance type and maps the module
 	Local Found = False
 	AI.ActorInstance = Object.ActorInstance(Actor)
 	AIContext.ActorInstance = Object.ActorInstance(CActor)
+
+	; Refuse the enqueue if we're already deep in pending work. Otherwise a
+	; script that ThreadScripts itself every tick (or a tight loop calling
+	; BVM_THREADEXECUTE) drives ScriptInstance allocation without bound and
+	; exhausts memory before any throttle kicks in.
+	Local pending% = CountScriptInstances() + CountThreadScripts()
+	If pending >= ScriptPendingMax
+		WriteLog(MainLog, "ThreadScript refused (pending=" + pending + " >= " + ScriptPendingMax + "): " + Name$ + " / " + Func$)
+		Return
+	EndIf
+
 	For SS.ScriptSource = Each ScriptSource
 		If Upper(SS\Name$) = Upper(Name$)
 			Found = 1
@@ -147,6 +165,18 @@ Function ThreadScript(Name$, Func$, Actor%, CActor%, Param$ = "", Privileged% = 
 	Else
 		 WriteLog(Mainlog, "Script " + Name$ + " does not exist.")
 	EndIf
+End Function
+
+Function CountScriptInstances%()
+	Local n% = 0
+	For SI.ScriptInstance = Each ScriptInstance : n = n + 1 : Next
+	Return n
+End Function
+
+Function CountThreadScripts%()
+	Local n% = 0
+	For TS.ThreadScript = Each ThreadScript : n = n + 1 : Next
+	Return n
 End Function
 
 ; Updates running scripts
@@ -231,7 +261,15 @@ Function UpdateScripts()
 					Local invokeRet% = BVM_Invoke(True) ; IMPORTANT: pass True To enable timeout
 					Select invokeRet
 						Case 0
-							RuntimeError("The script function aborted due to an error: " + BVM_GetLastErrorMsg())
+							; Script aborted with a VM error. Previously called
+							; RuntimeError() which halts the entire server
+							; process — a single buggy script then took the
+							; whole game down. Log the error, clean up the
+							; offending script's VM context, and continue.
+							WriteLog(MainLog, "Script '" + S\Name + "' aborted: " + BVM_GetLastErrorMsg())
+							BVM_ScriptLog("Script '" + S\Name + "' aborted: " + BVM_GetLastErrorMsg())
+							BVM_DeleteContext(S\hContext)
+							Delete S
 						Case 1
 							;Cleanup scripts which have finished executing
 							BVM_PopInt()

--- a/src/Modules/Scripting.bb
+++ b/src/Modules/Scripting.bb
@@ -152,14 +152,29 @@ End Function
 ; Updates running scripts
 Function UpdateScripts()
 	If Pass = 0 Then Pass = Order()
-	; Handle threaded scripts
-	For TS.ThreadScript = Each ThreadScript
+
+	; Each For-Each loop below is rewritten as a manual `After`-cursor walk
+	; because the bodies may Delete the iterator instance — the legacy
+	; `For X = Each Y ... Delete X` form re-reads the freed instance's next
+	; pointer on the following iteration step, intermittently skipping or
+	; crashing on bursts of simultaneous events. The fix matches the
+	; pattern Track E introduced for the water-damage KillActor sweep.
+
+	; Handle threaded scripts.
+	Local TS.ThreadScript = First ThreadScript
+	Local TSNext.ThreadScript = Null
+	While TS <> Null
+		TSNext = After TS
 		RunScript(TS\SS.ScriptSource, TS\Func$, TS\AI.ActorInstance, TS\AIContext.ActorInstance, TS\Param$, TS\Privileged)
 		Delete TS
-	Next
+		TS = TSNext
+	Wend
 
-	; Update paused scripts if necessary
-	For PS.PausedScript = Each PausedScript
+	; Update paused scripts if necessary.
+	Local PS.PausedScript = First PausedScript
+	Local PSNext.PausedScript = Null
+	While PS <> Null
+		PSNext = After PS
 		; Check whether waited for items are available
 		If PS\Reason = 3
 			If PS\ReasonActor <> Null
@@ -178,32 +193,37 @@ Function UpdateScripts()
 				Delete PS
 			EndIf
 		EndIf
-	Next
+		PS = PSNext
+	Wend
+
 	Scripts = 0
-	For S.ScriptInstance = Each ScriptInstance
-			;Clean up of prematurely exited scripts
-			If S\Ended = False
-				; Update waiting scripts
-				If S\Waiting = 1
-					If Len(S\WaitResult$) > 0
+	Local S.ScriptInstance = First ScriptInstance
+	Local SNext.ScriptInstance = Null
+	While S <> Null
+		SNext = After S
+		;Clean up of prematurely exited scripts
+		If S\Ended = False
+			; Update waiting scripts
+			If S\Waiting = 1
+				If Len(S\WaitResult$) > 0
+					S\Waiting = 0
+				EndIf
+			ElseIf S\Waiting = 2
+				If MilliSecs() - S\WaitStart >= S\WaitTime
+					S\Waiting = 0
+				EndIf
+			; Waiting for a certain game time
+			ElseIf S\Waiting = 3
+				If TimeH >= S\WaitHour
+					If TimeM >= S\WaitMinute
 						S\Waiting = 0
-					EndIf
-				ElseIf S\Waiting = 2
-					If MilliSecs() - S\WaitStart >= S\WaitTime
-						S\Waiting = 0
-					EndIf
-				; Waiting for a certain game time
-				ElseIf S\Waiting = 3
-					If TimeH >= S\WaitHour
-						If TimeM >= S\WaitMinute
-							S\Waiting = 0
-							S\WaitResult$ = "1"
-						EndIf
+						S\WaitResult$ = "1"
 					EndIf
 				EndIf
+			EndIf
 			;Threading Code
-				Scripts = Scripts + 1
-				If S\Thread = Pass Or S\Thread = -1
+			Scripts = Scripts + 1
+			If S\Thread = Pass Or S\Thread = -1
 				If S\Waiting = 0
 					hSI = Handle(S)
 					BVM_SelectContext(S\hContext)
@@ -221,15 +241,16 @@ Function UpdateScripts()
 							; The execution timed out.
 							; We just do nothing (keep running the loop)
 					End Select
-					 BVM_CheckError()
+					BVM_CheckError()
 					;BVM_EndDebug(S\hContext)
 				EndIf
-				EndIf
-			Else
-					BVM_DeleteContext(S\hContext)
-					Delete S
 			EndIf
-	Next
+		Else
+			BVM_DeleteContext(S\hContext)
+			Delete S
+		EndIf
+		S = SNext
+	Wend
 	If Pass <> 0 Then Pass = Pass - 1 Else Pass = Threads
 
 End Function
@@ -311,11 +332,17 @@ End Function
 Function FreeActorScripts(A.ActorInstance)
 		For S.ScriptInstance = Each ScriptInstance
 			If S\AI = Handle(A) Or S\AIContext = Handle(A)
-				For PS.PausedScript = Each PausedScript
+				; After-cursor walk: the body Deletes PS, which would corrupt
+				; a For-Each cursor on the next iteration step. Walk explicitly.
+				Local PS.PausedScript = First PausedScript
+				Local PSNext.PausedScript = Null
+				While PS <> Null
+					PSNext = After PS
 					If PS\Reason <> 1
 						If PS\S = S Then Delete PS
 					EndIf
-				Next
+					PS = PSNext
+				Wend
 				FreeScriptInstance(S)
 			EndIf
 		Next

--- a/src/Modules/Scripting.bb
+++ b/src/Modules/Scripting.bb
@@ -50,6 +50,14 @@ Type ThreadScript
 	Field AI.ActorInstance
 	Field AIContext.ActorInstance
 	Field Param$
+	; Privileged scripts are allowed to invoke admin-only BVM commands
+	; (BanPlayer, KickPlayer, GiveItem, Warp, SetGold, SetActorLevel, etc).
+	; Default 0; the chat `/script` command and any explicit ThreadScript
+	; call from a code path that has already verified GM status set this
+	; to 1. NPC scripts triggered by player interaction (Examine, Trade,
+	; RightClick, ItemUse) MUST stay non-privileged so they can't be used
+	; to ban/kick the clicker.
+	Field Privileged%
 End Type
 
 Type ScriptInstance
@@ -61,14 +69,18 @@ Type ScriptInstance
 	Field Param$
 
 	Field Persistent%
-	
+
 	Field Waiting%
 	Field WaitStart%, WaitTime%
 	Field WaitHour%, WaitMinute%
 	Field WaitResult$
-	
+
 	Field Ended%
 	Field Thread%
+
+	; Propagated from the ThreadScript that spawned this instance.
+	; See BVM_RequirePrivileged().
+	Field Privileged%
 End Type
 
 ; Returns True if the given ScriptInstance is currently waiting on behalf of
@@ -88,7 +100,7 @@ Function ScriptHandleBelongsTo(S.ScriptInstance, FromID)
 End Function
 
 ; Maps a script and places it on the execution stack
-Function RunScript(SS.ScriptSource, Func$, AI.ActorInstance, AIContext.ActorInstance, Param$ = "")
+Function RunScript(SS.ScriptSource, Func$, AI.ActorInstance, AIContext.ActorInstance, Param$ = "", Privileged% = 0)
 	; This function maps the module to the execution context in preperation to being run
 		If BVM_FindFunction(SS\hModule, Func$) <> -1
 			S.ScriptInstance = New ScriptInstance
@@ -98,6 +110,7 @@ Function RunScript(SS.ScriptSource, Func$, AI.ActorInstance, AIContext.ActorInst
 			S\AIContext = Handle(AIContext.ActorInstance)
 			S\Param = Param
 			S\Thread = -1 ;Every script gets one pass through the VM before being threaded
+			S\Privileged = Privileged%
 			BVM_MapModule(S\hContext, SS\hModule)
 			Local hEntryPoint% = BVM_FindEntryPoint(S\hContext, SS\hModule, Func$)
 			BVM_SelectContext(S\hContext)
@@ -111,7 +124,7 @@ Function RunScript(SS.ScriptSource, Func$, AI.ActorInstance, AIContext.ActorInst
 		EndIf
 End Function
 
-Function ThreadScript(Name$, Func$, Actor%, CActor%, Param$ = "")
+Function ThreadScript(Name$, Func$, Actor%, CActor%, Param$ = "", Privileged% = 0)
 	; This function only adds the scripts to the ScriptInstance type and maps the module
 	Local Found = False
 	AI.ActorInstance = Object.ActorInstance(Actor)
@@ -130,6 +143,7 @@ Function ThreadScript(Name$, Func$, Actor%, CActor%, Param$ = "")
 		TS\AI.ActorInstance = AI.ActorInstance
 		TS\AIContext.ActorInstance = AIContext.ActorInstance
 		TS\Param$ = Param$
+		TS\Privileged = Privileged%
 	Else
 		 WriteLog(Mainlog, "Script " + Name$ + " does not exist.")
 	EndIf
@@ -140,7 +154,7 @@ Function UpdateScripts()
 	If Pass = 0 Then Pass = Order()
 	; Handle threaded scripts
 	For TS.ThreadScript = Each ThreadScript
-		RunScript(TS\SS.ScriptSource, TS\Func$, TS\AI.ActorInstance, TS\AIContext.ActorInstance, TS\Param$)
+		RunScript(TS\SS.ScriptSource, TS\Func$, TS\AI.ActorInstance, TS\AIContext.ActorInstance, TS\Param$, TS\Privileged)
 		Delete TS
 	Next
 

--- a/src/Modules/ScriptingCommands.bb
+++ b/src/Modules/ScriptingCommands.bb
@@ -159,14 +159,20 @@ Function BVM_ACTORINTRIGGER%(Param1%, Param2%)
 	Actor.ActorInstance = Object.ActorInstance(Param1%)
 	If Actor <> Null
 		TriggerID = Param2%
-		AInstance.AreaInstance = Object.AreaInstance(Actor\ServerArea)
-		If Len(AInstance\Area\TriggerScript$[TriggerID]) > 0
-			Size# = AInstance\Area\TriggerSize#[TriggerID] * AInstance\Area\TriggerSize#[TriggerID]
-			DistX# = Abs(Actor\X# - AInstance\Area\TriggerX#[TriggerID])
-			DistY# = Abs(Actor\Y# - AInstance\Area\TriggerY#[TriggerID])
-			DistZ# = Abs(Actor\Z# - AInstance\Area\TriggerZ#[TriggerID])
-			Dist# = (DistX# * DistX#) + (DistY# * DistY#) + (DistZ# * DistZ#)
-			If Dist# < Size# Then Result% = 1
+		; TriggerScript$/TriggerSize#/etc. are Dim'd 0..149 on AreaInstance.
+		; Reject any out-of-range index from the script before indexing.
+		If TriggerID >= 0 And TriggerID <= 149
+			AInstance.AreaInstance = Object.AreaInstance(Actor\ServerArea)
+			If AInstance <> Null
+				If Len(AInstance\Area\TriggerScript$[TriggerID]) > 0
+					Size# = AInstance\Area\TriggerSize#[TriggerID] * AInstance\Area\TriggerSize#[TriggerID]
+					DistX# = Abs(Actor\X# - AInstance\Area\TriggerX#[TriggerID])
+					DistY# = Abs(Actor\Y# - AInstance\Area\TriggerY#[TriggerID])
+					DistZ# = Abs(Actor\Z# - AInstance\Area\TriggerZ#[TriggerID])
+					Dist# = (DistX# * DistX#) + (DistY# * DistY#) + (DistZ# * DistZ#)
+					If Dist# < Size# Then Result% = 1
+				EndIf
+			EndIf
 		EndIf
 	EndIf
 Return Result%
@@ -2477,13 +2483,20 @@ Function BVM_SETWAITKILL(Param1%, Param2%, Param3%)
 	SI.ScriptInstance = Object.ScriptInstance(hSI%)
 	If Actor <> Null
 		KillActor = Param2%
-		If ActorList(KillActor) <> Null
-			PS.PausedScript = New PausedScript
-			PS\S = SI
-			PS\Reason = 2
-			PS\ReasonActor = Actor
-			PS\ReasonKillActor = ActorList(KillActor)
-			PS\ReasonAmount = Param3%
+		; ActorList is Dim'd 0..65535. A script supplying a negative or
+		; out-of-range KillActor (BVM Param2 is signed-int from the bytecode)
+		; would index outside the Dim — Blitz3D doesn't bounds-check Dim
+		; accesses and writes through the resulting wild pointer, so this
+		; corrupts adjacent globals and crashes the server unpredictably.
+		If KillActor >= 0 And KillActor <= 65535
+			If ActorList(KillActor) <> Null
+				PS.PausedScript = New PausedScript
+				PS\S = SI
+				PS\Reason = 2
+				PS\ReasonActor = Actor
+				PS\ReasonKillActor = ActorList(KillActor)
+				PS\ReasonAmount = Param3%
+			EndIf
 		EndIf
 	EndIf
 End Function

--- a/src/Modules/ScriptingCommands.bb
+++ b/src/Modules/ScriptingCommands.bb
@@ -53,6 +53,7 @@ Function BVM_THREADEXECUTE(Name$, Func$, AI%=0, AIContext%=0, Param$ = "")
 End Function
 
 Function BVM_SAVESTATE()
+	If Not BVM_RequirePrivileged() Then Return
 	WriteLog(MainLog, "SaveState running...")
 	SaveAccounts()
 	WriteLog(MainLog, "Saved accounts...")
@@ -112,7 +113,24 @@ Function BVM_PLAYERISBANNED%(Param%)
 Return Result%
 End Function
 
+; Returns True iff the currently-executing script was spawned via a code
+; path that has already verified the caller is a GM. Used to gate
+; admin-only BVM commands (Ban/Kick/Warp/GiveItem/SetGold/SetActorLevel).
+;
+; Without this gate, any NPC's Examine / Trade / RightClick / ItemUse
+; script ran with the clicker's actor handle and could invoke BanPlayer
+; on the clicker. The only GM check in the entire scripting surface was
+; the chat `/script` command itself.
+Function BVM_RequirePrivileged%()
+	SI.ScriptInstance = Object.ScriptInstance(hSI)
+	If SI = Null Then Return False
+	If SI\Privileged <> 0 Then Return True
+	BVM_ScriptLog("Privileged BVM call refused from non-privileged script: " + SI\Name)
+	Return False
+End Function
+
 Function BVM_BANPLAYER(Param%)
+	If Not BVM_RequirePrivileged() Then Return
 	Actor.ActorInstance = Object.ActorInstance(Param)
 	If Actor <> Null
 		A.Account = Object.Account(Actor\Account)
@@ -121,6 +139,7 @@ Function BVM_BANPLAYER(Param%)
 End Function
 
 Function BVM_KICKPLAYER(Param%)
+	If Not BVM_RequirePrivileged() Then Return
 	Actor.ActorInstance = Object.ActorInstance(Param%)
 	If Actor <> Null
 			DataAux$ = RCE_StrFromInt(Actor\RNID)
@@ -368,6 +387,7 @@ Function BVM_KILLACTOR(Param1%, Param2%=0)
 End Function
 
 Function BVM_CHANGEACTOR(Param1%, Param2%)
+	If Not BVM_RequirePrivileged() Then Return
 	Local Success% = False
 	ID% = Param2
 	
@@ -1561,6 +1581,7 @@ Return Result%
 End Function
 
 Function BVM_WARP(Param1%, Param2$, Param3$, Param4%=0)
+	If Not BVM_RequirePrivileged() Then Return
 	Actor.ActorInstance = Object.ActorInstance(Param1%)
 	If Actor <> Null
 		Name$ = Upper$(Param2$)
@@ -1628,6 +1649,7 @@ Return Result%
 End Function
 
 Function BVM_SETACTORLEVEL(Param1%, Param2%)
+	If Not BVM_RequirePrivileged() Then Return
 	Actor.ActorInstance = Object.ActorInstance(Param1%)
 	If Actor <> Null
 		Actor\XP = 0
@@ -2069,6 +2091,7 @@ End Function
 
 
 Function BVM_SETGOLD(Param1%, Param2%)
+	If Not BVM_RequirePrivileged() Then Return
 	Actor.ActorInstance = Object.ActorInstance(Param1%)
 	If Actor <> Null
 		Amount = Param2%
@@ -2235,6 +2258,7 @@ Return Result$
 End Function
 
 Function BVM_GIVEITEM(Param1%, Param2$, Param3%=1)
+	If Not BVM_RequirePrivileged() Then Return
 	Actor.ActorInstance = Object.ActorInstance(Param1%)
 	If Actor <> Null
 		ItemName$ = Upper$(Param2$)

--- a/src/Modules/ServerNet.bb
+++ b/src/Modules/ServerNet.bb
@@ -1847,18 +1847,31 @@ Function UpdateNetwork()
 				; Non-MySQL version
 				Else*/
 
+					; Rate-limit failed verifications. Without this the lack of any
+					; throttle made dictionary / credential-stuffing attacks free,
+					; and the distinct "N/P/B/L" replies advertised whether each
+					; username existed (and whether it was banned or already on).
+					; LoginAttemptOk() returns False once the configured threshold
+					; for this source has been crossed; we send the same "N" reply
+					; as for an unknown account so the response itself doesn't
+					; betray why the attempt failed under attack.
+					If Not LoginAttemptOk(M\FromID)
+						RCE_Send(Host, M\FromID, P_VerifyAccount, "N", True)
+					Else
 					; Find account
 					Exists = False
 					For A.Account = Each Account
 						If Upper$(A\User$) = Upper$(Username$)
 							; Account is already logged in
 							If A\LoggedOn <> -1
+								LoginAttemptRecord(M\FromID, False)
 								RCE_Send(Host, M\FromID, P_VerifyAccount, "L", True)
 							Else
 								Offset = 2 + UsernameLen
 								PwdLen = RCE_IntFromStr(Mid$(M\MessageData$, Offset, 1))
 								; If password is correct, send back character list
 								If A\Pass$ = Mid$(M\MessageData$, Offset + 1, PwdLen) And A\IsBanned = False
+									LoginAttemptRecord(M\FromID, True)
 									Pa$ = "Y"
 									For i = 0 To 9
 										If A\Character[i] <> Null
@@ -1871,6 +1884,7 @@ Function UpdateNetwork()
 									RCE_Send(Host, M\FromID, P_VerifyAccount, Pa$, True)
 								; Otherwise return password failure
 								Else
+									LoginAttemptRecord(M\FromID, False)
 									If A\IsBanned = False
 										RCE_Send(Host, M\FromID, P_VerifyAccount, "P", True)
 									Else
@@ -1883,7 +1897,11 @@ Function UpdateNetwork()
 						EndIf
 					Next
 					; If account was not found, return failure
-					If Exists = False Then RCE_Send(Host, M\FromID, P_VerifyAccount, "N", True)
+					If Exists = False
+						LoginAttemptRecord(M\FromID, False)
+						RCE_Send(Host, M\FromID, P_VerifyAccount, "N", True)
+					EndIf
+					EndIf
 				//EndIf
 
 			; Change account password request

--- a/src/Modules/ServerNet.bb
+++ b/src/Modules/ServerNet.bb
@@ -1269,13 +1269,19 @@ Function UpdateNetwork()
 							Result = InventoryDrop(AI, Slot, Amount, False)
 							If Result <> 0
 								SendEquippedUpdate(AI)
-								; Create item on floor
+								; Create item on floor. Sanitise position floats
+								; before they're persisted into a DroppedItem and
+								; broadcast. AI\X#/Y#/Z# can carry a NaN/Inf from
+								; an unvalidated upstream packet (P_StandardUpdate
+								; only clamps Y; X and Z accept anything within
+								; magnitude limits but not NaN). A NaN dropped-item
+								; position poisons spatial code on every receiver.
 								D.DroppedItem = New DroppedItem
 								D\Item = Object.ItemInstance(Result)
 								D\Amount = Amount
-								D\X# = AI\X#
-								D\Y# = AI\Y#
-								D\Z# = AI\Z#
+								D\X# = ClampWorldCoord#(AI\X#)
+								D\Y# = ClampWorldCoord#(AI\Y#)
+								D\Z# = ClampWorldCoord#(AI\Z#)
 								D\ServerHandle = AI\ServerArea
 								; Tell other players in the area
 								Pa$ = "D" + RCE_StrFromInt$(Amount, 2) + RCE_StrFromFloat$(D\X#) + RCE_StrFromFloat$(D\Y#) + RCE_StrFromFloat$(D\Z#)
@@ -1372,18 +1378,17 @@ Function UpdateNetwork()
 					If AI\IgnoreUpdate = 0
 					; Player cannot move himself if he is a mount
 					If AI\Rider = Null
-						AI\DestX#    = RCE_FloatFromStr#(Mid$(M\MessageData$, 1, 4))
-						AI\DestZ#    = RCE_FloatFromStr#(Mid$(M\MessageData$, 5, 4))
-						; Client-supplied Y had no validation at all while X/Z carry an
-						; (commented but designed) anti-cheat. Reject obviously-bogus Y
-						; values (extreme magnitudes — covers NaN/Inf and the "set Y to
-						; +1e30 to phase through geometry" trick). The accepted-Y feedback
-						; loop in subsequent updates means a steady client is preserved;
-						; only blatantly out-of-world values get dropped.
-						NewY# = RCE_FloatFromStr#(Mid$(M\MessageData$, 9, 4))
-						If NewY# > -100000.0 And NewY# < 100000.0 Then AI\Y# = NewY#
-						NewX#        = RCE_FloatFromStr#(Mid$(M\MessageData$, 13, 4))
-						NewZ#        = RCE_FloatFromStr#(Mid$(M\MessageData$, 17, 4))
+						; All four position floats are clamped through
+						; ClampWorldCoord which rejects NaN/Inf and out-of-world
+						; magnitudes by falling back to 0. Track A's original
+						; Y-only filter is now uniform across X/Y/Z, and DestX/Z
+						; (which were previously raw) also sanitised.
+						AI\DestX#    = ClampWorldCoord#(RCE_FloatFromStr#(Mid$(M\MessageData$, 1, 4)))
+						AI\DestZ#    = ClampWorldCoord#(RCE_FloatFromStr#(Mid$(M\MessageData$, 5, 4)))
+						NewY#        = ClampWorldCoord#(RCE_FloatFromStr#(Mid$(M\MessageData$, 9, 4)))
+						AI\Y#        = NewY#
+						NewX#        = ClampWorldCoord#(RCE_FloatFromStr#(Mid$(M\MessageData$, 13, 4)))
+						NewZ#        = ClampWorldCoord#(RCE_FloatFromStr#(Mid$(M\MessageData$, 17, 4)))
 						AI\IsRunning = RCE_IntFromStr(Mid$(M\MessageData$, 21, 1))
 						AI\WalkingBackward = RCE_IntFromStr(Mid$(M\MessageData$, 22, 1))
 
@@ -1477,7 +1482,20 @@ Function UpdateNetwork()
 					; Delete him
 					A.Account = Object.Account(AI\Account)
 					If A <> Null Then SetLoginStatus(A, -1)
-					; Pause any persistent scripts and stop others
+					; Pause any persistent scripts and stop others.
+					;
+					; The original non-persistent branch called FreeActorScripts(AI)
+					; on every iteration. That function sweeps *every* ScriptInstance
+					; for AI — including the persistent SI we just paused above and
+					; whose handle is now sitting in a fresh PausedScript. The sweep
+					; flipped SI\Ended = True; the next UpdateScripts pass Deleted
+					; the SI; later resumes touched PausedScript\S\WaitResult\$ on a
+					; dangling pointer. Reliable use-after-free on any logout that
+					; happened while a quest script was in WaitSpeak / WaitKill.
+					;
+					; Fix: each iteration cleans only its own SI plus the
+					; PausedScript records that referenced exactly it, via an
+					; After-cursor walk (the body Deletes PS).
 					For SI.ScriptInstance = Each ScriptInstance
 						If SI\AI = Handle(AI) Or SI\AIContext = Handle(AI)
 							; Persistent
@@ -1491,7 +1509,13 @@ Function UpdateNetwork()
 								EndIf
 							; Not persistent
 							Else
-								FreeActorScripts(AI)
+								Local LPS.PausedScript = First PausedScript
+								Local LPSNext.PausedScript = Null
+								While LPS <> Null
+									LPSNext = After LPS
+									If LPS\Reason <> 1 And LPS\S = SI Then Delete LPS
+									LPS = LPSNext
+								Wend
 								FreeScriptInstance(SI)
 							EndIf
 						EndIf
@@ -2060,9 +2084,27 @@ Function UpdateNetwork()
 						If A\Pass$ = Mid$(M\MessageData$, Offset + 1, PwdLen)
 							Offset = Offset + 1 + PwdLen
 
-							; Check character name is valid
+							; Check character name is valid. Bound length and reject
+							; control bytes / non-printable characters before the
+							; name is persisted into Accounts.dat and broadcast
+							; into chat/nametag widgets. Without the cap a single
+							; CreateCharacter packet could write a multi-hundred-
+							; character name with embedded newlines into account
+							; data; clients that render nametags / list-box rows
+							; with raw bytes would then display garbage.
 							NameValid = True
 							Name$ = Upper$(Mid$(M\MessageData$, Offset + 47))
+							If Len(Name$) < 1 Or Len(Name$) > 32 Then NameValid = False
+							If NameValid
+								For nameI = 1 To Len(Name$)
+									Local nameCh = Asc(Mid$(Name$, nameI, 1))
+									; Allow printable ASCII (space..~) only.
+									If nameCh < 32 Or nameCh > 126
+										NameValid = False
+										Exit
+									EndIf
+								Next
+							EndIf
 							F = ReadFile("Data\Server Data\Names Filter.txt")
 							If F = 0 Then RuntimeError("Could not open Names Filter.txt!")
 								While Eof(F) = False

--- a/src/Modules/ServerNet.bb
+++ b/src/Modules/ServerNet.bb
@@ -983,9 +983,9 @@ Function UpdateNetwork()
 			Case P_ProgressBar
 				If Left$(M\MessageData$, 1) = "C"
 					S.ScriptInstance = Object.ScriptInstance(RCE_IntFromStr(Mid$(M\MessageData$, 2, 4)))
-					If S <> Null
+					If S <> Null And ScriptHandleBelongsTo(S, M\FromID)
 						S\WaitResult$ = Str$(RCE_IntFromStr(Mid$(M\MessageData$, 6)))
-					Else
+					ElseIf S = Null
 						RCE_Send(Host, M\FromID, P_ProgressBar, "D" + Mid$(M\MessageData$, 6), True)
 					EndIf
 				EndIf
@@ -996,25 +996,25 @@ Function UpdateNetwork()
 					; New dialog created
 					Case "N"
 						S.ScriptInstance = Object.ScriptInstance(RCE_IntFromStr(Mid$(M\MessageData$, 2, 4)))
-						If S <> Null
+						If S <> Null And ScriptHandleBelongsTo(S, M\FromID)
 							S\WaitResult$ = Str$(RCE_IntFromStr(Mid$(M\MessageData$, 6)))
-						Else
+						ElseIf S = Null
 							RCE_Send(Host, M\FromID, P_Dialog, "C" + Mid$(M\MessageData$, 6), True)
 						EndIf
 					; Dialog text received
 					Case "T"
 						S.ScriptInstance = Object.ScriptInstance(RCE_IntFromStr(Mid$(M\MessageData$, 2, 4)))
-						If S <> Null Then S\WaitResult$ = "0"
+						If S <> Null And ScriptHandleBelongsTo(S, M\FromID) Then S\WaitResult$ = "0"
 					; Dialog option picked
 					Case "O"
 						S.ScriptInstance = Object.ScriptInstance(RCE_IntFromStr(Mid$(M\MessageData$, 2, 4)))
-						If S <> Null Then S\WaitResult$ = RCE_IntFromStr(Mid$(M\MessageData$, 6, 1))
+						If S <> Null And ScriptHandleBelongsTo(S, M\FromID) Then S\WaitResult$ = RCE_IntFromStr(Mid$(M\MessageData$, 6, 1))
 				End Select
 
 			; Text input reply
 			Case P_ScriptInput
 				S.ScriptInstance = Object.ScriptInstance(RCE_IntFromStr(Mid$(M\MessageData$, 1, 4)))
-				If S <> Null Then S\WaitResult$ = Mid$(M\MessageData$, 5)
+				If S <> Null And ScriptHandleBelongsTo(S, M\FromID) Then S\WaitResult$ = Mid$(M\MessageData$, 5)
 
 			; A player ate an item
 			Case P_EatItem

--- a/src/Modules/ServerNet.bb
+++ b/src/Modules/ServerNet.bb
@@ -1578,7 +1578,7 @@ Function UpdateNetwork()
 							Offset = Offset + 1 + PwdLen
 							Number = Asc(Mid$(M\MessageData$, Offset, 1))
 
-							If Number > -1 And Number < 10
+							If Number > -1 And Number < 10 And A\Character[Number] <> Null
 								; Set his status to in game and put him in his area
 								SetLoginStatus(A, Number)
 								A\Character[Number]\RNID = M\FromID

--- a/src/Modules/ServerNet.bb
+++ b/src/Modules/ServerNet.bb
@@ -273,7 +273,11 @@ Function UpdateNetwork()
 								If A\IsDM = True
 									Name$ = Trim$(Split$(Params$, 1, ","))
 									Func$ = Trim$(Split$(Params$, 2, ","))
-									ThreadScript(Name$, Func$, Handle(AI), 0)
+									; Privileged=1: this code path has verified
+									; the invoker is a GM, so the spawned script
+									; is allowed to call Ban/Kick/Warp/etc. via
+									; BVM_RequirePrivileged().
+									ThreadScript(Name$, Func$, Handle(AI), 0, "", 1)
 								EndIf
 							Case LanguageString$(LS_SCMe)
 								Pa$ = Chr$(252) + "* " + AI\Name$ + " " + Params$

--- a/src/Modules/ServerNet.bb
+++ b/src/Modules/ServerNet.bb
@@ -1147,15 +1147,22 @@ Function UpdateNetwork()
 									ThreadScript("Mount", "Mount", Handle(AI), Handle(A2))
 								EndIf
 							EndIf
-							; Continue any paused scripts waiting for this conversation
-							For PS.PausedScript = Each PausedScript
+							; Continue any paused scripts waiting for this conversation.
+							; After-cursor walk: the body Deletes PS, which would
+							; corrupt a For-Each cursor when two WaitSpeak scripts
+							; resume on the same right-click.
+							Local PS.PausedScript = First PausedScript
+							Local PSNext.PausedScript = Null
+							While PS <> Null
+								PSNext = After PS
 								If PS\Reason = 4
 									If PS\ReasonActor = AI And PS\ReasonContextActor = A2
 										PS\S\WaitResult$ = "1"
 										Delete PS
 									EndIf
 								EndIf
-							Next
+								PS = PSNext
+							Wend
 						EndIf
 					EndIf
 				EndIf

--- a/src/Modules/ServerNet.bb
+++ b/src/Modules/ServerNet.bb
@@ -1896,8 +1896,12 @@ Function UpdateNetwork()
 					If Upper$(A\User$) = Upper$(Username$)
 						Offset = 2 + UsernameLen
 						PwdLen = RCE_IntFromStr(Mid$(M\MessageData$, Offset, 1))
-						; If password is correct, change it to the new one
-						If A\Pass$ = Mid$(M\MessageData$, Offset + 1, PwdLen)
+						; If password is correct AND the requester is the currently-
+						; logged-in session for this account, change it. Without
+						; the session check, a captured/replayed P_ChangePassword
+						; lets any party with the (broken-MD5) hash steal the
+						; account permanently.
+						If A\Pass$ = Mid$(M\MessageData$, Offset + 1, PwdLen) And RequesterOwnsAccountSession(A, M\FromID)
 							Offset = 2 + PwdLen
 							PwdLen = RCE_IntFromStr(Mid$(M\MessageData$, Offset, 1))
 							A\Pass$ = Mid$(M\MessageData$, Offset + 1, PwdLen)
@@ -2155,8 +2159,12 @@ Function UpdateNetwork()
 					If Upper$(A\User$) = Upper$(Username$)
 						Offset = 2 + UsernameLen
 						PwdLen = RCE_IntFromStr(Mid$(M\MessageData$, Offset, 1))
-						; If password is correct
-						If A\Pass$ = Mid$(M\MessageData$, Offset + 1, PwdLen)
+						; If password is correct AND the requester is the
+						; currently-logged-in session for this account.
+						; A replayed P_DeleteCharacter would otherwise let
+						; anyone with the hash permanently destroy character
+						; slots on the account.
+						If A\Pass$ = Mid$(M\MessageData$, Offset + 1, PwdLen) And RequesterOwnsAccountSession(A, M\FromID)
 							Offset = Offset + 1 + PwdLen
 							Number = Asc(Mid$(M\MessageData$, Offset, 1))
 							If Number > -1 And Number < 10

--- a/src/Modules/ServerNet.bb
+++ b/src/Modules/ServerNet.bb
@@ -1620,7 +1620,10 @@ Function UpdateNetwork()
 				Next
 		        ; If account was not found or was already logged on, return failure
 		        If Exists = False Then RCE_Send(Host, M\FromID, P_StartGame, "N", True)
-				If (M\FromID = 2) Stop
+				; (removed) `If (M\FromID = 2) Stop` — a leftover debug trap that
+				; halted the entire server process the first time the peer whose
+				; RakNet connection ID is 2 sent P_StartGame. Trivial remote DoS
+				; for the second connecting client.
 
 			; Fetch update files list request
 			Case P_FetchUpdateFiles ; :)

--- a/src/Tests/Modules/AccountsServerTest.bb
+++ b/src/Tests/Modules/AccountsServerTest.bb
@@ -3,6 +3,7 @@ EnableGC
 
 Type ActorInstance
 	Field Account
+	Field RNID
 End Type
 
 Type QuestLog


### PR DESCRIPTION
## Track I — Server resilience

Stacks on Track H.

Five hardenings consolidating "one bad input / corrupt save / runaway script shouldn't take the whole server down":

- **BVM script abort no longer kills the server.** `UpdateScripts` called `RuntimeError` on `BVM_Invoke = 0`, which halts Blitz3D. A buggy script crashed every connected player. Log + delete the offending SI's VM context + continue.
- **Script-pending cap.** `ThreadScript` refuses new enqueues once `CountScriptInstances + CountThreadScripts >= 2048`. A self-spawning script no longer drives unbounded allocation.
- **Persistent-script UAF on logout.** Logout's For Each loop called `FreeActorScripts(AI)` on every non-persistent SI; that sweeps every SI for AI, including the persistent one just paused. Next UpdateScripts pass Deleted it while its PausedScript still held the handle. Replaced the redundant sweep with an inline per-SI PausedScript cleanup that leaves persistent SIs alone.
- **Position-float NaN/Inf clamp.** Added `ClampWorldCoord#` / `ClampSaneFloat#` helpers in RCEnet.bb. Applied to `P_StandardUpdate` X/Y/Z/DestX/DestZ (extending Track A's Y-only filter uniformly) and to the dropped-item position before it's persisted and broadcast.
- **P_CreateCharacter name bounds.** 1..32 chars and printable ASCII before name lands in Accounts.dat / chat / nametag widgets.

### Test plan
- [x] compile.bat + test.bat green

🤖 Generated with [Claude Code](https://claude.com/claude-code)
