### PR TITLE
Guard /warpother against missing area name (DM-typo server crash)

### DIFF
--- a/src/Modules/ServerNet.bb
+++ b/src/Modules/ServerNet.bb
@@ -425,13 +425,21 @@ Function UpdateNetwork()
 										If A2\RNID > 0
 											If Upper$(A2\Name$) = Name$
 												Ar.Area = FindArea(Trim$(Split$(Params$, 2, ",")))
-												Instance = Split$(Params$, 3, ",")
-												For i = 0 To 99
-													If Ar\PortalName$[i] <> ""
-														SetArea(A2, Ar, Instance, -1, i)
-														Exit
-													EndIf
-												Next
+												; Sibling LS_SCWarp branch above
+												; checks `Ar <> Null` before the
+												; portal loop; this one didn't,
+												; so a DM typo (/warpother Alice,
+												; "Bad Name") crashed the entire
+												; server.
+												If Ar <> Null
+													Instance = Split$(Params$, 3, ",")
+													For i = 0 To 99
+														If Ar\PortalName$[i] <> ""
+															SetArea(A2, Ar, Instance, -1, i)
+															Exit
+														EndIf
+													Next
+												EndIf
 												Exit
 											EndIf
 										EndIf


### PR DESCRIPTION
## Summary
The \`/warp\` DM chat command checked \`Ar <> Null\` before iterating portals; \`/warpother\` (sibling branch four lines later in the same handler) did not. A DM typo like

\`\`\`
/warpother Alice, NotARealArea
\`\`\`

dereferenced Null in \`Ar\PortalName\$[i]\` and crashed the entire server, taking every connected player offline.

Mirror the [LS_SCWarp guard](src/Modules/ServerNet.bb:410) on the LS_SCWarpOther branch.

## Test plan
- [x] \`compile.bat -t\` builds Server / Client / GUE cleanly.
- [ ] As DM, \`/warpother SomePlayer, NotARealArea\` — server logs nothing (silent no-op) instead of crashing.
- [ ] As DM, \`/warpother SomePlayer, RealArea\` — player is warped as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)