### PR TITLE
SetArea Null-area guard + P_StartGame login validation

### DIFF
--- a/src/Modules/GameServer.bb
+++ b/src/Modules/GameServer.bb
@@ -1018,6 +1018,23 @@ End Function
 ; Changes the area of an actor instance
 Function SetArea(A.ActorInstance, Ar.Area, Instance, Waypoint = -1, Portal = 0, X# = 0, Y# = 0, Z# = 0)
 
+	; Defensive Null-area guard. Multiple call sites (P_StartGame,
+	; script BVM_WARP / BVM_CHANGEAREA, area-change packet handler)
+	; resolve a destination Area via FindArea, which returns Null
+	; whenever the named area was deleted from data files. Every
+	; subsequent line in this function dereferences Ar -- a missing
+	; saved-character area used to crash the server at the player's
+	; login, taking every other player offline with them. Bail out
+	; cleanly; the caller's actor stays in whatever area it was in
+	; (or, for a fresh login, never gets placed -- the login handler
+	; needs its own Null check, see P_StartGame).
+	If Ar = Null
+		Local AName$ = "<unknown>"
+		If A <> Null Then AName$ = A\Name$
+		WriteLog(MainLog, "SetArea: refusing to warp '" + AName$ + "' to a Null area")
+		Return
+	EndIf
+
 	; Check instance exists. The bounds check has to come BEFORE the
 	; Instances[] access — without it, a GM typing `/warp Area, 9999`
 	; indexed past the 100-slot Instances array (declared 0..99) and

--- a/src/Modules/ServerNet.bb
+++ b/src/Modules/ServerNet.bb
@@ -1838,11 +1838,24 @@ Function UpdateNetwork()
 							Number = Asc(Mid$(M\MessageData$, Offset, 1))
 
 							If Number > -1 And Number < 10 And A\Character[Number] <> Null
+								; Resolve saved area BEFORE flipping login state.
+								; If the saved area was deleted from data files,
+								; SetArea would silently no-op (PR adding Null
+								; guard) and leave the player in limbo with no
+								; ServerArea -- they'd see a black screen and
+								; the next packet would dereference Null. Refuse
+								; the login cleanly instead so the user can pick
+								; a different character.
+								Ar.Area = FindArea(A\Character[Number]\Area$)
+								If Ar = Null
+									WriteLog(MainLog, "P_StartGame: character '" + A\Character[Number]\Name$ + "' saved area '" + A\Character[Number]\Area$ + "' not found, refusing login")
+									RCE_Send(Host, M\FromID, P_StartGame, "N", True)
+									Exists = True : Exit
+								EndIf
 								; Set his status to in game and put him in his area
 								SetLoginStatus(A, Number)
 								A\Character[Number]\RNID = M\FromID
 								AssignRuntimeID(A\Character[Number])
-								Ar.Area = FindArea(A\Character[Number]\Area$)
 								SetArea(A\Character[Number], Ar, 0, -1, -1, A\Character[Number]\X#, A\Character[Number]\Y#, A\Character[Number]\Z#)
 								; Run login script
 								ThreadScript("Login", "Main", Handle(A\Character[Number]), 0)


### PR DESCRIPTION
## Summary
\`SetArea(A, Ar, ...)\` dereferenced \`Ar\` (\`Ar\Name\$\`, \`Ar\Instances[i]\`, \`Ar\FirstInZone\`, etc.) without a Null check. Multiple call sites (P_StartGame, script \`BVM_WARP\` / \`BVM_CHANGEAREA\`, the area-change packet handler, pet/mount warp recursion) resolve the destination via \`FindArea\`, which returns \`Null\` whenever the named area was deleted from data files.

The most visible failure: **any logged-in character whose saved \`Area\$\` no longer exists crashed the entire server at login**, kicking every other connected player off.

- **SetArea** (GameServer.bb): refuse cleanly on \`Null Ar\` — log + return without touching the actor's location. Defensive guard against all current and future callers.
- **P_StartGame** (ServerNet.bb): resolve \`Ar\` BEFORE flipping the login-status flag, and reject with \`P_StartGame, \"N\"\` if missing. Without this, the no-op'd \`SetArea\` would leave the player in limbo with no \`ServerArea\` and the next packet referencing them would Null-deref.

## Test plan
- [x] \`compile.bat -t\` builds Server / Client / GUE cleanly.
- [ ] Save a character into an area that is then renamed/deleted; subsequent login is refused cleanly and other players stay online.
- [ ] Script \`BVM_CHANGEAREA(\"NonExistent\", 0)\` from an NPC; server logs the refusal and continues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)