### PR TITLE
Soft-fail PreLoadSpawns on unknown ActorID (don't crash server at boot)

### DIFF
--- a/src/Server.bb
+++ b/src/Server.bb
@@ -740,6 +740,15 @@ For j = 0 To 99
 If ua\Instances[j] <> Null
 For i = 0 To 999
 If ua\Instances[j]\Spawned[i] < ua\SpawnMax[i]
+; Skip spawn points whose actor race no longer exists in Actors.dat.
+; CreateActorInstance(Null) RuntimeError's; the live spawner at the
+; main game loop already guards this (Server.bb:547) but PreLoadSpawns
+; -- called once at startup as an optimisation -- skipped the check.
+; A single misconfigured area (admin deleted the race but left
+; SpawnActor pointing at it) prevented the server from booting.
+If ActorList(ua\SpawnActor[i]) = Null
+WriteLog(MainLog, "PreLoadSpawns: skipping spawn point " + i + " in '" + ua\Name$ + "' (instance " + j + "): ActorID " + ua\SpawnActor[i] + " not in Actors.dat")
+Else
 For h = 0 To ua\SpawnMax[i] - 1
 Delay 10
 AI.ActorInstance = CreateActorInstance.ActorInstance(ActorList(ua\SpawnActor[i]))
@@ -758,6 +767,7 @@ AI\DeathScript$ = ua\SpawnDeathScript$[i]
 If Len(ua\SpawnScript$[i]) > 0 Then ThreadScript(ua\SpawnScript$[i], "Main", Handle(AI), 0)
 Count = Count + 1
 Next
+EndIf
 EndIf
 Next
 EndIf


### PR DESCRIPTION
## Summary
`PreLoadSpawns` iterates every spawn point at server startup and calls `CreateActorInstance(ActorList(ua\SpawnActor[i]))`. When an admin deletes a race from `Actors.dat` but leaves a spawn point in some area's `SpawnActor` referencing that race (typical content-editing footgun), `ActorList` returns Null, `CreateActorInstance` `RuntimeError`'s at [Actors.bb:491](src/Modules/Actors.bb#L491), and the entire server fails to boot.

The live in-game spawner at [Server.bb:547](src/Server.bb#L547) already has this guard. This PR brings `PreLoadSpawns` — the startup-time optimisation calling the same function — into parity.

Same root cause as the recently merged client-side fixes [#138](https://github.com/RydeTec/rcce2/pull/138) (`ActorInstanceFromString`) and [#139](https://github.com/RydeTec/rcce2/pull/139) (MainMenu character select). Closes the last unguarded `CreateActorInstance(ActorList(...))` call site in the engine.

## Test plan
- [x] \`compile.bat -t\` builds Server / Client / GUE / Project Manager cleanly.
- [ ] In GUE, place a spawn point referencing an existing race, save the area, then delete that race. Restart the server: it logs \`PreLoadSpawns: skipping spawn point N in 'AreaName' ...: ActorID X not in Actors.dat\` and completes boot. Other (valid) spawns still preload.

🤖 Generated with [Claude Code](https://claude.com/claude-code)