### PR TITLE
[RELIABILITY] save format bounds (Track DD)

### DIFF
--- a/src/Modules/AccountsServer.bb
+++ b/src/Modules/AccountsServer.bb
@@ -266,22 +266,31 @@ Function LoadAccounts()
 			Return 0
 		EndIf
 
-		; File does exist, read in all accounts
+		; File does exist, read in all accounts. Use ReadBoundedString$
+		; on every length-prefixed field so a corrupted / hostile save
+		; file with absurd length prefixes can't trigger 2GB allocations
+		; or read past EOF into silent zero-padded strings.
+		;   Usernames / passwords / emails: 256 bytes is a generous cap
+		;   QuestLog entry text: 1024 bytes
+		;   ActionBar slot text: 256 bytes
 		While Eof(F) = False
 			Accounts\TotalAccounts = Accounts\TotalAccounts + 1
 			A.Account = New Account
-			A\User$ = ReadString$(F)
-			A\Pass$ = ReadString$(F)
-			A\Email$ = ReadString$(F)
+			A\User$ = ReadBoundedString$(F, 256)
+			A\Pass$ = ReadBoundedString$(F, 256)
+			A\Email$ = ReadBoundedString$(F, 256)
 			A\IsDM = ReadByte(F)
 			A\IsBanned = ReadByte(F)
-			A\Ignore$ = ReadString$(F)
+			A\Ignore$ = ReadBoundedString$(F, 4096)
 			A\LoggedOn = -1
 			AddListBoxItem Accounts\List, FormatAccountListEntry$(A\IsDM, A\IsBanned, A\LoggedOn, A\User$, A\Email$)
 			If A\IsBanned Then Accounts\TotalBanned = Accounts\TotalBanned + 1
 			If A\IsDM Then Accounts\TotalDMs = Accounts\TotalDMs + 1
 			A\ListID = CountGadgetItems(Accounts\List) - 1
 			Chars = ReadByte(F)
+			; Bound the character count -- a corrupted file with 255 in
+			; this slot would read 255 character blobs, walking past EOF.
+			If Chars > 10 Then Chars = 10
 			For i = 1 To Chars
 				A\Character[i - 1] = ReadActorInstance(F)
 				; Previously this dereferenced A\Character[i - 1]\Account
@@ -296,12 +305,17 @@ Function LoadAccounts()
 				EndIf
 				A\QuestLog[i - 1] = New QuestLog
 				For j = 0 To 499
-					A\QuestLog[i - 1]\EntryName$[j] = ReadString$(F)
-					A\QuestLog[i - 1]\EntryStatus$[j] = ReadString$(F)
+					; Bail the per-character QuestLog block on early EOF so we
+					; don't fill the remaining 500 - j slots with zero-padded
+					; strings consumed off the end of the file.
+					If Eof(F) Then Exit
+					A\QuestLog[i - 1]\EntryName$[j] = ReadBoundedString$(F, 1024)
+					A\QuestLog[i - 1]\EntryStatus$[j] = ReadBoundedString$(F, 1024)
 				Next
 				A\ActionBar[i - 1] = New ActionBarData
 				For j = 0 To 35
-					A\ActionBar[i - 1]\Slots$[j] = ReadString$(F)
+					If Eof(F) Then Exit
+					A\ActionBar[i - 1]\Slots$[j] = ReadBoundedString$(F, 256)
 				Next
 				If A\Character[i - 1] = Null Then Delete A\QuestLog[i - 1] : Delete A\ActionBar[i - 1]
 			Next

--- a/src/Modules/Items.bb
+++ b/src/Modules/Items.bb
@@ -143,8 +143,16 @@ Function ReadItemInstance.ItemInstance(Stream)
 		I\ItemHealth = ReadByte(Stream)
 	Else
 		WriteLog(MainLog, "Item not found: Item with ID " + ID + " has been found during the character loading.!")
