### PR TITLE
[SECURITY] speed-hack clamp on P_StandardUpdate (Track PP)

### DIFF
--- a/src/Modules/Actors.bb
+++ b/src/Modules/Actors.bb
@@ -76,6 +76,10 @@ Type ActorInstance
 	Field X#, Y#, Z#
 	Field OldX#, OldZ#
 	Field DestX#, DestZ#
+	; Timestamp (MilliSecs) of the last P_StandardUpdate the server
+	; accepted from this actor. Used to bound per-packet movement
+	; deltas against actor Speed so the client can't teleport-hack.
+	Field LastPosUpdateMs%
 	Field Yaw#
 	Field WalkingBackward
 	Field Area$, ServerArea, Account

--- a/src/Modules/ServerNet.bb
+++ b/src/Modules/ServerNet.bb
@@ -1409,14 +1409,48 @@ Function UpdateNetwork()
 						; Players cannot run backwards, this will prevent cheaters from doing so
 						If AI\WalkingBackward = True Then AI\IsRunning = False
 
-						; Adjust to new x/z if they are less far than expected (i.e. client has undergone collision)
-						; Cannot just replace values because client could then lie about the values for an easy speed cheat!
-						;DistX# = Abs(NewX# - AI\OldX#)
-						;If DistX# < Abs(AI\X# - AI\OldX#) Then AI\X# = NewX#
-						;DistZ# = Abs(NewZ# - AI\OldZ#)
-						;If DistZ# < Abs(AI\Z# - AI\OldZ#) Then AI\Z# = NewZ#
-						AI\X# = NewX#
-						AI\Z# = NewZ#
+						; Speed-hack clamp: bound the per-packet position delta
+						; against actor's Speed attribute scaled by elapsed time
+						; since the previous accepted update. Without this the
+						; client can teleport arbitrarily within ClampWorldCoord
+						; bounds between updates, defeating PvP positioning
+						; checks and movement-based triggers. Tolerance factor
+						; covers lag spikes, collision shove-back, and the
+						; 1.5x base unit-per-tick coefficient that GameServer
+						; uses for server-driven movement.
+						Local NowMs% = MilliSecs()
+						Local ElapsedMs% = NowMs - AI\LastPosUpdateMs
+						If AI\LastPosUpdateMs = 0 Or ElapsedMs < 0 Or ElapsedMs > 5000
+							; First update for this actor, or clock skew, or
+							; a lag spike longer than 5s: accept the position
+							; this time and re-baseline.
+							AI\X# = NewX#
+							AI\Z# = NewZ#
+						Else
+							Local SpeedAttr# = 1.0
+							If AI\Attributes\Maximum[SpeedStat] > 0
+								SpeedAttr# = Float#(AI\Attributes\Value[SpeedStat]) / Float#(AI\Attributes\Maximum[SpeedStat])
+							EndIf
+							; Base unit/ms (matches GameServer's 1.5 base unit/tick
+							; for AI movement; assume ~50ms tick i.e. /50 -> /33 with
+							; a 1.5x running and 3x lag tolerance fold-in).
+							Local MaxUnitsPerMs# = 0.15 * (SpeedAttr# + 0.5)
+							Local MaxDelta# = MaxUnitsPerMs# * Float#(ElapsedMs)
+							If MaxDelta# < 2.0 Then MaxDelta# = 2.0
+							Local DX# = NewX# - AI\X#
+							Local DZ# = NewZ# - AI\Z#
+							Local Dist# = Sqr#(DX# * DX# + DZ# * DZ#)
+							If Dist# > MaxDelta#
+								; Too fast: hold the client at the prior position.
+								; The next update will look like the client agreed.
+								; Client will re-sync to server state on next
+								; reposition broadcast.
+							Else
+								AI\X# = NewX#
+								AI\Z# = NewZ#
+							EndIf
+						EndIf
+						AI\LastPosUpdateMs = NowMs
 						AI\OldX# = AI\X#
 						AI\OldZ# = AI\Z#
 

--- a/src/Modules/ServerNet.bb
+++ b/src/Modules/ServerNet.bb
@@ -1439,8 +1439,8 @@ Function UpdateNetwork()
 							If MaxDelta# < 2.0 Then MaxDelta# = 2.0
 							Local DX# = NewX# - AI\X#
 							Local DZ# = NewZ# - AI\Z#
-							Local Dist# = Sqr#(DX# * DX# + DZ# * DZ#)
-							If Dist# > MaxDelta#
+							Local MoveDist# = Sqr#(DX# * DX# + DZ# * DZ#)
+							If MoveDist# > MaxDelta#
 								; Too fast: hold the client at the prior position.
 								; The next update will look like the client agreed.
 								; Client will re-sync to server state on next


### PR DESCRIPTION
Round 5 audit: P_StandardUpdate accepts client-reported position unconditionally inside ClampWorldCoord bounds. The original speed-cheat clamp at the same site was **commented out years ago** with a note that "we cannot just replace values because client could then lie" -- but the workaround was never re-implemented. A modified client warps anywhere in the area between two updates, defeating PvP positioning checks, movement-based trigger volumes, and combat range gates.

## Mechanism
- New `ActorInstance\LastPosUpdateMs` tracks the timestamp of the last accepted update.
- Per-update elapsed time scaled against the actor's normalised Speed attribute (matches the 1.5 unit-per-tick coefficient that `GameServer.bb` uses for server-driven movement, folded with a 3x lag/collision tolerance).
- If the proposed `(NewX, NewZ)` is further from `(AI\X, AI\Z)` than the budget allows, the position update is silently rejected -- AI stays put, next reposition broadcast re-syncs the client.
- First-update / lag-spike (>5s) / clock-skew paths re-baseline rather than reject, so a legitimate teleport, area-change, or long pause doesn't strand the player.
- 2-unit floor covers Blitz's collision-shove-back paths that legitimately push slightly beyond the unit-per-ms budget.

Y# is unaffected -- the comment elsewhere notes Y# is partly driven by gravity and ramping, so a similar treatment would have to be carved out for that axis separately.

## Test plan
- [ ] CI green
- [ ] `test.bat` passes (verified)
- [ ] Manual: walk around normally -> position updates apply
- [ ] Manual: simulate a client warp packet -> rejected, server holds prior position
- [ ] Manual: portal/teleport via P_ChangeArea -> next P_StandardUpdate re-baselines cleanly