### PR TITLE
Soft-fail beard attach in LoadActorInstance3D on missing 'Head' joint

### DIFF
--- a/src/Modules/Actors3D.bb
+++ b/src/Modules/Actors3D.bb
@@ -290,13 +290,23 @@ Function LoadActorInstance3D(A.ActorInstance, Scale# = 1.0, SkipAttachments = Fa
 			BeardEN = GetMesh(ID, True)
 			If BeardEN <> 0
 				Bonce = FindChild(A\EN, "Head")
-				If Bonce = 0 Then RuntimeError(A\Actor\Race$ + " actor mesh is missing a 'Head' joint!")
-				EntityParent BeardEN, Bonce, False
-				PositionEntity BeardEN, LoadedMeshX#(ID), LoadedMeshY#(ID), LoadedMeshZ#(ID)
-				ScaleEntity BeardEN, LoadedMeshScales#(ID), LoadedMeshScales#(ID), LoadedMeshScales#(ID)
-				; Correct rotation for Max models
-				If A\TeamID = True Then TurnEntity BeardEN, 0, 180, 90
-				NameEntity(BeardEN, "Beard")
+				If Bonce = 0
+					; Beard is decorative. If the actor mesh has no Head
+					; joint, just skip it -- no reason to crash the client.
+					; Mirrors the P_AppearanceUpdate "D" soft-fail in
+					; ClientNet.bb (PR #130); LoadActorInstance3D is the
+					; sibling path that runs when an actor first appears
+					; with a beard configured.
+					WriteLog(MainLog, "LoadActorInstance3D: race '" + A\Actor\Race$ + "' mesh missing 'Head' joint, skipping beard")
+					FreeEntity BeardEN
+				Else
+					EntityParent BeardEN, Bonce, False
+					PositionEntity BeardEN, LoadedMeshX#(ID), LoadedMeshY#(ID), LoadedMeshZ#(ID)
+					ScaleEntity BeardEN, LoadedMeshScales#(ID), LoadedMeshScales#(ID), LoadedMeshScales#(ID)
+					; Correct rotation for Max models
+					If A\TeamID = True Then TurnEntity BeardEN, 0, 180, 90
+					NameEntity(BeardEN, "Beard")
+				EndIf
 			EndIf
 		EndIf
 


### PR DESCRIPTION
## Summary
[LoadActorInstance3D](src/Modules/Actors3D.bb#L288) attaches a beard mesh to the actor's `'Head'` joint when one is configured. If the actor mesh lacks a `'Head'` joint — a content-authoring gap, e.g. a custom non-humanoid race set up with a non-zero `BeardIDs` entry — `FindChild` returned `0` and the function `RuntimeError`'d, crashing the client the moment any actor of that race appeared.

This mirrors the soft-fail already in place at:
- [ClientNet.bb:301](src/Modules/ClientNet.bb#L301) — `P_AppearanceUpdate "D"` beard-change handler (merged in [#130](https://github.com/RydeTec/rcce2/pull/130)).
- [Actors3D.bb:150](src/Modules/Actors3D.bb#L150) and [Actors3D.bb:175](src/Modules/Actors3D.bb#L175) — `SetActorHat` hat/hair joint lookup.

`LoadActorInstance3D` is the sibling path that runs when an actor **first appears** with a beard configured (`P_NewActor`, MainMenu preview, etc.). The previously merged "D" soft-fail only covered later beard *changes*, leaving the initial-appearance path as the remaining crash surface.

## Behavior
Log + free the orphan beard mesh + skip. The rest of the actor still loads; the player just appears beardless. Same shape as the established sibling soft-fails.

## Test plan
- [x] `compile.bat -t` builds Server / Client / GUE / Project Manager cleanly.
- [ ] Configure a race in GUE with a non-default `BeardIDs[0]` pointing at a real beard mesh, but use an actor model that lacks a `'Head'` joint. Spawn an instance: the client logs the skip in `Main.log` and the actor renders beardless instead of crashing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)