### PR TITLE
[SECURITY] server-side password hash migration (CCC)

### DIFF
--- a/src/Modules/AccountsServer.bb
+++ b/src/Modules/AccountsServer.bb
@@ -167,13 +167,15 @@ Function SetAccountBanStatus(A.Account, Flag)
 
 End Function
 
-; Creates a new account
+; Creates a new account. Pass$ is the client-supplied MD5; we wrap it
+; in the v1 salted-SHA-256 storage format so the on-disk record is
+; not directly replayable on the wire.
 Function AddAccount(User$, Pass$, Email$)
 
 	; Create account
 	A.Account = New Account
 	A\User$ = User$
-	A\Pass$ = Pass$
+	A\Pass$ = HashPassword$(Pass$)
 	A\Email$ = Email$
 	A\LoggedOn = -1
 	AddListBoxItem(Accounts\List, User$ + "  (" + Email$ + ")")
@@ -184,9 +186,9 @@ Function AddAccount(User$, Pass$, Email$)
 	; Add to accounts file
 	F = OpenFile("Data\Server Data\Accounts.dat")
 	SeekFile(F, FileSize("Data\Server Data\Accounts.dat"))
-		WriteString F, User$
-		WriteString F, Pass$
-		WriteString F, Email$
+		WriteString F, A\User$
+		WriteString F, A\Pass$
+		WriteString F, A\Email$
 		WriteByte F, 0
 	CloseFile(F)
 

