### PR TITLE
[SECURITY] cap action-bar slot spell-name length (UU)

### DIFF
--- a/src/Modules/ServerNet.bb
+++ b/src/Modules/ServerNet.bb
@@ -937,7 +937,20 @@ Function UpdateNetwork()
 					If Num >= 0 And Num < 36 And A <> Null
 						If A\LoggedOn > -1
 							If Left$(M\MessageData$, 1) = "S"
-								A\ActionBar[A\LoggedOn]\Slots$[Num] = "S" + Mid$(M\MessageData$, 3)
+								; Cap the spell name to keep the stored slot
+								; string within the 256-byte bound that the
+								; save loader (ReadBoundedString$ in
+								; AccountsServer.bb) imposes on Slots$. Without
+								; this, a client can stuff arbitrary bytes
+								; (up to the packet limit) into one of 36
+								; slots, bloating the per-character save and,
+								; more importantly, the broadcast packet that
+								; re-encodes the action bar with a 2-byte
+								; length prefix per slot. 255 leaves room for
+								; the "S" prefix byte.
+								Local SpellName$ = Mid$(M\MessageData$, 3)
+								If Len(SpellName$) > 255 Then SpellName$ = Left$(SpellName$, 255)
+								A\ActionBar[A\LoggedOn]\Slots$[Num] = "S" + SpellName$
 							ElseIf Left$(M\MessageData$, 1) = "I"
 								A\ActionBar[A\LoggedOn]\Slots$[Num] = "I" + Mid$(M\MessageData$, 3, 2)
 							ElseIf Left$(M\MessageData$, 1) = "N"


### PR DESCRIPTION
## Summary

Closes the deferred Round 5 finding: `P_ActionBarUpdate`'s `S` (spell) branch in ServerNet.bb wrote `Mid$(M\MessageData$, 3)` straight into `A\ActionBar[A\LoggedOn]\Slots$[Num]` with no length cap.

A client could push arbitrarily long bytes into one of 36 slots:

- Per-character save grows unbounded (`WriteString` writes whatever's in memory).
- Loader's `ReadBoundedString$(F, 256)` truncates silently — but in-memory state persists until logout.
- Broadcast at [ServerNet.bb:1762](src/Modules/ServerNet.bb:1762) re-encodes each slot with a 2-byte length prefix and embeds it in the outbound action-bar packet, so a single oversized slot scales the response packet.

Cap the spell-name portion to **255 bytes** (matches the load bound, minus the `\"S\"` prefix byte) before storing. `I` (item ID) branch already fixed-slices `Mid(…,3,2)` — fine; `N` clears.

## Test plan

- [x] `blitzcc` compiles `Server.bb` clean.
- [x] Test suite passes locally.
- [ ] CI build + tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)