### PR TITLE
editor: RC tool data integrity (Track N)

### DIFF
--- a/src/Tools/Gubbin Tool.bb
+++ b/src/Tools/Gubbin Tool.bb
@@ -908,9 +908,14 @@ Function DecryptMesh(Name$)
 	If Len(Name$) > 5
 		If Lower$(Right$(Name$, 5)) = ".eb3d"
 			Size = FileSize(Name$)
+			If Size <= 0 Then Return
 			B = CreateBank(Size)
 
 			In = ReadFile(Name$)
+			If In = 0 Then
+				FreeBank(B)
+				Return
+			EndIf
 			ReadBytes(B, In, 0, Size)
 			CloseFile(In)
 
@@ -918,6 +923,10 @@ Function DecryptMesh(Name$)
 			Name$ = Name$ + ".b3d"
 
 			Out = WriteFile(Name$)
+			If Out = 0 Then
+				FreeBank(B)
+				Return
+			EndIf
 
 			DebugLog( "Out is: " + Out )
 			DecryptBank = CreateBank(64)

--- a/src/Tools/RC Caves Editor.BB
+++ b/src/Tools/RC Caves Editor.BB
@@ -2146,7 +2146,7 @@ For e.Event = Each event
        oldpath$=CurrentDir()
        rd$=""
 
-  	   tFile = FUI_SaveDialog( "Load saved geometry", "Data\RCCAVES\", "Blitz basic format (*.b3d)|*.b3d")
+  	   tFile = FUI_SaveDialog( "Save Cave", "Data\RCCAVES\", "Blitz basic format (*.b3d)|*.b3d")
        If tfile=True Then rd$ = app\currentfile
        rd$=strip_path$(rd$) 
        ChangeDir oldpath$ 
@@ -2656,7 +2656,8 @@ ChangeDir thispath$
 THISFOLD$=strip_path$(SF$)
 ;mysave=cave_copymesh(cube,1)
 savemultimesh (cube,"Data\RCCAVES\"+thisfold$,"Data\RCCAVES\",7)
-FreeEntity mysave
+; (mysave was set by a now-removed cave_copymesh path; the FreeEntity that
+; used to live here read an undefined local and was a no-op anyway.)
 lightf$=Left$(thisfold$,Len(thisfold$)-3)
 lightf$=lightf$+"LGT"
 ChangeDir thispath$
@@ -2703,8 +2704,16 @@ YN=fui_confirm("Load Cave ?","Yes","No")
 If yn=0 Then Return
 
 If FileType ("Data\RCCAVES\"+thisfold$)<>1 Then Return
+; Load the replacement BEFORE freeing the current cube. If LoadMesh fails
+; (e.g. file present but corrupt) we keep the prior geometry instead of
+; leaving the editor with a null cube that every later op dereferences.
+newcube=LoadMesh("Data\RCCAVES\"+thisfold$)
+If newcube=0 Then
+	FUI_Notify("Failed to load cave geometry.")
+	Return
+EndIf
 FreeEntity cube
-cube=LoadMesh("Data\RCCAVES\"+thisfold$)
+cube=newcube
 UpdateNormals (cube)
 
 ;cube_old=CopyMesh(cube)

--- a/src/Tools/RC Terrain Editor.bb
+++ b/src/Tools/RC Terrain Editor.bb
@@ -1513,7 +1513,15 @@ If sfilename3$<>""
 FN$=sFileName3$+".rct"
 ChangeDir thispath$+savepath$
 
-sfile=WriteFile (SF$)
+; Write to the .rct-suffixed FN$ we just computed, not the raw dialog
+; result SF$. Otherwise saving "foo" produces a file literally named
+; "foo" with no extension while the debug log claims the .rct path.
+sfile=WriteFile (FN$)
+If sfile = 0 Then
+	DebugLog "savework: WriteFile failed for " + FN$
+	ChangeDir thispath$
+	Return
+EndIf
 DebugLog "FINAL RCT SAVE !!!!!!!!!!!!!!!!!!!!! "+FN$
 DebugLog "Number of layers: " + numlayers + " and number of segments: " + lsegments
  WriteInt sfile, numlayers
@@ -5437,11 +5445,26 @@ If FileType(fname$)<>1 Then Return -1
 
 ;wite to file
 ; Newf=WriteFile(newn$)
+; Write to a .tmp first so a WriteFile failure can't leave us with
+; nothing on disk — the previous DeleteFile-then-WriteFile order would
+; have wiped the source if the target path was no longer writable.
+TmpPath$ = fname$ + ".tmp"
+If FileType(TmpPath$) = 1 Then DeleteFile(TmpPath$)
+Fsave=WriteFile(TmpPath$)
+If Fsave = 0 Then
+	FreeBank thisbank
+	Return -1
+EndIf
+WriteBytes thisbank,fsave,0,offset
+CloseFile fsave
+If FileSize(TmpPath$) <> offset Then
+	DeleteFile(TmpPath$)
+	FreeBank thisbank
+	Return -1
+EndIf
 DeleteFile (fname$)
- Fsave=WriteFile(fname$)
- b=PeekByte(thisbank,i)
- WriteBytes thisbank,fsave,0,offset
- CloseFile fsave
+CopyFile TmpPath$, fname$
+DeleteFile(TmpPath$)
 
 ; WriteBytes thisbank,newf,0,ts
 ; CloseFile newf


### PR DESCRIPTION
## Summary
Per-tool data-integrity fixes for the RC editor suite.

### Caves Editor
- Save dialog caption "Load saved geometry" -> "Save Cave" (was visibly an "Open" prompt in the Save flow)
- Removed a stale FreeEntity on an undefined mysave local in SAVEWORK
- loadwork loads the replacement mesh BEFORE freeing the current cube; on LoadMesh failure we keep the prior geometry and notify the user, instead of leaving the editor with a null cube that every later op would dereference

### Gubbin Tool
- DecryptMesh guards ReadFile / WriteFile returning 0 and refuses to allocate when FileSize <= 0

### RC Terrain Editor
- savework now writes to FN$ (the .rct-suffixed name) instead of SF$; previously WriteFile(SF$) wrote a no-extension file while the debug log claimed the .rct path was being persisted
- savework refuses gracefully on WriteFile = 0
- Encrypt_B3D writes to a .tmp first, validates length, then promotes -- previously DeleteFile(fname$) before WriteFile would wipe the source if the target couldn't be opened

## Test plan
- [ ] Compile passes (verified)
- [ ] Manual: save a terrain as "foo" -> file written as foo.rct
- [ ] Manual: try to load a deliberately corrupt .b3d in the Caves editor -> editor stays usable