--- a/src/Modules/PasswordHash.bb
+++ b/src/Modules/PasswordHash.bb
@@ -1,0 +1,248 @@
+; ============================================================================
+; Server-side password hashing with on-disk migration.
+;
+; Background
+; ----------
+; The wire protocol hands the server an MD5 of the user-typed password
+; (the client does `MD5Pass$ = MD5$(Pass$)` before send). The server
+; used to store that MD5 verbatim in Accounts.dat and compare incoming
+; vs. stored as plaintext: anyone who reads the file gets the
+; wire-equivalent of every account's password, and anyone who sees one
+; login packet on the wire can replay it forever.
+;
+; This module keeps the wire format intact (the MD5 is still what the
+; client sends) but wraps a salted SHA-256 around the at-rest copy, so
+; theft of Accounts.dat no longer hands an attacker working
+; credentials. Wire sniffing is still trivially replayable -- that
+; requires TLS or a challenge/response protocol, both bigger projects.
+;
+; Storage format
+; --------------
+; Legacy:   <32 lowercase hex chars>           ; raw MD5 from client
+; v1:       $1$<salt-16-chars>$<sha256-64-hex> ; SHA-256(salt + MD5)
+;
+; Verify accepts both; HashPassword$ always emits v1.
+;
+; Migration is automatic: on the first successful login of an account
+; whose Accounts.dat entry is still legacy MD5, the server replaces
+; A\Pass$ with a freshly salted v1 hash. The next SaveAccounts() then
+; persists the upgrade.
+; ============================================================================
+
+Const PWHASH_VERSION_TAG$ = "$1$"
+Const PWHASH_SALT_LEN%    = 16
+
+; ----------------------------------------------------------------------------
+; SHA-256 (FIPS 180-4) — pure Blitz3D implementation.
+; Compute SHA-256 of an arbitrary 8-bit-clean string. Returns a 64-character
+; lowercase hex string.
+;
+; Blitz uses signed 32-bit Int. Two-complement signed addition wraps the
+; same way as unsigned at the bit level, so plain `+` is fine for the
+; SHA-256 word arithmetic. `Shr` is logical right shift (zero fill) and
+; `Shl` is left shift -- both correct for the round/schedule math here.
+; ----------------------------------------------------------------------------
+
+; Round constants K[0..63] (first 32 bits of fractional parts of cube roots
+; of the first 64 primes). Initialised lazily on first use because Blitz3D
+; doesn't take large hex literals in array initialisers.
+Global PWHASH_KInit% = False
+Dim PWHASH_K%(63)
+
+; Message schedule array, shared across calls to keep allocation off the
+; hot path. SHA256Hex re-fills this from scratch each call so prior
+; contents don't matter.
+Dim PWHASH_W%(63)
+
+Function PWHASH_InitK()
+	If PWHASH_KInit Then Return
+	PWHASH_K(0)  = $428a2f98 : PWHASH_K(1)  = $71374491 : PWHASH_K(2)  = $b5c0fbcf : PWHASH_K(3)  = $e9b5dba5
+	PWHASH_K(4)  = $3956c25b : PWHASH_K(5)  = $59f111f1 : PWHASH_K(6)  = $923f82a4 : PWHASH_K(7)  = $ab1c5ed5
+	PWHASH_K(8)  = $d807aa98 : PWHASH_K(9)  = $12835b01 : PWHASH_K(10) = $243185be : PWHASH_K(11) = $550c7dc3
+	PWHASH_K(12) = $72be5d74 : PWHASH_K(13) = $80deb1fe : PWHASH_K(14) = $9bdc06a7 : PWHASH_K(15) = $c19bf174
+	PWHASH_K(16) = $e49b69c1 : PWHASH_K(17) = $efbe4786 : PWHASH_K(18) = $0fc19dc6 : PWHASH_K(19) = $240ca1cc
+	PWHASH_K(20) = $2de92c6f : PWHASH_K(21) = $4a7484aa : PWHASH_K(22) = $5cb0a9dc : PWHASH_K(23) = $76f988da
+	PWHASH_K(24) = $983e5152 : PWHASH_K(25) = $a831c66d : PWHASH_K(26) = $b00327c8 : PWHASH_K(27) = $bf597fc7
+	PWHASH_K(28) = $c6e00bf3 : PWHASH_K(29) = $d5a79147 : PWHASH_K(30) = $06ca6351 : PWHASH_K(31) = $14292967
+	PWHASH_K(32) = $27b70a85 : PWHASH_K(33) = $2e1b2138 : PWHASH_K(34) = $4d2c6dfc : PWHASH_K(35) = $53380d13
+	PWHASH_K(36) = $650a7354 : PWHASH_K(37) = $766a0abb : PWHASH_K(38) = $81c2c92e : PWHASH_K(39) = $92722c85
+	PWHASH_K(40) = $a2bfe8a1 : PWHASH_K(41) = $a81a664b : PWHASH_K(42) = $c24b8b70 : PWHASH_K(43) = $c76c51a3
+	PWHASH_K(44) = $d192e819 : PWHASH_K(45) = $d6990624 : PWHASH_K(46) = $f40e3585 : PWHASH_K(47) = $106aa070
+	PWHASH_K(48) = $19a4c116 : PWHASH_K(49) = $1e376c08 : PWHASH_K(50) = $2748774c : PWHASH_K(51) = $34b0bcb5
+	PWHASH_K(52) = $391c0cb3 : PWHASH_K(53) = $4ed8aa4a : PWHASH_K(54) = $5b9cca4f : PWHASH_K(55) = $682e6ff3
+	PWHASH_K(56) = $748f82ee : PWHASH_K(57) = $78a5636f : PWHASH_K(58) = $84c87814 : PWHASH_K(59) = $8cc70208
+	PWHASH_K(60) = $90befffa : PWHASH_K(61) = $a4506ceb : PWHASH_K(62) = $bef9a3f7 : PWHASH_K(63) = $c67178f2
+	PWHASH_KInit = True
+End Function
+
+; 32-bit logical right rotate.
+Function PWHASH_ROTR%(X%, N%)
+	; (X >>> N) | (X <<< (32 - N))
+	Return (X Shr N) Or (X Shl (32 - N))
+End Function
+
+; Lowercase hex of one 32-bit word, big-endian byte order, 8 chars.
+Function PWHASH_HexWord$(X%)
+	Local HexChars$ = "0123456789abcdef"
+	Local Out$ = ""
+	Local i%
+	For i = 7 To 0 Step -1
+		Local Nyb% = (X Shr (i * 4)) And $f
+		Out = Out + Mid$(HexChars, Nyb + 1, 1)
+	Next
+	Return Out
+End Function
+
+Function SHA256Hex$(Msg$)
+	PWHASH_InitK()
+
+	Local InputLen%    = Len(Msg)
+	Local TotalBitLen% = InputLen * 8
+
+	; Padding: append 0x80, then zero bytes, then the 64-bit big-endian
+	; bit length, so total length is a multiple of 64 bytes. We always
+	; need at least 1 (0x80) + 8 (length) = 9 trailing bytes, so the
+	; padded length rounds up from (InputLen + 9) to the next 64.
+	Local PaddedLen% = ((InputLen + 9 + 63) / 64) * 64
+	Local hMsg = CreateBank(PaddedLen)
+	; CreateBank zero-fills, so we only need to write the input bytes
+	; and the 0x80 marker explicitly. The length field is written below.
+	Local i%
+	For i = 1 To InputLen
+		PokeByte(hMsg, i - 1, Asc(Mid$(Msg, i, 1)))
+	Next
+	PokeByte(hMsg, InputLen, $80)
+
+	; 64-bit length, big-endian. Blitz strings are at most ~2^31 bytes,
+	; so the upper 32 bits of bit-length are always zero; we still write
+	; them for the spec-compliant 8-byte field.
+	PokeByte(hMsg, PaddedLen - 4, (TotalBitLen Shr 24) And $ff)
+	PokeByte(hMsg, PaddedLen - 3, (TotalBitLen Shr 16) And $ff)
+	PokeByte(hMsg, PaddedLen - 2, (TotalBitLen Shr 8)  And $ff)
+	PokeByte(hMsg, PaddedLen - 1,  TotalBitLen         And $ff)
+
+	; Initial hash state (FIPS 180-4 section 5.3.3).
+	Local H0% = $6a09e667
+	Local H1% = $bb67ae85
+	Local H2% = $3c6ef372
+	Local H3% = $a54ff53a
+	Local H4% = $510e527f
+	Local H5% = $9b05688c
+	Local H6% = $1f83d9ab
+	Local H7% = $5be0cd19
+
+	; Process each 512-bit (64-byte) block.
+	Local Block%
+	For Block = 0 To PaddedLen - 1 Step 64
+		Local t%
+		For t = 0 To 15
+			Local Off% = Block + t * 4
+			Local B0% = PeekByte(hMsg, Off)     Shl 24
+			Local B1% = PeekByte(hMsg, Off + 1) Shl 16
+			Local B2% = PeekByte(hMsg, Off + 2) Shl  8
+			Local B3% = PeekByte(hMsg, Off + 3)
+			PWHASH_W(t) = B0 Or B1 Or B2 Or B3
+		Next
+		For t = 16 To 63
+			Local W15% = PWHASH_W(t - 15)
+			Local W2%  = PWHASH_W(t - 2)
+			Local S0%  = PWHASH_ROTR(W15, 7)  Xor PWHASH_ROTR(W15, 18) Xor (W15 Shr 3)
+			Local S1%  = PWHASH_ROTR(W2,  17) Xor PWHASH_ROTR(W2,  19) Xor (W2  Shr 10)
+			PWHASH_W(t) = PWHASH_W(t - 16) + S0 + PWHASH_W(t - 7) + S1
+		Next
+
+		Local A% = H0
+		Local B% = H1
+		Local C% = H2
+		Local D% = H3
+		Local E% = H4
+		Local F% = H5
+		Local G% = H6
+		Local H% = H7
+
+		For t = 0 To 63
+			Local BigS1%  = PWHASH_ROTR(E, 6) Xor PWHASH_ROTR(E, 11) Xor PWHASH_ROTR(E, 25)
+			; `Not E` would be logical (0/1) in Blitz3D; we need bitwise
+			; complement. XOR with -1 (= 0xffffffff in two's complement)
+			; flips every bit -- equivalent to ~E in C.
+			Local Ch%     = (E And F) Xor ((E Xor -1) And G)
+			Local Temp1%  = H + BigS1 + Ch + PWHASH_K(t) + PWHASH_W(t)
+			Local BigS0%  = PWHASH_ROTR(A, 2) Xor PWHASH_ROTR(A, 13) Xor PWHASH_ROTR(A, 22)
+			Local Maj%    = (A And B) Xor (A And C) Xor (B And C)
+			Local Temp2%  = BigS0 + Maj
+			H = G : G = F : F = E : E = D + Temp1
+			D = C : C = B : B = A : A = Temp1 + Temp2
+		Next
+
+		H0 = H0 + A : H1 = H1 + B : H2 = H2 + C : H3 = H3 + D
+		H4 = H4 + E : H5 = H5 + F : H6 = H6 + G : H7 = H7 + H
+	Next
+
+	FreeBank hMsg
+
+	Local Out$ = PWHASH_HexWord$(H0) + PWHASH_HexWord$(H1)
+	Out = Out + PWHASH_HexWord$(H2) + PWHASH_HexWord$(H3)
+	Out = Out + PWHASH_HexWord$(H4) + PWHASH_HexWord$(H5)
+	Out = Out + PWHASH_HexWord$(H6) + PWHASH_HexWord$(H7)
+	Return Out
+
+End Function
+
+; Generate a 16-character random salt from a URL-safe alphabet (no '$'
+; or whitespace so the storage format stays parseable by a simple split).
+Function GenerateSalt$()
+	Local Alphabet$ = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789"
+	Local AlphaLen% = Len(Alphabet)
+	Local Out$ = ""
+	Local i%
+	For i = 1 To PWHASH_SALT_LEN
+		Out = Out + Mid$(Alphabet, Rand(1, AlphaLen), 1)
+	Next
+	Return Out
+End Function
+
+; Produce a v1 storage record for the given client-supplied MD5 hex.
+;
+; Note: this hashes whatever bytes you hand it. It does not validate
+; that ClientMD5 is in fact an MD5 -- that's the wire-format
+; verification's job, and we want the function to be a pure helper.
+Function HashPassword$(ClientMD5$)
+	Local Salt$ = GenerateSalt$()
+	Local Hash$ = SHA256Hex$(Salt + ClientMD5)
+	Return PWHASH_VERSION_TAG + Salt + "$" + Hash
+End Function
+
+; Compare a stored record to an incoming client MD5. Returns True on match.
+; Accepts both legacy (raw MD5) and v1 ($1$<salt>$<hash>) on-disk formats.
+Function VerifyPassword%(Stored$, ClientMD5$)
+	If Len(Stored) = 0 Or Len(ClientMD5) = 0 Then Return False
+	If Left$(Stored, Len(PWHASH_VERSION_TAG)) = PWHASH_VERSION_TAG
+		; $1$<salt-16>$<hash-64>
+		If Len(Stored) <> Len(PWHASH_VERSION_TAG) + PWHASH_SALT_LEN + 1 + 64 Then Return False
+		Local Salt$ = Mid$(Stored, Len(PWHASH_VERSION_TAG) + 1, PWHASH_SALT_LEN)
+		Local Sep$  = Mid$(Stored, Len(PWHASH_VERSION_TAG) + PWHASH_SALT_LEN + 1, 1)
+		If Sep <> "$" Then Return False
+		Local StoredHash$ = Mid$(Stored, Len(PWHASH_VERSION_TAG) + PWHASH_SALT_LEN + 2)
+		Return SHA256Hex$(Salt + ClientMD5) = StoredHash
+	EndIf
+	; Legacy plain-MD5 record.
+	Return Stored = ClientMD5
+End Function
+
+; True iff Stored is in the legacy plain-MD5 format and should be
+; upgraded to v1 on next save.
+Function PasswordIsLegacy%(Stored$)
+	If Len(Stored) = 0 Then Return False
+	If Left$(Stored, Len(PWHASH_VERSION_TAG)) = PWHASH_VERSION_TAG Then Return False
+	Return True
+End Function
+
+; Migrate a verified legacy entry to the v1 format. Returns the new
+; storage record, or Stored unchanged if it's already v1 / empty.
+; Callers should only invoke this AFTER a successful VerifyPassword%
+; against the same ClientMD5 -- otherwise we'd be re-stamping an
+; unverified credential.
+Function UpgradePasswordIfLegacy$(Stored$, ClientMD5$)
+	If Not PasswordIsLegacy%(Stored) Then Return Stored
+	Return HashPassword$(ClientMD5)
+End Function

--- a/src/Modules/ServerNet.bb
+++ b/src/Modules/ServerNet.bb
@@ -1787,7 +1787,12 @@ Function UpdateNetwork()
 						; PwdLen >= 1 + A\Pass$ <> "" reject truncated packets
 						; and accounts with empty stored passwords (same guard
 						; as P_VerifyAccount).
-						If PwdLen >= 1 And A\Pass$ <> "" And A\Pass$ = Mid$(M\MessageData$, Offset + 1, PwdLen) And A\IsBanned = False
+						Local IncomingPwd$ = Mid$(M\MessageData$, Offset + 1, PwdLen)
+						If PwdLen >= 1 And A\Pass$ <> "" And VerifyPassword%(A\Pass$, IncomingPwd$) And A\IsBanned = False
+							; Lazy-migrate the on-disk record to the salted v1
+							; format once we know this MD5 is valid. The next
+							; SaveAccounts() persists the upgrade.
+							A\Pass$ = UpgradePasswordIfLegacy$(A\Pass$, IncomingPwd$)
 							Offset = Offset + 1 + PwdLen
 							Number = Asc(Mid$(M\MessageData$, Offset, 1))
 
@@ -2089,8 +2094,10 @@ Function UpdateNetwork()
 									LoginAttemptRecord(M\FromID, False)
 									RCE_Send(Host, M\FromID, P_VerifyAccount, "P", True)
 								; If password is correct, send back character list
-								ElseIf A\Pass$ <> "" And A\Pass$ = Mid$(M\MessageData$, Offset + 1, PwdLen) And A\IsBanned = False
+								ElseIf A\Pass$ <> "" And VerifyPassword%(A\Pass$, Mid$(M\MessageData$, Offset + 1, PwdLen)) And A\IsBanned = False
 									LoginAttemptRecord(M\FromID, True)
+									; Lazy-migrate to v1 on first successful login.
+									A\Pass$ = UpgradePasswordIfLegacy$(A\Pass$, Mid$(M\MessageData$, Offset + 1, PwdLen))
 									Pa$ = "Y"
 									For i = 0 To 9
 										If A\Character[i] <> Null
@@ -2143,10 +2150,12 @@ Function UpdateNetwork()
 						; it. Without the session check, a captured/replayed
 						; P_ChangePassword lets any party with the (broken-
 						; MD5) hash steal the account permanently.
-						If PwdLen >= 1 And A\Pass$ <> "" And A\Pass$ = Mid$(M\MessageData$, Offset + 1, PwdLen) And RequesterOwnsAccountSession(A, M\FromID)
+						If PwdLen >= 1 And A\Pass$ <> "" And VerifyPassword%(A\Pass$, Mid$(M\MessageData$, Offset + 1, PwdLen)) And RequesterOwnsAccountSession(A, M\FromID)
 							Offset = 2 + PwdLen
 							PwdLen = RCE_IntFromStr(Mid$(M\MessageData$, Offset, 1))
-							A\Pass$ = Mid$(M\MessageData$, Offset + 1, PwdLen)
+							; Store the new password in the v1 salted format
+							; immediately, not the raw client MD5.
+							A\Pass$ = HashPassword$(Mid$(M\MessageData$, Offset + 1, PwdLen))
 							RCE_Send(Host, M\FromID, P_ChangePassword, "Y", True)
 							//If MySQL = True Then My_SaveAccount(A, False)
 						; Otherwise return password failure
@@ -2173,7 +2182,7 @@ Function UpdateNetwork()
 						PwdLen = RCE_IntFromStr(Mid$(M\MessageData$, Offset, 1))
 						; PwdLen >= 1 + A\Pass$ <> "" reject truncated packets
 						; and accounts with empty stored passwords.
-						If PwdLen >= 1 And A\Pass$ <> "" And A\Pass$ = Mid$(M\MessageData$, Offset + 1, PwdLen) And A\IsBanned = False
+						If PwdLen >= 1 And A\Pass$ <> "" And VerifyPassword%(A\Pass$, Mid$(M\MessageData$, Offset + 1, PwdLen)) And A\IsBanned = False
 							Offset = Offset + 1 + PwdLen
 							Number = Asc(Mid$(M\MessageData$, Offset, 1))
 							If Number > -1 And Number < 10
@@ -2276,7 +2285,7 @@ Function UpdateNetwork()
 						PwdLen = RCE_IntFromStr(Mid$(M\MessageData$, Offset, 1))
 						; If password is correct (PwdLen >= 1 + A\Pass$ <> ""
 						; reject truncated packets and empty stored passwords)
-						If PwdLen >= 1 And A\Pass$ <> "" And A\Pass$ = Mid$(M\MessageData$, Offset + 1, PwdLen)
+						If PwdLen >= 1 And A\Pass$ <> "" And VerifyPassword%(A\Pass$, Mid$(M\MessageData$, Offset + 1, PwdLen))
 							Offset = Offset + 1 + PwdLen
 
 							; Check character name is valid. Bound length and reject
@@ -2428,7 +2437,7 @@ Function UpdateNetwork()
 						; for this account. A replayed P_DeleteCharacter would
 						; otherwise let anyone with the hash permanently
 						; destroy character slots on the account.
-						If PwdLen >= 1 And A\Pass$ <> "" And A\Pass$ = Mid$(M\MessageData$, Offset + 1, PwdLen) And RequesterOwnsAccountSession(A, M\FromID)
+						If PwdLen >= 1 And A\Pass$ <> "" And VerifyPassword%(A\Pass$, Mid$(M\MessageData$, Offset + 1, PwdLen)) And RequesterOwnsAccountSession(A, M\FromID)
 							Offset = Offset + 1 + PwdLen
 							Number = Asc(Mid$(M\MessageData$, Offset, 1))
 							If Number > -1 And Number < 10

--- a/src/Server.bb
+++ b/src/Server.bb
@@ -27,6 +27,7 @@ Include "Modules\ServerAreas.bb"          ; Areas module
 Include "Modules\SpawnTracking.bb"        ; Spawn bookkeeping helpers
 Include "Modules\Scripting.bb"            ; Script language module
 Include "Modules\Logging.bb"              ; Logging module
+Include "Modules\PasswordHash.bb"         ; Password hashing (SHA-256 + salted v1 format)
 Include "Modules\AccountsServer.bb"       ; Accounts server module
 Include "Modules\GameServer.bb"           ; Game server module
 Include "Modules\UpdatesServer.bb"        ; Updates server module

--- a/src/Tests/Modules/AccountsServerTest.bb
+++ b/src/Tests/Modules/AccountsServerTest.bb
@@ -88,6 +88,7 @@ Function ReadBoundedString$(F, MaxLen)
 	Return ""
 End Function
 
+Include "Modules\PasswordHash.bb"
 Include "Modules\AccountsServer.bb"
 
 Test testFindAccountByListIDReturnsMatchingAccount()

--- a/src/Tests/Modules/PasswordHashTest.bb
+++ b/src/Tests/Modules/PasswordHashTest.bb
@@ -1,0 +1,86 @@
+; Tests for Modules/PasswordHash.bb.
+;
+; Includes RFC 6234 / FIPS 180-4 known-answer SHA-256 vectors plus
+; round-trip tests for the salted v1 format and legacy-MD5 acceptance.
+
+Include "Modules\PasswordHash.bb"
+
+Test sha256_empty()
+	Assert(SHA256Hex$("") = "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855")
+End Test
+
+Test sha256_abc()
+	Assert(SHA256Hex$("abc") = "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad")
+End Test
+
+Test sha256_quickbrownfox()
+	; SHA256("The quick brown fox jumps over the lazy dog")
+	Assert(SHA256Hex$("The quick brown fox jumps over the lazy dog") = "d7a8fbb307d7809469ca9abcb0082e4f8d5651e46d3cdb762d02d0bf37c9e592")
+End Test
+
+Test sha256_56byte_boundary()
+	; 56-byte input forces a padded length of 128 (two 64-byte blocks)
+	; because the trailing 0x80 + 8-byte length need 9 bytes that won't
+	; fit in the remaining 8 of the first block.
+	Local Msg$ = "abcdbcdecdefdefgefghfghighijhijkijkljklmklmnlmnomnopnopq"
+	Assert(SHA256Hex$(Msg) = "248d6a61d20638b8e5c026930c3e6039a33ce45964ff2167f6ecedd419db06c1")
+End Test
+
+Test sha256_one_block_long()
+	; A 100-character input ("a" * 100) -- exercises padding into a
+	; second block where the first is fully consumed by message bytes.
+	Local Msg$ = ""
+	Local i%
+	For i = 1 To 100
+		Msg = Msg + "a"
+	Next
+	Assert(SHA256Hex$(Msg) = "2816597888e4a0d3a36b82b83316ab32680eb8f00f8cd3b904d681246d285a0e")
+End Test
+
+Test hashpassword_roundtrip()
+	; HashPassword always produces a v1 record that VerifyPassword
+	; accepts for the same MD5, and rejects for a different one.
+	Local MD5$ = "5d41402abc4b2a76b9719d911017c592"   ; md5("hello")
+	Local Stored$ = HashPassword$(MD5)
+	Assert(Left$(Stored, 3) = "$1$")
+	Assert(Len(Stored) = 3 + 16 + 1 + 64)
+	Assert(VerifyPassword%(Stored, MD5) = True)
+	Assert(VerifyPassword%(Stored, "00000000000000000000000000000000") = False)
+End Test
+
+Test hashpassword_unique_salt()
+	; Two consecutive hashes of the same MD5 should produce different
+	; records because each picks a fresh random salt. Statistically the
+	; chance of two 16-char salts colliding is effectively zero.
+	Local MD5$ = "5d41402abc4b2a76b9719d911017c592"
+	SeedRnd MilliSecs()
+	Local A$ = HashPassword$(MD5)
+	Local B$ = HashPassword$(MD5)
+	Assert(A <> B)
+End Test
+
+Test verify_accepts_legacy_md5()
+	; Existing accounts on disk still have raw 32-char MD5 in A\Pass$.
+	; Verify must compare those as plaintext until migration runs.
+	Local MD5$ = "5d41402abc4b2a76b9719d911017c592"
+	Assert(VerifyPassword%(MD5, MD5) = True)
+	Assert(VerifyPassword%(MD5, "5d41402abc4b2a76b9719d911017c593") = False)
+End Test
+
+Test verify_rejects_empty()
+	Assert(VerifyPassword%("", "5d41402abc4b2a76b9719d911017c592") = False)
+	Assert(VerifyPassword%("5d41402abc4b2a76b9719d911017c592", "") = False)
+End Test
+
+Test verify_rejects_malformed_v1()
+	; Truncated v1 record must not crash and must not accept.
+	Assert(VerifyPassword%("$1$short", "5d41402abc4b2a76b9719d911017c592") = False)
+	; Wrong separator after salt.
+	Assert(VerifyPassword%("$1$abcdefghijklmnopXffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff", "5d41402abc4b2a76b9719d911017c592") = False)
+End Test
+
+Test test_passwordislegacy()
+	Assert(PasswordIsLegacy%("5d41402abc4b2a76b9719d911017c592") = True)
+	Assert(PasswordIsLegacy%(HashPassword$("5d41402abc4b2a76b9719d911017c592")) = False)
+	Assert(PasswordIsLegacy%("") = False)
+End Test


### PR DESCRIPTION
## Summary

Closes the deferred Round 5 finding: the server stored client-supplied MD5 password hashes **verbatim** in `Accounts.dat` and compared them by string equality. The MD5 was therefore wire-equivalent to the password — anyone with read access to `Accounts.dat` got working credentials for every account, and a captured login PCAP could be replayed indefinitely.

The wire-replay problem still requires a challenge/response protocol or TLS to fix (both bigger projects). **This PR addresses the at-rest problem** with a salted SHA-256 wrapper, forward-compatible with existing legacy accounts.

### Storage format

```
Legacy:   <32 lowercase hex chars>            # raw MD5 from client (existing entries)
v1:       $1$<salt-16-chars>$<sha256-64-hex>  # SHA-256(salt + MD5)
```

`VerifyPassword%` accepts both. `HashPassword$` always emits v1. `PasswordIsLegacy%` / `UpgradePasswordIfLegacy$` handle on-login migration.

### Changes

- **New `src/Modules/PasswordHash.bb`** with pure-Blitz3D SHA-256 (FIPS 180-4), salt/hash/verify helpers, and lazy-upgrade plumbing.
- **`src/Modules/AccountsServer.bb` `AddAccount`** now wraps the incoming MD5 in v1 storage immediately — new accounts never sit on disk as raw MD5.
- **`src/Modules/ServerNet.bb`** seven password-compare sites switch from string equality to `VerifyPassword%`:
  - `P_StartGame` login, `P_VerifyAccount`, `P_ChangePassword` (auth + new-password store), `P_FetchCharacterData`, `P_CreateCharacter`, `P_DeleteCharacter`.
  - The two session-establishing flows (`P_StartGame`, `P_VerifyAccount`) also call `UpgradePasswordIfLegacy$` on success so the on-disk record migrates to v1 on the next `SaveAccounts()`.

### Tests

`src/Tests/Modules/PasswordHashTest.bb` covers:

- SHA-256 against FIPS-180-4 vectors: empty, `\"abc\"`, quick brown fox, 56-byte multi-block boundary, 100-byte `a`-fill.
- v1 round-trip via `HashPassword$` / `VerifyPassword%`.
- Fresh salt per call.
- Legacy MD5 still accepted for back-compat.
- Empty / malformed-v1 entries rejected.

`AccountsServerTest` now `Include`s `PasswordHash` so `AddAccount` resolves `HashPassword$` in the unit-test build.

### Bitwise note

Blitz3D's `Not` is logical (returns 0/1), not bitwise — a SHA-256 implementation that uses `Not E` instead of bitwise complement produces deterministic but wrong digests. The Ch function in `PasswordHash.bb` uses `(E Xor -1)` for bitwise complement and a short comment calls this out for future readers.

## Test plan

- [x] `blitzcc -o Server.exe Server.bb` compiles clean.
- [x] Full rcce2 `test.bat` (server-module suite incl. new PasswordHashTest) passes locally.
- [ ] CI build + tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)