### PR TITLE
fix: NOT-precedence bugs + un-track MySQL.dat with default creds (Track JJ)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -81,6 +81,8 @@ data/Server Data/Accounts.dat
 
 data/Server Data/Environment.dat
 
+data/Server Data/MySQL.dat
+
 .vscode/settings.json
 
 Game/

--- a/data/Server Data/MySQL.dat
+++ b/data/Server Data/MySQL.dat
@@ -1,5 +1,0 @@
-localhost
-root
-
-rc2
-3306

--- a/data/Server Data/MySQL.dat.example
+++ b/data/Server Data/MySQL.dat.example
@@ -1,0 +1,20 @@
+; MySQL connection settings for the rcce2 server. Copy this file to
+; `MySQL.dat` in this same directory and fill in your own credentials.
+;
+; The actual `MySQL.dat` is .gitignored so per-operator secrets don't
+; leak into the repo. The legacy default that shipped here was
+; `localhost / root / (empty password) / rc2 / 3306` -- replace with a
+; dedicated MySQL user that has only the privileges the rcce2 server
+; needs, never `root`.
+;
+; Format (one value per line, in order):
+;   1. Host
+;   2. User
+;   3. Password
+;   4. Database
+;   5. Port
+localhost
+rcce_user
+CHANGE_ME
+rc2
+3306

--- a/src/Modules/Framework/RCCEApp.bb
+++ b/src/Modules/Framework/RCCEApp.bb
@@ -39,7 +39,12 @@ Type RCCEApp
     Method version$()
         Local version$ = self\semMajor + "." + self\semMinor + "." + self\semPatch
 
-        If (NOT self\preReleasePhase = 0)
+        ; preReleasePhase is a string field but callers assign 0 to mean
+        ; "no pre-release". The previous form `If (NOT self\preReleasePhase = 0)`
+        ; parsed as `(NOT self\preReleasePhase) = 0` and happened to give the
+        ; intended behaviour because Blitz coerces "0" / "" to int 0, but
+        ; the spelling was a maintenance trap.
+        If self\preReleasePhase <> "" And self\preReleasePhase <> "0"
             version = version + "-" + self\preReleasePhase
 
             If (self\preReleaseCount > 0)

--- a/src/Modules/Helpers/Random.bb
+++ b/src/Modules/Helpers/Random.bb
@@ -22,7 +22,11 @@ Type Random
                 End If
             End If
         Else
-            If (NOT self\seed = seed)
+            ; Re-seed only when the value differs. The previous form
+            ; `If (NOT self\seed = seed)` parses as `(NOT self\seed) = seed`
+            ; (operator precedence), so re-seeding silently never fired
+            ; for any non-zero seed value.
+            If self\seed <> seed
                 self\seed = seed
                 SeedRnd(self\seed)
             End If

--- a/src/Modules/IO/File.bb
+++ b/src/Modules/IO/File.bb
@@ -11,10 +11,13 @@ Type File
     End Method
 
     Method close()
-        if (NOT self\stream = Null)
+        ; `If (NOT self\stream = Null)` accidentally evaluates to the
+        ; intended `<> Null` semantics (Null coerces to 0), but reads as
+        ; the opposite -- prefer the unambiguous spelling.
+        If self\stream <> Null
             CloseFile(self\stream)
             self\stream = Null
-        end if
+        End If
     End Method
 
     Method readLine$()

--- a/src/Tests/ExampleTest.bb
+++ b/src/Tests/ExampleTest.bb
@@ -6,5 +6,5 @@ Test test1()
     ;Assert(False) ; Fail
     DebugLog "You can inline asserts " + Assert(True) + " and false asserts " + Assert(NOT False)
     assert2 = Assert("this" = "this") ; Assert returns True if pass and False if fail.
-    assert3 = Assert(NOT "this" = "that")
+    assert3 = Assert("this" <> "that")
 End Test

--- a/src/Tests/Helpers/RandomTest.bb
+++ b/src/Tests/Helpers/RandomTest.bb
@@ -8,12 +8,16 @@ Test testRandom()
 
     local seed% = r\seed
     Assert(seed%)
-    Assert(NOT Random::i(r) = Random::i(r))
+    ; Two consecutive draws from the same RNG should almost never collide.
+    ; The previous form `NOT Random::i(r) = Random::i(r)` parsed as
+    ; `(NOT Random::i(r)) = Random::i(r)` and asserted a tautology --
+    ; the test passed for the wrong reason and never exercised the RNG.
+    Assert(Random::i(r) <> Random::i(r))
     Assert(seed = r\seed)
 
     Assert(Random::i())
-    Assert(NOT Random::f() = 0)
-    Assert(NOT Random::f() = Random::f())
+    Assert(Random::f() <> 0)
+    Assert(Random::f() <> Random::f())
 
     DebugLog("Random int: " + Random::i())
     DebugLog("Random float: " + Random::f())


### PR DESCRIPTION
Closes the highest-leverage findings from Round 4: a project-wide operator-precedence trap (`If NOT x = y` parses as `(NOT x) = y`) plus a tracked file leaking default MySQL credentials.

## Functional bugs
- **Random.bb re-seed** silently no-op'd after first call -- `(NOT old_seed) = new_seed` is essentially never true
- **RandomTest.bb** asserted tautologies; test passed for wrong reason (and is why the Random bug was never caught)
- **ExampleTest.bb** string inequality demo asserted nothing useful

## Clarity (semantics happen to be correct, but read backwards)
- File.bb `File::close` stream-presence check
- RCCEApp.bb preReleasePhase suffix gate

Other tracked `(NOT x = Null)` sites in Project Manager.bb, ComponentTest.bb, ListTest.bb are equivalent to intent (compared to Null/0); left alone for now.

## Secret leak
- `data/Server Data/MySQL.dat` shipped with `localhost / root / (empty pw) / rc2 / 3306` -- a "use root with no password" suggestion baked into the repo
- Un-tracked, gitignored, replaced with a documented `MySQL.dat.example`

## Test plan
- [ ] CI green
- [ ] `test.bat` passes locally (verified)