### PR TITLE
Fix P_StandardUpdate speed-hack clamp's stale variable name

### DIFF
--- a/src/Modules/ServerNet.bb
+++ b/src/Modules/ServerNet.bb
@@ -1596,7 +1596,7 @@ Function UpdateNetwork()
 								AI\Z# = NewZ#
 							EndIf
 						EndIf
-						AI\LastPosUpdateMs = NowMs
+						AI\LastPosUpdateMs = PosNowMs
 						AI\OldX# = AI\X#
 						AI\OldZ# = AI\Z#
 


### PR DESCRIPTION
## Summary
The P_StandardUpdate speed-hack clamp added in [#125-era refactor](https://github.com/RydeTec/rcce2/commit/f0c595a) renamed its `Local NowMs` to `PosNowMs` to resolve a duplicate-`Local` collision with the spell-cooldown clamp added in the same PR. The rename caught the declaration ([ServerNet.bb:1567](src/Modules/ServerNet.bb#L1567)) and the `ElapsedMs` computation ([ServerNet.bb:1568](src/Modules/ServerNet.bb#L1568)) but missed the bottom-of-block assignment at [ServerNet.bb:1599](src/Modules/ServerNet.bb#L1599):

```basic
AI\LastPosUpdateMs = NowMs   ; <-- still references the old name
```

`NowMs` is undeclared in this scope (the `P_SpellUpdate` `Local` is in a different `Case` block). In non-Strict Blitz3D an undeclared variable reads as 0, so `AI\LastPosUpdateMs` gets overwritten with 0 after every position update. The next update's clamp then hits the `If AI\LastPosUpdateMs = 0 ...` re-baseline branch and accepts the client's position unconditionally — **the speed-hack clamp silently never engages**.

Real impact: anti-cheat regression. A client running a modified RCEnet payload can teleport up to `ClampWorldCoord`'s bounds between every `P_StandardUpdate`, defeating PvP positioning checks and movement-based triggers that the clamp was added to defend.

Fix: rename the assignment to `PosNowMs` so `LastPosUpdateMs` actually carries forward.

## Test plan
- [x] `compile.bat -t` builds Server / Client / GUE / Project Manager cleanly.
- [ ] On a live server, observe `AI\LastPosUpdateMs` in a debug print before and after a position update — should now equal the just-computed `MilliSecs()` rather than 0.
- [ ] A client sending consecutive `P_StandardUpdate` packets with positions further apart than `MaxDelta#` should now have the second one rejected (server holds prior position) instead of accepted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)