### PR TITLE
graphics: per-frame Options read, NaN guards, Media ID bounds (Track J)

### DIFF
--- a/src/Modules/Animations.bb
+++ b/src/Modules/Animations.bb
@@ -115,6 +115,13 @@ Function LoadAnimSets(Filename$)
 		While Not Eof(F)
 			A.AnimSet = New AnimSet
 			A\ID = ReadShort(F)
+			; AnimList is Dim'd 0..999. ReadShort is signed, so a malformed
+			; AnimSets.dat (or a mod with ID >= 1000) would write past the
+			; array via Blitz's unchecked Dim write. Reject + stop loading.
+			If A\ID < 0 Or A\ID > 999
+				Delete A
+				Exit
+			EndIf
 			AnimList(A\ID) = A
 			A\Name$ = ReadString$(F)
 			For i = 0 To 149

--- a/src/Modules/Environment3D.bb
+++ b/src/Modules/Environment3D.bb
@@ -246,25 +246,14 @@ Function UpdateEnvironment3D()
 	Next
 
 ;Add Animated water to options menu Cysis145
-		F = ReadFile("Data\Options.dat")
-		If F = 0 Then RuntimeError("Could not open Data\Options.dat!")
-		Width = ReadShort(F)
-		Height = ReadShort(F)
-		Depth = ReadByte(F)
-		AA = ReadByte(F)
-		DefaultVolume# = ReadFloat#(F)
-		GrassEnabled = ReadByte(F)
-		AnisotropyLevel = ReadByte(F)
-		FullScreen = ReadByte(F)
-		VSync = ReadByte(F)
-		Bloom = ReadByte(F)
-		Rays = ReadByte(F)
-		AWater = ReadByte(F)
-		ShadowC = ReadByte(F)
-		ShadowQ = ReadByte(F)
-		ShadowR = ReadByte(F)
-		CloseFile(F)
-		
+		; Options are loaded once at startup by LoadGame() in ClientLoaders.bb
+		; and populate the same globals (AWater, ShadowC, etc.) read below. A
+		; previous version of this block re-opened Data\Options.dat every
+		; frame just to refresh AWater — a needless file open/read/close on
+		; the hot render path. Same fix as Track F applied to Client.bb.
+		; Settings dialogs that mutate these globals are responsible for
+		; re-running LoadGame() (or equivalent) on apply.
+
 	Select AWater
 	Case 0
 	; Water
@@ -318,7 +307,12 @@ Next
 	; Lightning
 	If CurrentWeather = W_Storm
 		If LightningToDo = 0
