### PR TITLE
docs: add CLAUDE.md + agent skills

### DIFF
--- a/.claude/skills/blitzforge-language/SKILL.md
+++ b/.claude/skills/blitzforge-language/SKILL.md
@@ -1,0 +1,325 @@
+---
+name: blitzforge-language
+description: Write or review code in the BlitzForge language (a modernized Blitz3D fork used by rcce2 and other projects). Invoke whenever editing, reviewing, or generating any `.bb` file — INCLUDING when the user only says "Blitz", "Blitz3D", "BlitzBasic", or shows .bb source — because your training data is base Blitz3D from ~2003 and does not have BlitzForge's modern additions (Strict mode, garbage collection, type inheritance, methods, BBList, function pointers, Async/Await, Try/Catch/Throw, the `Continue` keyword, `//` and `/* */` comments). Without this skill you WILL write outdated code that fails to compile under Strict or misses safer modern alternatives.
+---
+
+# BlitzForge language
+
+BlitzForge is a community fork of the Blitz3D compiler that keeps full source-compatibility with original `.bb` programs but adds modern language features. Your training data covers original Blitz3D (Mark Sibly, 2003); it does **not** cover the additions below. When you write Blitz code without this skill, the most common failure modes are:
+
+- Using `Type Foo` with `New Foo` instead of `New Foo()` (BlitzForge needs the parens — the implicit `create` method requires a call).
+- Skipping `Strict` / `EnableGC` at the top of files that should have them, then writing untyped `Local`s or relying on implicit globals.
+- Writing manual `For obj.Type = Each Type ... Delete obj : Next` cleanup in GC-enabled files instead of letting GC handle it.
+- Using `;` comments only — BlitzForge accepts `;` for back-compat but `//` and `/* ... */` are the preferred modern style.
+- Reimplementing iteration/storage with `For Each` everywhere instead of reaching for `BBList` when a dynamic container is the right tool.
+- Throwing `RuntimeError` for recoverable failures instead of `Throw` + `TryCatch`.
+- Spawning manual threads instead of using `Async` / `Await` / `Poll` / `AsyncThen`.
+
+This document is the always-on quick reference. For deep examples or edge cases, read [references/syntax-reference.md](references/syntax-reference.md). The canonical, executable examples live in [compiler/BlitzForge/tests/](../../../compiler/BlitzForge/tests/) — every feature below has a matching `*Test.bb` file.
+
+## File preamble
+
+Every new `.bb` file you author should start with:
+
+```basic
+Strict
+EnableGC
+```
+
+**`Strict`** enforces explicit `Local` / `Global` / `Const` declarations and type sigils. **`EnableGC`** opts the file into reference-counted garbage collection so you don't have to `Delete` objects manually. Both must be the very first lines of the file (before `Include`s).
+
+**Exception**: when adding to an existing module that is not `Strict`, leave it as-is. Mixing Strict and non-Strict via includes works, but converting a large legacy module to Strict is its own audit-worthy change.
+
+## Comments
+
+```basic
+// Single-line preferred (modern)
+; Single-line (legacy, accepted for back-compat — avoid in new code)
+/* Block comment
+   spanning lines */
+```
+
+## Custom types
+
+### Definition + construction
+
+```basic
+Type Player
+    Field name$
+    Field health%, maxHealth%
+
+    Method create.Player(name$, maxHealth%)    // implicit constructor
+        self\name = name
+        self\maxHealth = maxHealth
+        self\health = maxHealth
+        Return self
+    End Method
+
+    Method heal(amount%)
+        self\health = self\health + amount
+        If self\health > self\maxHealth Then self\health = self\maxHealth
+    End Method
+End Type
+
+Local p.Player = New Player("Alice", 100)   // <-- parens are REQUIRED
+p\heal(25)
+```
+
+Key facts your training data won't have:
+
+- **`Method name(args) ... End Method`** declares an instance method. `self` is implicit. Call dynamically as `obj\method(args)` (with the field-access backslash) or statically as `TypeName::method(obj, args)`.
+- **`create.TypeName(...)`** is a special constructor method. When present, `New TypeName(args)` calls it and `New` returns whatever `create` returns (typically `self`). When absent, `New TypeName()` works and gives you a zero-initialized instance.
+- **`new TypeName()` parens are required** even with no args. Bare `new TypeName` errors.
+
+### Inheritance
+
+```basic
+Type Base
+    Field baseVar$
+End Type
+
+Type Child.Base                  // Child extends Base
+    Field childVar$
+End Type
+
+Type Grandchild.Child            // multi-level
+    Field grandchildVar$
+End Type
+
+Local gc.Grandchild = New Grandchild()
+gc\baseVar = "from base"         // inherited field works
+gc\childVar = "from child"
+```
+
+**Casting between related types:**
+
+```basic
+// Casting down (child -> base) is implicit:
+Local b.Base = New Child()       // OK; b is typed as Base but holds a Child
+Print b\baseVar                  // OK
+// Print b\childVar              // ERROR — b is declared as Base
+
+// Casting up requires Recast:
+Local c.Child = Recast.Child(b)  // explicit; runtime-checked
+Print c\childVar                 // OK now
+```
+
+Method overrides work as you'd expect — a `Method` in `Child` overrides the same-name `Method` in `Base`. Dispatch is dynamic (based on the runtime type, not declared type).
+
+**Recast is memory-unsafe across unrelated branches.** `Recast.SecondInherit(child_of_first_inherit)` silently aliases fields by memory offset. Stay within the actual inheritance chain.
+
+## Variables (Strict mode)
+
+```basic
+Local count% = 0              // integer
+Local ratio# = 1.5            // float
+Local name$ = "Bob"           // string
+Local p.Player = Null         // typed object reference
+
+Global serverPort% = 1234     // module-level
+Const MaxSlots% = 32          // compile-time constant
+```
+
+Sigils: `%` int (default), `#` float, `$` string, `.TypeName` typed reference. The default for integer is unwritten (i.e., `Local count = 0` is equivalent to `Local count% = 0`), but in Strict mode declarations are still required.
+
+`Local`-shadowing-a-`Global` of the same name compiles but produces confusing behavior; pick distinct names.
+
+## Loops
+
+```basic
+For i = 0 To 9                 // 0..9 inclusive
+    If i = 5 Then Continue     // <-- new keyword, skips to next iteration
+    If i = 8 Then Exit         // breaks out
+    Print i
+Next
+
+While condition
+    ; ...
+Wend
+
+Repeat
+    ; ...
+Until condition
+```
+
+**`Continue`** is a BlitzForge addition. Note: an old codegen bug affected `Continue` inside certain `Select Case`-inside-`For` shapes (fixed in commit `78f3204`); current versions are stable, but verify after large refactors.
+
+## Arrays
+
+Sizes are **inclusive upper bounds**: `Dim arr(N)` and `Field arr[N]` both allocate `N+1` slots indexed `0..N`. `For i = 0 To N` is the correct iteration; `0 To N-1` skips the last slot. This is the #1 off-by-one source for agents from training data.
+
+```basic
+Dim NPCs.Player(99)            // 100 slots, 0..99
+NPCs(0) = New Player("Goblin", 20)
+
+Type Inventory
+    Field Items.ItemInstance[45]   // 46 slots, 0..45
+End Type
+```
+
+## BBList (modern dynamic container)
+
+When you need a resizable, ordered collection (and especially when you'd otherwise write awkward `For Each` filtering), reach for `BBList`. Critical syntax:
+
+```basic
+Local items.BBList = CreateList()
+ListAdd(items, New Item())
+ListAdd(items, anotherItem)
+ListInsert(items, 0, frontItem)    // insert at index
+ListRemove(items, 1)               // remove at index
+ListReplace(items, 2, newItem)     // overwrite at index
+
+Local count% = ListSize(items)
+Local empty% = ListIsEmpty(items)
+Local idx% = ListFind(items, target)   // -1 if absent
+
+Local first.Item = ListFirst(items)
+Local last.Item = ListLast(items)
+Local mid.Item = ListAt(items, 5)
+
+ListClear(items)
+FreeList(items)
+```
+
+When to use:
+- **`BBList`** — heterogeneous collections, insertion/removal at arbitrary positions, finite scope outside a `Type` instance pool.
+- **`For instance.Type = Each Type`** — iterating *all* live instances of a Type managed by the runtime. The legacy `Each` enumerator is still the right tool when that's what you actually want.
+
+## Function pointers
+
+```basic
+Function handler@(arg.MyDTO = Null)   // @ suffix marks "returns a FunctionPtr"
+    If arg = Null Then Return FunctionPtr()   // self-pointer when called with Null
+    ; ... real work ...
+    Return New MyDTO(result)
+End Function
+
+Local fp.BBFunction = handler(Null)            // get pointer
+Local out.MyDTO = Call(fp, Ptr New MyDTO(5))   // invoke; Ptr cast required
+```
+
+Idiom: a function-returning-`FunctionPtr` accepts a `Null` sentinel arg to mean "give me your own pointer." This is how you bootstrap a pointer without calling the function for real.
+
+`Call(fp, Ptr arg)` invokes through the pointer. Multi-arg functions need a DTO (data transfer object) Type to pack arguments — there is no varargs `Call`.
+
+## Async / Await / Poll / AsyncThen
+
+```basic
+Local fp.BBFunction = slowWorker(Null)
+Local thread.BBThread = Async(fp, New WorkerInput("payload"))
+
+// Main thread keeps going while the async runs.
+doOtherStuff()
+
+// Non-blocking check:
+If Poll(thread)
+    Local result.WorkerOutput = Await(thread)   // returns immediately when done
+EndIf
+
+// Or just wait:
+Local result.WorkerOutput = Await(thread)       // blocks until done
+
+// Chain:
+Local thread2.BBThread = AsyncThen(thread, nextStepFp)
+Local final.Result = Await(thread2)
+```
+
+`Async(fp, arg)` launches `fp(arg)` on a worker, returns a `.BBThread` handle (a future). `Await` blocks; `Poll` peeks; `AsyncThen` chains another function pointer to run after the first finishes.
+
+Use cases that previously required ugly polling loops: file I/O, network ops, expensive scripts spawned from gameplay code, anything that would otherwise stall the game tick.
+
+## Try / Throw / Catch
+
+```basic
+Function tryFn@(arg.MyDTO = Null)
+    If arg = Null Then Return FunctionPtr()
+    If somethingWentWrong Then Throw New ErrorDTO("descriptive message")
+    Return New MyDTO(successResult)
+End Function
+
+Function catchFn@(err.ErrorDTO = Null)
+    If err = Null Then Return FunctionPtr()
+    WriteLog(MainLog, "tryFn threw: " + err\msg)
+    Return New MyDTO(fallbackResult)
+End Function
+
+Local result.MyDTO = TryCatch(tryFn(Null), catchFn(Null), New MyDTO(0))
+```
+
+`Throw obj` unwinds the stack and invokes the catch handler with the thrown object. `TryCatch(tryFp, catchFp, arg)` is the entry point. Returns whichever completed (`tryFn`'s return value if no throw, `catchFn`'s if there was one). Throws propagate up nested calls until caught.
+
+Replaces the old `RuntimeError(...)` pattern for recoverable failures. Reserve `RuntimeError` for genuinely unrecoverable invariant violations.
+
+## Pointers (`@` and `Ptr`)
+
+```basic
+Local p.MyType = New MyType()
+Local raw% = Ptr p              // cast object reference to integer pointer
+; ... pass raw through APIs that want an int ...
+Local back.MyType = Object.MyType(raw)   // recover the typed reference
+```
+
+Used for callbacks across native API boundaries and inside `Call(fp, Ptr arg)`. Do not arithmetic on pointers; treat as opaque handles.
+
+## Includes (namespace-style)
+
+```basic
+Strict
+EnableGC
+
+Include "Modules/Items.bb"
+Include "Modules/Spells.bb"
+```
+
+`Include` paths resolve relative to the **root file being compiled** (typically `src/Server.bb` or `src/Client.bb`), not the file the `Include` lives in. This is a behavior change from base Blitz3D and behaves more like namespaces — predict imports from the top of the include cascade, not from the file you're editing.
+
+## Tests
+
+BlitzForge has a built-in test framework:
+
+```basic
+Strict
+EnableGC
+
+Include "Modules/MyModule.bb"
+
+Test testThing()
+    Local result = doThing(input)
+    Assert(result = expected)              // asserts also return Bool if you want to chain
+End Test
+```
+
+Run with `blitzcc -t file.bb`. In rcce2 the test runner is `test.bat` (Windows) / `test.sh` (Unix) which walks `src/Tests/` recursively. See the `rcce2-test-writing` skill for the project-specific test-file pattern (Strict + inline stubs to avoid network/world dep pull-in).
+
+## Not present (so don't try)
+
+- Ternary `?:`, null-coalesce `??`, null-conditional `?.`
+- Lambdas / anonymous functions (use named `Function ...@(...)` + pass the pointer)
+- Generics / templates (use `BBList` + DTOs for type-erased containers)
+- Multiple return values (return a DTO)
+- Real namespaces beyond `Include` (use type-prefixed function naming: `BVM_*`, `RCE_*`, `GY_*`)
+- Conditional compilation (`#If` / `#IfDef`) — not exposed in Blitz source
+- Operator overloading
+- Typed `Const` with sigil — `Const Foo = 1` works but `Const Foo% = 1` is not the preferred form (use `Global Foo% = 1` if you specifically need a typed compile-time value)
+
+## Common training-data corrections
+
+| Training-data Blitz3D | BlitzForge correct form |
+|---|---|
+| `New Foo` (no parens) | `New Foo()` |
+| `Local x = 1` (in non-Strict) | `Local x% = 1` (in Strict) |
+| `obj.method()` | `obj\method()` |
+| `For each.Type ... Delete each : Next` in GC file | omit `Delete`, GC handles it |
+| `; comment` (preferred) | `// comment` (preferred) |
+| Manual array resize via copy | `BBList` + `ListAdd` |
+| `RuntimeError(...)` for any failure | `Throw newDTO` + `TryCatch` for recoverable; `RuntimeError` for invariants only |
+| Polling loop with `Delay` for background work | `Async` + `Poll`/`Await` |
+| `For i = 0 To N-1` over `Dim arr(N)` | `For i = 0 To N` (Dim is inclusive) |
+
+## Reference materials
+
+- [references/syntax-reference.md](references/syntax-reference.md) — deeper feature reference with extended examples, edge cases, gotchas
+- [compiler/BlitzForge/tests/](../../../compiler/BlitzForge/tests/) — authoritative executable examples. Every feature here has a matching `*Test.bb`
+- [compiler/BlitzForge/help/language/](../../../compiler/BlitzForge/help/language/) — HTML language reference (most pages cover legacy Blitz3D, but still useful for basics)
+- [compiler/BlitzForge/.cursor/rules/blitzforge.mdc](../../../compiler/BlitzForge/.cursor/rules/blitzforge.mdc) — the BlitzForge maintainers' own short-form "what changed" notes
+- [compiler/BlitzForge/ReadMe.md](../../../compiler/BlitzForge/ReadMe.md) — project overview, repo layout, build instructions

--- a/.claude/skills/blitzforge-language/references/syntax-reference.md
+++ b/.claude/skills/blitzforge-language/references/syntax-reference.md
@@ -1,0 +1,413 @@
+# BlitzForge syntax reference (deep dive)
+
+This file is loaded on demand when the SKILL.md surface isn't enough. Topics in order:
+
+1. [Strict mode rules](#strict-mode-rules)
+2. [Garbage collection in depth](#garbage-collection-in-depth)
+3. [Type inheritance internals](#type-inheritance-internals)
+4. [Methods: dispatch and constructor semantics](#methods-dispatch-and-constructor-semantics)
+5. [BBList operations and patterns](#bblist-operations-and-patterns)
+6. [Function pointers and async deep dive](#function-pointers-and-async-deep-dive)
+7. [Try / Throw / Catch deep dive](#try--throw--catch-deep-dive)
+8. [Standard-library highlights](#standard-library-highlights)
+9. [Bank operations and binary serialization](#bank-operations-and-binary-serialization)
+10. [Common idiom translations](#common-idiom-translations)
+
+---
+
+## Strict mode rules
+
+`Strict` must appear as the first non-comment, non-blank line. It enables:
+
+- **Mandatory declarations**: every variable must be introduced with `Local`, `Global`, or `Const`. Implicit globals are rejected at compile time. A typo that auto-created a new variable in legacy Blitz3D now errors loudly.
+- **Type sigil consistency**: assigning a float to a `%`-sigil variable errors. Truncate explicitly with `Int(x#)`.
+- **Function signature enforcement**: arg count and types must match the declared signature. The legacy "Blitz silently ignores extra args" behavior is gone.
+- **Field access discipline**: `obj\unknownField` errors. The field must exist on the declared type (or its inheritance chain).
+
+When inheriting non-Strict modules via `Include`, those modules continue to compile under their own rules. Your Strict file can call into them. The boundary is the file, not the program.
+
+### What Strict does NOT do
+
+- It does not change runtime behavior of legacy ops. `Mid$(s, large_offset)` still returns empty string rather than erroring.
+- It does not enforce const correctness — assigning to a `Const` errors, but a `Global` is just a global, mutable from anywhere.
+- It does not catch logical errors (writing 0 where you meant -1, off-by-one), only declaration / type / arity errors.
+
+## Garbage collection in depth
+
+`EnableGC` requires `Strict`. It opts the **whole file** (and the program as a whole if all files opt in) into the reference-counting runtime:
+
+- Every `Type` instance carries a refcount in its header. `RefCount(obj)` returns it.
+- Field assignments do retain/release: `a\field = b` releases the old `a\field`, retains `b`.
+- When refcount drops to 0, the runtime calls the per-type release dispatch (which recursively releases owned fields, including `BBList` contents).
+- `BBList`s are GC-aware: when the list itself is freed, contained elements are released.
+- Strings are reference-counted independently.
+
+### What this changes for you
+
+- **Don't write `Delete obj`** for objects whose lifetime is owned by reachability. The GC will free them when no live reference exists.
+- **`Delete obj` still works** but it's a manual free that bypasses GC tracking. Useful when you have a specific reason to release immediately (e.g., during shutdown), but generally unnecessary.
+- **Cycles leak**. The GC is purely refcount-based; there's no cycle detector. If `A` references `B` and `B` references `A`, neither will free even when both become otherwise unreachable. Break cycles manually or use a non-owning index/handle pattern.
+
+### Inspecting refcounts in tests
+
+```basic
+Type Foo
+    Field x
+End Type
+
+Test testRetain()
+    Local a.Foo = New Foo()
+    Assert(RefCount(First Foo) = 1)
+    Local b.Foo = a
+    Assert(RefCount(First Foo) = 2)   // both vars reference the same object
+End Test
+```
+
+The `RefCount(First Foo)` pattern uses the legacy `First Foo` enumerator to grab the first live instance. Useful for diagnostics; don't rely on the iteration order in production code.
+
+## Type inheritance internals
+
+```basic
+Type Base
+    Field a$, b$
+End Type
+
+Type Child.Base
+    Field c$
+End Type
+```
+
+Memory layout: `Child` is `Base`'s fields followed by `Child`'s additional fields. Casting down to `Base` doesn't change the object — it just narrows the visible field set. Casting back up with `Recast.Child(b)` is unchecked: the runtime trusts that the underlying memory really is a `Child`.
+
+### Why `Recast` is "unsafe"
+
+```basic
+Type A
+    Field x$
+End Type
+Type B.A
+    Field bField$
+End Type
+Type C.A
+    Field cField$
+End Type
+
+Local b.B = New B()
+b\bField = "B's value"
+
+Local a.A = b                       // narrow to A (safe, same memory)
+Local c.C = Recast.C(a)             // tell runtime "treat as C" — UNCHECKED
+Print c\cField                      // prints "B's value" — same memory slot, wrong field name
+```
+
+This is documented as `testIncorrectCrossCasting` in [InheritTest.bb](../../../compiler/BlitzForge/tests/InheritTest.bb). Field-by-position aliasing means `Recast` between unrelated children of the same base is structurally legal but semantically nonsense. Only `Recast` to a type that the object actually is.
+
+### Method overriding
+
+```basic
+Type Base
+    Method greet()
+        DebugLog "Hello from Base"
+    End Method
+End Type
+
+Type Child.Base
+    Method greet()
+        DebugLog "Hello from Child"
+    End Method
+End Type
+
+Local c.Child = New Child()
+c\greet()                           // "Hello from Child"
+
+Local b.Base = c                    // narrow to Base
+b\greet()                           // "Hello from Child" — dispatch is dynamic
+```
+
+Dispatch goes by the *runtime* type, not the declared type. So once you've created a `Child`, narrowing to `Base` doesn't change which method runs.
+
+### Calling parent method
+
+There's no `super.method()` syntax. To call the base implementation from an override, use static call form:
+
+```basic
+Type Child.Base
+    Method greet()
+        Base::greet(self)           // call parent's version
+        DebugLog "...and from Child"
+    End Method
+End Type
+```
+
+## Methods: dispatch and constructor semantics
+
+### Constructor convention
+
+`create` is the special method name that `New TypeName(args)` calls. If `create` is absent, `New TypeName()` allocates a zero-initialized instance.
+
+```basic
+Type Player
+    Field name$
+    Field level%
+
+    Method create.Player(name$)     // <-- note the `.Player` return type
+        self\name = name
+        self\level = 1
+        Return self                 // <-- must return self
+    End Method
+End Type
+
+Local p.Player = New Player("Bob")   // calls create("Bob"); p\name = "Bob", p\level = 1
+```
+
+The `.Player` return type on `create` is required (it returns the constructed object). You must `Return self` (the runtime uses the return value, not the allocation).
+
+### Multiple constructors?
+
+Not supported directly. Common patterns:
+
+- Default args: `Method create.Foo(a$, b% = 0, c# = 0.0)`.
+- Static factory functions: `Function NewFooFromBar.Foo(bar.Bar)`.
+
+### Static method call form
+
+```basic
+Local p.Player = New Player("Alice")
+p\heal(10)                          // dynamic; dispatch by runtime type
+Player::heal(p, 10)                 // static; always calls Player::heal regardless of runtime type
+```
+
+Use static form (a) inside an override to call the parent's version, or (b) when you specifically need to bypass dynamic dispatch.
+
+## BBList operations and patterns
+
+Full API surface from [ListTest.bb](../../../compiler/BlitzForge/tests/ListTest.bb):
+
+| Function | Returns | Purpose |
+|---|---|---|
+| `CreateList()` | `.BBList` | new empty list |
+| `ListAdd(list, obj)` | — | append |
+| `ListInsert(list, idx, obj)` | — | insert before index |
+| `ListRemove(list, idx)` | — | remove at index |
+| `ListReplace(list, idx, obj)` | — | overwrite at index |
+| `ListSize(list)` | `%` | count |
+| `ListIsEmpty(list)` | `%` | True if empty |
+| `ListFind(list, obj)` | `%` | index, or -1 if absent |
+| `ListFirst(list)` | obj | first element (or Null) |
+| `ListLast(list)` | obj | last element (or Null) |
+| `ListAt(list, idx)` | obj | element at index (or Null if out of range) |
+| `ListClear(list)` | — | remove all elements (list still usable) |
+| `FreeList(list)` | — | release the list itself |
+
+### Iteration
+
+There is no built-in `for each element in list` syntax. Use index iteration:
+
+```basic
+For i = 0 To ListSize(items) - 1            // note -1: ListSize is count, not max index
+    Local item.Item = ListAt(items, i)
+    ; ... use item ...
+Next
+```
+
+For nested or mutation-during-iteration, take a snapshot first:
+
+```basic
+Local count = ListSize(items)
+For i = count - 1 To 0 Step -1              // iterate backwards if removing
+    Local item.Item = ListAt(items, i)
+    If shouldRemove(item) Then ListRemove(items, i)
+Next
+```
+
+### When NOT to use BBList
+
+- **All-live-instances iteration**: the legacy `For obj.Type = Each Type` walks the runtime's instance list. This is what you want for "do something to every Player" semantics. `BBList` is a separate, explicit container — you choose what goes in.
+- **Fixed-size collections**: `Dim arr.Type(N)` and `Field arr.Type[N]` remain the right tool for fixed-size slots (player character slots, action bar slots).
+- **Sparse maps by integer key**: there's no `Dictionary` / `Map` type. Use a `Dim` array with `Null` for missing entries, or a `BBList` of key-value DTOs if order matters.
+
+## Function pointers and async deep dive
+
+### Anatomy of an `@`-tagged function
+
+```basic
+Function worker@(input.MyInput = Null)
+    If input = Null Then Return FunctionPtr()    // self-pointer bootstrap
+    // ... real work using `input` ...
+    Return New MyOutput(result)                  // typed return
+End Function
+```
+
+The `@` after the function name marks the *function* as returning a `FunctionPtr`. Internally:
+
+- When called with `Null` (the conventional sentinel), it returns its own pointer via `FunctionPtr()`.
+- Otherwise it does the actual work.
+- Return value type is determined by the actual return statement; if you `Return New MyOutput(...)`, the caller can declare `Local r.MyOutput = Call(fp, Ptr arg)`.
+
+Why the `Null`-sentinel idiom? Because there's no way to get a function pointer without calling the function. The Null branch is the bootstrap path.
+
+### Calling with `Call(fp, Ptr arg)`
+
+`Call` invokes through the pointer. The single argument is a generic pointer (`Ptr`), so you must:
+
+```basic
+Local fp.BBFunction = worker(Null)
+Local input.MyInput = New MyInput("payload")
+Local output.MyOutput = Call(fp, Ptr input)
+```
+
+The `Ptr input` cast converts the typed object reference to a raw pointer. The called function receives it back as its typed `input.MyInput` parameter (Blitz handles the cast on entry).
+
+### Multiple arguments
+
+`Call` takes one pointer arg. To pass multiple values, pack them in a DTO Type:
+
+```basic
+Type WorkerInput
+    Field id%
+    Field payload$
+    Field flags%
+End Type
+
+Local input.WorkerInput = New WorkerInput()
+input\id = 42
+input\payload = "hello"
+input\flags = 0
+Local out = Call(workerFp, Ptr input)
+```
+
+### Async / Await / Poll / AsyncThen
+
+```basic
+Local fp.BBFunction = slowJob(Null)
+Local future.BBThread = Async(fp, New JobInput("payload"))
+
+// Three ways to handle the future:
+
+// 1) Wait synchronously
+Local result.JobOutput = Await(future)
+
+// 2) Non-blocking poll, then await
+While True
+    If Poll(future)
+        Local result.JobOutput = Await(future)
+        Exit
+    EndIf
+    doOtherWork()
+Wend
+
+// 3) Chain — run nextFp on the result of the first
+Local nextFp.BBFunction = postProcess(Null)
+Local future2.BBThread = AsyncThen(future, nextFp)
+Local final = Await(future2)
+```
+
+`Async` is preemptive (real thread/coroutine), not cooperative. Inside the async function:
+
+- `Delay`, file I/O, network ops block the async without freezing the main thread.
+- Shared globals are still shared — synchronize access carefully.
+- The async function's return value is captured by the future and delivered to `Await`.
+
+Use for:
+
+- Loading assets in the background while UI stays responsive.
+- Spawning long-running scripts from gameplay code (rcce2's `ThreadScript` is built on this).
+- Network I/O that shouldn't stall the game tick.
+
+## Try / Throw / Catch deep dive
+
+```basic
+Function divide@(input.DivInput = Null)
+    If input = Null Then Return FunctionPtr()
+    If input\divisor = 0 Then Throw New DivError("division by zero")
+    Return New DivResult(input\dividend / input\divisor)
+End Function
+
+Function handleDivError@(err.DivError = Null)
+    If err = Null Then Return FunctionPtr()
+    WriteLog(MainLog, "divide failed: " + err\msg)
+    Return New DivResult(0)            // fallback
+End Function
+
+Local result.DivResult = TryCatch( ..
+    divide(Null), ..
+    handleDivError(Null), ..
+    New DivInput(10, 0))
+```
+
+### Semantics
+
+- `TryCatch(tryFp, catchFp, arg)` calls `tryFp(arg)`.
+- If `tryFp` returns normally, that return value is the `TryCatch` result.
+- If `tryFp` (or anything it calls) executes `Throw obj`, the stack unwinds and `catchFp(obj)` is called instead. That return value is the `TryCatch` result.
+- Both `tryFp` and `catchFp` must have compatible return types from the caller's perspective (callers `Local r.X = TryCatch(...)` and X has to work for both).
+
+### Nested throws
+
+`Throw` propagates up the call stack until a `TryCatch` catches it. If nothing catches, it's a runtime error (process exit). See [TryThrowCatchTest.bb](../../../compiler/BlitzForge/tests/TryThrowCatchTest.bb) `testNestedThrow`.
+
+### When to throw vs. `RuntimeError`
+
+- **Throw** — recoverable conditions where you want the caller to be able to handle (bad input, missing optional resource, network blip). Caller can catch and fall back.
+- **RuntimeError** — invariant violations, programmer errors, unrecoverable corruption. Process should die so the operator sees the failure clearly.
+
+In rcce2 specifically: server packet handlers and client renderers should **almost never** call `RuntimeError` on data sourced from network or save files. Soft-fail via `WriteLog` + graceful skip (see [src/CLAUDE.md](../../../CLAUDE.md) and recently merged "soft-fail" PRs).
+
+## Standard-library highlights
+
+These exist in legacy Blitz3D but are commonly forgotten:
+
+- **`Asc(c$)` / `Chr$(n)`** — char ↔ ASCII int (`Asc("A")` = 65).
+- **`Trim$(s)`** — strip leading/trailing whitespace.
+- **`Replace$(s, find, replacement)`** — string substitution.
+- **`Instr(s, find, start=1)`** — find substring (1-based, 0 if absent).
+- **`Mid$(s, start, len)`** — substring, 1-based start.
+- **`Left$(s, n)`, `Right$(s, n)`** — first/last n chars.
+- **`Upper$(s)` / `Lower$(s)`** — case conversion.
+- **`Str$(n)`** — number to string (no separator).
+- **`Int(x)` / `Float(x)`** — numeric conversion.
+- **`Abs(x)`, `Sgn(x)`, `Min(a,b)`, `Max(a,b)`, `Sqr(x)`** — math primitives.
+- **`Rand(low, high)`** — pseudo-random int in `[low, high]` inclusive.
+- **`Sin(deg)` / `Cos(deg)`** — angle is in **degrees, not radians**.
+- **`MilliSecs()`** — monotonic ms counter (wraps at int32 max ~24 days, beware).
+
+## Bank operations and binary serialization
+
+`Bank` is a fixed-size byte buffer for binary I/O. Used heavily in rcce2 for wire encoding.
+
+```basic
+Local b.BBBank = CreateBank(8)        // 8 bytes
+PokeInt b, 0, 42                       // write int at offset 0
+PokeByte b, 4, $FF                     // write byte at offset 4
+Local n = PeekInt(b, 0)                // read int from offset 0
+FreeBank b
+```
+
+Functions: `PokeByte`, `PokeShort`, `PokeInt`, `PokeFloat`, `PeekByte`, `PeekShort`, `PeekInt`, `PeekFloat`. Lengths: 1, 2, 4, 4 bytes. **Be deliberate with length tags**: writing `PokeInt b, 0, 5` then `PeekShort b, 0` gives you 5's low 16 bits.
+
+rcce2's `RCE_StrFromInt$(n, length=4)` and `RCE_IntFromStr(s$)` are built on `Bank`. The bank is a 8-byte module global, so `length > 8` will silently truncate.
+
+## Common idiom translations
+
+| Training-data idiom (won't compile / won't work right) | BlitzForge correct form |
+|---|---|
+| `enable_strict = True` | `Strict` (top of file) |
+| `Type Foo .. End Type ; obj = New Foo` | `New Foo()` (parens required) |
+| `obj.method()` | `obj\method()` |
+| `Function Foo.Bar.SomeFn()` (nested namespace) | use prefix in name: `BVM_SomeFn` / `RCE_SomeFn` |
+| `Const Foo As Int = 5` | `Const Foo = 5` (no `As`; sigil if needed: `Const Foo% = 5`) |
+| `Public/Private` keywords | not present; use `_`-prefix naming convention for private |
+| `Module Foo .. End Module` | `Include "Foo.bb"` |
+| `For Each item In list` | `For i = 0 To ListSize(list) - 1` + `ListAt(list, i)` |
+| `obj?.field` (null-conditional) | `If obj <> Null Then field = obj\field` |
+| `x = a > 0 ? a : 0` (ternary) | `If a > 0 Then x = a Else x = 0` |
+| `try { ... } catch (e) { ... }` (block) | `TryCatch(tryFp, catchFp, arg)` |
+| `await someAsync()` (keyword) | `Await(future)` where `future = Async(fp, arg)` |
+| `goto label` | `Goto label` works but rare; structured flow preferred |
+| `print x` | `DebugLog x` (test contexts) or `Print x` (interactive) |
+| `len(s)` (function-style) | `Len(s)` |
+| `s.Length` | `Len(s)` |
+| `arr.Length` | no length attr; track manually or use `BBList` + `ListSize` |
+| `String.Format(...)` | string concatenation with `+`; use `Str$()` for numbers |
+
+When in doubt, grep the rcce2 codebase for the operation you need — there's a working example for almost everything. The `compiler/BlitzForge/tests/*Test.bb` files are the second source of truth.

--- a/.claude/skills/rcce2-bvm-command/SKILL.md
+++ b/.claude/skills/rcce2-bvm-command/SKILL.md
@@ -1,0 +1,220 @@
+---
+name: rcce2-bvm-command
+description: Add, modify, or audit a BVM scripting command in rcce2. Invoke whenever the user wants to expose a new built-in function to Blitz game scripts (the BVM_* function family in ScriptingCommands.bb), tweak the dispatch table in RC_Standard_Invoker.bb, fix a BVM bounds check, change a function's privilege gating, or audit a scripting-engine vulnerability. Critical to know: BVM opcodes are assigned ALPHABETICALLY by function name. Inserting a single new function in the middle of the alphabet shifts every subsequent opcode by 1, requiring renumbering hundreds of dispatch cases — easy to corrupt the table by hand. This skill documents the safe insertion procedure, the privilege gating rules, the bounds-check patterns, and the SAFE-APPEND ordering trick that lets you avoid renumbering.
+---
+
+# rcce2 BVM scripting command
+
+## The two files
+
+The rcce2 BVM (Blitz Virtual Machine) lets game data scripts (under `data/Server Data/Scripts/`) call native code. Two files implement this:
+
+- **[src/Modules/ScriptingCommands.bb](../../../src/Modules/ScriptingCommands.bb)** — the native implementations. Each exposed command is a `Function BVM_NAME[%/$/#](...)` returning the BVM stack value.
+- **[src/Modules/RC_Standard_Invoker.bb](../../../src/Modules/RC_Standard_Invoker.bb)** — two things:
+  1. **Declaration block** (lines ~25 to ~460) — a long `s = s + "Function NAME<BVM_NAME>%(PARAMS)"+Chr(10)` literal that the BVM command-set parser ingests to build its symbol table and assign opcodes.
+  2. **Dispatch block** (lines ~462 to ~1700) — a `Select Case opcode` switch that pops args from the BVM stack, calls the native `BVM_NAME` function, and pushes the result back.
+
+The declaration string is parsed by `BVM_CreateCommandSet` at runtime; it **sorts the declarations alphabetically by name** and assigns sequential opcode numbers starting from 256. The dispatch `Case N` numbers must match this sorted order.
+
+## The alphabetical-opcode trap
+
+Adding a new function called `BVM_NEAREST_ACTOR_IN_RADIUS` in declaration order looks innocent. But because the BVM sorts alphabetically by name, "NEAREST_*" sorts between "NAME" (currently opcode 436) and "NEWQUEST" (currently opcode 437). Inserting it shifts every opcode from 437 upward by 1.
+
+If you insert a new declaration and just add a new `Case 579` at the end of the dispatch (where the highest existing case currently sits), you will appear to compile fine — but every script that calls anything past "NAME" alphabetically will silently call the wrong native function. The dispatch table is now out of sync with the command-set parser.
+
+**Verifying the alphabetical claim**: in the current dispatch, Case 436 = `BVM_NAME`, 437 = `BVM_NEWQUEST`, 438 = `BVM_NEXTACTOR`, 439 = `BVM_NEXTACTORINZONE`, 440 = `BVM_OPENFILE`, 441 = `BVM_OPENTRADING`. Pure alphabetical order. The same pattern holds across the whole range (256–578).
+
+## Two safe insertion strategies
+
+### Strategy A: SAFE-APPEND ordering (preferred for small additions)
+
+Name your new function so it sorts at the **end** of the existing range. The current alphabetical maximum is `BVM_ZONEOUTDOORS` (opcode 578). Anything that sorts after "ZONEOUTDOORS" lands at opcode 579+ without renumbering.
+
+In practice this means prefixing or naming such that alphabetical order is preserved. A common technique: use a `Z`-prefixed namespace for new helpers that don't naturally land at the end. Less ideal for readability but completely safe.
+
+Example for the `BVM_NEAREST_ACTOR_IN_RADIUS` / `BVM_NEAREST_WAYPOINT` proposal: rename to `BVM_ZNEAREST_ACTOR_IN_RADIUS` and `BVM_ZNEAREST_WAYPOINT`. They land at the end, no renumbering.
+
+Trade-off: a slightly uglier name in exchange for a small, mechanical, low-risk PR.
+
+### Strategy B: Full renumber (when the natural name matters)
+
+If the natural name belongs in the middle and you'd rather not prefix:
+
+1. Insert the new declaration line in alphabetical position in the `s = s + ...` block.
+2. Shift every dispatch `Case N` from the new insertion point upward by `+1` (or `+K` if inserting K functions).
+3. Insert the new `Case` entries at the correct alphabetical position in the dispatch.
+4. Re-test thoroughly — even one off-by-one in the renumber silently mis-dispatches every later command.
+
+For a single insertion that lands at position M, you need to bump cases `M..578` to `M+1..579`. That's typically 100+ cases to renumber. **Don't do this by hand** — write a small script that bumps every `Case N` line where N is in the bump range, then visually verify.
+
+**Heuristic for the choice**: if `K` (number of cases to shift) is more than ~5, prefer Strategy A. The renumber risk is too high for the gain.
+
+## Native function shape
+
+```basic
+Function BVM_DOTHETHING%(Param1%, Param2$, Param3#)
+    ; Step 1: privilege check (see below)
+    If Not BVM_RequirePrivileged() Then Return
+
+    ; Step 2: resolve & null-check handles
+    Local target.ActorInstance = Object.ActorInstance(Param1%)
+    If target = Null Then Return -1
+
+    ; Step 3: bounds check on raw values
+    If Param3# < 0.0 Or Param3# > 1000.0 Then Param3# = 1000.0
+
+    ; Step 4: do the work
+    Local result = doIt(target, Param2$, Param3#)
+    Return result
+End Function
+```
+
+### Return type sigil matters
+
+- `Function BVM_NAME%(...)` returns an int (BVM pushes int).
+- `Function BVM_NAME$(...)` returns a string.
+- `Function BVM_NAME#(...)` returns a float.
+- `Function BVM_NAME(...)` (no sigil) — void; no push.
+
+The sigil in the declaration string must match: `s = s + "Function NAME<BVM_NAME>%(PARAM1%, PARAM2$)"+Chr(10)`.
+
+### Parameter sigils
+
+Same rules — `%` int, `$` string, `#` float. Default values are supported: `PARAM3% = 1`.
+
+## Dispatch case shape
+
+```basic
+Case 579
+    fparam2# = BVM_PopFloat()
+    sparam1$ = BVM_PopString()
+    iparam0% = BVM_PopInt()
+    BVM_PushInt(BVM_DOTHETHING(iparam0%, sparam1$, fparam2#))
+```
+
+**Critical: args pop in reverse declared order.** The BVM stack is LIFO. If declaration is `BVM_DOTHETHING%(Param1%, Param2$, Param3#)`, the stack has Param3 on top, then Param2, then Param1. Pop in reverse, then call in declared order.
+
+If the function is void (no return), use `BVM_DOTHETHING(...)` directly without `BVM_PushInt(...)`. For string return, use `BVM_PushString(...)`. For float, `BVM_PushFloat(...)`.
+
+## Privilege gating
+
+The default for most BVM commands is **non-privileged**: any NPC's right-click/examine/use/trade script runs with the *clicker's* actor handle. Without privilege checks, an NPC could call `BVM_BANPLAYER(SCRIPT_ACTOR)` and ban the player who right-clicked it.
+
+Three gating functions exist in [ScriptingCommands.bb](../../../src/Modules/ScriptingCommands.bb):
+
+### `BVM_RequirePrivileged%()` — admin-only ops
+
+Use for: `BVM_BANPLAYER`, `BVM_KICKPLAYER`, `BVM_SETGOLD`, `BVM_WARP`, faction mutators, anything that affects global state.
+
+```basic
+Function BVM_BANPLAYER(Param%)
+    If Not BVM_RequirePrivileged() Then Return
+    Actor.ActorInstance = Object.ActorInstance(Param)
+    If Actor <> Null
+        A.Account = Object.Account(Actor\Account)
+        If A <> Null Then A\IsBanned = 1
+    EndIf
+End Function
+```
+
+This passes only when the currently-executing script's `SI\Privileged` flag is set. That flag is set by the calling context — currently only `/script` chat commands from a GM and a few other admin paths.
+
+### `BVM_RequireSelfOrPrivileged%(Param1%)` — actor mutators that are safe for self
+
+Use for: `BVM_SETACTORLEVEL`, `BVM_MOVETO`, attribute mutators — anything that takes an actor handle but is fine when the script is mutating its own actor or its context.
+
+```basic
+Function BVM_MOVETO(Param1%, Param2#, Param3#, Param4#)
+    If Not BVM_RequireSelfOrPrivileged(Param1%) Then Return
+    Local A.ActorInstance = Object.ActorInstance(Param1%)
+    If A <> Null Then
+        A\X# = Param2# : A\Y# = Param3# : A\Z# = Param4#
+    EndIf
+End Function
+```
+
+This passes when (a) the script is privileged, OR (b) Param1 matches `SI\AI` (the script's owning actor) or `SI\AIContext` (the context actor that triggered the script). Lets NPCs move themselves without letting them move random players.
+
+### No gating — pure reads
+
+`BVM_PLAYERISGM`, `BVM_ACTORX`, `BVM_NEXTACTORINZONE` etc. — pure reads of state that scripts always need access to. No gate. Even hostile NPC scripts can read; they just can't mutate.
+
+### Which to choose
+
+Ask: "if a malicious NPC's `Examine` script calls this with the clicker's handle, what's the damage?"
+
+- No damage (pure read) → no gate.
+- Damage only to the script's own state → `BVM_RequireSelfOrPrivileged(target_handle)`.
+- Damage to anyone → `BVM_RequirePrivileged()`.
+
+## Bounds checks for client-controlled values
+
+Scripts can be edited by anyone with project-author access, but they're still data — they're parsed at server start and run in the same process. Bad scripts shouldn't crash the server.
+
+```basic
+Function BVM_GETKNOWNSPELL$(Param1%, Param2%)
+    Actor.ActorInstance = Object.ActorInstance(Param1%)
+    If Actor = Null Then Return ""
+
+    ; Bounds-check the index before reading from a fixed array
+    If Param2% < 0 Or Param2% > 999 Then Return ""
+
+    Local SpellID = Actor\KnownSpells[Param2%]
+    If SpellID < 0 Or SpellID > 999 Then Return ""
+
+    If SpellList(SpellID) = Null Then Return ""
+    Return SpellList(SpellID)\Name$
+End Function
+```
+
+`KnownSpells[]` is dimensioned `[999]` (1000 slots), and any script can pass any Param2 value. The check chain is: bounds the index, bounds the value read, Null-check the lookup. Skipping any step is a server crash.
+
+## Stack discipline
+
+If your function has multiple early-return paths, **every path must leave the stack in the right state**:
+
+- Functions declared `%` must always push an int (use `BVM_PushInt(0)` for the default).
+- Functions declared `$` must always push a string (`BVM_PushString("")`).
+- Void functions must not push anything.
+
+The dispatch `Case` block in `RC_Standard_Invoker.bb` handles the push for you — but the function itself must return something for the dispatch to push. Missing returns silently produce 0/"" which is usually fine, but be deliberate.
+
+## Logging
+
+Use `BVM_ScriptLog(msg$)` for messages tied to script execution (logs include the script name and execution context). Use `WriteLog(MainLog, msg$)` for server-level messages that aren't script-attributed.
+
+Don't `RuntimeError` for bad script input. Log and return a sentinel value (-1, 0, "") — the script will see the error in its result and can handle it.
+
+## Compile + test
+
+```powershell
+.\compile.bat -t        # builds Server (where BVM commands run)
+```
+
+Strict-mode catches signature mismatches between the declaration string and the native function. If `Function BVM_X%(P1%, P2$)` declares two params but the native takes three, compile fails. The dispatch `Case` is your other line of defense; double-check the pop order matches the declared param order in reverse.
+
+There are no per-BVM-function tests yet (the test framework can't easily mock script execution). End-to-end is "compile, run server, run a script that exercises the command."
+
+## Reading the dispatch table
+
+To find where a specific BVM is dispatched:
+
+```bash
+# Find the Case for BVM_NEXTACTORINZONE
+grep -n "BVM_NEXTACTORINZONE" src/Modules/RC_Standard_Invoker.bb
+# 203:    s = s + "Function NEXTACTORINZONE<BVM_NEXTACTORINZONE>%(PARAM1%)"+Chr(10)
+# 1115:                  BVM_PushInt(BVM_NEXTACTORINZONE(iparam0%))
+```
+
+Two hits: declaration (line 203) and dispatch (line 1115). The `Case` number for the dispatch tells you the opcode — useful when verifying you haven't broken the table.
+
+## Checklist before committing
+
+- [ ] Native function in [ScriptingCommands.bb](../../../src/Modules/ScriptingCommands.bb) follows the privilege check → resolve handle → bounds check → work pattern.
+- [ ] Declaration string in [RC_Standard_Invoker.bb](../../../src/Modules/RC_Standard_Invoker.bb) is in correct alphabetical position OR named to safe-append at end.
+- [ ] Dispatch `Case N` pops args in reverse-declared order, calls in declared order.
+- [ ] Dispatch case number is correct (alphabetical position relative to existing commands).
+- [ ] Return-type sigil matches everywhere (declaration string, native function, dispatch push).
+- [ ] No `RuntimeError` paths reachable from script input — only `Return sentinel` + `BVM_ScriptLog`.
+- [ ] `compile.bat -t` clean.
+- [ ] If you renumbered, you spot-checked at least 3 cases from the bumped range to confirm they still call the right function.

--- a/.claude/skills/rcce2-packet-handler/SKILL.md
+++ b/.claude/skills/rcce2-packet-handler/SKILL.md
@@ -1,0 +1,205 @@
+---
+name: rcce2-packet-handler
+description: Add, modify, or harden a packet handler in rcce2's ServerNet.bb or ClientNet.bb. Invoke whenever the work involves the wire protocol — adding a new P_* packet type, fixing a Mid$ offset bug, hardening a handler against malformed input, adding a Case branch to the giant Select Case on packet type, or any code that calls RCE_Send / RCE_StrFromInt$ / RCE_IntFromStr. The wire encoding has subtle conventions (length-prefixed strings, fixed-byte integer fields, paired sender/receiver byte counts) and the server is a single shared process — one unchecked Mid$ or one unguarded array index is a one-packet client-to-server DoS for every connected player. This skill encodes the established encoding, validation, and soft-fail patterns from the existing handlers.
+---
+
+# rcce2 packet handler
+
+The rcce2 server is a single shared process. Every packet handler runs in the same loop, and any `RuntimeError` from any handler crashes the server for every connected player. This skill captures the established patterns for adding or modifying handlers safely.
+
+## Where things live
+
+- [src/Modules/Packets.bb](../../../src/Modules/Packets.bb) — all `Const P_* = N` packet type definitions. New packet types get added here first.
+- [src/Modules/RCEnet.bb](../../../src/Modules/RCEnet.bb) — wire encoding helpers (`RCE_StrFromInt$`, `RCE_IntFromStr`, `RCE_Send`, `RCE_FloatFromStr#`, `RCE_StrFromFloat$`). Read this once to understand the byte-level format.
+- [src/Modules/ServerNet.bb](../../../src/Modules/ServerNet.bb) — server's packet dispatch. Large `Select Case PacketType` around line 80+. Each `Case P_X` is a handler.
+- [src/Modules/ClientNet.bb](../../../src/Modules/ClientNet.bb) — client's packet dispatch. Same shape as ServerNet but client-side.
+
+## Wire encoding rules
+
+### Integer fields are fixed-byte
+
+`RCE_StrFromInt$(num, length=4)` packs `num` into `length` bytes via the `RCE_ConvertBank` (8 bytes). The receiver must read **exactly the same length** with `Mid$(MessageData$, offset, length)`. The bank is 8 bytes total, so:
+
+- Lengths 1, 2, 4 work normally.
+- Length 8 works (max).
+- Length > 8 silently truncates — the bank doesn't grow. Don't ever pass `length > 8`.
+
+```basic
+// Sender:
+Local payload$ = "U" + RCE_StrFromInt$(slot, 1) + RCE_StrFromInt$(amount, 2)
+
+// Receiver:
+Local opcode$ = Left$(M\MessageData$, 1)            // "U"
+Local slot   = RCE_IntFromStr(Mid$(M\MessageData$, 2, 1))   // matches Length=1 above
+Local amount = RCE_IntFromStr(Mid$(M\MessageData$, 3, 2))   // matches Length=2 above
+```
+
+**Common bug**: sender writes `RCE_StrFromInt$(x, 2)` (2 bytes) but receiver reads `RCE_IntFromStr(Mid$(M\MessageData$, offset, 4))` (4 bytes). Receiver overshoots into the next field, corrupting everything downstream. Always pair the byte counts.
+
+### Floats use the same pattern with `RCE_FloatFromStr#` and `RCE_StrFromFloat$`
+
+Always 4 bytes (IEEE 754 single).
+
+### Strings are length-prefixed
+
+The convention: a 1- or 2-byte length, then the bytes:
+
+```basic
+// Sender:
+Local payload$ = RCE_StrFromInt$(Len(name$), 1) + name$
+
+// Receiver:
+Local nameLen = RCE_IntFromStr(Mid$(M\MessageData$, offset, 1))
+Local name$   = Mid$(M\MessageData$, offset + 1, nameLen)
+```
+
+**Use `ReadBoundedString$(buf$, offset, maxLen)`** if it exists for the operation — it caps `nameLen` to `maxLen` so a hostile sender can't claim a string longer than the buffer (which would `Mid$` past the end and return garbage). When adding a string-receiving handler, write or reuse a bounded helper rather than raw `Mid$`.
+
+### Multi-byte integers are big-endian via Bank
+
+`PokeInt b, 0, num` writes machine-byte-order, then `PeekByte b, i` reads byte-by-byte from offset 0 upward. The reverse (`RCE_StrFromInt$`) builds the string by prepending each byte (offset 0 first, then offset 1, ...) — this gives a fixed wire byte order regardless of host endianness. Don't try to micro-optimize this; the helpers handle it.
+
+### `RCE_Send` signature
+
+```basic
+RCE_Send(Connection, PeerID, P_Type, Payload$, ReliableFlag)
+```
+
+- `Connection` — `Host` (server) or `PeerToHost` (client).
+- `PeerID` — destination peer ID. On server, `M\FromID` is the sender; you typically send back to the same ID or to `AI\RNID` of a specific actor. On client, always `PeerToHost`.
+- `P_Type` — one of the `Const P_*` values from `Packets.bb`.
+- `Payload$` — the encoded payload. Leading byte is conventionally a sub-opcode for handlers that multiplex (e.g., `P_AppearanceUpdate` uses `"C"`, `"G"`, `"D"`, `"H"`, `"F"` for the field being updated).
+- `ReliableFlag` — `True` for state-mutating packets, `False` for high-frequency lossy updates (position, animation).
+
+## Anatomy of a server packet handler
+
+```basic
+Case P_SomeAction
+    ; Step 1: find the sending actor
+    AI.ActorInstance = FindActorInstanceFromRNID(M\FromID)
+    If AI <> Null
+        ; Step 2: subdivide by leading opcode if applicable
+        Select Left$(M\MessageData$, 1)
+            Case "X"
+                ; Step 3: length-check BEFORE reading
+                If Len(M\MessageData$) < 5 Then ; need 1 opcode + 4-byte field
+                    WriteLog(MainLog, "P_SomeAction X: truncated packet, dropping")
+                    ; just drop — no reply, no crash
+                Else
+                    ; Step 4: read fields with matched byte counts
+                    Local handle = RCE_IntFromStr(Mid$(M\MessageData$, 2, 4))
+
+                    ; Step 5: bounds + Null check before dereference
+                    Local target.ActorInstance = Object.ActorInstance(handle)
+                    If target = Null Then
+                        WriteLog(MainLog, "P_SomeAction X: bad handle, dropping")
+                    Else
+                        ; Step 6: authorize — does AI have the right to act on target?
+                        If target\ServerArea <> AI\ServerArea Then
+                            WriteLog(MainLog, "P_SomeAction X: cross-area, refusing")
+                        Else
+                            ; Step 7: do the work
+                            DoTheThing(AI, target)
+                        EndIf
+                    EndIf
+                EndIf
+        End Select
+    EndIf
+```
+
+The steps in order:
+
+1. **Find sender by RNID** — `FindActorInstanceFromRNID(M\FromID)`. Null means stale or unauth; bail.
+2. **Sub-opcode dispatch** if the packet multiplexes.
+3. **Length check** before reading. `Mid$(s, large_offset)` returns "" rather than erroring, and `RCE_IntFromStr("")` returns 0 — silent corruption.
+4. **Match byte counts** with the sender's `RCE_StrFromInt$` calls.
+5. **Bounds and Null check** before dereferencing arrays or handles. The client can send any byte values. `Object.X(handle)` returns Null for stale/invalid handles.
+6. **Authorize**: same area? owns the item? is target alive? Combat sends to dead actors are use-after-free if you skip this.
+7. **Then** do the work.
+
+## The "client-can-crash-server" trap
+
+Every handler shares the server process. A `RuntimeError`, a Null deref, or an out-of-range array index in any handler kills every connected player. The audit history has many examples; the most recently shipped:
+
+- **[PR #132](https://github.com/RydeTec/rcce2/pull/132)** — `P_CreateCharacter` passed a client-supplied 2-byte ActorID straight into `ActorList(id)` → `CreateActorInstance(Null)` → `RuntimeError`. **One crafted packet** crashed the server. Fix: bounds-check + `ActorList(id) <> Null` before use.
+- **[PR #133](https://github.com/RydeTec/rcce2/pull/133)** — `SetArea` dereferenced `Ar` without Null check; a saved character whose Area$ was deleted from data files crashed the server at login. Fix: defensive guard at top of `SetArea`, plus validate at `P_StartGame` call site before flipping login status.
+- **[PR #134](https://github.com/RydeTec/rcce2/pull/134)** — `/warpother` DM chat command had no `Ar <> Null` check after `FindArea` (the sibling `/warp` did). DM typo crashed the server. Fix: mirror the sibling guard.
+
+The recovery patterns:
+
+### Invalid handle / stale reference → log + skip
+
+```basic
+Local target.ActorInstance = Object.ActorInstance(handle)
+If target = Null
+    WriteLog(MainLog, "P_Whatever: stale actor handle " + handle + ", dropping")
+    ; no reply needed; just drop
+    ; (continue to next packet — the surrounding `For M = Each MessageBuffer` loop handles iteration)
+EndIf
+```
+
+### Invalid client-supplied list index → reject with response
+
+```basic
+If ActorID < 0 Or ActorID > 65535 Or ActorList(ActorID) = Null
+    WriteLog(MainLog, "P_CreateCharacter: invalid ActorID " + ActorID + " from '" + A\User$ + "'")
+    RCE_Send(Host, M\FromID, P_CreateCharacter, "N", True)   ; tell client the request failed
+    Exists = True : Exit                                       ; bail out of the surrounding For loop
+EndIf
+```
+
+### Missing optional referenced object → log + continue without it
+
+```basic
+Local Ar.Area = FindArea(name$)
+If Ar = Null
+    WriteLog(MainLog, "P_Warp: area '" + name$ + "' not found, ignoring")
+    ; don't touch the actor; just skip
+Else
+    SetArea(actor, Ar, 0, -1, -1, x#, y#, z#)
+EndIf
+```
+
+### State must be cleaned up if you bail
+
+If the partial setup already created objects (allocated an actor slot, opened a file), free/close them before bailing:
+
+```basic
+A\Character[FreeSlot] = CreateActorInstance(ActorList(ActorID))
+; ... 50 lines of setup ...
+If somethingWrong
+    FreeActorInstance(A\Character[FreeSlot])           // cleanup
+    A\Character[FreeSlot] = Null                       // clear pointer
+    RCE_Send(Host, M\FromID, P_CreateCharacter, "N", True)
+    Exists = True : Exit
+EndIf
+```
+
+See the `AttributeAssignment` cheat check in `P_CreateCharacter` ([ServerNet.bb around line 2443](../../../src/Modules/ServerNet.bb)) for the canonical bail-with-cleanup pattern.
+
+## Adding a brand-new packet type
+
+1. Add `Const P_NewThing = NNN` to [Packets.bb](../../../src/Modules/Packets.bb). Pick the next unused number; both server and client read the same file, so they agree.
+2. **Sender** — wherever the action originates (UI button, NPC script, game tick), call `RCE_Send(Host, target, P_NewThing, payload$, reliable)`.
+3. **Receiver** — add `Case P_NewThing` to the appropriate `Select Case` in [ServerNet.bb](../../../src/Modules/ServerNet.bb) or [ClientNet.bb](../../../src/Modules/ClientNet.bb).
+4. Follow the validation steps above for the receive side.
+5. If it's a server-side handler that mutates persistent state, save through an atomic write (see [Logging.bb](../../../src/Modules/Logging.bb)'s `SafeWriteOpen$` / `SafeWriteCommit%`).
+6. Test by running `compile.bat -t` (builds both Server and Client) and verifying the round trip in a manual session.
+
+## Client-side soft-fail (rendering)
+
+Client-side mesh/animation/UI handlers face the same DoS surface from a hostile or out-of-sync server. The pattern is the same: log + skip + free any partial entity. Examples from merged PRs:
+
+- **[PR #128](https://github.com/RydeTec/rcce2/pull/128)** — `P_NewActor` mesh load failure now does `WriteLog + SafeFreeActorInstance + Return` instead of `RuntimeError`. Actor stays invisible to this client until they re-enter the zone; the rest of the world keeps rendering.
+- **[PR #129](https://github.com/RydeTec/rcce2/pull/129)** — equipment/gubbin mesh failures soft-fail to "unequipped" instead of crashing.
+- **[PR #130](https://github.com/RydeTec/rcce2/pull/130)** — `P_AppearanceUpdate` C/G (race/gender change) mesh failures soft-fail for other actors; the player's own avatar still hard-errors (no reconnect-state recovery yet).
+
+## Things to double-check before committing
+
+- [ ] Sender's `RCE_StrFromInt$` byte counts match receiver's `Mid$` byte counts.
+- [ ] Every value read from the wire is bounds/Null-checked before being used as an index or dereferenced.
+- [ ] No `RuntimeError` calls on wire-derived data. Use `WriteLog` + soft-fail recovery.
+- [ ] If the handler allocates partial state, the bail path frees it.
+- [ ] Packet length is checked against the minimum needed bytes before reading the last field.
+- [ ] `compile.bat -t` builds Server and Client cleanly.
+- [ ] If your change spans both sides, both sides agree on the new packet format (no version skew).

--- a/.claude/skills/rcce2-test-writing/SKILL.md
+++ b/.claude/skills/rcce2-test-writing/SKILL.md
@@ -1,0 +1,242 @@
+---
+name: rcce2-test-writing
+description: Write or modify a unit test under src/Tests/ in rcce2. Invoke whenever the user asks to test a module, cover a bug fix with a regression test, add coverage for a serialization round-trip, or asks about the test framework's Strict-mode + inline-stub pattern. Also invoke when CI is failing on a test file, when the known intermittent "ItemsTest Stack overflow" flake appears, or when the user wants to understand why a test compiles standalone but breaks under test.bat. The rcce2 test framework has a specific structure (Strict + EnableGC + inline type/function stubs to keep the dependency graph small) that does NOT match generic Blitz3D testing, and the build runner has a known-flake retry workflow that's documented nowhere else.
+---
+
+# rcce2 test writing
+
+The rcce2 test suite lives under [src/Tests/](../../../src/Tests/) and runs via [test.bat](../../../test.bat) (Windows) or [test.sh](../../../test.sh) (Unix). The runner walks every `.bb` in `src/Tests/` and runs each through `blitzcc -t -w src` (test mode, working dir = `src`). First failure exits non-zero.
+
+The framework itself is part of BlitzForge — `Test foo() ... End Test` blocks compile into test entry points that `-t` mode runs. Inside a Test block, `Assert(expr)` records a pass/fail and (importantly) **does not abort the test on failure** — every Assert runs and the test fails if any failed.
+
+## The cardinal pattern: Strict + inline stubs
+
+Test files do NOT include `Server.bb` or `Client.bb`. Those entry points pull in dozens of modules — network code, the BVM, the world, the renderer. A test compiling against them would take ages and need real handles, MySQL, etc.
+
+Instead, every test file:
+
+1. Opens with `Strict` + `EnableGC` so type/sigil mistakes are caught at compile time.
+2. Inlines **type stubs** for any Type the module-under-test references but doesn't define itself.
+3. Inlines **function stubs** for any cross-module functions the module-under-test calls that aren't being exercised.
+4. Then `Include "Modules\TheModule.bb"`.
+5. Then defines `Test ...()` blocks that exercise the module's exported functions.
+
+Canonical example: [src/Tests/Modules/ItemsTest.bb](../../../src/Tests/Modules/ItemsTest.bb). Walks the pattern step by step. Read it before writing a new test.
+
+### Why this matters
+
+Items.bb references `Attributes` (a Type defined in Actors.bb) and `ActorInstance` (also Actors.bb). Including Actors.bb pulls in the world graph, network code, and a server-only dependency cascade. Inlining stubs:
+
+```basic
+; --- External type stubs ---
+Type Attributes
+    Field Value[39]
+    Field Maximum[39]
+    Field My_ID
+End Type
+
+Type ActorInstance
+    Field Account
+End Type
+```
+
+...gives the compiler enough to resolve field accesses in Items.bb without dragging in the rest of the world. Items.bb works on `Attributes\Value[i]` — the test stub gives it that shape, and that's all.
+
+### Function stubs
+
+If Items.bb calls `WriteLog(MainLog, msg$)` from Logging.bb, you need a stub:
+
+```basic
+Global MainLog = 0
+
+Function WriteLog(LogID%, Message$, Timestamp% = True, Datestamp% = False)
+End Function
+```
+
+The body is empty because the test doesn't care about logging. The signature must match the real one (param count, sigils, default values).
+
+### Module-specific helper stubs
+
+Items.bb calls `RCE_StrFromInt$` and `RCE_IntFromStr` from RCEnet.bb. Re-implement them in the test with a private Bank:
+
+```basic
+Global ItemsTest_ConvertBank.BBBank = CreateBank(8)
+
+Function RCE_IntFromStr(Dat$)
+    PokeInt ItemsTest_ConvertBank, 0, 0
+    Local i
+    For i = 1 To Len(Dat$)
+        PokeByte ItemsTest_ConvertBank, i - 1, Asc(Mid$(Dat$, i, 1))
+    Next
+    Return PeekInt(ItemsTest_ConvertBank, 0)
+End Function
+
+Function RCE_StrFromInt$(Num, Length = 4)
+    PokeInt ItemsTest_ConvertBank, 0, Num
+    Local Dat$ = ""
+    Local i
+    For i = Length - 1 To 0 Step -1
+        Dat$ = Chr$(PeekByte(ItemsTest_ConvertBank, i)) + Dat$
+    Next
+    Return Dat$
+End Function
+```
+
+Verbatim from the real RCEnet.bb except the Bank is private to the test (avoids the global-bank dependency).
+
+## When the module's API changed
+
+Recurring failure mode: a PR adds a new helper function to a real module (e.g., `SafeWriteOpen$` / `SafeWriteCommit%` in Logging.bb), and a test that includes the consumer module now fails because the new helper isn't stubbed.
+
+Example from merged history: [PR #124](https://github.com/RydeTec/pulls/124) added atomic-write helpers to several Save functions. ItemsTest.bb (which doesn't include Logging.bb) suddenly broke on CI: `"Function 'safewriteopen' not found"`. Fix was to add stubs:
+
+```basic
+; --- SafeWrite stubs ---
+Function SafeWriteOpen$(FinalPath$)
+    Return FinalPath$
+End Function
+
+Function SafeWriteCommit%(TempPath$, FinalPath$, F)
+    Return True
+End Function
+```
+
+When you change a module's exported surface, **grep `src/Tests/` for any test that includes the changed module** and update its stubs to match.
+
+## The `Test foo()` / `End Test` block
+
+```basic
+Test testItemInstanceRoundTrip()
+    ClearItemList()                         ; setup
+    Local sword.Item = SeedItem("Sword")    ; arrange
+
+    Local original.ItemInstance = CreateItemInstance(sword)
+    original\ItemHealth = 75
+
+    Local s$ = ItemInstanceToString$(original)
+    Assert(Len(s$) = ItemInstanceStringLength())
+
+    Local restored.ItemInstance = ItemInstanceFromString(s$)
+    Assert(restored <> Null)
+    Assert(ItemInstancesIdentical(original, restored) = True)
+
+    ClearItemList()                         ; teardown
+End Test
+```
+
+- One Test per concern. Group setup/arrange/act/assert clearly.
+- Use `Assert(expr)` — returns True/False, does not abort. Every Assert in the test runs even after a failure.
+- Test outputs `Active strings : N` and friends at the end — the BlitzForge GC is checking for leaks. Tests with reachable leaks fail.
+- Setup/teardown is manual: write a `ClearItemList()` helper (see [ItemsTest.bb line 83](../../../src/Tests/Modules/ItemsTest.bb#L83)) that resets the module state.
+- Test names start with `test` by convention.
+
+## Pinning contract values
+
+Pin tests are valuable: they document and enforce specific values that downstream code depends on.
+
+```basic
+; ItemInstanceStringLength is a contract constant -- pin it so anyone who
+; changes the serialization format has to update the test consciously.
+Test testItemInstanceStringLengthIs83Bytes()
+    Assert(ItemInstanceStringLength() = 83)
+End Test
+```
+
+The test name encodes the expected value. Anyone changing the serialization format and breaking this test sees exactly what they broke.
+
+## Testing rejection paths
+
+For functions that should return Null / -1 / False on bad input:
+
+```basic
+; Truncated payload: ItemInstanceFromString must return Null rather than
+; crash on under-length input.
+Test testItemInstanceFromStringRejectsShortPayload()
+    ClearItemList()
+    Local defaultItem.Item = SeedItem("Default")
+
+    Assert(ItemInstanceFromString("") = Null)
+    Assert(ItemInstanceFromString("xx") = Null)
+    Local underSized$ = String$("x", ItemInstanceStringLength() - 1)
+    Assert(ItemInstanceFromString(underSized) = Null)
+
+    ClearItemList()
+End Test
+```
+
+These tests are the safety net for hostile-server / malformed-packet recovery. Add one for every soft-fail path you ship.
+
+## The "test compiles standalone but breaks under test.bat" problem
+
+`blitzcc -t -w src TheTest.bb` from the `src/Tests/Modules/` directory with `-w src` as the working dir. Includes resolve from `src/`, so `Include "Modules\PasswordHash.bb"` works.
+
+If a test passes standalone (`blitzcc -t PasswordHashTest.bb` from the file's directory) but fails under `test.bat`, the include path is the most likely cause. Always use `Include "Modules\..."` (capital M, backslashes — the convention matches the runtime).
+
+## The known ItemsTest flake
+
+There's an intermittent flake where `ItemsTest.bb` fails with `Error: Stack overflow!` in CI. It's pre-existing infrastructure noise, not caused by Items.bb itself. The flake's been seen on PRs that touch nothing item-related.
+
+**Workaround**: close + reopen the PR to re-trigger CI:
+
+```bash
+gh pr close <N> && sleep 3 && gh pr reopen <N>
+```
+
+Usually passes on the second run. If it fails twice in a row on an unrelated PR, investigate — but two retries is the established norm.
+
+When you write a long-running test (heavy loops, large data structures), watch for the stack-overflow shape. The framework's per-test isolation is imperfect; bleeding state between tests can compound.
+
+## Test runner details
+
+[test.bat](../../../test.bat) (~46 lines):
+
+```batch
+@echo off
+setlocal
+set "ROOTDIR=%~dp0"
+set "BLITZPATH=%ROOTDIR%\compiler\BlitzForge"
+set "TESTDIR=%ROOTDIR%\src\Tests"
+cd /d "%TESTDIR%"
+
+REM walk every .bb and run blitzcc -t against it
+for /r %%f in (*.bb) do (
+    "%BLITZPATH%\bin\blitzcc.exe" -t -w "%ROOTDIR%\src" "%%f"
+    if errorlevel 1 (
+        echo "%%f failed at least one test"
+        set FAILED=1
+    )
+)
+```
+
+Exit code 1 on any failure. The script keeps running through all tests so you see every failure, not just the first.
+
+## Where tests live
+
+```
+src/Tests/
+├── Modules/                       # most module tests
+│   ├── AccountsServerTest.bb
+│   ├── EnvironmentTest.bb
+│   ├── ItemsTest.bb               # canonical example
+│   ├── PasswordHashTest.bb
+│   ├── SafeWriteTest.bb
+│   ├── MediaImportTest.bb
+│   ├── SpawnTrackingTest.bb
+│   └── RecentProjectsTest.bb
+├── Framework/                     # tests for src/Modules/Framework/
+├── Helpers/                       # helper-utility tests
+└── UI/Components/                 # UI component tests
+```
+
+When adding coverage for a new module, mirror the source path: a test for `src/Modules/Foo.bb` goes in `src/Tests/Modules/FooTest.bb`. Easy to navigate, easy to grep.
+
+## Checklist before committing a new test
+
+- [ ] File opens with `Strict` then `EnableGC`.
+- [ ] All `Type` references resolve (stubs for non-included types).
+- [ ] All function calls resolve (stubs for non-included functions; signatures match real ones).
+- [ ] `Include "Modules\TheModule.bb"` uses backslash + capital M.
+- [ ] One Test block per concern; test names start with `test`; setup/teardown call helpers (`ClearXList()` pattern).
+- [ ] No reachable leaks (GC report at end shows 0 unreleased objects).
+- [ ] `test.bat` runs cleanly with your new file.
+- [ ] If you also changed a real module's exported surface, you've updated every consumer test's stubs.

--- a/.gitignore
+++ b/.gitignore
@@ -107,4 +107,11 @@ bin/ReShade.ini
 
 compiler/BlitzPlus/
 
+# Claude Code session ephemera. Track .claude/skills/ and any CLAUDE.md
+# files, but never the per-session state, locks, or local config that
+# the runtime drops here.
+.claude/*
+!.claude/skills/
+.claude/settings.local.json
+
 scripts/msbuild_blitzrcplus.bat

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,201 @@
+# CLAUDE.md — RCCE 2 (RealmCrafter Community Edition)
+
+Orientation for Claude agents working in this repo. User-facing docs live in [ReadMe.md](ReadMe.md) and [docs/](docs/); this file is the developer's-eye view that the README skips.
+
+## What this repo is
+
+Server + Client + tools for an open-source MMORPG engine, written in the **BlitzForge** language (a modernized Blitz3D fork — *not* base Blitz3D). The compiler is vendored as a git submodule at [compiler/BlitzForge](compiler/BlitzForge).
+
+The four shipping executables built from `src/`:
+
+| Source | Output | Purpose |
+|---|---|---|
+| [src/Server.bb](src/Server.bb) | `bin/Server.exe` | Authoritative game server |
+| [src/Client.bb](src/Client.bb) | `bin/Client.exe` | Game client |
+| [src/GUE.bb](src/GUE.bb) | `bin/GUE.exe` | Graphical world editor |
+| [src/Project Manager.bb](src/Project%20Manager.bb) | `Project Manager.exe` | Project launcher |
+
+Plus seven editor tools under `src/Tools/` (RC Architect, Terrain/Cave/Rock/Tree editors, Gubbin Tool).
+
+## Skills available in this repo
+
+Always check `.claude/skills/` for relevant skills before working in a specialty area. The user-invocable list shows them at session start; the most load-bearing ones:
+
+- **blitzforge-language** — invoke whenever writing or reviewing any `.bb` file. Your training data is base Blitz3D from 2003; BlitzForge added Strict, GC, inheritance, methods, `BBList`, `Async/Await`, `Try/Catch`. Without this skill you *will* write outdated code.
+- **rcce2-packet-handler** — invoke before touching [ServerNet.bb](src/Modules/ServerNet.bb) or [ClientNet.bb](src/Modules/ClientNet.bb). Wire encoding, bounds-checking, soft-fail patterns.
+- **rcce2-bvm-command** — invoke before adding/modifying a `BVM_*` function in [ScriptingCommands.bb](src/Modules/ScriptingCommands.bb). The dispatch in [RC_Standard_Invoker.bb](src/Modules/RC_Standard_Invoker.bb) is alphabetically opcode-ordered and has a 142-case renumber trap.
+- **rcce2-test-writing** — invoke before adding a test under `src/Tests/`. Test files are `Strict`+`EnableGC`+inline-stubbed and must not pull in network/world deps.
+
+## Build and test
+
+Always run from the repo root.
+
+```powershell
+# Windows (PowerShell or cmd)
+.\compile.bat              # build engine + all tools
+.\compile.bat -t           # build engine only (skip tools — ~10x faster)
+.\compile.bat -b           # also rebuild BlitzForge (slow, MSBuild)
+.\compile.bat -e           # skip engine, build tools only
+.\test.bat                 # compile + run every Strict test under src/Tests/
+
+# macOS (Apple Silicon, alpha)
+./compile.sh
+./test.sh
+```
+
+After any change to a `.bb` file under `src/`, run `compile.bat -t` and confirm clean compile before committing. `Local`-shadowing-a-`Global`, missing field, wrong sigil — Strict mode catches all of these at compile time.
+
+The compile target (`Server.exe`, `Client.exe`, `GUE.exe`, `Project Manager.exe`) depends on which top-level `.bb` includes the file. Most modules are included by Server *and* Client, so check both compile.
+
+## Repo layout
+
+```
+rcce2/
+├── src/                          # all engine source — your primary work area
+│   ├── Server.bb · Client.bb     # entry points (include cascade — start here)
+│   ├── GUE.bb · Project Manager.bb
+│   ├── Modules/                  # ~70 .bb files; see "Module map" below
+│   ├── Tools/                    # standalone editor utilities (each .bb → .exe)
+│   └── Tests/                    # Strict-mode test files (see test skill)
+├── compiler/BlitzForge/          # SUBMODULE — compiler + runtime (C++17)
+├── extras/vscode-blitz-forge/    # SUBMODULE — VS Code language extension
+├── extras/reshade/               # SUBMODULE — post-processing
+├── data/                         # default game project (worlds, scripts, assets)
+├── docs/                         # user-facing engine + scripting docs
+├── bin/                          # compiled binaries + vendored DLLs (gitignored .exe)
+├── scripts/                      # cross-platform build helpers
+├── .claude/skills/               # agent skills for specialty work
+├── compile.bat · compile.sh      # build scripts (read these for flags)
+├── test.bat · test.sh
+└── ReadMe.md                     # user-facing overview
+```
+
+## Module map (`src/Modules/`)
+
+The ~70 module files split into rough categories. Names overloaded with `Server*` or `Client*` are split intentionally — same name without a prefix means it's shared.
+
+| Category | Files |
+|---|---|
+| **Wire / packets** | [RCEnet.bb](src/Modules/RCEnet.bb), [Packets.bb](src/Modules/Packets.bb), [ServerNet.bb](src/Modules/ServerNet.bb) (huge `Select Case` packet dispatch), [ClientNet.bb](src/Modules/ClientNet.bb) |
+| **World / areas** | [Actors.bb](src/Modules/Actors.bb), [ServerAreas.bb](src/Modules/ServerAreas.bb), [ClientAreas.bb](src/Modules/ClientAreas.bb), [GameServer.bb](src/Modules/GameServer.bb), [Environment.bb](src/Modules/Environment.bb), [Environment3D.bb](src/Modules/Environment3D.bb) |
+| **Items / combat / spells** | [Items.bb](src/Modules/Items.bb), [Inventories.bb](src/Modules/Inventories.bb), [Spells.bb](src/Modules/Spells.bb), [Projectiles.bb](src/Modules/Projectiles.bb), [ClientCombat.bb](src/Modules/ClientCombat.bb) |
+| **Persistence / auth** | [AccountsServer.bb](src/Modules/AccountsServer.bb), [PasswordHash.bb](src/Modules/PasswordHash.bb), [MySQL.bb](src/Modules/MySQL.bb), [Logging.bb](src/Modules/Logging.bb) (`SafeWriteOpen$` / `SafeWriteCommit%` atomic write helpers) |
+| **BVM scripting** | [Scripting.bb](src/Modules/Scripting.bb), [ScriptingCommands.bb](src/Modules/ScriptingCommands.bb) (native `BVM_*` functions), [RC_Standard_Invoker.bb](src/Modules/RC_Standard_Invoker.bb) (opcode dispatch table) |
+| **UI** | [Gooey.bb](src/Modules/Gooey.bb), [F-UI.bb](src/Modules/F-UI.bb), [Interface.bb](src/Modules/Interface.bb), [Interface3D.bb](src/Modules/Interface3D.bb), [MainMenu.bb](src/Modules/MainMenu.bb) |
+| **3D / media** | [Actors3D.bb](src/Modules/Actors3D.bb), [Animations.bb](src/Modules/Animations.bb), [Projectiles3D.bb](src/Modules/Projectiles3D.bb), [Media.bb](src/Modules/Media.bb) |
+| **Misc** | [Language.bb](src/Modules/Language.bb), [Radar.bb](src/Modules/Radar.bb), [b3dfile.bb](src/Modules/b3dfile.bb), [MD5.bb](src/Modules/MD5.bb) |
+
+Subdirectories under `Modules/` (`Framework/`, `Graphics/`, `Helpers/`, `IO/`, `Project Manager/`, `Traits/`) hold smaller utility groups.
+
+## Conventions you must follow
+
+### Wire encoding ([RCEnet.bb](src/Modules/RCEnet.bb))
+
+`RCE_StrFromInt$(num, length=4)` packs an integer into `length` bytes (big-endian-ish via Bank). `RCE_IntFromStr(s$)` reverses it. Every packet field uses these. The bundled `length` is critical — a 2-byte ID written as 4 bytes will corrupt every subsequent field. Always pair sender's `RCE_StrFromInt$(x, N)` with receiver's `Mid$(MessageData$, offset, N)` of the same `N`.
+
+### Atomic writes ([Logging.bb](src/Modules/Logging.bb))
+
+Never write to a final on-disk file directly. Use:
+
+```basic
+Local TempPath$ = SafeWriteOpen$(FinalPath$)
+Local F = WriteFile(TempPath$)
+; ... WriteX(F, ...) ...
+SafeWriteCommit%(TempPath$, FinalPath$, F)   ; closes F + atomic rename
+```
+
+This prevents corruption if the process crashes mid-write. Apply to any persistent data file.
+
+### Soft-fail on server-controlled data
+
+Server packet handlers and client renderers must **not** call `RuntimeError` on values they read from the wire or from save files. A single malformed packet or a missing mesh ID would crash the entire process and disconnect every other player. Recovery pattern:
+
+```basic
+If Result = False
+    WriteLog(MainLog, "Handler: bad value, dropping (context: " + ctx + ")")
+    SafeFreeActorInstance(A)   ; or appropriate cleanup
+    Return                     ; or skip the rest of the Case
+EndIf
+```
+
+See the `Soft-fail` series of merged PRs (#128–#134) for the established pattern — the audit comment block in each fix explains the threat model.
+
+### Bounds checks before array index
+
+Any value read from a packet or save file used as an array index must be range-checked first. `ActorList` is `Dim`ed `[65535]`, but a client-supplied ActorID also needs `<> Null` check on the slot (most slots are empty). Pattern in [ServerNet.bb:2398](src/Modules/ServerNet.bb#L2398):
+
+```basic
+If ActorID < 0 Or ActorID > 65535 Or ActorList(ActorID) = Null
+    WriteLog(MainLog, "rejecting invalid ActorID " + ActorID)
+    RCE_Send(Host, M\FromID, P_..., "N", True)
+    Exists = True : Exit
+EndIf
+```
+
+### Strict-mode tests
+
+Test files under [src/Tests/](src/Tests/) use `Strict` + `EnableGC` at the top. They cannot include `Server.bb` or other heavy entry points (would pull in network/world deps). Instead they `Include` the one module under test and *inline-stub* its missing dependencies — see [src/Tests/Modules/ItemsTest.bb:8-49](src/Tests/Modules/ItemsTest.bb#L8) for the canonical pattern. The **rcce2-test-writing** skill walks through this.
+
+### Privilege gating in BVM commands
+
+BVM functions that mutate global server state (`BVM_BANPLAYER`, `BVM_SETGOLD`, `BVM_WARP`, faction mutators) must guard with `If Not BVM_RequirePrivileged() Then Return` at the top. Functions that take an actor handle but are safe when targeting the script's own actor use `BVM_RequireSelfOrPrivileged(handle)` instead. Without these, any NPC's right-click script can ban its own clicker.
+
+## Workflow
+
+### Branching + PRs
+
+- Branch from `develop`. PRs target `develop`. Releases are `develop → master` PRs.
+- Commits include the trailer `Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>` when authored with Claude.
+- PRs merge via `gh pr merge <N> --merge --admin --delete-branch`. **Squash merge is not used.**
+- Never push directly to `develop` or `master`.
+
+### CI ([.github/workflows/ci.yml](.github/workflows/ci.yml))
+
+- Build step caches BlitzForge binaries keyed on the submodule SHA. Most PRs hit cache.
+- Test step runs every file under `src/Tests/` and exits 1 on first failure.
+- **Known intermittent flake**: `ItemsTest.bb` sometimes fails with `Stack overflow!` for unrelated PRs. If a PR's CI fails *only* with that error and your change doesn't touch items/inventory/serialization, retry via close + reopen of the PR:
+  ```bash
+  gh pr close <N> && sleep 3 && gh pr reopen <N>
+  ```
+  Two retries is plenty; if it still fails, investigate.
+
+### Git submodules
+
+`compiler/BlitzForge`, `extras/vscode-blitz-forge`, `extras/reshade` are submodules.
+
+```bash
+# After cloning:
+git submodule update --init --recursive
+
+# Updating: stage submodule pointer like any other file, but never `git submodule update --remote`
+# unless you intend to bump the version. The BlitzForge submodule moves frequently;
+# bump it in a dedicated "BlitzForge bump" PR (see merged PR history for examples).
+```
+
+## Gotchas
+
+- **Blitz3D array semantics**: `Field arr[N]` and `Dim arr(N)` both allocate **`N+1` slots, indexed `0..N` inclusive**. `For i = 0 To N` is correct, not `0 To N-1`. Frequent source of "off-by-one" misreads.
+- **BVM opcode ordering**: opcodes in [RC_Standard_Invoker.bb](src/Modules/RC_Standard_Invoker.bb) are assigned by the BlitzForge command-set parser in **alphabetical order of function name**. Inserting `BVM_NEAREST_*` between `BVM_NAME` (case 436) and `BVM_NEWQUEST` (case 437) shifts every subsequent case number. Don't manually renumber unless you mean to; the **rcce2-bvm-command** skill covers the safe insertion procedure.
+- **Stale `.bb_bak1` / `.bb_bak2` files**: gitignored snapshots from a legacy IDE. Never edit them; they are not the source of truth. If you see one in a diff, something is wrong.
+- **Backup file naming**: same convention applies to `ServerNet.bb_bak2` etc. — ignore.
+- **PowerShell vs Bash**: both work via tools (PowerShell for `.bat` build scripts, Bash for git/gh). `gh.exe` lives at `/c/Program Files/GitHub CLI/gh.exe` in Bash — `gh` alone isn't on PATH in MSYS.
+- **Encoding**: write `.bb` files as UTF-8 without BOM. `Set-Content` and `Out-File` default to UTF-16 LE; use `-Encoding utf8` if you must use them. Prefer the Write tool, which is correct by default.
+- **`Continue` keyword**: BlitzForge added it but it was buggy in earlier versions — see commit `78f3204` "Fix RC Terrain Editor use of continue keyword". Safe to use now in current BlitzForge, but be wary inside `Select Case` inside `For` (test the specific shape).
+- **`Local` shadowing `Global`**: Strict mode flags this. Many legacy modules in `src/Modules/` aren't Strict — they tolerate the pattern but it's still a code smell.
+- **`.cursor/` and `compiler/IDEs/Visual Studio Code.url`**: local IDE state, not tracked. Don't `git add` them.
+
+## Memory + skills hygiene for you (the agent)
+
+When you discover something **non-obvious, project-specific, and durable** while working, save it as a memory (see your auto-memory instructions). Examples of save-worthy:
+
+- A subtle invariant: "the Bank used by `RCE_StrFromInt$` is 8 bytes; `Length > 8` will silently truncate."
+- A workflow tip the user explicitly confirmed.
+- A surprising consequence: "ScriptInstance handles can become stale across `BVM_THREADEXECUTE` boundaries; always re-resolve via `Object.ScriptInstance(hSI)`."
+
+Do not save things derivable from reading the code. The memory store is at `C:\Users\dyanr\.claude\projects\C--Users-dyanr-Desktop-rcce2\memory\`.
+
+## What's NOT in this repo
+
+- The game's actual content (worlds, scripted quests, custom art). The `data/` directory has a starter project but real content lives in user installations.
+- BlitzForge compiler source — it's in the [submodule](compiler/BlitzForge). Has its own [CLAUDE.md](compiler/BlitzForge/CLAUDE.md) for C++ work.
+- Documentation site / wiki — that's on `realmcrafter.fandom.com`, not in-repo.


### PR DESCRIPTION
## Summary
Adds developer-focused orientation for Claude Code agents working in this repo. Complements the user-facing [ReadMe.md](ReadMe.md) without duplicating it. Zero code changes.

### New files

- **[CLAUDE.md](CLAUDE.md)** — repo orientation: entry points, build/test commands, module map, conventions (wire encoding, atomic writes, soft-fail patterns, privilege gating), CI + submodule workflow, the known ItemsTest flake retry workflow.

- **[.claude/skills/blitzforge-language/](.claude/skills/blitzforge-language/)** — the headline. Programming reference for the BlitzForge dialect that this repo's \`.bb\` files actually use. Agents' training data covers original Blitz3D (2003) but does **not** have BlitzForge's modern additions (\`Strict\`, \`EnableGC\`, type inheritance, methods, \`BBList\`, function pointers, \`Async\`/\`Await\`/\`Poll\`, \`TryCatch\`/\`Throw\`, \`Continue\`, \`//\` comments). Without this skill agents reliably write outdated code that fails to compile under Strict or misses safer modern alternatives.
  - \`SKILL.md\` — always-on quick reference (325 lines)
  - \`references/syntax-reference.md\` — on-demand deep dive (413 lines)
  - Examples sourced from the authoritative [BlitzForge tests](compiler/BlitzForge/tests/)

- **[.claude/skills/rcce2-packet-handler/](.claude/skills/rcce2-packet-handler/)** — safe ServerNet/ClientNet handler development. Wire encoding rules, length-checking and bounds-checking patterns, the soft-fail recovery pattern that several recent PRs (#128–#134) established, the "client can crash server" trap.

- **[.claude/skills/rcce2-bvm-command/](.claude/skills/rcce2-bvm-command/)** — BVM scripting command development. Documents the critical \"opcodes are alphabetical, inserting mid-range shifts every later opcode\" trap (the same one that almost cost me the BVM_NEAREST_* helpers PR), two safe insertion strategies, the privilege-gating taxonomy (\`BVM_RequirePrivileged\` vs \`BVM_RequireSelfOrPrivileged\`), and bounds-check patterns.

- **[.claude/skills/rcce2-test-writing/](.claude/skills/rcce2-test-writing/)** — Strict-mode test files with the inline-stub pattern (avoid pulling in network/world deps), contract-pin tests, rejection-path tests, the ItemsTest flake workaround.

### Companion changes

- \`.gitignore\` now excludes \`.claude/*\` except \`.claude/skills/\`, so per-session state (locks, \`settings.local.json\`) never pollutes commits.
- Sibling [BlitzForge PR](https://github.com/RydeTec/blitz-forge/pull/59) adds a matching CLAUDE.md to the BlitzForge submodule. After both merge, a small submodule-bump PR will pull in that file too.

### Skill design notes

Skills follow the [skill-creator](https://github.com/anthropics) anatomy: YAML frontmatter with explicit triggering description, body under 500 lines for progressive disclosure, deep reference docs in \`references/\` for on-demand loading. Descriptions are deliberately specific about WHEN to invoke so the runtime triggers them on relevant tasks instead of agents falling back to training-data guesses.

## Test plan
- [x] All six files render correctly in GitHub preview.
- [x] All cited paths exist and resolve.
- [x] \`.claude/scheduled_tasks.lock\` is correctly ignored; \`.claude/skills/\` is correctly tracked.
- [ ] An agent unfamiliar with the repo can complete a small PR (e.g., add a BVM command) by reading just CLAUDE.md + the relevant skill, without re-discovering the alphabetical-opcode trap.
- [ ] An agent writing a new \`.bb\` file produces \`Strict\` + \`EnableGC\` preamble and uses \`New Foo()\` (with parens), not training-data-style \`New Foo\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)