### PR TITLE
tests: Environment TimeDelta + SafeWrite helpers (Track R, first wave)

### DIFF
--- a/src/Tests/Modules/EnvironmentTest.bb
+++ b/src/Tests/Modules/EnvironmentTest.bb
@@ -1,0 +1,50 @@
+Strict
+EnableGC
+
+; Logging stubs so Environment's SafeWrite/WriteLog calls resolve without
+; pulling Modules\Logging.bb (which has its own UI/file deps).
+Global MainLog = 0
+
+Function WriteLog(LogID%, Message$)
+End Function
+
+Function SafeWriteOpen$(FinalPath$)
+	Return FinalPath$ + ".tmp"
+End Function
+
+Function SafeWriteCommit%(TempPath$, FinalPath$, F)
+	Return True
+End Function
+
+Function SafeWriteAbort(TempPath$, F)
+End Function
+
+Include "Modules\Environment.bb"
+
+; TimeDelta is pure arithmetic over hour/minute pairs. The function has three
+; branches (same-hour, forward-in-day, wraps-past-midnight); pin each one so
+; later refactors of the day-cycle math can't drift the wall-clock delta the
+; rest of the engine relies on (script timers, sun position, etc.).
+
+Test testTimeDeltaWithinSameHourReturnsMinuteDifference()
+	Assert(TimeDelta(10, 5, 10, 30) = 25)
+	Assert(TimeDelta(0, 0, 0, 59) = 59)
+	Assert(TimeDelta(23, 10, 23, 10) = 0)
+End Test
+
+Test testTimeDeltaForwardInSameDayCrossesHourBoundary()
+	; 10:50 -> 11:05 = 15
+	Assert(TimeDelta(10, 50, 11, 5) = 15)
+	; 10:00 -> 12:00 = 120
+	Assert(TimeDelta(10, 0, 12, 0) = 120)
+	; 10:30 -> 11:00 = 30
+	Assert(TimeDelta(10, 30, 11, 0) = 30)
+End Test
+
+Test testTimeDeltaSpansMidnightWhenEndHourBeforeStartHour()
+	; 23:50 -> 00:10 = 20
+	Assert(TimeDelta(23, 50, 0, 10) = 20)
+	; 22:00 -> 01:00 = 180
+	Assert(TimeDelta(22, 0, 1, 0) = 180)
+End Test
+

