### PR TITLE
ui+db: F-UI image leaks and MySQL XPBarLevel load typo (Track P)

### DIFF
--- a/src/Modules/F-UI.bb
+++ b/src/Modules/F-UI.bb
@@ -2768,10 +2768,12 @@ Function FUI_SendMessage$( ID, Message, Param1$="", Param2$="" )
 					EndIf
 				EndIf
 			Case M_SETIMAGE
+				; Free the prior icon before replacing it; otherwise the
+				; old image handle leaks every time M_SETIMAGE is sent.
+				If tabp\Icon <> 0 Then FreeImage tabp\Icon
+				tabp\Icon = Null
 				If FUI_IsImageSource( Param1$ ) = True
 					tabp\Icon = LoadImage( Param1$ )
-				Else
-					tabp\Icon = Null
 				EndIf
 				FUI_BuildTabPage tabp
 				
@@ -2951,10 +2953,12 @@ Function FUI_SendMessage$( ID, Message, Param1$="", Param2$="" )
 			Case M_SETID
 				btn\ID = Int(Param1)
 			Case M_SETIMAGE
+				; Free the prior icon before replacing it; otherwise the
+				; old image handle leaks every time M_SETIMAGE is sent.
+				If btn\Icon <> 0 Then FreeImage btn\Icon
+				btn\Icon = Null
 				If FUI_IsImageSource( Param1$ ) = True
 					btn\Icon = LoadImage( Param1$ )
-				Else
-					btn\Icon = Null
 				EndIf
 				FUI_BuildButton btn
 				
@@ -3352,11 +3356,17 @@ Function FUI_SendMessage$( ID, Message, Param1$="", Param2$="" )
 			Case M_SETSIZE_H
 				img\H = Int Param1
 				FUI_BuildImageBox img
-			Case M_SETIMAGE 
+			Case M_SETIMAGE
+				; Free the prior image before replacing it; sending
+				; M_SETIMAGE repeatedly to the same ImageBox would
+				; otherwise leak one image handle per call.
+				If img\Image <> 0 Then FreeImage img\Image
 				img\Image = LoadImage(Param1)
-				If (img\Flags And CS_RESIZE) = CS_RESIZE 
-				   ResizeImage img\Image, img\W, img\H 
-				EndIf 
+				If img\Image <> 0
+					If (img\Flags And CS_RESIZE) = CS_RESIZE
+					   ResizeImage img\Image, img\W, img\H
+					EndIf
+				EndIf
 				FUI_BuildImageBox img
 				
 			Case M_GETPOS

--- a/src/Modules/MySQL.bb
+++ b/src/Modules/MySQL.bb
@@ -594,7 +594,10 @@ Function My_LoadActorInstance.ActorInstance(ActID, Q.Questlog, C.ActionBarData, 
 	A\Gold				= ReadSQLField(Row, "gold")
 	A\NumberOfslaves	= ReadSQLField(Row, "slaves")
 	A\HomeFaction		= ReadSQLField(Row, "homefaction")
-	A\XPBarLevel		= ReadSQLField(Row, "xbbarlev")
+	; Column is `xpbarlev` on the SaveActor side (above); the read here
+	; used to look up `xbbarlev`, which silently returned 0 on every load
+	; and made the XP bar reset to empty on relog.
+	A\XPBarLevel		= ReadSQLField(Row, "xpbarlev")
 	A\Account_ID		= AccountID
 
 	; Query attributes


### PR DESCRIPTION
## Summary
F-UI image leaks and a load-side schema typo.

### F-UI.bb
- TabPage / Button / ImageBox M_SETIMAGE handlers now FreeImage the prior image before LoadImage; previously every call leaked one image handle (any code that animates an icon, swaps button art on hover, or rebinds an ImageBox on scroll would leak forever)
- ImageBox M_SETIMAGE also null-guards the ResizeImage path so a failed LoadImage doesn't pass 0 downstream

### MySQL.bb
- LoadActor read column \`xbbarlev\` but SaveActor writes \`xpbarlev\` — the DB schema uses \`xpbarlev\`, so every load returned 0 for XPBarLevel and the client XP bar reset to empty on relog. Read side now matches write side; no schema change required.

## Test plan
- [ ] Compile passes; tests pass (verified locally)
- [ ] Manual: log a character, level up partway, relog -> XP bar restored at the partial level