### PR TITLE
Don't crash entire server when new character's start zone missing

### DIFF
--- a/src/Modules/ServerNet.bb
+++ b/src/Modules/ServerNet.bb
@@ -2406,7 +2406,19 @@ Function UpdateNetwork()
 									C\Gold = StartGold
 									C\Reputation = StartReputation
 									Ar.Area = FindArea(C\Area$)
-									If Ar = Null Then RuntimeError("Start zone for new character not found!")
+									If Ar = Null
+										; Misconfigured race (StartArea references
+										; a deleted area). Previously RuntimeError
+										; here killed the entire server -- and with
+										; it every other connected player -- the
+										; moment any user tried to create a
+										; character on a broken race. Reject the
+										; creation cleanly and log instead.
+										WriteLog(MainLog, "P_CreateCharacter: race '" + C\Actor\Race$ + "' StartArea '" + C\Area$ + "' not found, rejecting")
+										FreeActorInstance(A\Character[FreeSlot])
+										RCE_Send(Host, M\FromID, P_CreateCharacter, "N", True)
+										Exists = True : Exit
+									EndIf
 									For i = 0 To 99
 										If Upper$(Ar\PortalName$[i]) = Upper$(C\Actor\StartPortal$)
 											C\LastPortal = i


### PR DESCRIPTION
## Summary
In \`P_CreateCharacter\`, the server resolved the chosen race's \`StartArea\$\` via \`FindArea\` and called \`RuntimeError\` on miss. A single misconfigured race (\`StartArea\` pointing at a deleted area) took the **entire server** down — and with it every connected player — the moment any user tried to create a character on that race.

Log the failure and reject the creation cleanly with \`P_CreateCharacter, \"N\"\`, matching the existing recovery pattern used by the \`AttributeAssignment\` cheat check just below at [ServerNet.bb:2443](src/Modules/ServerNet.bb:2443).

## Test plan
- [x] \`compile.bat -t\` builds Server / Client / GUE cleanly.
- [ ] Configure a race with \`StartArea\$\` pointing at a non-existent area; new-character creation on that race rejects with "N" instead of taking down the server.
- [ ] Existing characters and other players' sessions are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)