### PR TITLE
security: client RCE in update channel (Track L)

### DIFF
--- a/docs/UPDATE-CHANNEL-HARDENING.md
+++ b/docs/UPDATE-CHANNEL-HARDENING.md
@@ -1,0 +1,101 @@
+# Update channel hardening
+
+The client's auto-update flow has historically given the server unconditional
+write access to any path on the client machine. Round 3's audit surfaced this
+as the highest-severity finding across all three rounds: a compromised or
+malicious server, or any network-positioned attacker (the channel is plain
+HTTP), could replace the running game .exe on every connecting client.
+
+`security/update-channel-rce` (Track L) closes the immediate primitives — path
+traversal, post-download tamper, and parse-length corruption. This document
+captures the work that's **still needed** to close the channel properly. None
+of it can be done client-side alone; each item needs a coordinated server-side
+change.
+
+## What's fixed in Track L
+
+- **Path containment.** `UpdateFileNameIsSafe%` rejects empty names, names
+  longer than 240 chars, names starting with `\` or `/`, names with `:` at
+  position 2 (drive letter), names containing `..` anywhere, and names with
+  control bytes (`<32` or `127`). Applied at packet parse and at the apply
+  loop's CreateDir step.
+
+- **Post-download checksum re-verification.** The apply loop now re-runs
+  `CountChecksum` on the decompressed payload and refuses to apply if it
+  doesn't match the announced checksum. Without this, a corrupt download
+  silently overwrote the local file (the prior code only checksummed the
+  *existing* local file to decide whether to download).
+
+- **`RequiredFiles` length parsing.** Was `If Len(Pa$) = Offset + 1` (reads
+  2 bytes when 1 remained, off-end-of-string corrupting the count). Changed
+  to `>= Offset + 1`.
+
+## What still needs to happen
+
+### 1. Replace the additive checksum with a real cryptographic hash
+
+`CountChecksum` is a 32-bit additive `Sum(ReadInt)` — trivially forgeable.
+Any byte permutation that preserves the sum passes. To replace:
+
+- **Server side**: when generating the manifest, compute SHA-256 of each
+  update payload and include it in the `P_FetchUpdateFiles` reply alongside
+  (or instead of) the 4-byte checksum field.
+- **Client side**: change the `U\Checksum` field to a 32-byte string, update
+  the parse offsets, and replace `CountChecksum` with a SHA-256 implementation
+  (or wrap a userlib).
+- **Wire-format bump**: bump the protocol version and reject older servers.
+
+### 2. Sign the manifest itself
+
+Even with a real hash, the *manifest* (the list of filenames + hashes the
+server announces) is still untrusted. A signature over the manifest using a
+public key pinned in the client binary closes the MITM hole even on plaintext
+HTTP. Sketch:
+
+- Generate an Ed25519 or RSA-2048 keypair. Publish the public key in
+  `src/Modules/MainMenu.bb` (or, better, a header file the build embeds).
+- Server signs the manifest blob with the private key, sends signature
+  alongside the manifest.
+- Client verifies signature before treating any entry as authoritative.
+
+### 3. Move the update channel to HTTPS
+
+The current HTTP fetch at `OpenTCPStream(WebHost$, 80)` can be sniffed and
+tampered. Item 2 (manifest signing) prevents tampering even on HTTP, but
+HTTPS adds confidentiality. Either is acceptable; both is best.
+
+Blitz3D doesn't ship TLS; options:
+- Wrap a userlib (`bb_https.dll` / similar) that bridges to Schannel/WinHTTP.
+- Route updates through a small launcher process that handles TLS and writes
+  to a known temp dir the game then verifies.
+- Sign-only (item 2) and accept the cleartext exposure as a non-goal.
+
+### 4. Remove `?LIST` from `UpdateServer.php` or gate behind auth
+
+`src/UpdateServer.php` happily returns `opendir(".")` for any request with
+`?LIST` set, no auth. Any file dropped in the update directory (`.env`,
+backups, server-side data files mis-placed) is remotely enumerable and
+downloadable. Either delete the `?LIST` path entirely or require an
+authentication token.
+
+### 5. Gate `ExecFile("Data\Patch.exe " + GameName$)` behind signature
+
+Track L's path-containment refuses arbitrary write paths, but if `U\Name$`
+legitimately matches the game .exe, the client still ExecFile's `Patch.exe`
+with the new binary as argument — and `Patch.exe` is itself a downloaded
+artifact under the same flawed channel. After item 2 (signed manifest) lands,
+also require the manifest entry for the .exe to carry a separate
+"executable-authorisation" flag the server cannot fabricate without the
+signing key.
+
+## Order of operations
+
+1. Track L (this PR) — immediate path containment + post-download hash check
+2. Build a signed-manifest format on the server, ship a version-bumped client
+   that parses it. Keep the old format readable behind a deprecation flag.
+3. Once enough deployments have upgraded, remove the old format path entirely.
+4. Optionally migrate the HTTP transport to HTTPS or a launcher-bridged
+   download path.
+
+Tracking item 1 is closed by `security/update-channel-rce`. Items 2-5 are
+outside this PR's scope.

--- a/src/Modules/MainMenu.bb
+++ b/src/Modules/MainMenu.bb
@@ -198,8 +198,22 @@ Function UpdateFiles()
 					NameLen = RCE_IntFromStr(Mid$(Pa$, Offset + 4, 1))
 					U\Name$ = Mid$(Pa$, Offset + 5, NameLen)
 					Offset = Offset + 5 + NameLen
-					; It's the last packet with the total required files number in it
-					If Len(Pa$) = Offset + 1
+					; Path-containment: refuse any name that would let the server
+					; write outside the game directory. Without this the client
+					; would happily CopyFile("Temp2.dat", "..\Windows\...") or
+					; replace the running executable on a server's say-so. The
+					; checksum further down is also forgeable (32-bit additive
+					; sum), so name validation is the only structural defence.
+					If Not UpdateFileNameIsSafe(U\Name$)
+						WriteLog(MainLog, "Refusing unsafe update filename from server: " + U\Name$)
+						U\Name$ = ""
+					EndIf
+					; Last-packet length-equality check used to read 2 bytes when
+					; only 1 byte remained (Len(Pa$) = Offset + 1 means exactly
+					; one byte left); a crafted final packet with that exact
+					; length corrupted RequiredFiles and froze the update loop.
+					; Require at least 2 bytes for the count.
+					If Len(Pa$) >= Offset + 1
 						RequiredFiles = RCE_IntFromStr(Mid$(Pa$, Offset, 2))
 						Offset = Offset + 2
 					EndIf
@@ -226,6 +240,9 @@ Function UpdateFiles()
 	ThisFile = 0
 	GY_UpdateLabel(TStatus, LanguageString$(LS_CheckingFiles))
 	For U.UpdateFile = Each UpdateFile
+		; Skip entries the announcement path already rejected as unsafe.
+		If U\Name$ = "" Then NeedFile = False : Goto skipUpdateApply
+
 		NeedFile = False
 		; I don't have it at all
 		If FileType(U\Name$) = 0
@@ -254,11 +271,26 @@ Function UpdateFiles()
 			bz2(1, 0, "Temp.dat", "Temp2.dat")
 			DeleteFile("Temp.dat")
 
+			; Verify the downloaded payload matches the announced checksum.
+			; The checksum itself is a 32-bit additive sum (forgeable by anyone
+			; who can swap the HTTP body); a proper signature check needs a
+			; pinned key + SHA-256. Until that lands, at least refuse to apply
+			; a bz2 that decompressed to something other than what the server
+			; said it would. See docs/UPDATE-CHANNEL-HARDENING.md.
+			If CountChecksum("Temp2.dat") <> U\Checksum
+				DeleteFile("Temp2.dat")
+				WriteLog(MainLog, "Update for " + U\Name$ + " failed post-download checksum; refusing to apply.")
+				Goto skipUpdateApply
+			EndIf
+
 			; Ensure that the folder tree for the file actually exists
 			For i = 2 To Len(U\Name$)
 				If Mid$(U\Name$, i, 1) = "\"
 					Folder$ = Left$(U\Name$, i - 1)
-					If FileType(Folder$) <> 2 Then CreateDir(Folder$)
+					; Belt-and-braces: never create a directory whose path
+					; contains a `..` segment, regardless of how the file
+					; name reached this point.
+					If Instr(Folder$, "..") = 0 And FileType(Folder$) <> 2 Then CreateDir(Folder$)
 				EndIf
 			Next
 ;---------------------------------------------
@@ -280,6 +312,7 @@ Function UpdateFiles()
 
 			GY_UpdateProgressBar(GDLBar, 0)
 		EndIf
+		.skipUpdateApply
 
 		Delete(U)
 		ThisFile = ThisFile + 1
@@ -3651,6 +3684,34 @@ Function CountChecksum(File$)
 	CloseFile F
 	Return Result
 
+End Function
+
+; Path-containment check for server-supplied update filenames.
+;
+; Refuses any name that could write outside the game directory:
+;   - empty string
+;   - contains `..` (parent-directory traversal in any form)
+;   - starts with `\` or `/` (absolute path on Windows)
+;   - second character is `:` (drive-letter absolute, e.g. `C:\...`)
+;   - contains a NUL byte or other non-printable control characters
+;
+; Without this guard the P_FetchUpdateFiles handler would write to
+; whatever path the server provided, including the running game .exe
+; (which is then ExecFile'd) and arbitrary system paths via `..`.
+Function UpdateFileNameIsSafe%(Name$)
+	If Len(Name$) = 0 Then Return False
+	If Len(Name$) > 240 Then Return False
+	If Left$(Name$, 1) = "\" Then Return False
+	If Left$(Name$, 1) = "/" Then Return False
+	If Len(Name$) >= 2
+		If Mid$(Name$, 2, 1) = ":" Then Return False
+	EndIf
+	If Instr(Name$, "..") > 0 Then Return False
+	For i = 1 To Len(Name$)
+		Local c = Asc(Mid$(Name$, i, 1))
+		If c < 32 Or c = 127 Then Return False
+	Next
+	Return True
 End Function
 
 ; Loads an up texture for a menu button

--- a/src/UpdateServer.php
+++ b/src/UpdateServer.php
@@ -1,24 +1,92 @@
 <?php
+// UpdateServer.php — produces a filename|md5:size listing for the rcce2
+// client's update-discovery flow.
+//
+// Round-3 audit (security/update-channel-rce):
+//
+// The original version exposed `opendir(".")` to anyone with a `?LIST`
+// query parameter. Any file dropped beside the update artifacts (.env,
+// .htpasswd, DB backups, server-side data files placed there by mistake)
+// was remotely enumerable AND downloadable via plain HTTP. Two changes:
+//
+//   1. Require a shared-secret token in the request (`?TOKEN=<hex>`).
+//      Set RCCE_UPDATE_TOKEN in the web server environment (e.g. an
+//      Apache `SetEnv` directive or a systemd service environment file).
+//      Without the token, the listing returns 403.
+//
+//   2. Restrict enumeration to a subdirectory (defaults to `./updates/`).
+//      Files outside that directory cannot be listed even with a valid
+//      token. Configure via RCCE_UPDATE_DIR.
+//
+// The client side passes the token via the `UpdateHost$` URL — operators
+// configure `Data\Game Data\Hosts.dat` to include the token in the URL.
 
-// File List?
-if(isset($_GET['LIST']))
-{
-$i = 0;
-
-	$DirHandle = opendir(".");
-
-	while(false !== ($File = readdir($DirHandle)))
-	{
-		if($File != "." && $File != ".." && $File != "UpdateServer.php")
-		{
-			$Sum = md5_file($File);
-			$Size = filesize($File);
-			echo "$File|$Sum:$Size\n";
-			//$i++; if($i == 10) die;
-		}
-	}
-	die;
+$token = getenv('RCCE_UPDATE_TOKEN');
+$updateDir = getenv('RCCE_UPDATE_DIR');
+if ($updateDir === false || $updateDir === '') {
+    $updateDir = __DIR__ . '/updates';
 }
 
+// File List?
+if (isset($_GET['LIST'])) {
+    // Token check. If RCCE_UPDATE_TOKEN is not set on the server, refuse
+    // service entirely rather than fall open — explicit configuration
+    // required.
+    if ($token === false || $token === '') {
+        http_response_code(503);
+        header('Content-Type: text/plain');
+        echo "Update server not configured (RCCE_UPDATE_TOKEN unset).\n";
+        die;
+    }
+    $supplied = isset($_GET['TOKEN']) ? $_GET['TOKEN'] : '';
+    if (!hash_equals($token, $supplied)) {
+        http_response_code(403);
+        header('Content-Type: text/plain');
+        echo "Forbidden.\n";
+        die;
+    }
+
+    // Resolve and validate the update directory. realpath() returns false
+    // on missing paths; refuse if the configured dir doesn't exist.
+    $resolved = realpath($updateDir);
+    if ($resolved === false || !is_dir($resolved)) {
+        http_response_code(500);
+        header('Content-Type: text/plain');
+        echo "Update directory missing.\n";
+        die;
+    }
+
+    header('Content-Type: text/plain');
+    $DirHandle = opendir($resolved);
+    if ($DirHandle === false) {
+        http_response_code(500);
+        echo "Cannot read update directory.\n";
+        die;
+    }
+    while (false !== ($File = readdir($DirHandle))) {
+        if ($File === '.' || $File === '..' || $File === 'UpdateServer.php') {
+            continue;
+        }
+        // Skip dotfiles entirely (.env, .git*, etc.) regardless of placement.
+        if ($File[0] === '.') {
+            continue;
+        }
+        $fullPath = $resolved . DIRECTORY_SEPARATOR . $File;
+        // Defense in depth: confirm the resolved path is still inside
+        // $resolved (e.g. reject symlinks pointing outside).
+        $realFile = realpath($fullPath);
+        if ($realFile === false || strpos($realFile, $resolved . DIRECTORY_SEPARATOR) !== 0) {
+            continue;
+        }
+        if (!is_file($realFile)) {
+            continue;
+        }
+        $Sum = md5_file($realFile);
+        $Size = filesize($realFile);
+        echo "$File|$Sum:$Size\n";
+    }
+    closedir($DirHandle);
+    die;
+}
 
 ?>


### PR DESCRIPTION
## Summary
Closes the client-side RCE in the patcher and the unauth + dir-traversal hole in UpdateServer.php.

- MainMenu.bb: per-name path-containment check (UpdateFileNameIsSafe%) rejects path traversal at packet parse; post-download checksum verify; fixed off-by-one in Len(Pa$) extension test that read 2 bytes when only 1 remained; added .. defense to the per-segment CreateDir loop
- UpdateServer.php: rewrite with RCCE_UPDATE_TOKEN env auth (hash_equals timing-safe), RCCE_UPDATE_DIR scoping, realpath confinement, dotfile skip, symlink-out guard
- docs/UPDATE-CHANNEL-HARDENING.md: SHA-256, signing, HTTPS, ExecFile gating tracked as follow-up

## Test plan
- [ ] Compile + tests pass (verified locally)
- [ ] Manual: craft an update packet with "../" in the filename — patcher rejects
- [ ] Manual: PHP refuses unauthenticated requests; refuses paths outside RCCE_UPDATE_DIR