### PR TITLE
[SECURITY] Tier 2: anti-cheat gaps (Round 6)

### DIFF
--- a/src/Modules/ScriptingCommands.bb
+++ b/src/Modules/ScriptingCommands.bb
@@ -1469,6 +1469,12 @@ Function BVM_CREATEEMITTER(Param1%, Param2$, Param3%, Param4%, Param5#=0, Param6
 End Function
 
 Function BVM_SETFACTIONRATING(Param1%, Param2$, Param3%)
+	; Faction rating drives the combat-engagement gate in GameServer.bb
+	; (an unprivileged script that flips a guard's faction rating > 150
+	; against the player makes the guard friendly). Restrict the
+	; mutator the same way Round 5's privilege sweep restricted the
+	; admin family.
+	If Not BVM_RequirePrivileged() Then Return
 	Actor.ActorInstance = Object.ActorInstance(Param1%)
 	If Actor <> Null
 		Faction$ = Upper$(Param2$)
@@ -1487,6 +1493,8 @@ Function BVM_SETFACTIONRATING(Param1%, Param2$, Param3%)
 End Function
 
 Function BVM_CHANGEFACTIONRATING(Param1%, Param2$, Param3%)
+	; See BVM_SETFACTIONRATING above -- same privilege story.
+	If Not BVM_RequirePrivileged() Then Return
 	Actor.ActorInstance = Object.ActorInstance(Param1%)
 	If Actor <> Null
 		Faction$ = Upper$(Param2$)
@@ -1505,6 +1513,10 @@ Function BVM_CHANGEFACTIONRATING(Param1%, Param2$, Param3%)
 End Function
 
 Function BVM_SETHOMEFACTION(Param1%, Param2$)
+	; HomeFaction is the rating-table key against which NPC
+	; engagement is decided; unprivileged scripts that flip it
+	; can make the player invisible to any aggressive faction.
+	If Not BVM_RequirePrivileged() Then Return
 	Actor.ActorInstance = Object.ActorInstance(Param1%)
 	If Actor <> Null
 		Faction$ = Upper$(Param2$)

--- a/src/Modules/ServerNet.bb
+++ b/src/Modules/ServerNet.bb
@@ -987,7 +987,14 @@ Function UpdateNetwork()
 							; Spell ID and target
 							Num = RCE_IntFromStr(Mid$(M\MessageData$, 2, 2))
 							Context.ActorInstance = Null
-							If Len(M\MessageData$) > 3
+							; Bug fix: previously `Len > 3` admitted 4-byte
+							; packets that then read `Mid$(...,4,2)` past
+							; end of string -- Blitz pads short Mid$ with
+							; empty bytes and RCE_IntFromStr returns a
+							; truncated/zero RuntimeID, aliasing Context
+							; to actor 0. Require both target-RuntimeID
+							; bytes to be present.
+							If Len(M\MessageData$) >= 5
 								RuntimeID = RCE_IntFromStr(Mid$(M\MessageData$, 4, 2))
 								Context = RuntimeIDList(RuntimeID)
 								; Reject targets that are dead or in a different


### PR DESCRIPTION
## Summary

Two anti-cheat improvements surfaced by Round 6:

### 1. Spell-fire packet length — `ServerNet.bb:990`
`If Len > 3` admitted 4-byte packets that then read `Mid$(...,4,2)` past end of string. Blitz pads short `Mid$` with empty bytes and `RCE_IntFromStr` returns a truncated/zero RuntimeID, aliasing Context to actor 0. Tighten to `Len >= 5` so the optional target-RuntimeID requires both bytes to be present.

### 2. Faction-mutation script commands now require Privileged — `ScriptingCommands.bb:1471, 1489, 1507`
`BVM_SETFACTIONRATING` / `BVM_CHANGEFACTIONRATING` / `BVM_SETHOMEFACTION` were missed by Round 5's privilege sweep. Faction rating drives the combat-engagement gate (`A1\FactionRatings[A2\HomeFaction] > 150` skips combat at `GameServer.bb:323,351`), so an unprivileged item or dialog script could flip a guard's rating above 150 against the player, making the guard friendly. Flipping HomeFaction makes the player invisible to any aggressive faction. Add `BVM_RequirePrivileged()` gates matching the admin command pattern.

## Test plan

- [x] `blitzcc -o Server.exe Server.bb` compiles clean.
- [ ] CI build + tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)