### PR TITLE
[SECURITY] Accounts.dat format v1 magic + LastPortal persistence

### DIFF
--- a/src/Modules/AccountsServer.bb
+++ b/src/Modules/AccountsServer.bb
@@ -1,3 +1,23 @@
+; Accounts.dat format version. Older files have no magic header
+; (the very first ReadString$ in legacy LoadAccounts is User$),
+; so we use the absence of the magic to detect them. The magic is
+; carefully chosen so the first byte cannot legally be the first byte
+; of a Blitz ReadString$ length prefix that would actually parse as a
+; sensible string -- it's a four-byte sentinel "ACCT" (Big-endian).
+;
+; Version history:
+;   v0 -- pre-magic (legacy). Identified by the file not starting
+;         with ACCOUNTS_MAGIC.
+;   v1 -- adds the per-character LastPortal / LastPortalArea /
+;         LastPortalTime triad at the END of WriteActorInstance, so
+;         the portal-lock anti-exploit (Track TT) survives a
+;         logout/login cycle. Older saves load with all three
+;         defaulted to 0/-1, which still locks out per-area portals
+;         on the first re-entry.
+Const ACCOUNTS_MAGIC = $41434354  ; "ACCT"
+Const ACCOUNTS_VERSION_CURRENT% = 1
+Global ACCOUNTS_LOAD_VERSION% = 0
+
 Type AccountsWindow
 	Field Window
 	Field List
@@ -218,6 +238,10 @@ Function SaveAccounts()
 		Return False
 	EndIf
 
+		; v1 header: magic + version. New writes always v1.
+		WriteInt F, ACCOUNTS_MAGIC
+		WriteByte F, ACCOUNTS_VERSION_CURRENT%
+
 		For A.Account = Each Account
 			WriteString F, A\User$
 			WriteString F, A\Pass$
@@ -266,6 +290,26 @@ Function LoadAccounts()
 			SetGadgetText(Accounts\DMLabel, "GM accounts: 0")
 			SetGadgetText(Accounts\BannedLabel, "Banned accounts: 0")
 			Return 0
+		EndIf
+
+		; Detect format version by peeking the first 4 bytes for the
+		; magic header. If absent (pre-v1 file), seek back to 0 and
+		; read as legacy.
+		Local PeekMagic = ReadInt(F)
+		If PeekMagic = ACCOUNTS_MAGIC
+			ACCOUNTS_LOAD_VERSION% = ReadByte(F)
+			; Reject unknown versions to avoid silently mis-reading a
+			; future format. New rcce2 builds must be paired with the
+			; saves they wrote.
+			If ACCOUNTS_LOAD_VERSION% > ACCOUNTS_VERSION_CURRENT%
+				WriteLog(MainLog, "LoadAccounts: file version " + ACCOUNTS_LOAD_VERSION% + " > supported " + ACCOUNTS_VERSION_CURRENT% + ", aborting load")
+				CloseFile(F)
+				Return 0
+			EndIf
+		Else
+			; Legacy file: no magic, treat as v0 and rewind.
+			ACCOUNTS_LOAD_VERSION% = 0
+			SeekFile(F, 0)
 		EndIf
 
 		; File does exist, read in all accounts. Use ReadBoundedString$

--- a/src/Modules/Actors.bb
+++ b/src/Modules/Actors.bb
@@ -93,6 +93,13 @@ Type ActorInstance
 	; portal #5 (different physical portal), and conversely the AI spawn
 	; path's deliberate LastPortal=0 stamp would bleed across areas.
 	Field LastPortal, LastTrigger, LastPortalTime, LastPortalArea
+	; Transient companion of LastPortalArea: the area's name string,
+	; persisted across save/load (Handle() is process-local and cannot
+	; survive a server restart). When non-empty AND LastPortalArea = 0,
+	; the portal-walk in Server.bb resolves the name to a live Handle
+	; once at first opportunity. Cleared back to "" when LastPortal
+	; gets reset to -1.
+	Field LastPortalAreaName$
 	Field TeamID ; Used to allow scripting to put people together in teams
 	Field PartyID, AcceptPending ; Holds the handle of a Party object (or 0 if the actor is not in a party)
 	Field Gender ; 0 for male, 1 for female
@@ -282,20 +289,13 @@ Function WriteActorInstance(Stream, A.ActorInstance)
 	; a logout/login cycle resets the portal-lock anti-cheat (Track
 	; TT) to zero -- a returning player can immediately re-trigger
 	; the portal they were placed at by their previous session.
