### PR TITLE
Soft-fail MainMenu character-select on unknown ActorID (don't crash client)

### DIFF
--- a/src/Modules/MainMenu.bb
+++ b/src/Modules/MainMenu.bb
@@ -1599,19 +1599,31 @@ Function CharSelect()
 
 				A.Actor = ActorList(CharActors(i))
 				If PreviewA <> Null Then SafeFreeActorInstance(PreviewA)
+				If A = Null
+					; Race no longer exists client-side (admin deleted from
+					; Actors.dat after this character was saved, or update
+					; channel is out of sync). CreateActorInstance would
+					; RuntimeError on Null; leave the preview empty instead
+					; so the player can still pick another character. The
+					; Press Start path below catches the same gap before
+					; entering the game.
+					PreviewA = Null
+					WriteLog(MainLog, "Character preview: ActorID " + CharActors(i) + " for '" + CharNames$(i) + "' not in client ActorList; skipping preview")
+				Else
 				PreviewA = CreateActorInstance(A)
 				PreviewA\Gender = CharGender(i)
 				PreviewA\FaceTex = CharFaceTex(i)
 				PreviewA\Hair = CharHair(i)
 				PreviewA\Beard = CharBeard(i)
 				PreviewA\BodyTex = CharBodyTex(i)
-				
+
 				Result = LoadActorInstance3D(PreviewA, 1, False, False)
 				If Result = False Then RuntimeError("Could not load actor mesh for " + A\Race$ + "!")
 				;If PreviewA\ShadowEN <> 0 Then HideEntity(PreviewA\ShadowEN) [###]
 				;If PreviewA\NametagEN <> 0 Then HideEntity(PreviewA\NametagEN)
 				PlayAnimation(PreviewA, 1, 0.001, Anim_Idle)
 				PositionEntity PreviewA\CollisionEN, 30, -(35.0 + EntityY#(PreviewA\EN, True)), 100
+				EndIf
 				Exit
 			EndIf
 		Next
@@ -1693,14 +1705,26 @@ Function CharSelect()
 
 		; Start game button
 		If GY_ButtonHit(BStart) = True And SelectedChar > -1
-		
-		RP_Clear(SnowEmitter1)	
+			; Validate the selected character's race before committing to the
+			; start sequence. CreateActorInstance below would RuntimeError on
+			; a Null Actor template -- this happens when the server's
+			; Actors.dat had the race deleted since this account's character
+			; was saved, or when the update channel is out of sync. Refuse
+			; cleanly so the player can pick another character.
+			If ActorList(CharActors(SelectedChar)) = Null
+				WriteLog(MainLog, "Press Start: ActorID " + CharActors(SelectedChar) + " for character '" + CharNames$(SelectedChar) + "' not in client ActorList; cannot enter game")
+				GY_SetButtonState(CharButtons(SelectedChar), False)
+				SelectedChar = -1
+				Goto StartGameAborted
+			EndIf
+
+		RP_Clear(SnowEmitter1)
 		RP_Clear(SnowEmitter2)
 		RP_Clear(SnowEmitter3)
 		RP_Clear(SnowEmitter4)
 		RP_Clear(SnowEmitter5)
 		RP_Clear(SnowEmitter6)
-					
+
 			GY_LockGadget(BStart) : GY_LockGadget(BDelete)
 			For i = 0 To LastChar + 1 : GY_LockGadget(CharButtons(i)) : Next
 
@@ -1829,11 +1853,12 @@ Function CharSelect()
 			; Start the game!
 			RCE_Disconnect()
 			SelectedCharacter = SelectedChar
-			
-			
+
+
 			Exit
 		EndIf
-		
+		.StartGameAborted
+
 		; Camera
 		;If GY_ButtonDown(BRight)
 		;	CamAngle# = CamAngle# + 90/fps


### PR DESCRIPTION
## Summary
Two sites in `MainMenu.CharSelect` dereferenced `ActorList(CharActors(i))` without a Null check:

1. **Character button click** ([MainMenu.bb:1600-1602](src/Modules/MainMenu.bb#L1600)) — builds the preview avatar. `CreateActorInstance(Null)` `RuntimeError`'d at [Actors.bb:491](src/Modules/Actors.bb#L491), killing the client the moment a player clicked a character whose race no longer exists.

2. **Press Start** ([MainMenu.bb:1711](src/Modules/MainMenu.bb#L1711)) — builds the live `Me` instance before the game starts. Same crash.

Reachable in normal operation when an admin deletes a race from `Actors.dat` between sessions while a saved character still references it (the saved `ActorID` lives in `Accounts.dat` and is sent back in the character list as-is). Also reachable from an out-of-sync update channel or a hostile server.

Same root cause as the just-merged [#138](https://github.com/RydeTec/rcce2/pull/138) (`ActorInstanceFromString` soft-fail), applied to the two remaining unguarded callers identified in that PR's follow-up list.

## Behavior
- **Click handler**: log + leave `PreviewA = Null`. Player can pick another character. The Press Start handler catches them if they press Start on this character anyway.
- **Press Start**: log, un-toggle the selected button, clear `SelectedChar`, and `Goto` past the start sequence. The event loop continues, buttons stay clickable, the player can pick another character.

## Test plan
- [x] `compile.bat -t` builds Server / Client / GUE / Project Manager cleanly.
- [ ] Save a character on a race, then delete that race in GUE between sessions; reconnect with the stale client. Clicking that character logs a message and leaves the preview empty (no crash). Pressing Start on it logs, deselects, and stays on the character-select screen (no crash). Other characters still work normally.

## Out of scope (follow-ups)
- `Server.bb:745` (`PreLoadSpawns`) — server-startup crash on a misconfigured `SpawnActor` ID. Different attack surface (server admin error, not network).
- `MainMenu.bb:1610` — mesh-load `RuntimeError("Could not load actor mesh for ...")`. Same scenario shape but separate failure (race exists, mesh file missing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)