-		; Jump the block
-		SeekFile( stream, FilePos(stream) + 40*2 + 1)
+		; Consume the 40 attribute shorts + 1 health byte one read at a
+		; time so EOF stops us rather than the SeekFile silently moving
+		; the cursor past the end of the file (which would then surface
+		; on the next ReadShort as a silent zero).
+		Local k
+		For k = 0 To 39
+			If Eof(Stream) Then Exit
+			ReadShort(Stream)
+		Next
+		If Not Eof(Stream) Then ReadByte(Stream)
 	EndIf
 	Return I
 

--- a/src/Modules/Logging.bb
+++ b/src/Modules/Logging.bb
@@ -72,6 +72,37 @@ Function SafeWriteAbort(TempPath$)
 	If FileType(TempPath$) = 1 Then DeleteFile(TempPath$)
 End Function
 
+; --- Bounded ReadString --------------------------------------------------
+;
+; Blitz3D's ReadString$ reads a 4-byte length prefix and then that many
+; bytes. A truncated, corrupted, or hostile save file with a wild length
+; (negative, or e.g. 0x7FFFFFFF) makes the runtime try to allocate gigs
+; of memory and read past EOF -- which Blitz silently zero-fills,
+; producing huge empty-padding strings that then propagate through the
+; rest of the load.
+;
+; ReadBoundedString$ peeks the length prefix as an Int, refuses lengths
+; outside [0, MaxLen], and reads the bytes manually. On a bad length it
+; logs once via MainLog (caller is expected to bail the surrounding load
+; if they care about partial-state corruption -- the function itself
+; just returns "" so the caller can detect the failure).
+Function ReadBoundedString$(F, MaxLen)
+	If F = 0 Then Return ""
+	Local L = ReadInt(F)
+	If L < 0 Or L > MaxLen
+		WriteLog(MainLog, "ReadBoundedString: length " + L + " out of range (cap " + MaxLen + "), refusing to read")
+		Return ""
+	EndIf
+	If L = 0 Then Return ""
+	Local s$ = ""
+	Local i
+	For i = 1 To L
+		If Eof(F) Then Exit
+		s$ = s$ + Chr$(ReadByte(F))
+	Next
+	Return s$
+End Function
+
 ; Cached debug-log handle. WriteLog used to call StartLog+StopLog every
 ; entry under LogMode>0, which opens, writes one line, and closes the
 ; DEBUG log per call — a serious IO load. Hold the handle for the life

--- a/src/Tests/Modules/AccountsServerTest.bb
+++ b/src/Tests/Modules/AccountsServerTest.bb
@@ -84,6 +84,10 @@ End Function
 Function SafeWriteAbort(TempPath$, F)
 End Function
 
+Function ReadBoundedString$(F, MaxLen)
+	Return ""
+End Function
+
 Include "Modules\AccountsServer.bb"
 
 Test testFindAccountByListIDReturnsMatchingAccount()


### PR DESCRIPTION
Round 4 finding #6, #7, #8, #9: every save-format loader trusts the file completely. A corrupted, truncated, or hostile file silently allocates gigabytes (length prefix > 2^31) or reads past EOF (Blitz zero-fills) and produces silently-broken state across the rest of the load.

## Logging.bb
New `ReadBoundedString$(F, MaxLen)` helper -- peeks the 4-byte length prefix, refuses lengths outside `[0, MaxLen]`, reads bytes manually with per-byte `Eof` checks.

## AccountsServer.LoadAccounts
- Every `ReadString$` replaced with `ReadBoundedString$` + per-field cap
- Character count clamped to 10 (was a 1-byte 0..255 from disk that drove the outer loop)
- QuestLog + ActionBar inner loops `Eof`-bail mid-character

## Items.ReadItemInstance
The unknown-item-ID skip path used `SeekFile(pos + 81)` which moves past EOF on a malformed save and surfaces silent zero reads on the next call. Replaced with explicit `ReadShort` / `ReadByte` loops gated on `Eof`.

## Test plan
- [ ] CI green
- [ ] `test.bat` passes (verified)
- [ ] Manual: hex-edit Accounts.dat to set a username length prefix to `0x7FFFFFFF` -> log line + bail, not a 2GB allocation