### PR TITLE
[EDITOR] atomic save sweep + Gubbin .eb3d doc + GUE guard (Track FF)

### DIFF
--- a/src/GUE.bb
+++ b/src/GUE.bb
@@ -3437,6 +3437,10 @@ Cls
 			; Allow new account creation from client
 			Case BNewAccounts
 				F = WriteFile("Data\Game Data\Hosts.dat")
+				; Match the F=0 guard that the surrounding TServerHost /
+				; TUpdatesHost cases use. Without it, WriteLine on a 0
+				; handle null-derefs and crashes the editor.
+				If F = 0 Then RuntimeError("Could not open Data\Game Data\Hosts.dat!")
 					WriteLine F, FUI_SendMessage(TServerHost, M_GETCAPTION)
 					WriteLine F, FUI_SendMessage(TUpdatesHost, M_GETCAPTION)
 					WriteLine F, FUI_SendMessage(BNewAccounts, M_GETCHECKED)

--- a/src/Tools/Gubbin Tool.bb
+++ b/src/Tools/Gubbin Tool.bb
@@ -787,13 +787,19 @@ Function SaveAll()
 
 End Function
 
-; Updates the B3D file of the current mesh with its rotation
+; Updates the B3D file of the current mesh with its rotation.
+;
+; Note: .eb3d (encrypted Blitz3D) rotation editing is not fully supported
+; in this build -- EncryptMesh below is empty, so any rotation save on an
+; encrypted mesh writes the rotated vertices to a sibling foo.eb3d.b3d
+; file (the DecryptMesh scratch output) and leaves the original .eb3d
+; untouched. Callers should treat .eb3d rotation as a no-op until the
+; encryption pipeline is restored.
 Function SaveRotation(TargetMeshID)
 
 	Local TName$ = ""
 	Local Name$ = ""
-	Local isEncrypted = False
-	
+
 	If PreviewMesh <> 0
 		Name$ = EditorMeshName$(TargetMeshID)
 		If Right$(Upper$(Name$), 3) = "B3D" Then