--- a/src/Tests/Modules/SafeWriteTest.bb
+++ b/src/Tests/Modules/SafeWriteTest.bb
@@ -1,0 +1,132 @@
+Strict
+EnableGC
+
+; Exercise the real SafeWriteOpen / SafeWriteCommit / SafeWriteAbort in
+; Logging.bb against the working directory's filesystem. WriteLog needs
+; LogMode + MainLog globals to exist; default LogMode=0 keeps it quiet
+; so no Data\Logs directory is required.
+Global LogMode = 0
+Global MainLog = 0
+
+Include "Modules\Logging.bb"
+
+Global testDir$ = CurrentDir$()
+Global ProductionPath$ = testDir$ + "safewrite_test.dat"
+Global TempPathExpected$ = ProductionPath$ + ".tmp"
+Global BakPath$ = ProductionPath$ + ".bak"
+
+Function CleanupTestFiles()
+	If FileType(ProductionPath$) = 1 Then DeleteFile(ProductionPath$)
+	If FileType(TempPathExpected$) = 1 Then DeleteFile(TempPathExpected$)
+	If FileType(BakPath$) = 1 Then DeleteFile(BakPath$)
+End Function
+
+; Helper: write payload to path and close the handle. We close locally
+; (rather than letting SafeWriteCommit close) because Strict mode can't
+; bridge a BBStream local to SafeWriteCommit's untyped Int parameter --
+; passing F=0 tells the helper "I already closed it".
+Function SeedFile(path$, payload$)
+	Local s.BBStream = WriteFile(path$)
+	If s = Null Then Return
+	WriteString(s, payload$)
+	CloseFile(s)
+End Function
+
+Function SeedEmptyFile(path$)
+	Local s.BBStream = WriteFile(path$)
+	If s = Null Then Return
+	CloseFile(s)
+End Function
+
+Function ReadFileString$(path$)
+	Local s.BBStream = ReadFile(path$)
+	If s = Null Then Return ""
+	Local payload$ = ReadString(s)
+	CloseFile(s)
+	Return payload$
+End Function
+
+; SafeWriteOpen is a pure helper: it just appends .tmp to the final path.
+; Pin that contract -- callers rely on the temp name being deterministic
+; so cleanup paths (SafeWriteAbort) can target it.
+Test testSafeWriteOpenReturnsTempSuffixedPath()
+	Local temp$ = SafeWriteOpen$(ProductionPath$)
+	Assert(temp$ = ProductionPath$ + ".tmp")
+End Test
+
+; Happy path: write to temp, commit promotes the temp into production and
+; deletes the temp. No prior production file exists, so no .bak is made.
+Test testSafeWriteCommitPromotesTempToProductionOnFirstSave()
+	CleanupTestFiles()
+
+	Local temp$ = SafeWriteOpen$(ProductionPath$)
+	SeedFile(temp$, "first save payload")
+
+	Local ok% = SafeWriteCommit%(temp$, ProductionPath$, 0)
+
+	Assert(ok = True)
+	Assert(FileType(ProductionPath$) = 1)
+	Assert(FileType(temp$) <> 1) ; temp consumed
+	Assert(FileType(BakPath$) <> 1) ; no prior file -> no .bak
+
+	CleanupTestFiles()
+End Test
+
+; When a production file already exists, commit demotes it to .bak before
+; promoting the new temp. Lets a crash mid-promote recover the previous
+; version.
+Test testSafeWriteCommitDemotesPriorProductionToBak()
+	CleanupTestFiles()
+
+	SeedFile(ProductionPath$, "previous save")
+
+	Local temp$ = SafeWriteOpen$(ProductionPath$)
+	SeedFile(temp$, "newer save")
+
+	Local ok% = SafeWriteCommit%(temp$, ProductionPath$, 0)
+
+	Assert(ok = True)
+	Assert(FileType(ProductionPath$) = 1)
+	Assert(FileType(BakPath$) = 1) ; previous version preserved
+	Assert(FileType(temp$) <> 1)
+	Assert(ReadFileString$(BakPath$) = "previous save")
+	Assert(ReadFileString$(ProductionPath$) = "newer save")
+
+	CleanupTestFiles()
+End Test
+
+; Empty temp = silent WriteFile failure. SafeWriteCommit must refuse to
+; promote an empty file, otherwise production would be replaced with 0
+; bytes (which is the whole bug the helper exists to prevent).
+Test testSafeWriteCommitRefusesEmptyTemp()
+	CleanupTestFiles()
+
+	SeedFile(ProductionPath$, "must survive")
+
+	Local temp$ = SafeWriteOpen$(ProductionPath$)
+	SeedEmptyFile(temp$)
+
+	Local ok% = SafeWriteCommit%(temp$, ProductionPath$, 0)
+
+	Assert(ok = False)
+	Assert(FileType(ProductionPath$) = 1) ; production untouched
+	Assert(FileType(temp$) <> 1) ; empty temp deleted by commit
+	Assert(ReadFileString$(ProductionPath$) = "must survive")
+
+	CleanupTestFiles()
+End Test
+
+; SafeWriteAbort cleans up the temp when the caller decides not to commit
+; (e.g. a serialization error mid-write).
+Test testSafeWriteAbortRemovesTemp()
+	CleanupTestFiles()
+
+	Local temp$ = SafeWriteOpen$(ProductionPath$)
+	SeedFile(temp$, "abandoned")
+
+	Assert(FileType(temp$) = 1)
+	SafeWriteAbort(temp$)
+	Assert(FileType(temp$) <> 1)
+
+	CleanupTestFiles()
+End Test


### PR DESCRIPTION
First wave of broader server-module test coverage to land under the new CI workflow.

### EnvironmentTest.bb
Pins TimeDelta's three branches (same-hour, forward-in-day, wraps-past-midnight). Function is shared by every script timer + sun-position math; silent drift here drifts gameplay clock.

### SafeWriteTest.bb
End-to-end coverage of SafeWriteOpen / Commit / Abort against the working directory's filesystem:
- temp suffix contract is deterministic (Abort relies on it)
- first save promotes temp -> production, no .bak
- subsequent save demotes prior production to .bak before promoting; payload asserted on both
- empty temp is refused so production is never replaced with 0 bytes (the whole reason the helper exists)
- Abort cleans up the temp without touching production

Both run under the CI workflow merged in #85.

## Follow-up (not in this PR)
More server modules to cover in subsequent waves: Items (ItemInstanceFromString / ItemInstancesIdentical), Inventories slot management, MySQL ReadSQLField paths, ServerNet packet bounds. Doing it in waves so each test file is reviewable on its own.

## Test plan
- [ ] CI green on this PR
- [ ] `test.bat` passes locally (verified)