### PR TITLE
[SECURITY] portal lock keys on (Area, index) pair (TT)

### DIFF
--- a/src/Modules/Actors.bb
+++ b/src/Modules/Actors.bb
@@ -84,7 +84,15 @@ Type ActorInstance
 	Field WalkingBackward
 	Field Area$, ServerArea, Account
 	Field Name$, Tag$
-	Field LastPortal, LastTrigger, LastPortalTime
+	; LastPortal is a portal index 0..99 within an Area's portal list, so
+	; it only makes sense paired with the area it was set in. LastPortalArea
+	; stores Handle(Ar) of that area; the portal-lock check in Server.bb
+	; compares both (Ar, i) and the time window. Without the area component,
+	; an actor who entered Area B via waypoint/script while holding a stale
+	; LastPortal=5 from Area A would be falsely locked out of Area B's
+	; portal #5 (different physical portal), and conversely the AI spawn
+	; path's deliberate LastPortal=0 stamp would bleed across areas.
+	Field LastPortal, LastTrigger, LastPortalTime, LastPortalArea
 	Field TeamID ; Used to allow scripting to put people together in teams
 	Field PartyID, AcceptPending ; Holds the handle of a Party object (or 0 if the actor is not in a party)
 	Field Gender ; 0 for male, 1 for female
@@ -447,6 +455,7 @@ Function CreateActorInstance.ActorInstance(Actor.Actor)
 	A\SourceSP = -1
 	A\LastTrigger = -1
 	A\LastPortal = -1
+	A\LastPortalArea = 0
 	A\IgnoreUpdate = 0
 	Return A
 

--- a/src/Modules/GameServer.bb
+++ b/src/Modules/GameServer.bb
@@ -1098,6 +1098,7 @@ Function SetArea(A.ActorInstance, Ar.Area, Instance, Waypoint = -1, Portal = 0, 
 			A\Y# = Ar\PortalY#[Portal]
 			A\Z# = Ar\PortalZ#[Portal]
 			A\LastPortal = Portal
+			A\LastPortalArea = Handle(Ar)
 			A\LastPortalTime = MilliSecs()
 		; Direct position
 		Else
@@ -1112,7 +1113,14 @@ Function SetArea(A.ActorInstance, Ar.Area, Instance, Waypoint = -1, Portal = 0, 
 		A\Y# = Ar\WaypointY#[Waypoint]
 		A\Z# = Ar\WaypointZ#[Waypoint]
 		A\CurrentWaypoint = Waypoint
-		A\LastPortal = 0
+		; Waypoint-based placement is not a portal entry: -1 disables the
+		; lock so a legitimate portal in the destination area triggers
+		; normally. The previous LastPortal=0 stamp had no lock-time
+		; refresh, so it never actually applied; pair the sentinel with a
+		; cleared LastPortalArea now that the lock checks the (Ar, i)
+		; pair.
+		A\LastPortal = -1
+		A\LastPortalArea = 0
 	EndIf
 
 	; Reset target

--- a/src/Modules/ServerNet.bb
+++ b/src/Modules/ServerNet.bb
@@ -2316,6 +2316,7 @@ Function UpdateNetwork()
 									For i = 0 To 99
 										If Upper$(Ar\PortalName$[i]) = Upper$(C\Actor\StartPortal$)
 											C\LastPortal = i
+											C\LastPortalArea = Handle(Ar)
 											C\X# = Ar\PortalX#[i]
 											C\Y# = Ar\PortalY#[i]
 											C\Z# = Ar\PortalZ#[i]

--- a/src/Server.bb
+++ b/src/Server.bb
@@ -581,7 +581,13 @@ Repeat
 										DistZ# = Abs(AI\Z# - UpdateArea\PortalZ#[i])
 										Dist# = (DistX# * DistX#) + (DistY# * DistY#) + (DistZ# * DistZ#)
 										; Inside portal area
-										If Dist# < Size# And (AI\LastPortal <> i Or (MilliSecs() - AI\LastPortalTime > PortalLockTime))
+										; Lock keys on the (Area, index) pair: a stale
+										; LastPortal index left over from a different
+										; area must not block a same-index portal in the
+										; current one, and the time floor still bars
+										; immediate re-entry of the exact portal the
+										; actor was just placed on.
+										If Dist# < Size# And (AI\LastPortal <> i Or AI\LastPortalArea <> Handle(UpdateArea) Or (MilliSecs() - AI\LastPortalTime > PortalLockTime))
 											InPortal = False
 											Name$ = Upper$(UpdateArea\PortalLinkArea$[i])
 											For Ar.Area = Each Area


### PR DESCRIPTION
## Summary

Closes the deferred Round 5 finding: the portal-trigger lock in Server.bb keyed only on the bare 0..99 portal index, so a stale `LastPortal` value carried across areas could falsely block legitimate portals (different physical portal, same index) and the AI-spawn waypoint branch left a misleading \"`LastPortal = 0`\" stamp behind.

The lock now keys on the full **(Area, portal index)** pair plus the existing `PortalLockTime` window.

### Changes

- **Actors.bb** — add `LastPortalArea` field; init to 0 in `CreateActorInstance`; documenting comment.
- **GameServer.bb / SetArea** — portal branch sets `LastPortalArea = Handle(Ar)` next to `LastPortal/LastPortalTime`; waypoint branch clears to `LastPortal = -1, LastPortalArea = 0` (no portal context).
- **ServerNet.bb** — new-character creation also sets `LastPortalArea = Handle(Ar)` where it stamps the start portal.
- **Server.bb** — lock check becomes `AI\LastPortal <> i Or AI\LastPortalArea <> Handle(UpdateArea) Or (MilliSecs - LastPortalTime > PortalLockTime)`.

`LastPortal` is runtime-only state, so no save-format change is required.

## Test plan

- [x] `blitzcc` compile of `Server.bb` clean against the rebuilt BlitzForge submodule.
- [x] Test suite passes locally.
- [ ] CI build + tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)