### PR TITLE
[SECURITY] unify spell cooldown storage + per-actor fire floor

### DIFF
--- a/src/Modules/Actors.bb
+++ b/src/Modules/Actors.bb
@@ -113,7 +113,12 @@ Type ActorInstance
 	Field KnownSpells[999]
 	Field SpellLevels[999]
 	Field MemorisedSpells[9]
-	Field SpellCharge[999] ; How long until the spell is usable
+	Field SpellCharge[999] ; How long until the spell is usable -- indexed by spell ID (matches SpellsList)
+	; Server-side cooldown floor: timestamp of the last P_SpellUpdate "F"
+	; this actor was allowed to process. Prevents same-tick spell spam
+	; against zero-RechargeTime spells (a legal but cheese-prone setting
+	; in the spell data).
+	Field LastSpellFireMs
 	Field IsTrading ; 0 for not trading, 1 for trading with NPC, 2 for trading with pet, 3 for trading with player, 4/5 for accepted trading with player
 	Field TradingActor.ActorInstance
 	Field TradeResult$

--- a/src/Modules/GameServer.bb
+++ b/src/Modules/GameServer.bb
@@ -624,17 +624,16 @@ Function UpdateActorInstances(Broadcast)
 		If AI\RuntimeID > -1
 			AInstance.AreaInstance = Object.AreaInstance(AI\ServerArea)
 
-			; Recharge spells
+			; Recharge spells. SpellCharge is now uniformly indexed by
+			; spell ID (matches the unified P_SpellUpdate "F" handler in
+			; ServerNet.bb). The previous split (memorise-slot 0..9 vs
+			; known-spell-index 0..999) let a player double-cast by
+			; toggling RequireMemorise or re-memorising into a different
+			; slot.
 			If Recharge = True
-				If RequireMemorise
-					For i = 0 To 9
-						If AI\SpellCharge[i] > 0 Then AI\SpellCharge[i] = AI\SpellCharge[i] - 100
-					Next
-				Else
-					For i = 0 To 999
-						If AI\SpellCharge[i] > 0 Then AI\SpellCharge[i] = AI\SpellCharge[i] - 100
-					Next
-				EndIf
+				For i = 0 To 999
+					If AI\SpellCharge[i] > 0 Then AI\SpellCharge[i] = AI\SpellCharge[i] - 100
+				Next
 			EndIf
 
 			; Move (except mounts)

--- a/src/Modules/ServerNet.bb
+++ b/src/Modules/ServerNet.bb
@@ -1502,8 +1502,8 @@ Function UpdateNetwork()
 						; covers lag spikes, collision shove-back, and the
 						; 1.5x base unit-per-tick coefficient that GameServer
 						; uses for server-driven movement.
-						Local NowMs% = MilliSecs()
-						Local ElapsedMs% = NowMs - AI\LastPosUpdateMs
+						Local PosNowMs% = MilliSecs()
+						Local ElapsedMs% = PosNowMs - AI\LastPosUpdateMs
 						If AI\LastPosUpdateMs = 0 Or ElapsedMs < 0 Or ElapsedMs > 5000
 							; First update for this actor, or clock skew, or
 							; a lag spike longer than 5s: accept the position

--- a/src/Modules/ServerNet.bb
+++ b/src/Modules/ServerNet.bb
@@ -1000,29 +1000,42 @@ Function UpdateNetwork()
 								EndIf
 							Next
 							If Found = True
