### PR TITLE
[CLIENT] music leak + gravity + Media polish (Track KK)

### DIFF
--- a/src/Modules/ClientNet.bb
+++ b/src/Modules/ClientNet.bb
@@ -4,6 +4,11 @@ Global TradeMsg1$, TradeMsg2$, TradeMsg3$
 Global newEntityX#,newEntityY#,newEntityZ#
 Global oldEntityX#,oldEntityY#,oldEntityZ#
 
+; Track the currently-playing P_Music handles so the next P_Music can
+; release them. Used to leak one sound and one channel per zone change.
+Global CurrentMusicSound = 0
+Global CurrentMusicChannel = 0
+
 ; Connects to the server
 Function Connect()
 
@@ -635,13 +640,22 @@ Function UpdateNetwork()
 					If Channel <> 0 Then ChannelVolume(Channel, DefaultVolume#)
 				EndIf
 
-			; Music
+			; Music. Each P_Music packet loads and starts looping a sound;
+			; the previous code never stopped the prior channel or freed
+			; the prior sound handle, so every zone-transition leaked one
+			; sound and one channel for the life of the session.
 			Case P_Music
 				Name$ = GetMusicName$(RCE_IntFromStr(Mid$(M\MessageData$, 1, 2)))
-				Loaded = LoadSound("Data\Music\" + Name$, False)
-				LoopSound Loaded
-				Channel = PlaySound(Loaded)
-				If Channel <> 0 Then ChannelVolume(Channel, DefaultVolume#)
+				If CurrentMusicChannel <> 0 Then StopChannel CurrentMusicChannel
+				If CurrentMusicSound <> 0 Then FreeSound CurrentMusicSound
+				CurrentMusicChannel = 0
+				CurrentMusicSound = 0
+				CurrentMusicSound = LoadSound("Data\Music\" + Name$, False)
+				If CurrentMusicSound <> 0
+					LoopSound CurrentMusicSound
+					CurrentMusicChannel = PlaySound(CurrentMusicSound)
+					If CurrentMusicChannel <> 0 Then ChannelVolume(CurrentMusicChannel, DefaultVolume#)
+				EndIf
 
 			; Particles effect
 			Case P_CreateEmitter
@@ -1457,7 +1471,14 @@ Function UpdateNetwork()
 				Yaw# = RCE_FloatFromStr#(Mid$(M\MessageData$, 13, 4))
 				PvPEnabled = RCE_IntFromStr(Mid$(M\MessageData$, 17, 1))
 				Grav = RCE_IntFromStr(Mid$(M\MessageData$, 18, 2))
-				Gravity# = 0.05 * Float#((Grav - 200) / 100)
+				; The original `Float#((Grav - 200) / 100)` did integer
+				; division before promotion, so Grav = 250 rounded to 0
+				; (instead of 0.5) and Grav = 0 produced -0.1 (negative
+				; gravity, players launched skyward). Convert to float
+				; before division and clamp to a sane physical range.
+				Gravity# = 0.05 * (Float#(Grav - 200) / 100.0)
+				If Gravity# < -2.0 Then Gravity# = -2.0
+				If Gravity# > 2.0 Then Gravity# = 2.0
 				CurrentAreaID = RCE_IntFromStr(Mid$(M\MessageData$, 20, 4))
 				NameLen = RCE_IntFromStr(Mid$(M\MessageData$, 25, 1))
 				AreaName$ = Mid$(M\MessageData$, 26, NameLen)

--- a/src/Modules/Media.bb
+++ b/src/Modules/Media.bb
@@ -483,9 +483,12 @@ Function AddMusicToDatabase(Filename$)
 	SeekFile F, (65535 * 4)
 	While Eof(F) = False
 		Name$ = ReadString$(F)
-		; If this music is already in the file, return error
+		; If this music is already in the file, return error. Previously
+		; the dup branch closed the file but then fell through to the
+		; insert path below -- so every duplicate was added a second time.
 		If Upper$(Name$) = Upper$(Filename$)
 			If LockedMusic = 0 Then CloseFile(F)
+			Return -1
 		EndIf
 	Wend
 
@@ -762,6 +765,13 @@ Function GetMesh(ID, Duplicate = False)
 		Name$ = ReadString$(F)
 
 		If LockedMeshes = 0 Then CloseFile(F)
+
+		; Reject path-traversal in Meshes.dat-stored names. The update
+		; channel can rewrite Meshes.dat, so a hostile update payload could
+		; plant `..\..\<x>` and force a LoadMesh on an arbitrary file.
+		; LoadMesh would mostly return 0 on miss, but the attempt itself is
+		; the wrong shape -- bail before we touch the filesystem.
+		If Instr(Name$, "..") > 0 Then Return 0
 
 		; Load the mesh
 		If IsAnim = True


### PR DESCRIPTION
Round 4 client-hygiene grab-bag. Four independent fixes:

- **P_Music handle leak** -- each zone-change packet loaded a new sound + started a new channel without releasing the previous ones. New `CurrentMusicSound` / `CurrentMusicChannel` globals track live handles so the next P_Music stops and frees them
- **Gravity integer-division bug** -- `Float#((Grav - 200) / 100)` did integer division before float promotion (Grav=250 rounded to 0, Grav=0 -> -0.1 -> players launched skyward). Convert to float first, clamp final to `[-2.0, 2.0]`
- **Media.GetMesh path-traversal** -- mesh names read out of Meshes.dat (which the update channel can rewrite) now reject names containing `..` before passing to LoadMesh
- **Media.AddMusicToDatabase dedup bug** -- when a duplicate was found, the dup branch closed the file but fell through to the insert path (so duplicates were added twice). Mirrored the AddMeshToDatabase pattern with `Return -1` in the branch

## Test plan
- [ ] CI green
- [ ] `test.bat` passes (verified)
- [ ] Manual: traverse 10 zones in sequence, watch sound handle count stay flat