### PR TITLE
[SECURITY] combat correctness: dead actor + freed spell target + PvP cross-area (Track OO)

### DIFF
--- a/src/Modules/GameServer.bb
+++ b/src/Modules/GameServer.bb
@@ -274,6 +274,14 @@ End Function
 ; Makes one actor instance attack another
 Function ActorAttack(A1.ActorInstance, A2.ActorInstance)
 
+	; Bail on null and on already-dead targets. Two attackers landing
+	; in the same tick previously both saw HP>0, both subtracted, both
+	; called KillActor -- second call ran against freed (NPC) memory
+	; for double XP + a use-after-free crash window. Also guards
+	; against script-spawned attacks racing the death broadcast.
+	If A1 = Null Or A2 = Null Then Return False
+	If A2\Attributes\Value[HealthStat] <= 0 Then Return False
+
 	; Get distance between the actor instances
 	XDist# = A1\X# - A2\X#
 	ZDist# = A1\Z# - A2\Z#

--- a/src/Modules/ServerNet.bb
+++ b/src/Modules/ServerNet.bb
@@ -943,6 +943,18 @@ Function UpdateNetwork()
 							If Len(M\MessageData$) > 3
 								RuntimeID = RCE_IntFromStr(Mid$(M\MessageData$, 4, 2))
 								Context = RuntimeIDList(RuntimeID)
+								; Reject targets that are dead or in a different
+								; area. Without this, the spell script fires
+								; against an actor whose FreeActorInstance is
+								; queued in PendingKill (use-after-free), and a
+								; cross-area target can be hit despite the
+								; client's view being area-local.
+								If Context <> Null
+									If Context\Attributes\Value[HealthStat] <= 0 Then Context = Null
+								EndIf
+								If Context <> Null
+									If Context\ServerArea <> AI\ServerArea Then Context = Null
+								EndIf
 							EndIf
 							; Convert ID into known spell number
 							Found = False
@@ -1206,10 +1218,19 @@ Function UpdateNetwork()
 					If MilliSecs() - AI\LastAttack >= CombatDelay And AI\Mount = Null
 						A2.ActorInstance = RuntimeIDList(RCE_IntFromStr(M\MessageData$))
 						If A2 <> Null
+							; Require attacker and target to be in the same
+							; AreaInstance. Without this, a target mid-portal
+							; (target's ServerArea hasn't ack'd P_ChangeArea
+							; yet) could be hit from the attacker's old area,
+							; and friendly-fire / PvP rules from the wrong
+							; area apply.
 							AInstance.AreaInstance = Object.AreaInstance(AI\ServerArea)
-							If A2\RNID < 0 Or AInstance\Area\PvP = True
-								ActorAttack(AI, A2)
-								AI\AITarget = A2
+							TInstance.AreaInstance = Object.AreaInstance(A2\ServerArea)
+							If AInstance <> Null And AInstance = TInstance
+								If A2\RNID < 0 Or AInstance\Area\PvP = True
+									ActorAttack(AI, A2)
+									AI\AITarget = A2
+								EndIf
 							EndIf
 						EndIf
 					EndIf


### PR DESCRIPTION
Round 5 combat findings -- three real bugs around target liveness and area scoping:

### ActorAttack: dead-target early-out
No HP<=0 check at function entry. Two attackers landing in the same tick previously both saw HP>0, both subtracted, both called `KillActor` -- second call ran against an NPC whose `FreeActorInstance` had already executed (use-after-free), and faction-rating + XP credits ran twice. Now early-return on Null or already-dead target.

### P_SpellUpdate "F" target validation
`ThreadScript(spell, target=RuntimeIDList[id])` ran against a RuntimeID that could resolve to an actor whose `FreeActorInstance` is queued in PendingKill (use-after-free), and a cross-area target (RuntimeID collisions on long-running servers) could be hit despite the client's view being area-local. Now drop Context when target is dead or in a different ServerArea -- spells with optional target still fire (Context=Null), spells that require a same-area live target silently no-op.

### P_AttackActor cross-area
Friendly-fire / PvP check read attacker's AreaInstance only; a target mid-portal (ServerArea not yet updated by P_ChangeArea ack) could be hit from attacker's old area applying that area's PvP rules. Now require attacker and target AreaInstance to be the same object.

## Test plan
- [ ] CI green
- [ ] `test.bat` passes (verified)
- [ ] Manual: two players damage the same NPC simultaneously -> no double XP / no crash