### PR TITLE
Fix BVM_NEXTACTORINZONE wrap-around infinite loop

### DIFF
--- a/src/Modules/ScriptingCommands.bb
+++ b/src/Modules/ScriptingCommands.bb
@@ -2325,14 +2325,18 @@ Return Result%
 End Function
 
 Function BVM_NEXTACTORINZONE%(Param1%)
+	; Bug fix: the original implementation wrapped to FirstInZone
+	; when reaching end-of-list, which made every AOE / "for each
+	; actor in zone" script using the `Repeat ... Until Player =
+	; Target` pattern (see AOE Damage Spell Template) loop forever
+	; if the player wasn't the very first actor in the zone. Return
+	; 0 at end-of-list instead so the standard `Until iter = 0`
+	; termination idiom works. Scripts that genuinely want the
+	; wrapping behaviour can call BVM_FIRSTACTORINZONE explicitly.
 	StartActor.ActorInstance = Object.ActorInstance(Param1%)
 	If StartActor <> Null
 		Actor.ActorInstance = StartActor\NextInZone
-		If Actor = Null
-			AInstance.AreaInstance = Object.AreaInstance(StartActor\ServerArea)
-			Actor.ActorInstance = AInstance\FirstInZone
-		EndIf
-		Result% = Handle(Actor)
+		If Actor <> Null Then Result% = Handle(Actor)
 	EndIf
 Return Result%
 End Function


### PR DESCRIPTION
## Summary
- `BVM_NEXTACTORINZONE` wrapped to `FirstInZone` when the iterator hit the end of the zone's actor list.
- The standard AOE-spell loop idiom (`Repeat Target = NextActorInZone(prev) ... Until Target = 0`, used in the AOE Damage Spell Template and several pet/AOE scripts) relies on a `0` terminator to break out — the wrap made it spin forever whenever the calling player wasn't at the head of the zone's actor list, hanging the script worker until the watchdog killed it.
- Return `0` at end-of-list. Scripts that genuinely wanted the wrapping behavior can call `BVM_FIRSTACTORINZONE` to restart the walk.

## Test plan
- [x] `compile.bat -t` builds Server.exe + Client.exe cleanly with the patch.
- [ ] Run an AOE-template spell with no other actors in the zone — script terminates cleanly instead of looping.
- [ ] Run an AOE-template spell against a NPC where the caster isn't the first actor in the zone — script iterates all actors and terminates cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)