### PR TITLE
[SECURITY] Tier 1: combat/AI/scripting silent defects (Round 6)

### DIFF
--- a/src/Modules/Actors.bb
+++ b/src/Modules/Actors.bb
@@ -958,10 +958,20 @@ Function CreateActorEffect.ActorEffect( AI.ActorInstance, Effects.Attributes, Ef
 	EndIf
 	FoundAE\CreatedTime = MilliSecs()
 	FoundAE\Length = EffectLength%
+	; Bug fix: previously read from `AI\Inventory\Items[Slot]` where
+	; `Slot` is not a parameter of this function -- Blitz silently
+	; resolved it to whatever module-global of that name existed (the
+	; ServerNet P_EatItem handler's local, post-call, or zero). Every
+	; script-applied buff therefore copied attributes from whatever
+	; was in the actor's inventory slot 0, not from the `Effects`
+	; table the caller passed in. P_EatItem's open-coded inventory
+	; copy at ServerNet.bb:1131+ already does the right thing; this
+	; function takes `Effects.Attributes` precisely so script callers
+	; can pass arbitrary buff vectors -- honour that.
 	For i = 0 To 39
 		If Effects\Value[i] <> 0
 			Old = FoundAE\Attributes\Value[i]
-			FoundAE\Attributes\Value[i] = AI\Inventory\Items[Slot]\Attributes\Value[i]
+			FoundAE\Attributes\Value[i] = Effects\Value[i]
 			Pa$ = RCE_StrFromInt$(i, 1) + RCE_StrFromInt$(FoundAE\Attributes\Value[i] - Old, 4)
 			FoundAE\Owner\Attributes\Value[i] = FoundAE\Owner\Attributes\Value[i] + (FoundAE\Attributes\Value[i] - Old)
 			RCE_Send(Host, FoundAE\Owner\RNID, P_ActorEffect, "E" + Pa$, True)

--- a/src/Modules/GameServer.bb
+++ b/src/Modules/GameServer.bb
@@ -884,7 +884,13 @@ Function UpdateActorInstances(Broadcast)
 				ElseIf AI\AIMode = AI_PetChase
 					; Keep updated with leader's target
 					AI\AITarget = AI\Leader\AITarget
-					If AI\AITarget <> Null Then AI\AIMode = AI_Pet
+					; Bug fix: the original condition demoted the pet OUT
+					; of chase mode the moment it acquired a target,
+					; oscillating between AI_Pet and AI_PetChase every
+					; frame. The "lost target" demotion at line ~901 below
+					; already handles the AI_PetChase -> AI_Pet transition
+					; when the target goes Null; remove the inverted line
+					; here.
 
 					; Check if leader is too far away
 					XDist# = AI\X# - AI\Leader\X#

--- a/src/Modules/ServerNet.bb
+++ b/src/Modules/ServerNet.bb
@@ -1045,9 +1045,29 @@ Function UpdateNetwork()
 											RCE_Send(Host, AI\RNID, P_ChatMessage, Chr$(253) + LanguageString$(LS_AbilityNotRecharged), True)
 										Else
 											Sp.Spell = SpellsList(SpellID)
-											ThreadScript(Sp\Script$, Sp\SMethod$, Handle(AI), Handle(Context), AI\SpellLevels[Num])
-											AI\SpellCharge[SpellID] = Sp\RechargeTime
-											AI\LastSpellFireMs = NowMs
+											; Race / class restriction check.
+											; The Spell type has ExclusiveRace$/ExclusiveClass$
+											; (persisted by SaveSpells / loaded by
+											; LoadSpells, editor-exposed in GUE), but
+											; the cast path never enforced them -- so
+											; a paladin-only Smite taught to a thief
+											; via script or recovered from a stale save
+											; would fire normally. The check mirrors
+											; the item-eat gate in P_EatItem.
+											Local SpellAllowed = True
+											If Len(Sp\ExclusiveRace$) > 0
+												If Upper$(AI\Actor\Race$) <> Upper$(Sp\ExclusiveRace$) Then SpellAllowed = False
+											EndIf
+											If SpellAllowed And Len(Sp\ExclusiveClass$) > 0
+												If Upper$(AI\Actor\Class$) <> Upper$(Sp\ExclusiveClass$) Then SpellAllowed = False
+											EndIf
+											If SpellAllowed = False
+												RCE_Send(Host, AI\RNID, P_ChatMessage, Chr$(253) + LanguageString$(LS_AbilityNotRecharged), True)
+											Else
+												ThreadScript(Sp\Script$, Sp\SMethod$, Handle(AI), Handle(Context), AI\SpellLevels[Num])
+												AI\SpellCharge[SpellID] = Sp\RechargeTime
+												AI\LastSpellFireMs = NowMs
+											EndIf
 										EndIf
 									EndIf
 								EndIf
@@ -1171,7 +1191,12 @@ Function UpdateNetwork()
 					EndIf
 					If SlotIndex >= 0 And SlotIndex < 50
 						If AI\Inventory\Items[SlotIndex] <> Null
-							If AI\Inventory\Items[SlotIndex]\Item\ExclusiveClass$ = "" Or Upper$(AI\Actor\Race$) = Upper$(AI\Inventory\Items[SlotIndex]\Item\ExclusiveClass$)
+							; Bug fix: the ExclusiveClass gate originally
+							; compared Actor\Race$ against ExclusiveClass$
+							; (copy-paste typo from the line below). Compare
+							; Class$ against ExclusiveClass$, mirroring
+							; P_EatItem at line ~1107.
+							If AI\Inventory\Items[SlotIndex]\Item\ExclusiveClass$ = "" Or Upper$(AI\Actor\Class$) = Upper$(AI\Inventory\Items[SlotIndex]\Item\ExclusiveClass$)
 								If AI\Inventory\Items[SlotIndex]\Item\ExclusiveRace$ = "" Or Upper$(AI\Actor\Race$) = Upper$(AI\Inventory\Items[SlotIndex]\Item\ExclusiveRace$)
 									If AI\Inventory\Items[SlotIndex]\Item\Script$ <> ""
 										If AI\Inventory\Amounts[SlotIndex] > 0
@@ -1215,7 +1240,16 @@ Function UpdateNetwork()
 								If (A2\Leader = Null Or A2\Leader = AI) And AI\Mount = Null
 									AI\Mount = A2
 									A2\Rider = AI
-									A2\AIMode = AI_None
+									; Bug fix: AI_None was never declared in
+									; Actors.bb (only AI_Wait..AI_PetWait
+									; exist). Blitz silently coerced it to 0
+									; (= AI_Wait), so the AILookForTargets
+									; sweep still ran every 10 ticks against
+									; the mount's own rider. Clear the AI
+									; target and use the existing AI_Wait
+									; sentinel.
+									A2\AIMode = AI_Wait
+									A2\AITarget = Null
 									ThreadScript("Mount", "Mount", Handle(AI), Handle(A2))
 								EndIf
 							EndIf

--- a/src/Server.bb
+++ b/src/Server.bb
@@ -680,17 +680,33 @@ Repeat
 	EndIf
 	UpdateEnvironment()
 
-	; Update spell memorisation progress
+	; Update spell memorisation progress.
+	;
+	; Bug fix: SpellCharge[] is keyed by spell ID 0..999 across the rest
+	; of the codebase (see Actors.bb field comment and the unified
+	; cooldown handling in ServerNet.bb's P_SpellUpdate "F" branch).
+	; The old line `MS\AI\SpellCharge[i] = 0` indexed by the
+	; memorise-slot 0..9, so completing any memorisation zeroed the
+	; cooldown for spell IDs 0..9 -- making low-ID spells instantly
+	; recastable. Zero the cooldown for the spell that was actually
+	; learned instead.
+	;
+	; Also guard against the owning actor having been freed mid-
+	; memorise (e.g. logout race): MemorisingSpell records were not
+	; previously reaped on FreeActorInstance, so a stale MS\AI here
+	; would null-deref on SpellLevels.
 	For MS.MemorisingSpell = Each MemorisingSpell
 		If MilliSecs() - MS\CreatedTime > 6000
-			If MS\AI\SpellLevels[MS\KnownNum] > 0
-				For i = 0 To 9
-					If MS\AI\MemorisedSpells[i] = 5000
-						MS\AI\MemorisedSpells[i] = MS\KnownNum
-						MS\AI\SpellCharge[i] = 0
-						Exit
-					EndIf
-				Next
+			If MS\AI <> Null And MS\KnownNum >= 0 And MS\KnownNum <= 999
+				If MS\AI\SpellLevels[MS\KnownNum] > 0
+					For i = 0 To 9
+						If MS\AI\MemorisedSpells[i] = 5000
+							MS\AI\MemorisedSpells[i] = MS\KnownNum
+							MS\AI\SpellCharge[MS\KnownNum] = 0
+							Exit
+						EndIf
+					Next
+				EndIf
 			EndIf
 			Delete MS
 		EndIf


### PR DESCRIPTION
## Summary

Cluster of six small, surgical fixes for silent gameplay-correctness bugs surfaced in the Round 6 audit. Each is independently tiny; they're grouped here because they all share the property of producing wrong behaviour without any log/RuntimeError — exactly the class the existing test suite can't catch.

### 1. Spell cooldown wipe on memorisation — `Server.bb:687-693`
`MS\AI\SpellCharge[i] = 0` indexed by the memorise-slot (0..9), but PR #108 unified `SpellCharge[]` to be keyed by spell ID 0..999. Every completed memorisation zeroed the cooldown of spell IDs 0..9 — low-ID spells were instantly recastable. Index by `MS\KnownNum`, with a bounds + null-AI guard for the logout-mid-memorise race.

### 2. Pet AI mode oscillation — `GameServer.bb:887`
`If AI\AITarget <> Null Then AI\AIMode = AI_Pet` inside the `AI_PetChase` branch — inverted predicate, demoted the pet out of chase the moment it acquired a target. The \"lost target\" guard below already handles the demote-to-AI_Pet case; remove the line.

### 3. Mount uses undeclared `AI_None` — `ServerNet.bb:1218`
`Actors.bb` declares `AI_Wait..AI_PetWait` only. Blitz silently coerced the bare identifier to 0 (= `AI_Wait`), so `AILookForTargets` still ran every 10 ticks against the mount's own rider. Use `AI_Wait` explicitly and clear `AITarget`.

### 4. `CreateActorEffect` reads undeclared `Slot` — `Actors.bb:964`
`AI\Inventory\Items[Slot]\Attributes\Value[i]` — `Slot` is not a parameter; Blitz resolved it to whatever global of that name existed (zero). Every script-applied buff copied from inventory slot 0, not the `Effects` table the caller passed in. Honour `Effects`.

### 5. `P_ItemScript` class/race typo — `ServerNet.bb:1174`
`Upper$(AI\Actor\Race$) = Upper$(...\ExclusiveClass$)` — both sides of the Class gate compared Race, so the ExclusiveClass restriction was effectively unenforced for the use-item flow. Mirror the correct pattern from `P_EatItem`.

### 6. Spell `ExclusiveRace$`/`ExclusiveClass$` never enforced on cast — `ServerNet.bb:1047+`
Declared on `Spell`, persisted, editor-exposed — but the `P_SpellUpdate \"F\"` branch never checked them. A paladin-only spell taught to a thief via script or recovered from a stale character would fire. Added the gate; reports `LS_AbilityNotRecharged` on rejection to avoid leaking the reason.

## Test plan

- [x] `blitzcc -o Server.exe Server.bb` compiles clean.
- [x] `AccountsServerTest` passes standalone (full `test.bat` flake is the documented pre-existing infra issue).
- [ ] CI build + tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)