### PR TITLE
fix: correct BlitzForge submodule pointer + pin to develop

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,7 @@
 [submodule "compiler/BlitzForge"]
 	path = compiler/BlitzForge
 	url = https://github.com/RydeTec/blitz-forge.git
+	branch = develop
 [submodule "extras/vscode-blitz-forge"]
 	path = extras/vscode-blitz-forge
 	url = https://github.com/RydeTec/vscode-blitz-forge.git


### PR DESCRIPTION
Track O's render-path NaN guards weren't being picked up by rcce2 because the prior bump pointed the submodule at a 2015 commit on a dead branch. `git submodule update --remote` defaulted to `master` since `.gitmodules` had no `branch` field. This commit sets the pointer to BlitzForge develop tip (5913451) and adds `branch = develop` so future `--remote` calls land in the right place.