### PR TITLE
[SECURITY] trade item-validation gap closed (NN wave 2)

### DIFF
--- a/src/Modules/Actors.bb
+++ b/src/Modules/Actors.bb
@@ -117,6 +117,14 @@ Type ActorInstance
 	Field IsTrading ; 0 for not trading, 1 for trading with NPC, 2 for trading with pet, 3 for trading with player, 4/5 for accepted trading with player
 	Field TradingActor.ActorInstance
 	Field TradeResult$
+	; Server-authoritative per-slot trade offer state. Populated by
+	; each P_UpdateTrading packet from this actor (slot index 0..31,
+	; value = amount of Inventory[SlotI_Backpack + i] offered). Used
+	; on accept to ignore the client-supplied accept-packet TradeResult$
+	; amounts and only swap what was actually shown via UpdateTrading
+	; -- prevents the dupe where the accept packet swaps a different
+	; stack than what the trade UI displayed.
+	Field TradeOfferedAmount[31]
 	Field Underwater
 	Field IgnoreUpdate   ;used to ignore standard update while waiting for client to complete actor moves
 	

--- a/src/Modules/ServerNet.bb
+++ b/src/Modules/ServerNet.bb
@@ -637,7 +637,18 @@ Function UpdateNetwork()
 						; would push the array index past the inventory bounds; without this,
 						; a crafted Slot reads (and the ItemInstanceToString$ helper writes)
 						; from adjacent ActorInstance fields.
-						If Slot >= 0 And Slot + SlotI_Backpack <= Slots_Inventory
+						If Slot >= 0 And Slot <= 31 And Slot + SlotI_Backpack <= Slots_Inventory
+							; Record the server-authoritative offer state.
+							; The accept-side swap reads from this rather than
+							; from the client-controlled accept-packet bytes;
+							; that closes the dupe where the client's accept
+							; payload claims a different stack than what the
+							; trade UI showed via P_UpdateTrading.
+							If Amount > AI\Inventory\Amounts[Slot + SlotI_Backpack]
+								Amount = AI\Inventory\Amounts[Slot + SlotI_Backpack]
+							EndIf
+							If Amount < 0 Then Amount = 0
+							AI\TradeOfferedAmount[Slot] = Amount
 							Pa$ = M\MessageData$
 							If Amount > 0 Then Pa$ = Pa$ + ItemInstanceToString$(AI\Inventory\Items[Slot + SlotI_Backpack])
 							RCE_Send(Host, AI\TradingActor\RNID, P_UpdateTrading, Pa$, True)
@@ -830,11 +841,19 @@ Function UpdateNetwork()
 										RCE_Send(Host, A2\RNID, P_GoldChange, "U" + RCE_StrFromInt$(A2Cost, 4), True)
 									EndIf
 
-									; Swap items
+									; Swap items. Read amounts from the server-tracked
+									; TradeOfferedAmount[i] (populated by each
+									; P_UpdateTrading) rather than the client's
+									; accept-packet TradeResult$ bytes; otherwise
+									; either party could craft an accept packet
+									; that promises to give a different stack
+									; (smaller, less valuable, or a stack they
+									; don't have at all) than the trade UI
+									; displayed during negotiation.
 									For i = 0 To 31
 										SlotID = i + SlotI_Backpack
 										; Actor 1
-										Amount = RCE_IntFromStr(Mid$(AI\TradeResult$, 101 + (i * 2), 2))
+										Amount = AI\TradeOfferedAmount[i]
 										If Amount > AI\Inventory\Amounts[SlotID] Then Amount = AI\Inventory\Amounts[SlotID]
 										If AI\Inventory\Items[SlotID] <> Null And Amount > 0
 											GiveItem.ItemInstance = CopyItemInstance(AI\Inventory\Items[SlotID])
@@ -849,7 +868,7 @@ Function UpdateNetwork()
 											RCE_Send(Host, A2\RNID, P_InventoryUpdate, "G" + RCE_StrFromInt$(Handle(GiveItem), 4) + Pa$, True)
 										EndIf
 										; Actor 2
-										Amount = RCE_IntFromStr(Mid$(A2\TradeResult$, 101 + (i * 2), 2))
+										Amount = A2\TradeOfferedAmount[i]
 										If Amount > A2\Inventory\Amounts[SlotID] Then Amount = A2\Inventory\Amounts[SlotID]
 										If A2\Inventory\Items[SlotID] <> Null And Amount > 0
 											GiveItem.ItemInstance = CopyItemInstance(A2\Inventory\Items[SlotID])
@@ -866,7 +885,14 @@ Function UpdateNetwork()
 									Next
 								 EndIf
 
-								; End trading mode for both players
+								; End trading mode for both players. Clear the
+								; per-slot offer state so it can't carry stale
+								; amounts into the next trade either side
+								; opens.
+								For ResetI = 0 To 31
+									AI\TradeOfferedAmount[ResetI] = 0
+									A2\TradeOfferedAmount[ResetI] = 0
+								Next
 								AI\TradeResult$ = ""
 								AI\IsTrading = 0
 								AI\TradingActor = Null


### PR DESCRIPTION
Round 5's still-open trade-side exploit.

## Bug
The historical per-item validation block in the accept handler was commented out (still preserved as comment for context). What remained validated only the *gold magnitude* (A1Cost = -A2Cost). The accept-side swap loop then read each side's offered item amounts from the **client's** accept-packet `TradeResult$` bytes (offset 101 + i*2). Either party could craft an accept packet that promised to swap a different stack (smaller, less valuable, or a stack they don't actually have) than the trade UI displayed during the P_UpdateTrading phase.

## Fix
Server tracks the offer amounts authoritatively.

- New `ActorInstance\TradeOfferedAmount[31]` -- per-slot amount of `Inventory[SlotI_Backpack + i]` this actor offered. Set by each P_UpdateTrading packet from this actor.
- The accept-side swap loop now reads from this array rather than from the client-supplied TradeResult$.
- Inventory cap applied at both write time (P_UpdateTrading) and swap time (defense in depth -- inventory may shrink between offer and accept via a drop / use / death).
- Trade-end clears the per-slot array so it can't leak amounts into the next trade either side opens.

Also tightened the Slot bound in P_UpdateTrading from `Slot + SlotI_Backpack <= Slots_Inventory` to also require `Slot >= 0 And Slot <= 31` since the array is sized [31].

## Test plan
- [ ] CI green
- [ ] `test.bat` passes (verified)
- [ ] Manual: trade two items, then before clicking accept edit the accept payload to claim a different stack -> swap only consumes what was actually offered