-	; LastPortalArea is Handle(Ar) which is process-local, so on
-	; reload we must remap by name on the load side; persist the
-	; area's name string here instead of the raw handle, plus the
-	; numeric remainder of the triad.
-	If A\LastPortalArea <> 0
-		Local ParArea.Area = Object.Area(A\LastPortalArea)
-		If ParArea <> Null
-			WriteString Stream, ParArea\Name$
-		Else
-			WriteString Stream, ""
-		EndIf
-	Else
-		WriteString Stream, ""
-	EndIf
+	; LastPortalAreaName$ is the persistable companion of
+	; LastPortalArea (Handle, process-local). Don't reference the
+	; Area type here: Actors.bb is included by Client.bb too, and the
+	; Area type only exists on the server. Writing the name string
+	; and re-resolving lazily in Server.bb's portal walk keeps the
+	; serializer pure.
+	WriteString Stream, A\LastPortalAreaName$
 	WriteShort Stream, A\LastPortal
 	WriteInt Stream, A\LastPortalTime
 
@@ -388,25 +388,16 @@ Function ReadActorInstance.ActorInstance(Stream)
 
 	; v1: LastPortal triad. Older saves (no magic header in
 	; Accounts.dat) skip this block; the fields default to the
-	; New-actor sentinel (LastPortal=-1, LastPortalArea=0,
-	; LastPortalTime=0). The version is exposed via the
+	; New-actor sentinel. The version is exposed via the
 	; ACCOUNTS_LOAD_VERSION global set in LoadAccounts before any
-	; per-actor reads.
+	; per-actor reads. Re-resolving the area-name string back into
+	; a live Handle is deferred to Server.bb's portal walk (Actors.bb
+	; is shared with Client.bb and cannot reference the Area type).
 	If ACCOUNTS_LOAD_VERSION% >= 1
-		Local PortalAreaName$ = ReadBoundedString$(Stream, 256)
+		A\LastPortalAreaName$ = ReadBoundedString$(Stream, 256)
 		A\LastPortal = ReadShort(Stream)
 		A\LastPortalTime = ReadInt(Stream)
-		; Remap the area-name into a Handle the live world knows
-		; about. If the area has been renamed/deleted between
-		; sessions the lock just stays cleared (LastPortalArea = 0),
-		; which is the safe direction.
 		A\LastPortalArea = 0
-		If Len(PortalAreaName$) > 0
-			Local ResolvedArea.Area = FindArea(PortalAreaName$)
-			If ResolvedArea <> Null
-				A\LastPortalArea = Handle(ResolvedArea)
-			EndIf
-		EndIf
 	EndIf
 
 	; Slaves
@@ -500,6 +491,7 @@ Function CreateActorInstance.ActorInstance(Actor.Actor)
 	A\LastTrigger = -1
 	A\LastPortal = -1
 	A\LastPortalArea = 0
+	A\LastPortalAreaName$ = ""
 	A\IgnoreUpdate = 0
 	Return A
 

--- a/src/Modules/Actors.bb
+++ b/src/Modules/Actors.bb
@@ -278,6 +278,27 @@ Function WriteActorInstance(Stream, A.ActorInstance)
 		WriteShort Stream, A\MemorisedSpells[i]
 	Next
 
+	; v1: LastPortal triad. Persisting these closes the bypass where
+	; a logout/login cycle resets the portal-lock anti-cheat (Track
+	; TT) to zero -- a returning player can immediately re-trigger
+	; the portal they were placed at by their previous session.
+	; LastPortalArea is Handle(Ar) which is process-local, so on
+	; reload we must remap by name on the load side; persist the
+	; area's name string here instead of the raw handle, plus the
+	; numeric remainder of the triad.
+	If A\LastPortalArea <> 0
+		Local ParArea.Area = Object.Area(A\LastPortalArea)
+		If ParArea <> Null
+			WriteString Stream, ParArea\Name$
+		Else
+			WriteString Stream, ""
+		EndIf
+	Else
+		WriteString Stream, ""
+	EndIf
+	WriteShort Stream, A\LastPortal
+	WriteInt Stream, A\LastPortalTime
+
 	; Data for any slaves
 	Slaves = A\NumberOfSlaves
 	While Slaves > 0
@@ -364,6 +385,29 @@ Function ReadActorInstance.ActorInstance(Stream)
 	For i = 0 To 9
 		A\MemorisedSpells[i] = ReadShort(Stream)
 	Next
+
+	; v1: LastPortal triad. Older saves (no magic header in
+	; Accounts.dat) skip this block; the fields default to the
+	; New-actor sentinel (LastPortal=-1, LastPortalArea=0,
+	; LastPortalTime=0). The version is exposed via the
+	; ACCOUNTS_LOAD_VERSION global set in LoadAccounts before any
+	; per-actor reads.
+	If ACCOUNTS_LOAD_VERSION% >= 1
+		Local PortalAreaName$ = ReadBoundedString$(Stream, 256)
+		A\LastPortal = ReadShort(Stream)
+		A\LastPortalTime = ReadInt(Stream)
+		; Remap the area-name into a Handle the live world knows
+		; about. If the area has been renamed/deleted between
+		; sessions the lock just stays cleared (LastPortalArea = 0),
+		; which is the safe direction.
+		A\LastPortalArea = 0
+		If Len(PortalAreaName$) > 0
+			Local ResolvedArea.Area = FindArea(PortalAreaName$)
+			If ResolvedArea <> Null
+				A\LastPortalArea = Handle(ResolvedArea)
+			EndIf
+		EndIf
+	EndIf
 
 	; Slaves
 	For i = 1 To A\NumberOfSlaves

