### PR TITLE
[SECURITY] SafeWrite sweep across remaining Save* functions

### DIFF
--- a/src/Modules/Actors.bb
+++ b/src/Modules/Actors.bb
@@ -616,10 +616,13 @@ Function LoadActors(Filename$)
 
 End Function
 
-; Saves all actors to file
+; Saves all actors to file via SafeWriteOpen/Commit (atomic). A crash
+; mid-write previously truncated Actors.dat, losing the entire actor
+; template catalog -- same Track FF rationale as SaveItems.
 Function SaveActors(Filename$)
 
-	F = WriteFile(Filename$)
+	Local Temp$ = SafeWriteOpen$(Filename$)
+	F = WriteFile(Temp$)
 	If F = 0 Then Return False
 
 		For A.Actor = Each Actor
@@ -666,8 +669,7 @@ Function SaveActors(Filename$)
 			WriteByte(F, A\PolyCollision)
 		Next
 
-	CloseFile F
-	Return True
+	Return SafeWriteCommit%(Temp$, Filename$, F)
 
 End Function
 
@@ -689,10 +691,11 @@ Function LoadAttributes(Filename$)
 
 End Function
 
-; Saves attribute names to file
+; Saves attribute names to file via SafeWriteOpen/Commit (atomic).
 Function SaveAttributes(Filename$)
 
-	F = WriteFile(Filename$)
+	Local Temp$ = SafeWriteOpen$(Filename$)
+	F = WriteFile(Temp$)
 	If F = 0 Then Return False
 
 		WriteByte(F, AttributeAssignment)
@@ -702,8 +705,7 @@ Function SaveAttributes(Filename$)
 			WriteByte(F, AttributeHidden(i))
 		Next
 
-	CloseFile(F)
-	Return True
+	Return SafeWriteCommit%(Temp$, Filename$, F)
 
 End Function
 
@@ -856,10 +858,11 @@ Function LoadFactions(Filename$)
 
 End Function
 
-; Saves faction data to file
+; Saves faction data to file via SafeWriteOpen/Commit (atomic).
 Function SaveFactions(Filename$)
 
-	F = WriteFile(Filename$)
+	Local Temp$ = SafeWriteOpen$(Filename$)
+	F = WriteFile(Temp$)
 	If F = 0 Then Return False
 
 		For i = 0 To 99
@@ -872,8 +875,7 @@ Function SaveFactions(Filename$)
 			Next
 		Next
 
-	CloseFile(F)
-	Return True
+	Return SafeWriteCommit%(Temp$, Filename$, F)
 
 End Function
 

--- a/src/Modules/Animations.bb
+++ b/src/Modules/Animations.bb
@@ -138,10 +138,11 @@ Function LoadAnimSets(Filename$)
 
 End Function
 
-; Saves all animation sets
+; Saves all animation sets via SafeWriteOpen/Commit (atomic).
 Function SaveAnimSets(Filename$)
 
-	F = WriteFile(Filename$)
+	Local Temp$ = SafeWriteOpen$(Filename$)
+	F = WriteFile(Temp$)
 	If F = 0 Then Return False
 
 		For A.AnimSet = Each AnimSet
@@ -155,10 +156,12 @@ Function SaveAnimSets(Filename$)
 			Next
 		Next
 
-	CloseFile(F)
+	If Not SafeWriteCommit%(Temp$, Filename$, F) Then Return False
+
 	;Allows for animation sets to be recovered or something... cysis145
+	; The debug dump is not load-critical; direct write is fine.
 	G = WriteFile("Data\Game Data\Animations_debug.txt")
-	If G = 0 Then Return False  
+	If G = 0 Then Return True
 	For A.AnimSet = Each AnimSet
 		WriteLine(G, "Anim ID: " + A\ID)
 		WriteLine(G, "Anim Set: " + A\Name$)
@@ -170,7 +173,6 @@ Function SaveAnimSets(Filename$)
 	Next
 	CloseFile(G)
 
-	
 	Return True
 
 End Function

--- a/src/Modules/Interface.bb
+++ b/src/Modules/Interface.bb
@@ -336,10 +336,11 @@ Function LoadInterfaceSettings(Filename$)
 
 End Function
 
-; Saves the interface settings to a file
+; Saves the interface settings via SafeWriteOpen/Commit (atomic).
 Function SaveInterfaceSettings(Filename$)
 
-	F = WriteFile(Filename$)
+	Local Temp$ = SafeWriteOpen$(Filename$)
+	F = WriteFile(Temp$)
 	If F = 0 Then Return False
 
 		; Main game screen
@@ -362,8 +363,7 @@ Function SaveInterfaceSettings(Filename$)
 			WriteInterfaceComponent(InventoryButtons(i), F)
 		Next
 
-	CloseFile(F)
-	Return True
+	Return SafeWriteCommit%(Temp$, Filename$, F)
 
 End Function
 

--- a/src/Modules/Items.bb
+++ b/src/Modules/Items.bb
@@ -311,7 +311,14 @@ End Function
 ; Saves all loaded items to a file
 Function SaveItems(Filename$)
 
-	F = WriteFile(Filename$)
+	; Atomic-save through SafeWriteOpen/Commit so a crash, power loss,
+	; or disk-full mid-write doesn't truncate Items.dat (the entire
+	; item catalog). The previous direct WriteFile was the unfinished
+	; half of Track FF; the editor's "Save All" path blasted through
+	; nine such direct-write savers in sequence, any one of which
+	; could leave the catalog half-written.
+	Local Temp$ = SafeWriteOpen$(Filename$)
+	F = WriteFile(Temp$)
 	If F = 0 Then Return False
 
 		For I.Item = Each Item
