### PR TITLE
Null-guard PlayerTarget derefs on every-frame client hot paths

### DIFF
--- a/src/Modules/ClientCombat.bb
+++ b/src/Modules/ClientCombat.bb
@@ -18,8 +18,14 @@ Function UpdateCombat()
 	; If I have a human target and I'm not riding a mount
 	If PlayerTarget > 0 And Me\Attributes\Value[HealthStat] > 0 And AttackTarget = True And Me\Mount = Null
 		A.ActorInstance = Object.ActorInstance(PlayerTarget)
-		
-		If A\Attributes\Value[HealthStat] < 1
+
+		; PlayerTarget can carry a stale handle if the target was
+		; freed without the usual SafeFreeActorInstance / P_ActorDead /
+		; P_ActorGone path clearing PlayerTarget (race window, mount
+		; pathway, or simply a missed cleanup site). Treat a Null
+		; lookup the same as a dead target so the next deref doesn't
+		; crash UpdateCombat -- this runs every frame.
+		If A = Null Or A\Attributes\Value[HealthStat] < 1
 			PlayerTarget = 0
 			HideEntity(ActorSelectEN)			; Replace through clean function
 			DestroyCharInteractionWindow()

--- a/src/Modules/Interface3D.bb
+++ b/src/Modules/Interface3D.bb
@@ -985,11 +985,19 @@ Function UpdateInterface()
 	; Update selection highlight mesh
 	If PlayerTarget > 0
 		AI.ActorInstance = Object.ActorInstance(PlayerTarget)
-		SetPickModes()
-		Result = LinePick(EntityX#(AI\CollisionEN), EntityY#(AI\CollisionEN), EntityZ#(AI\CollisionEN), 0.0, -5000.0, 0.0)
-		If Result <> 0
-			PositionEntity(ActorSelectEN, PickedX#(), PickedY#() + 0.2, PickedZ#())
-			AlignToVector(ActorSelectEN, PickedNX#(), PickedNY#(), PickedNZ#(), 2)
+		; Stale handle (target freed without PlayerTarget being cleared)
+		; would crash this every-frame LinePick. Clear the highlight and
+		; bail; the next interaction picks a fresh target.
+		If AI = Null
+			PlayerTarget = 0
+			HideEntity(ActorSelectEN)
+		Else
+			SetPickModes()
+			Result = LinePick(EntityX#(AI\CollisionEN), EntityY#(AI\CollisionEN), EntityZ#(AI\CollisionEN), 0.0, -5000.0, 0.0)
+			If Result <> 0
+				PositionEntity(ActorSelectEN, PickedX#(), PickedY#() + 0.2, PickedZ#())
+				AlignToVector(ActorSelectEN, PickedNX#(), PickedNY#(), PickedNZ#(), 2)
+			EndIf
 		EndIf
 	Else
 		HideEntity(ActorSelectEN)
@@ -1142,7 +1150,11 @@ Function UpdateInterface()
 				If Me\SpellCharge[Num] <= 0
 					If PlayerTarget > 0
 						AI.ActorInstance = Object.ActorInstance(PlayerTarget)
-						Pa$ = Pa$ + RCE_StrFromInt$(AI\RuntimeID, 2)
+						; Stale target handle: send the cast untargeted
+						; rather than crash on AI\RuntimeID. Server's
+						; P_SpellUpdate "F" handler tolerates a missing
+						; target (Context = Null).
+						If AI <> Null Then Pa$ = Pa$ + RCE_StrFromInt$(AI\RuntimeID, 2)
 					EndIf
 					RCE_Send(Connection, PeerToHost, P_SpellUpdate, "F" + Pa$, True)
 					Me\SpellCharge[Num] = RechargeTime
@@ -1415,7 +1427,9 @@ Function UpdateInterface()
 						Pa$ = RCE_StrFromInt$(Me\KnownSpells[Num], 2)
 						If PlayerTarget > 0
 							AI.ActorInstance = Object.ActorInstance(PlayerTarget)
-							Pa$ = Pa$ + RCE_StrFromInt$(AI\RuntimeID, 2)
+							; Mirror the action-bar cast path: stale target
+							; handle means cast untargeted, not crash.
+							If AI <> Null Then Pa$ = Pa$ + RCE_StrFromInt$(AI\RuntimeID, 2)
 						EndIf
 						RCE_Send(Connection, PeerToHost, P_SpellUpdate, "F" + Pa$, True)
 						Me\SpellCharge[Num] = SpellsList(Me\KnownSpells[Num])\RechargeTime
@@ -4017,7 +4031,10 @@ Function UseItem(SlotIndex, Amount)
 				Pa$ = RCE_StrFromInt$(SlotIndex, 1)
 				If PlayerTarget > 0
 					AI.ActorInstance = Object.ActorInstance(PlayerTarget)
-					Pa$ = Pa$ + RCE_StrFromInt$(AI\RuntimeID, 2)
+					; Stale target handle: send the script untargeted
+					; rather than crash on AI\RuntimeID. The server's
+					; P_ItemScript handler tolerates A2 = Null.
+					If AI <> Null Then Pa$ = Pa$ + RCE_StrFromInt$(AI\RuntimeID, 2)
 				EndIf
 				RCE_Send(Connection, PeerToHost, P_ItemScript, Pa$, True)
 ;-------------------------------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
`PlayerTarget` is the client's currently-selected combat target (an actor-instance handle). Several sites check `If PlayerTarget > 0`, look up the handle with `Object.ActorInstance(PlayerTarget)`, then dereference the result without checking it's non-Null. When the target's actor is freed without `PlayerTarget` being cleared — race window, code path that frees an actor without going through `SafeFreeActorInstance` / `P_ActorDead` / `P_ActorGone`, or just a missed cleanup site — `Object.ActorInstance` returns Null and the next deref crashes the client. **Two of these run every frame**, so a single stale handle is a guaranteed crash on the next tick.

## Sites fixed

1. **[ClientCombat.bb:22](src/Modules/ClientCombat.bb#L22)** — `UpdateCombat` reads `A\Attributes\Value[HealthStat]` without checking `A`. Runs every frame combat is active. Treats Null lookup the same as a dead target: clear `PlayerTarget`, hide highlight, bail.

2. **[Interface3D.bb:989](src/Modules/Interface3D.bb#L989)** — Selection highlight runs `LinePick` on `AI\CollisionEN` without checking `AI`. Runs every frame any target is selected. Clear `PlayerTarget` + hide highlight on stale lookup.

3–5. **[Interface3D.bb:1145](src/Modules/Interface3D.bb#L1145) / [1418](src/Modules/Interface3D.bb#L1418) / [4020](src/Modules/Interface3D.bb#L4020)** — Spell-cast (action bar, spellbook) and item-script flows append `AI\RuntimeID` to the outbound packet without checking `AI`. Cast/run untargeted instead. The server-side [P_SpellUpdate "F"](src/Modules/ServerNet.bb#L994) and [P_ItemScript](src/Modules/ServerNet.bb#L1198) handlers already tolerate a missing target (`Context` / `A2` = Null).

## Test plan
- [x] `compile.bat -t` builds Server / Client / GUE / Project Manager cleanly.
- [ ] Reproduce a stale `PlayerTarget` (e.g. force-kill a targeted actor while skipping the network cleanup). `UpdateCombat` clears the target cleanly instead of crashing; selection highlight hides; subsequent spell/item casts run untargeted.
- [ ] Sanity: normal combat against a live target unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)