--- a/src/Modules/GameServer.bb
+++ b/src/Modules/GameServer.bb
@@ -1105,6 +1105,7 @@ Function SetArea(A.ActorInstance, Ar.Area, Instance, Waypoint = -1, Portal = 0, 
 			A\Z# = Ar\PortalZ#[Portal]
 			A\LastPortal = Portal
 			A\LastPortalArea = Handle(Ar)
+			A\LastPortalAreaName$ = Ar\Name$
 			A\LastPortalTime = MilliSecs()
 		; Direct position
 		Else
@@ -1127,6 +1128,7 @@ Function SetArea(A.ActorInstance, Ar.Area, Instance, Waypoint = -1, Portal = 0, 
 		; pair.
 		A\LastPortal = -1
 		A\LastPortalArea = 0
+		A\LastPortalAreaName$ = ""
 	EndIf
 
 	; Reset target

--- a/src/Modules/ServerNet.bb
+++ b/src/Modules/ServerNet.bb
@@ -2411,6 +2411,7 @@ Function UpdateNetwork()
 										If Upper$(Ar\PortalName$[i]) = Upper$(C\Actor\StartPortal$)
 											C\LastPortal = i
 											C\LastPortalArea = Handle(Ar)
+											C\LastPortalAreaName$ = Ar\Name$
 											C\X# = Ar\PortalX#[i]
 											C\Y# = Ar\PortalY#[i]
 											C\Z# = Ar\PortalZ#[i]

--- a/src/Server.bb
+++ b/src/Server.bb
@@ -588,6 +588,19 @@ Repeat
 										; current one, and the time floor still bars
 										; immediate re-entry of the exact portal the
 										; actor was just placed on.
+										;
+										; Lazy resolve LastPortalAreaName$ -> Handle.
+										; The persisted form is the area NAME (Handles
+										; are process-local); first time we see this
+										; actor in a portal area after login, re-bind
+										; the area handle. If the area was renamed /
+										; deleted between sessions, leave the handle
+										; at 0 and the lock just stays clear -- safe
+										; direction.
+										If AI\LastPortalArea = 0 And AI\LastPortalAreaName$ <> ""
+											Local LpAr.Area = FindArea(AI\LastPortalAreaName$)
+											If LpAr <> Null Then AI\LastPortalArea = Handle(LpAr)
+										EndIf
 										If Dist# < Size# And (AI\LastPortal <> i Or AI\LastPortalArea <> Handle(UpdateArea) Or (MilliSecs() - AI\LastPortalTime > PortalLockTime))
 											InPortal = False
 											Name$ = Upper$(UpdateArea\PortalLinkArea$[i])


### PR DESCRIPTION
## Summary

Track DD added bounded string reads and atomic save. What was still missing was a **versioned header** on `Accounts.dat` itself — without one, every new field on the per-character payload silently corrupts every prior save (an old reader treats the new bytes as the next field's data).

This PR introduces format **v1**:

- `Accounts.dat` now starts with `ACCT` (`0x41434354`) + 1-byte version. `LoadAccounts` peeks the first 4 bytes; if not the magic, treats the file as v0 (legacy, no header) and rewinds. If the version is higher than `ACCOUNTS_VERSION_CURRENT`, the load aborts with a log — prevents a downgraded build from silently mis-reading a future format.
- `SaveAccounts` always writes v1.
- `WriteActorInstance` appends the **LastPortal triad** after existing fields. `LastPortalArea` is persisted as the **Area name string** (Handles are process-local), and remapped by name in `ReadActorInstance`. If the area was renamed/deleted between sessions, `LastPortalArea` stays 0 and the lock effectively clears — safe direction.
- `ReadActorInstance` gates the new block on `ACCOUNTS_LOAD_VERSION >= 1`; legacy saves still load and default the triad to the same values `CreateActorInstance` uses.

### Why this matters

PR #110 (Track TT) made the portal-trigger lock key on `(Area, index)` pair, so an actor placed at a portal can't immediately re-trigger it for `PortalLockTime` ms. But every previous build threw away the triad on logout — a returning player landed fresh and could ping-pong the portal. The anti-cheat now survives a session boundary.

## Test plan

- [x] `blitzcc -o Server.exe Server.bb` compiles clean.
- [x] Full rcce2 `test.bat` passes locally.
- [ ] CI build + tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)