### PR TITLE
docs: capture Object.X(handle) Null-deref discipline in CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -118,7 +118,7 @@ If Result = False
 EndIf
 ```
 
-See the `Soft-fail` series of merged PRs (#128–#134) for the established pattern — the audit comment block in each fix explains the threat model.
+See the `Soft-fail` series of merged PRs (#128–#134 for the original cluster, #138–#144 for the follow-up rounds covering `CreateActorInstance(ActorList(...))`, `PreLoadSpawns`, missing-`Head`-joint, character-select preview, and stale `PlayerTarget` handles) — the audit comment block in each fix explains the threat model.
 
 ### Bounds checks before array index
 
@@ -131,6 +131,38 @@ If ActorID < 0 Or ActorID > 65535 Or ActorList(ActorID) = Null
     Exists = True : Exit
 EndIf
 ```
+
+### Handle-lookup Null discipline
+
+`Object.X(handle)` returns `Null` for stale or invalid handles — it does not error. Any deref on the result without a `<> Null` check is a crash waiting for a freed-but-unreferenced handle. This applies on both sides:
+
+- **Server**: handles read off the wire (`Object.ActorInstance(RCE_IntFromStr(...))`, `Object.ScriptInstance(...)`, `Object.DroppedItem(...)`). The client can send any 4 bytes.
+- **Client globals**: `PlayerTarget`, `CharInteract`, and similar "currently selected" handles. Cleanup at the source side (`SafeFreeActorInstance` clears `PlayerTarget`, `P_ActorDead` / `P_ActorGone` clear it on remote death/zone-leave) catches most paths but there is no compiler enforcement. Code that runs **every frame** (`UpdateCombat`, the selection-highlight `LinePick`) is the highest-impact site for a stale-handle crash — one missed cleanup is a guaranteed crash on the next tick.
+
+Pattern:
+
+```basic
+AI.ActorInstance = Object.ActorInstance(SomeHandle)
+If AI = Null
+    ; Clear the source global so the next iteration doesn't hit this again.
+    SomeHandle = 0
+    ; Skip the work that needed AI; don't crash.
+    Return       ; or `: Continue`, depending on the loop
+EndIf
+; ... deref AI freely below ...
+```
+
+For outbound packets that include an optional target (`P_SpellUpdate "F"`, `P_ItemScript`), the server-side handlers already tolerate a missing target, so the client should send the packet **without** the target bytes rather than crash:
+
+```basic
+If PlayerTarget > 0
+    AI.ActorInstance = Object.ActorInstance(PlayerTarget)
+    If AI <> Null Then Pa$ = Pa$ + RCE_StrFromInt$(AI\RuntimeID, 2)
+EndIf
+RCE_Send(Connection, PeerToHost, P_X, Pa$, True)
+```
+
+See PRs [#144](https://github.com/RydeTec/rcce2/pull/144) (every-frame `PlayerTarget` cluster) and the audit history of `Object.ActorInstance` callers under `src/Modules/` for the established pattern.
 
 ### Strict-mode tests
 


### PR DESCRIPTION
## Summary
The soft-fail and bounds-check sections already covered packet-derived input. The recurring follow-up cluster ([#138](https://github.com/RydeTec/rcce2/pull/138)–[#144](https://github.com/RydeTec/rcce2/pull/144)) surfaced the sister pattern: `Object.X(handle)` returns Null for stale handles, and any deref on the result without a guard crashes. Several sites lived on the **client** side specifically — every-frame `UpdateCombat`, the selection highlight `LinePick`, action-bar + spellbook spell casts, the item script flow — where the previously documented soft-fail discipline applied naturally but the pattern wasn't in writing.

Adds a "Handle-lookup Null discipline" subsection to [CLAUDE.md](CLAUDE.md) with:
- Server-vs-client framing (wire-derived vs UI-global handles).
- Standard recovery pattern (clear the source global, bail).
- "Send untargeted instead of crash" pattern for outbound packets whose server-side handlers tolerate a missing target.

Also updates the soft-fail series reference to include the follow-up PRs so future audits start from the full backlog of established fixes.

## Test plan
- [x] Docs-only change, no compile needed (verified locally regardless).
- [ ] Read the new subsection from a cold context (e.g. a fresh agent session) and confirm it routes to the right pattern for a stale-handle scenario without needing to also load the `rcce2-packet-handler` skill.

🤖 Generated with [Claude Code](https://claude.com/claude-code)