@@ -350,10 +357,13 @@ Function SaveItems(Filename$)
 			WriteString F, I\MiscData$
 		Next
 
-	CloseFile(F)
+	If Not SafeWriteCommit%(Temp$, Filename$, F) Then Return False
+
 	; Small edit, allows to quickly find IMPORTANT item values, cysis145
+	; The debug dump is not load-critical; keep it as a direct write
+	; (overwriting Items_debug.txt with a partial copy is harmless).
 	G = WriteFile("Data\Server Data\Items_debug.txt")
-	If G = 0 Then Return False
+	If G = 0 Then Return True
 		For I.Item = Each Item
 			WriteLine(G, "Item ID: " + I\ID)
 			WriteLine(G, "Item Name: " + I\Name$)
@@ -361,7 +371,6 @@ Function SaveItems(Filename$)
 		Next
 	CloseFile(G)
 
-	
 	Return True
 
 End Function

--- a/src/Modules/Projectiles.bb
+++ b/src/Modules/Projectiles.bb
@@ -65,10 +65,11 @@ Function LoadProjectiles(Filename$)
 
 End Function
 
-; Saves all loaded projectiles to a file
+; Saves all loaded projectiles via SafeWriteOpen/Commit (atomic).
 Function SaveProjectiles(Filename$)
 
-	F = WriteFile(Filename$)
+	Local Temp$ = SafeWriteOpen$(Filename$)
+	F = WriteFile(Temp$)
 	If F = 0 Then Return False
 
 		For P.Projectile = Each Projectile
@@ -86,8 +87,7 @@ Function SaveProjectiles(Filename$)
 			WriteByte F, P\Speed
 		Next
 
-	CloseFile F
-	Return True
+	Return SafeWriteCommit%(Temp$, Filename$, F)
 
 End Function
 

--- a/src/Modules/Spells.bb
+++ b/src/Modules/Spells.bb
@@ -72,10 +72,11 @@ Function LoadSpells(Filename$)
 
 End Function
 
-; Saves all spells to file
+; Saves all spells to file via SafeWriteOpen/Commit (atomic).
 Function SaveSpells(Filename$)
 
-	F = WriteFile(Filename$)
+	Local Temp$ = SafeWriteOpen$(Filename$)
+	F = WriteFile(Temp$)
 	If F = 0 Then Return False
 
 		For S.Spell = Each Spell
@@ -90,7 +91,6 @@ Function SaveSpells(Filename$)
 			WriteString F, S\SMethod$
 		Next
 
-	CloseFile(F)
-	Return True
+	Return SafeWriteCommit%(Temp$, Filename$, F)
 
 End Function

--- a/src/Tests/Modules/ItemsTest.bb
+++ b/src/Tests/Modules/ItemsTest.bb
@@ -47,6 +47,21 @@ Global MainLog = 0
 Function WriteLog(LogID%, Message$, Timestamp% = True, Datestamp% = False)
 End Function
 
+; --- SafeWrite stubs --------------------------------------------------------
+; SaveItems now routes through SafeWriteOpen/Commit in Logging.bb. This
+; test build doesn't include Logging.bb (and doesn't actually exercise
+; the save path), so stub the helpers as pass-throughs: SafeWriteOpen
+; returns the same filename, SafeWriteCommit just closes the handle.
+Function SafeWriteOpen$(FinalPath$)
+	Return FinalPath$
+End Function
+
+Function SafeWriteCommit%(TempPath$, FinalPath$, F)
+	; Stub: the test build doesn't exercise SaveItems, so we never
+	; receive a real file handle here. Just acknowledge.
+	Return True
+End Function
+
 ; --- Language helper stub ---------------------------------------------------
 ; GetItemType$ / GetWeaponType$ in Items.bb route through LanguageString
 ; (from Language.bb) for localization. We don't exercise those paths here.


### PR DESCRIPTION
## Summary

Track FF retrofitted `SafeWriteOpen/Commit` (atomic save) onto `SaveAccounts`, `SaveSuperGlobals`, `SaveDroppedItems`, and `SaveEnvironment`. The audit found six other `Save*` functions still doing direct `WriteFile → truncate → write → close`. The editor's \"Save All\" path blasts through these in sequence; any one mid-write crash truncated:

- `Items.dat` (entire item catalog)
- `Actors.dat` (every actor template)
- `Spells.dat`
- `Projectiles.dat`
- `Attributes.dat`
- `Factions.dat` (and the 100×100 default-rating matrix)
- `AnimationSets.dat`
- Interface settings dat

Convert each to the SafeWrite pattern: `WriteFile` to a `.tmp`, then `SafeWriteCommit` which demotes the live file to `.bak` and promotes the temp into place. A crash leaves either the `.bak` (recovery) or the `.tmp` (manual promote) usable; the live file always reflects a complete commit.

The debug-text dumps in `SaveItems` (`Items_debug.txt`) and `SaveAnimSets` (`Animations_debug.txt`) are not load-critical and stay as direct writes — overwriting a debug text with a partial copy is harmless.

## Test plan

- [x] `blitzcc -o Server.exe Server.bb` compiles clean.
- [x] `blitzcc -o Client.exe Client.bb` compiles clean.
- [x] `blitzcc -o GUE.exe GUE.bb` compiles clean.
- [ ] CI build + tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)