### PR TITLE
Validate ActorID in P_CreateCharacter to prevent client-triggered server crash

### DIFF
--- a/src/Modules/ServerNet.bb
+++ b/src/Modules/ServerNet.bb
@@ -2392,6 +2392,19 @@ Function UpdateNetwork()
 								; If we have a free slot and haven't exceeded the maximum allowed characters
 								If FreeSlot > -1 And TotalChars < MaxAccountChars
 									ActorID = RCE_IntFromStr(Mid$(M\MessageData$, Offset, 2))
+									; Validate ActorID before passing to
+									; CreateActorInstance. The client controls
+									; this 2-byte value, and ActorList() returns
+									; Null for any race that doesn't exist (or
+									; was deleted). CreateActorInstance previously
+									; RuntimeError'd on Null, so any client could
+									; crash the entire server with one crafted
+									; P_CreateCharacter packet.
+									If ActorID < 0 Or ActorID > 65535 Or ActorList(ActorID) = Null
+										WriteLog(MainLog, "P_CreateCharacter: rejecting invalid ActorID " + ActorID + " from account '" + A\User$ + "'")
+										RCE_Send(Host, M\FromID, P_CreateCharacter, "N", True)
+										Exists = True : Exit
+									EndIf
 									A\QuestLog[FreeSlot] = New QuestLog
 									A\ActionBar[FreeSlot] = New ActionBarData
 									A\Character[FreeSlot] = CreateActorInstance(ActorList(ActorID))


### PR DESCRIPTION
## Summary
\`ActorID\` is read as 2 raw bytes from the client's \`P_CreateCharacter\` packet, then passed straight to \`ActorList(ActorID)\` and on into \`CreateActorInstance\`. Any value that doesn't map to a real Actor returned \`Null\`, and \`CreateActorInstance(Null)\` called \`RuntimeError\` — crashing the **entire server** and disconnecting every other player.

**Any connected client could take down the server with one crafted P_CreateCharacter packet.**

Validate before the call: bounds-check \`ActorID\` and reject with \`P_CreateCharacter, \"N\"\` when \`ActorList(ActorID)\` is \`Null\`. Matches the recovery pattern used by the \`StartArea\`-missing check ([PR #131](https://github.com/RydeTec/rcce2/pull/131)) and the \`AttributeAssignment\` cheat check just below it in the same handler.

## Test plan
- [x] \`compile.bat -t\` builds Server / Client / GUE cleanly.
- [ ] Send P_CreateCharacter with ActorID = 65000 (no race defined at that slot); server logs the rejection and stays up.
- [ ] Send P_CreateCharacter with a valid ActorID; character creation succeeds as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)