-								; Spell must be memorised to fire
-								If RequireMemorise
-									For i = 0 To 9
-										If AI\MemorisedSpells[i] = Num
-											Sp.Spell = SpellsList(AI\KnownSpells[Num])
-											If AI\SpellCharge[i] <= 0
-												ThreadScript(Sp\Script$, Sp\SMethod$, Handle(AI), Handle(Context), AI\SpellLevels[Num])
-												AI\SpellCharge[i] = Sp\RechargeTime
-											Else
-												ml = Len(Chr$(253) + LanguageString$(LS_AbilityNotRecharged))
-												RCE_Send(Host, AI\RNID, P_ChatMessage, Chr$(253) + LanguageString$(LS_AbilityNotRecharged), True)
-											EndIf
-											Exit
-										EndIf
-									Next
-								; Fire spell directly
-								Else
-									Sp.Spell = SpellsList(AI\KnownSpells[Num])
-									If AI\SpellCharge[Num] <= 0
-										ThreadScript(Sp\Script$, Sp\SMethod$, Handle(AI), Handle(Context), AI\SpellLevels[Num])
-										AI\SpellCharge[Num] = Sp\RechargeTime
+								; Both cooldown paths now index AI\SpellCharge by
+								; the underlying spell ID (KnownSpells[Num])
+								; rather than two different slot-index spaces.
+								; Previously, RequireMemorise=True stored at the
+								; memorise-slot index 0..9 while
+								; RequireMemorise=False stored at the known-
+								; spell-index 0..999 -- same physical spell had
+								; two independent cooldowns, and toggling the
+								; global RequireMemorise or re-memorising into a
+								; different slot let the player double-cast.
+								; Also enforce a per-actor 100ms floor so
+								; zero-RechargeTime spells can't be spammed
+								; every UpdateNetwork tick.
+								Local SpellID = AI\KnownSpells[Num]
+								If SpellID >= 0 And SpellID <= 999
+									Local NowMs = MilliSecs()
+									Local Memorised = False
+									If RequireMemorise
+										For i = 0 To 9
+											If AI\MemorisedSpells[i] = Num Then Memorised = True : Exit
+										Next
 									Else
-										RCE_Send(Host, AI\RNID, P_ChatMessage, Chr$(253) + LanguageString$(LS_AbilityNotRecharged), True)
+										Memorised = True
+									EndIf
+									If Memorised
+										If NowMs - AI\LastSpellFireMs < 100
+											; Too fast; drop silently to avoid
+											; chat-spamming the user.
+										ElseIf AI\SpellCharge[SpellID] > 0
+											RCE_Send(Host, AI\RNID, P_ChatMessage, Chr$(253) + LanguageString$(LS_AbilityNotRecharged), True)
+										Else
+											Sp.Spell = SpellsList(SpellID)
+											ThreadScript(Sp\Script$, Sp\SMethod$, Handle(AI), Handle(Context), AI\SpellLevels[Num])
+											AI\SpellCharge[SpellID] = Sp\RechargeTime
+											AI\LastSpellFireMs = NowMs
+										EndIf
 									EndIf
 								EndIf
 							EndIf


### PR DESCRIPTION
Round 5 audit: `P_SpellUpdate "F"` stored cooldowns in two different index spaces depending on `RequireMemorise`:

| Mode | Storage index |
|---|---|
| `RequireMemorise = True` | `AI\SpellCharge[i]` — memorise slot 0..9 |
| `RequireMemorise = False` | `AI\SpellCharge[Num]` — known-spell slot 0..999 |

Same physical spell had two independent cooldowns. A player who toggled the global mid-session, or re-memorised the spell into a different memorise slot, could cast the same spell twice in rapid succession because the *other* cooldown index was still zero.

## Fix
Both fire path (ServerNet.bb) and per-tick recharge walk (GameServer.bb) now use the underlying spell ID (`AI\KnownSpells[Num]`, range 0..999). `Field SpellCharge[999]` is sized to fit spell IDs 0..999.

Plus a per-actor 100ms fire floor (`ActorInstance\LastSpellFireMs`): zero-RechargeTime spells (legal per the spell data file) could otherwise be spammed every `UpdateNetwork` tick.

## Test plan
- [ ] CI green
- [ ] `test.bat` passes (verified)
- [ ] Manual: cast a 10s-cooldown spell -> wait -> cast again works at t=10s; cast attempt at t=1s rejected