### PR TITLE
ci: cache BlitzForge bin + add status badge

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,17 +28,42 @@ jobs:
           # compile/test so we skip recursive to keep the checkout fast.
           submodules: true
 
+      # Cache the BlitzForge runtime binaries keyed on the submodule SHA.
+      # rcce2 PRs rarely change the BlitzForge pointer, so the common-case
+      # CI run avoids the ~3min MSBuild step entirely.
+      - name: Resolve BlitzForge submodule SHA
+        id: bf
+        shell: bash
+        run: echo "sha=$(git -C compiler/BlitzForge rev-parse HEAD)" >> "$GITHUB_OUTPUT"
+
+      - name: Restore BlitzForge bin from cache
+        id: bf-cache
+        uses: actions/cache@v4
+        with:
+          path: |
+            compiler/BlitzForge/bin/blitzcc.exe
+            compiler/BlitzForge/bin/runtime.dll
+            compiler/BlitzForge/bin/linker.dll
+            compiler/BlitzForge/bin/debugger.dll
+          key: blitzforge-bin-${{ runner.os }}-${{ steps.bf.outputs.sha }}
+
       - name: Add MSBuild to PATH
+        if: steps.bf-cache.outputs.cache-hit != 'true'
         uses: microsoft/setup-msbuild@v2
 
       - name: Build BlitzForge compiler
+        if: steps.bf-cache.outputs.cache-hit != 'true'
         shell: cmd
         working-directory: compiler/BlitzForge
         run: |
           call compile.bat
           if errorlevel 1 exit /b %errorlevel%
-          if not exist bin\blitzcc.exe (
-            echo BlitzForge compile.bat did not produce bin\blitzcc.exe
+
+      - name: Verify BlitzForge binaries are present
+        shell: cmd
+        run: |
+          if not exist compiler\BlitzForge\bin\blitzcc.exe (
+            echo blitzcc.exe missing after build/restore
             exit /b 1
           )
 

--- a/ReadMe.md
+++ b/ReadMe.md
@@ -11,6 +11,7 @@ RCCE picks up where the original RealmCrafter left off — modernized, cross-pla
 
 ---
 
+[![CI](https://github.com/RydeTec/rcce2/actions/workflows/ci.yml/badge.svg?branch=develop)](https://github.com/RydeTec/rcce2/actions/workflows/ci.yml?query=branch%3Adevelop)
 [![Latest Release](https://img.shields.io/github/v/release/RydeTec/rcce2?display_name=tag&sort=semver&color=2ea44f)](https://github.com/RydeTec/rcce2/releases/latest)
 [![Downloads](https://img.shields.io/github/downloads/RydeTec/rcce2/total?color=blue)](https://github.com/RydeTec/rcce2/releases)
 [![Stars](https://img.shields.io/github/stars/RydeTec/rcce2?style=flat&color=yellow)](https://github.com/RydeTec/rcce2/stargazers)


### PR DESCRIPTION
Caches `compiler/BlitzForge/bin/{blitzcc.exe,runtime.dll,linker.dll,debugger.dll}` keyed on the BlitzForge submodule SHA. rcce2 PRs rarely change that pointer, so common-case CI runs skip the ~3min MSBuild step and finish in seconds. Cache miss falls through to setup-msbuild + BlitzForge `compile.bat` as before.

Separate verify step asserts `blitzcc.exe` is present after either path so a poisoned cache fails fast.

Also adds a CI status badge to ReadMe for develop-branch visibility.

## Test plan
- [ ] First run on this PR: cache miss -> full build -> green
- [ ] Re-run / subsequent PR: cache hit -> fast green