### PR TITLE
[RELIABILITY] PM Misc.dat + ServerSaveArea + SaveSuns + safeCopyFile (atomic save sweep cont'd)

### DIFF
--- a/src/Modules/ClientAreas.bb
+++ b/src/Modules/ClientAreas.bb
@@ -800,10 +800,14 @@ Function LoadArea(Name$, CameraEN, DisplayItems = False, UpdateRottNet = False)
 
 End Function
 
-; Saves the current area back to file
+; Saves the current area back to file. Atomic rewrite via SafeWrite:
+; a crash mid-flush previously truncated the area file and broke load
+; on the next area entry.
 Function SaveArea(Name$)
 
-	F = WriteFile("Data\Areas\" + Name$ + ".dat")
+	Local FinalPath$ = "Data\Areas\" + Name$ + ".dat"
+	Local TempPath$ = SafeWriteOpen(FinalPath$)
+	F = WriteFile(TempPath$)
 	If F = 0 Then Return False
 
 		; Loading screen
@@ -953,8 +957,7 @@ Function SaveArea(Name$)
 			WriteByte F, SZ\Volume
 		Next
 
-	CloseFile(F)
-	Return True
+	Return SafeWriteCommit(TempPath$, FinalPath$, F)
 
 End Function
 

--- a/src/Modules/Environment.bb
+++ b/src/Modules/Environment.bb
@@ -249,25 +249,33 @@ Function LoadSuns()
 
 End Function
 
-; Saves sun settings
+; Saves sun settings atomically. Crash mid-write previously left
+; Suns.dat truncated -- LoadSuns would then read a wrong sun count
+; and either skip suns or read garbage for the trailing entries.
 Function SaveSuns()
 
-	F = WriteFile("Data\Game Data\Suns.dat")
+	Local FinalPath$ = "Data\Game Data\Suns.dat"
+	Local TempPath$ = SafeWriteOpen(FinalPath$)
+	F = WriteFile(TempPath$)
+	If F = 0
+		WriteLog(MainLog, "SaveSuns: cannot open " + TempPath$ + " for write")
+		Return False
+	EndIf
 
 		Count = 0
 		For S.Sun = Each Sun : Count = Count + 1 : Next
 		WriteInt(F, Count)
 		For S.Sun = Each Sun
-		
+
 		;WriteShort(F, S\TexID)
-		
+
 			For i = 0 To 7
 				WriteShort(F, S\TexID[i])
 			Next
-			
+
 			WriteByte(F, S\ShowPhases)
 			WriteByte(F, S\Phase_Length)
-		
+
 			WriteFloat(F, S\Size#)
 			WriteByte(F, S\LightR)
 			WriteByte(F, S\LightG)
@@ -282,7 +290,7 @@ Function SaveSuns()
 			WriteByte(F, S\ShowFlares)
 		Next
 
-	CloseFile(F)
+	Return SafeWriteCommit(TempPath$, FinalPath$, F)
 
 End Function
 

--- a/src/Modules/IO/Filesystem.bb
+++ b/src/Modules/IO/Filesystem.bb
@@ -3,13 +3,39 @@ Strict
 Include "Modules\IO\File.bb"
 
 Type Filesystem
-	; Copies a file, but deletes the destination first if it already exists
+	; Copies a file atomically. The previous implementation (DeleteFile
+	; destination, then CopyFile source -> destination) was not safe at
+	; all -- a crash, lock, or disk-full between the two left the caller
+	; with no destination. Used by GenerateFullInstall / GenerateServer
+	; to assemble release artefacts, so an aborted publish would silently
+	; produce a broken release.
+	;
+	; Pattern: copy to {ToFile}.tmp, verify size, swap in. A crash mid-
+	; sequence leaves either the original ToFile intact (early failure)
+	; or the .tmp on disk for manual recovery (late failure).
 	Method safeCopyFile(FromFile$, ToFile$)
 
-		If FileType(FromFile$) = 1
-			If FileType(ToFile$) = 1 Then DeleteFile(ToFile$)
-			CopyFile(FromFile$, ToFile$)
+		If FileType(FromFile$) <> 1 Then Return
+
+		Local TmpFile$ = ToFile$ + ".tmp"
+		If FileType(TmpFile$) = 1 Then DeleteFile(TmpFile$)
+
+		CopyFile(FromFile$, TmpFile$)
+		If FileType(TmpFile$) <> 1 Then Return
+		If FileSize(TmpFile$) <> FileSize(FromFile$)
+			DeleteFile(TmpFile$)
+			Return
 		EndIf
+
+		If FileType(ToFile$) = 1 Then DeleteFile(ToFile$)
+		CopyFile(TmpFile$, ToFile$)
+		If FileType(ToFile$) <> 1
+			; Promote failed -- try to roll back from the still-present
+			; temp. Caller's destination is now missing either way.
+			CopyFile(TmpFile$, ToFile$)
+			Return
+		EndIf
+		DeleteFile(TmpFile$)
 
 	End Method
 

--- a/src/Modules/ServerAreas.bb
+++ b/src/Modules/ServerAreas.bb
@@ -272,11 +272,20 @@ Function ServerLoadArea.Area(Name$)
 
 End Function
 
-; Saves the server data for an area
+; Saves the server data for an area.
+;
+; Atomic rewrite: writes to <area>.dat.tmp first; on success demotes
+; the existing area file to <area>.dat.bak and promotes the temp. A
+; crash mid-write previously left the area file truncated -- areas
+; hold NPC spawn data, scripts, waypoints, weather configuration,
+; trigger volumes; a 0-byte save was a meaningful data loss every
+; time the server crashed during a save flush.
 Function ServerSaveArea(A.Area)
 
 	; Save map data
-	F = WriteFile("Data\Server Data\Areas\" + A\Name$ + ".dat")
+	Local FinalPath$ = "Data\Server Data\Areas\" + A\Name$ + ".dat"
+	Local TempPath$ = SafeWriteOpen(FinalPath$)
+	F = WriteFile(TempPath$)
 	If F = 0 Then Return False
 
 		For i = 0 To 4 : WriteByte F, A\WeatherChance[i] : Next
@@ -343,7 +352,7 @@ Function ServerSaveArea(A.Area)
 			EndIf
 		Next
 
-	CloseFile(F)
+	If Not SafeWriteCommit(TempPath$, FinalPath$, F) Then Return False
 
 	;ServerSaveAreaOwnerships(A) {##}
 

--- a/src/Project Manager.bb
+++ b/src/Project Manager.bb
@@ -442,12 +442,31 @@ Repeat
 		Case BCLOSE
 			app\Quit = True
 		Case ProName
-			local F.BBStream = WriteFile("Data\Game Data\Misc.dat")
-			If F = Null Then RuntimeError("Could not open Data\Game Data\Misc.dat!")
+			; Atomic rewrite: previous direct-WriteFile truncated and
+			; started writing immediately, so any crash between WriteFile
+			; and CloseFile (operator clicks Quit, AV scan, disk full)
+			; left the project's core metadata file with whatever bytes
+			; had landed -- typically empty. Write to .tmp, then on
+			; success demote current Misc.dat to .bak and swap in.
+			local MiscFinal$ = "Data\Game Data\Misc.dat"
+			local MiscTemp$ = MiscFinal + ".tmp"
+			local F.BBStream = WriteFile(MiscTemp)
+			If F = Null Then RuntimeError("Could not open " + MiscTemp + " for write")
 			WriteLine F, FUI_SendMessage(ProName, M_GETCAPTION)
 			WriteLine F, UpdateGame$
 			WriteLine F, UpdateMusic
 			CloseFile(F)
+			If FileSize(MiscTemp) > 0
+				If FileType(MiscFinal) = 1
+					If FileType(MiscFinal + ".bak") = 1 Then DeleteFile(MiscFinal + ".bak")
+					CopyFile(MiscFinal, MiscFinal + ".bak")
+					DeleteFile(MiscFinal)
+				EndIf
+				CopyFile(MiscTemp, MiscFinal)
+				DeleteFile(MiscTemp)
+			Else
+				DeleteFile(MiscTemp)
+			EndIf
 		Case M_Meshes
 			ExecFile(OMF$)
 		Case M_Textures


### PR DESCRIPTION
Continuation of the atomic-save sweep started in Track FF + GUE PR #97. Four more sites now safe under crash / disk-full / lock during write:

### `Project Manager.bb` -- Misc.dat
`ProName` text-box edit case wrote directly to Misc.dat. A crash between WriteFile and CloseFile (operator clicks Quit, AV scan, disk full) left the project's core metadata file empty. PM doesn't include Logging.bb so the swap body is inlined.

### `Filesystem::safeCopyFile`
"Safe" wrapper was `DeleteFile(dest) ; CopyFile(src, dest)` -- not safe at all. Used by `GenerateFullInstall` / `GenerateServer` to assemble release artefacts; an aborted publish silently produced a broken release. Now writes to `{dest}.tmp`, validates size matches source, swaps in.

### `ServerAreas::ServerSaveArea`
Per-area .dat under `Data/Server Data/Areas/`. Holds NPC spawn data, trigger volumes, scripts, weather config, 2000 waypoints per area. A 0-byte file after a crash mid-flush silently dropped all of it on next load. Routed through `SafeWriteOpen` / `SafeWriteCommit`.

### `Environment::SaveSuns`
`Suns.dat` holds the sun-table count then per-sun config. A truncated file caused `LoadSuns` to read a wrong count and skip or garbage-read trailing entries. Same atomic swap.

## Test plan
- [ ] CI green
- [ ] `test.bat` passes (verified)