-			If Rand(1, Int(500.0 / Delta#)) = 1 Then LightningToDo = Rand(1, 3)
+			; Guard Delta=0 (first frame after pause / window-restore makes
+			; Int(500/0) panic). When Delta isn't usable, just skip this
+			; frame's lightning roll.
+			If Delta# > 0.0
+				If Rand(1, Int(500.0 / Delta#)) = 1 Then LightningToDo = Rand(1, 3)
+			EndIf
 		ElseIf Rand(1, 50) = 1
 			LightningToDo = LightningToDo - 1
 			ScreenFlash(255, 255, 255, 65535, Rand(200, 1000), 0.9)
@@ -566,8 +560,16 @@ Function UpdateLensFlare()
 							vX# = ProjectedX#() - ScreenX#
 							vY# = ProjectedY#() - ScreenY#
 							Length# = Sqr#((vX# * vX#) + (vY# * vY#))
-							vX# = vX# / Length#
-							vY# = vY# / Length#
+							; Guard against the sun projecting exactly onto the
+							; screen centre: Length=0 made vX/vY NaN, which then
+							; poisoned every flare entity's PositionEntity below.
+							If Length# > 0.0
+								vX# = vX# / Length#
+								vY# = vY# / Length#
+							Else
+								vX# = 0.0
+								vY# = 0.0
+							EndIf
 							Scale# = 1.0
 							cR = S\LightR - (TotalFlares * 10)
 							cG = S\LightG

--- a/src/Modules/FastExt.bb
+++ b/src/Modules/FastExt.bb
@@ -414,11 +414,15 @@ Function InitPostprocess% ()
 		If InitPostprocess_ (BackBuffer(), TextureBuffer(FE_PostprocessTexture1), TextureBuffer(FE_PostprocessTexture2), TextureBuffer(FE_PostprocessTexture3), TextureBuffer(FE_PostprocessTexture4), TextureBuffer(FE_PostprocessTexture5))<>0 Then
 			FE_InitPostprocessFlag = 1
 		Else
-			If FE_PostprocessTexture1<>0 Then FreeTexture FE_PostprocessTexture1
-			If FE_PostprocessTexture2<>0 Then FreeTexture FE_PostprocessTexture2
-			If FE_PostprocessTexture3<>0 Then FreeTexture FE_PostprocessTexture3
-			If FE_PostprocessTexture4<>0 Then FreeTexture FE_PostprocessTexture4
-			If FE_PostprocessTexture5<>0 Then FreeTexture FE_PostprocessTexture5
+			; Clear the texture handles after FreeTexture so a retry call to
+			; InitPostprocess doesn't try to free the same (already-freed)
+			; IDs and DeInitPostprocess doesn't double-free stale handles
+			; that have since been reassigned.
+			If FE_PostprocessTexture1<>0 Then FreeTexture FE_PostprocessTexture1 : FE_PostprocessTexture1 = 0
+			If FE_PostprocessTexture2<>0 Then FreeTexture FE_PostprocessTexture2 : FE_PostprocessTexture2 = 0
+			If FE_PostprocessTexture3<>0 Then FreeTexture FE_PostprocessTexture3 : FE_PostprocessTexture3 = 0
+			If FE_PostprocessTexture4<>0 Then FreeTexture FE_PostprocessTexture4 : FE_PostprocessTexture4 = 0
+			If FE_PostprocessTexture5<>0 Then FreeTexture FE_PostprocessTexture5 : FE_PostprocessTexture5 = 0
 		EndIf
 		SetBuffer CurrentBuffer
 	EndIf

--- a/src/Modules/Media.bb
+++ b/src/Modules/Media.bb
@@ -728,6 +728,11 @@ End Function
 ; Gets the handle for a given mesh (this will load it if it isn't present)
 Function GetMesh(ID, Duplicate = False)
 
+	; Mirror GetSound's ID guard. LoadedMeshes is Dim'd 0..65534; a caller
+	; passing -1 (the inconsistent sentinel some Actors3D paths use instead
+	; of 65535) or any out-of-range ID would write through a wild pointer.
+	If ID < 0 Or ID > 65534 Then Return 0
+
 	; Load from file if this is the first time the mesh has been loaded
 	If LoadedMeshes(ID) = 0
 
@@ -803,6 +808,8 @@ End Function
 
 ; Gets the handle for a given texture (this will load it if it isn't present)
 Function GetTexture(ID, Copy = False)
+
+	If ID < 0 Or ID > 65534 Then Return 0
 
 	If LoadedTextures(ID) = 0
 

--- a/src/Modules/Radar.bb
+++ b/src/Modules/Radar.bb
@@ -88,6 +88,11 @@ Function Load_Radar(AreaName$, X#, Y#, Width#, Height#, Interior, BorderTex$ = "
  	ResizeImage TempImage, Radar_TexSize, Radar_TexSize
 	Radar_Tex1 = CreateTexture(Radar_TexSize, Radar_TexSize, 1)
 	CopyRect 0, 0, Radar_TexSize, Radar_TexSize, 0, 0, ImageBuffer(TempImage), TextureBuffer(Radar_Tex1)
+	; Free the screen-sized scratch image — Load_Radar runs on every zone
+	; change, and TempImage was previously leaked each time (~8 MB at
+	; 1920x1080x32bpp; 20 zones = 160 MB of orphaned image data in a
+	; Blitz3D 2 GB address space).
+	FreeImage TempImage
 
 	; Restore scenery FX
 	For Sc.Scenery = Each Scenery
@@ -302,8 +307,18 @@ Function UpdateRadar(ent,areashow=50)
 If radar_lastx#=EntityX(ent,1) And radar_lasty#=EntityZ(ent,1) Then Return
 radar_lastx#=EntityX(ent,1):radar_lasty#=EntityZ(ent,1)
 
-	plrx# = (Radar_TexSize / (Radar_WorldSize / -EntityX#(ent, 1)))
-	plry# = (Radar_TexSize / (Radar_WorldSize / EntityZ#(ent, 1)))
+	; Guard divides by zero: at exact world origin EntityX/Z is 0 and the
+	; inverted division produces Inf, which propagates into PositionEntity
+	; below and corrupts the player marker. The math was also doubly-
+	; inverted (`tex / (world / -x)` = `-x * tex / world`); inline that
+	; form so we don't blow up on origin spawns.
+	If Radar_WorldSize = 0
+		plrx# = 0.0
+		plry# = 0.0
+	Else
+		plrx# = (-EntityX#(ent, 1) * Radar_TexSize) / Radar_WorldSize
+		plry# = (EntityZ#(ent, 1) * Radar_TexSize) / Radar_WorldSize
+	EndIf
 
 fromfx=plrx#+(Radar_TexSize/2)-areashow
 tofx=plrx#+(Radar_TexSize/2)+areashow


### PR DESCRIPTION
## Track J — Graphics hygiene

Independent of G/H/I (different files). Eight findings in one commit; each isolated.

- **Environment3D no longer re-reads `Data\Options.dat` every frame.** Same fix as Track F applied to Client.bb — `LoadGame()` populates the same globals at startup; the per-frame open/read/close was pure overhead.
- **Lens-flare normalization zero-length guard.** When the sun projects exactly onto the screen centre, `Length = 0` makes vX/vY NaN which propagates into PositionEntity for every flare. Guard with `If Length > 0`.
- **Lightning Delta=0 guard.** First frame after pause / window-restore can have `Delta=0`; `Rand(1, Int(500/Delta))` panics. Skip the roll on that frame.
- **Radar TempImage leak.** `Load_Radar` allocated a screen-sized scratch image per zone change and never freed it (~8 MB × 20 zones = 160 MB orphaned in a 2 GB address space).
- **Radar div-by-zero at world origin.** Inverted-divide by `EntityX/Z` produced Inf/NaN positions when the player spawned at exact origin. Rewrite to algebraically equivalent form without the inversion + guard `Radar_WorldSize = 0`.
- **LoadAnimSets ID bounds.** Same defensive guard as Items/Spells/Projectiles (Track A) — AnimList is Dim 0..999; malformed file with out-of-range ID corrupted memory via unchecked Dim write.
- **GetMesh / GetTexture ID guard.** GetSound had a 0..65534 check; the other two didn't (Actors3D mixes -1 and 65535 sentinels).
- **FastExt InitPostprocess null-out on free.** After `FreeTexture` in the error path, set the `FE_PostprocessTextureN` globals to 0 so a retry / DeInit doesn't double-free.

### Test plan
- [x] compile.bat + test.bat green

🤖 Generated with [Claude Code](https://claude.com/claude-code)
