### PR TITLE
Soft-fail PlayAnimation on missing animation set or out-of-range Seq

### DIFF
--- a/src/Modules/Animations.bb
+++ b/src/Modules/Animations.bb
@@ -45,6 +45,16 @@ Function PlayAnimation(AI.ActorInstance, Mode, Speed#, Seq, FixedSpeed = True)
 	Else
 		A.AnimSet = AnimList(AI\Actor\FAnimationSet)
 	EndIf
+	; AnimList is sparse: a slot is Null when the referenced animation
+	; set was deleted from Animations.dat (typical content-editing drift
+	; -- admin deletes an animset while existing actors still reference
+	; it). The unguarded deref below was an every-frame crash since
+	; PlayAnimation is called from the actor render / movement code.
+	If A = Null Then Return
+	; Bound Seq against the animation arrays (declared [149]). Defensive
+	; even though callers use the Anim_* constants -- one bad caller or
+	; an Asc()-derived index from the wire shouldn't crash.
+	If Seq < 0 Or Seq > 149 Then Return
 	If A\AnimEnd[Seq] = 0 Or A\AnimStart[Seq] > A\AnimEnd[Seq] Then Return
 	If FixedSpeed = True
 		Length# = A\AnimEnd[Seq] - A\AnimStart[Seq]


### PR DESCRIPTION
## Summary
[PlayAnimation](src/Modules/Animations.bb#L41) looked up `AnimList(AI\Actor\MAnimationSet)` and immediately dereferenced `A\AnimEnd[Seq]` without checking `A` for Null. `AnimList` is sparse — a slot is Null when the referenced animation set was deleted from `Animations.dat` (typical content-editing drift: admin deletes an animset while existing actors still reference it). Every actor still keyed to that animset crashes the client / server on the next render or movement tick, since `PlayAnimation` is an every-frame hot path.

Also bound `Seq` against the `[149]` arrays before indexing. Callers use the `Anim_*` constants today so this is defensive, but a corrupted constant or a future `Asc()`-derived sequence index from the wire shouldn't be a crash.

Same shape as the recently merged `Object.X(handle)` Null discipline (PR [#144](https://github.com/RydeTec/rcce2/pull/144), doc'd in [#145](https://github.com/RydeTec/rcce2/pull/145)) but applied to a different array-lookup primitive (`AnimList[ID]` rather than `Object.ActorInstance(handle)`).

## Test plan
- [x] `compile.bat -t` builds Server / Client / GUE / Project Manager cleanly.
- [ ] In GUE, delete an animation set that an actor's `MAnimationSet` / `FAnimationSet` references. Spawn an instance of that actor: the actor renders without animations (frozen pose) instead of crashing.
- [ ] Sanity: normal animated actors unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)