### PR TITLE
Soft-fail ActorInstanceFromString on unknown ActorID (don't crash client)

### DIFF
--- a/src/Modules/Actors.bb
+++ b/src/Modules/Actors.bb
@@ -832,6 +832,19 @@ Function ActorInstanceFromString.ActorInstance(Pa$)
 
 	RuntimeID = RCE_IntFromStr(Mid$(Pa$, 5, 2))
 	ActorID = RCE_IntFromStr(Mid$(Pa$, 13, 2))
+	; Race the server announced is unknown to this client. Same DoS
+	; surface as P_NewActor's mesh-load failure (see PR #128) but one
+	; step earlier: CreateActorInstance previously RuntimeError'd on
+	; a Null Actor template, so any P_NewActor / P_FetchCharacter for
+	; a race the client doesn't have loaded would crash the client.
+	; Reachable when the client is running an older Actors.dat than
+	; the server (update-channel skew), or from a hostile/buggy
+	; server. The lone caller (P_NewActor at ClientNet.bb:1456)
+	; already drops the actor on a Null return.
+	If ActorID < 0 Or ActorID > 65535 Or ActorList(ActorID) = Null
+		WriteLog(MainLog, "ActorInstanceFromString: unknown ActorID " + ActorID + " (RuntimeID=" + RuntimeID + "), dropping actor")
+		Return Null
+	EndIf
 	A.ActorInstance = CreateActorInstance(ActorList(ActorID))
 	A\RuntimeID = RuntimeID
 	RuntimeIDList(RuntimeID) = A


### PR DESCRIPTION
## Summary
`ActorInstanceFromString` looked up `ActorList(ActorID)` and passed the result straight to `CreateActorInstance`, which `RuntimeError`'d on a Null Actor template at [Actors.bb:491](src/Modules/Actors.bb#L491). The lone caller is `P_NewActor` ([ClientNet.bb:1455](src/Modules/ClientNet.bb#L1455)), which the server hits any time it announces an actor entering the area.

When the client is running an older `Actors.dat` than the server (update-channel skew — server admin added a new race the client hasn't re-fetched) or the server is hostile/buggy, the announced `ActorID` is not in the client's `ActorList`. `ActorList(ActorID) = Null` → `CreateActorInstance(Null)` → `RuntimeError` → the client crashes. One packet, no recovery.

Same shape as the merged P_NewActor mesh-load soft-fail ([#128](https://github.com/RydeTec/rcce2/pull/128)) but one line *earlier* in the same flow: the actor-template lookup runs *before* the mesh load, so the mesh-load soft-fail at [ClientNet.bb:1461](src/Modules/ClientNet.bb#L1461) is unreachable when the template lookup `RuntimeError`s first. This closes that gap.

Reject unknown ActorIDs with a log + `Return Null` from `ActorInstanceFromString`. The caller at [ClientNet.bb:1456](src/Modules/ClientNet.bb#L1456) already guards with `If A <> Null` and drops the actor, so the existing recovery path handles it. Other actors and the local player keep rendering.

## Test plan
- [x] `compile.bat -t` builds Server / Client / GUE / Project Manager cleanly.
- [ ] Add a new playable Actor in GUE on the server; do not refresh the client's `Actors.dat`. Connect with the stale client and have another player (or NPC spawner) introduce that race into the area. Expected: the unknown actor is silently dropped on this client (log entry in `Main.log`) and the rest of the world keeps rendering.
- [ ] Sanity: a normal `P_NewActor` for a known race still spawns and animates correctly.

## Out of scope (follow-up PRs)
The same `CreateActorInstance(ActorList(...))` Null-deref pattern still lives in:
- [MainMenu.bb:1602](src/Modules/MainMenu.bb#L1602) and [MainMenu.bb:1711](src/Modules/MainMenu.bb#L1711) — character-select preview / "Press Start" with a stale character's race.
- [Server.bb:745](src/Server.bb#L745) — `PreLoadSpawns` crashes server startup on a misconfigured `SpawnActor` ID.

Each is its own focused PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)