@@ -801,7 +807,6 @@ Function SaveRotation(TargetMeshID)
 				TName$ = Name$
 				DecryptMesh("Data\Meshes\" + Name$)
 				Name$ = Name$ + ".b3d"
-				;isEncrypted = True
 			End If
 		Else
 			Return
@@ -889,13 +894,16 @@ Function SaveRotation(TargetMeshID)
 	
 	
 ; REMOVE FOR DECRYPT SIREDBLOOD SAYS MUHAHAHA #######################
-	
+;
+; Re-encrypt path retired: the isEncrypted gate was always False (its
+; setter at line 804 was commented out), and EncryptMesh below has been
+; an empty function for the lifetime of this tool. The branch only ran
+; to delete the just-written .b3d sidecar; without re-encryption the
+; .eb3d would have been the stale original anyway. See header comment
+; on SaveRotation -- .eb3d rotation is documented as a no-op until the
+; encryption pipeline is restored.
+
 	Name$ = EditorMeshName$(TargetMeshID)
-	
-	If TName$ <> "" And isEncrypted Then
-		EncryptMesh("Data\Meshes\" + Name$)
-		DeleteFile "Data\Meshes\" + Name$
-	End If
 
 ;#####################################################################
 

--- a/src/Tools/RC Architect.BB
+++ b/src/Tools/RC Architect.BB
@@ -1550,12 +1550,24 @@ If FileType(fname$)<>1 Then Return -1
  EndIf
 
 ;wite to file
-; Newf=WriteFile(newn$)
-DeleteFile (fname$)
- Fsave=WriteFile(fname$)
- b=PeekByte(thisbank,i)
- WriteBytes thisbank,fsave,0,offset
- CloseFile fsave
+; Write to .tmp first so a failed WriteFile can't wipe the source.
+TmpPath$ = fname$ + ".tmp"
+If FileType(TmpPath$) = 1 Then DeleteFile(TmpPath$)
+Fsave = WriteFile(TmpPath$)
+If Fsave = 0
+	FreeBank thisbank
+	Return -1
+EndIf
+WriteBytes thisbank, fsave, 0, offset
+CloseFile fsave
+If FileSize(TmpPath$) <> offset
+	DeleteFile(TmpPath$)
+	FreeBank thisbank
+	Return -1
+EndIf
+DeleteFile(fname$)
+CopyFile TmpPath$, fname$
+DeleteFile(TmpPath$)
 
 ; WriteBytes thisbank,newf,0,ts
 ; CloseFile newf

--- a/src/Tools/RC Caves Editor.BB
+++ b/src/Tools/RC Caves Editor.BB
@@ -2921,12 +2921,24 @@ If FileType(fname$)<>1 Then Return -1
  EndIf
 
 ;wite to file
-; Newf=WriteFile(newn$)
-DeleteFile (fname$)
- Fsave=WriteFile(fname$)
- b=PeekByte(thisbank,i)
- WriteBytes thisbank,fsave,0,offset
- CloseFile fsave
+; Write to .tmp first so a failed WriteFile can't wipe the source.
+TmpPath$ = fname$ + ".tmp"
+If FileType(TmpPath$) = 1 Then DeleteFile(TmpPath$)
+Fsave = WriteFile(TmpPath$)
+If Fsave = 0
+	FreeBank thisbank
+	Return -1
+EndIf
+WriteBytes thisbank, fsave, 0, offset
+CloseFile fsave
+If FileSize(TmpPath$) <> offset
+	DeleteFile(TmpPath$)
+	FreeBank thisbank
+	Return -1
+EndIf
+DeleteFile(fname$)
+CopyFile TmpPath$, fname$
+DeleteFile(TmpPath$)
 
 ; WriteBytes thisbank,newf,0,ts
 ; CloseFile newf

--- a/src/Tools/RC Rock Editor.bb
+++ b/src/Tools/RC Rock Editor.bb
@@ -814,12 +814,26 @@ If FileType(fname$)<>1 Then Return -1
  EndIf
 
 ;wite to file
-; Newf=WriteFile(newn$)
-DeleteFile (fname$)
- Fsave=WriteFile(fname$)
- b=PeekByte(thisbank,i)
- WriteBytes thisbank,fsave,0,offset
- CloseFile fsave
+; Write to a .tmp first so a WriteFile failure can't leave the user
+; with nothing on disk — the previous DeleteFile-then-WriteFile order
+; would have wiped the source if the target path was no longer writable.
+TmpPath$ = fname$ + ".tmp"
+If FileType(TmpPath$) = 1 Then DeleteFile(TmpPath$)
+Fsave = WriteFile(TmpPath$)
+If Fsave = 0
+	FreeBank thisbank
+	Return -1
+EndIf
+WriteBytes thisbank, fsave, 0, offset
+CloseFile fsave
+If FileSize(TmpPath$) <> offset
+	DeleteFile(TmpPath$)
+	FreeBank thisbank
+	Return -1
+EndIf
+DeleteFile(fname$)
+CopyFile TmpPath$, fname$
+DeleteFile(TmpPath$)
 
 ; WriteBytes thisbank,newf,0,ts
 ; CloseFile newf

--- a/src/Tools/RC Tree Editor.BB
+++ b/src/Tools/RC Tree Editor.BB
@@ -2660,12 +2660,24 @@ If FileType(fname$)<>1 Then Return -1
  EndIf
 
 ;wite to file
-; Newf=WriteFile(newn$)
-DeleteFile (fname$)
- Fsave=WriteFile(fname$)
- b=PeekByte(thisbank,i)
- WriteBytes thisbank,fsave,0,offset
- CloseFile fsave
+; Write to .tmp first so a failed WriteFile can't wipe the source.
+TmpPath$ = fname$ + ".tmp"
+If FileType(TmpPath$) = 1 Then DeleteFile(TmpPath$)
+Fsave = WriteFile(TmpPath$)
+If Fsave = 0
+	FreeBank thisbank
+	Return -1
+EndIf
+WriteBytes thisbank, fsave, 0, offset
+CloseFile fsave
+If FileSize(TmpPath$) <> offset
+	DeleteFile(TmpPath$)
+	FreeBank thisbank
+	Return -1
+EndIf
+DeleteFile(fname$)
+CopyFile TmpPath$, fname$
+DeleteFile(TmpPath$)
 
 ; WriteBytes thisbank,newf,0,ts
 ; CloseFile newf


### PR DESCRIPTION
Round 4 audit found the encrypt-output path in 4 RC mesh editors (Rock, Architect, Caves, Tree) still used `DeleteFile(fname)` followed by `WriteFile(fname)`. A crash or transient write failure between the two destroyed the user's mesh with no backup. RCTE already got the .tmp+swap pattern in Round 3; this PR applies it to the other four.

Plus two smaller items:
- **Gubbin Tool .eb3d:** `SaveRotation`'s `isEncrypted` was always False (setter commented out) and `EncryptMesh` has been an empty stub for the tool's lifetime, so .eb3d rotation edits wrote to a sidecar and left the original untouched. Documented the limitation and removed the dead branch.
- **GUE BNewAccounts:** added the F=0 guard that the surrounding TServerHost / TUpdatesHost cases use.

Deferred (note in commit body): GUE has another ~10 direct-write sites that warrant their own atomic-save pass.

## Test plan
- [ ] CI green
- [ ] `test.bat` passes (verified)
- [ ] Manual: simulate a write failure in any of the 4 editors (e.g. read-only target) -> tmp lingers but production untouched