### PR TITLE
Bound LoadSuperGlobals reads with ReadBoundedString$ (8KiB cap)

### DIFF
--- a/src/Modules/Scripting.bb
+++ b/src/Modules/Scripting.bb
@@ -293,7 +293,16 @@ Function UpdateScripts()
 
 End Function
 
-; Loads the superglobal variables
+; Loads the superglobal variables.
+;
+; Each slot is read via ReadBoundedString$ (cap 8192 bytes) so a
+; corrupted or tampered Superglobals.dat with a wild length prefix
+; can't hang the server at startup allocating gigabytes or silently
+; zero-padding past EOF. The 8 KiB cap is generously larger than
+; any realistic gameplay-state string a script would stuff in a
+; superglobal -- BVM_SETSUPERGLOBAL doesn't enforce a per-call cap
+; today, but real-world content uses superglobals for short flags,
+; quest state, counters, and the like.
 Function LoadSuperGlobals(File$)
 
 	F = ReadFile(File$)
@@ -301,7 +310,7 @@ Function LoadSuperGlobals(File$)
 		F = WriteFile(File$)
 	Else
 		For i = 0 To 99
-			SuperGlobals$(i) = ReadString$(F)
+			SuperGlobals$(i) = ReadBoundedString$(F, 8192)
 		Next
 	EndIf
 	CloseFile(F)


### PR DESCRIPTION
## Summary
[LoadSuperGlobals](src/Modules/Scripting.bb#L297) walked 100 `ReadString$` calls without any per-string length cap. A corrupted or tampered `Superglobals.dat` with a wild length prefix (e.g. negative or huge `ReadInt` values) would either hang the server at startup allocating gigabytes or read garbage past EOF.

Route through `ReadBoundedString$` ([Logging.bb:89](src/Modules/Logging.bb#L89)) with an 8 KiB per-string cap. Real superglobals are short flags, quest state, counters, and the like; 8 KiB leaves comfortable headroom while keeping a corrupted file from being a startup DoS. Same defensive shape as `ReadActorInstance`'s `ReadBoundedString$` guards.

## Compatibility
- Format unchanged: `ReadBoundedString$` reads a `ReadInt`-prefixed string, same encoding `WriteString` writes. Valid existing files load identically.
- Cap exceeds any realistic gameplay-state string. No content breakage expected.
- On a malformed length, the slot loads as `""` and `ReadBoundedString$` logs once via `MainLog`.

## Test plan
- [x] `compile.bat -t` builds Server / Client / GUE / Project Manager cleanly.
- [ ] Boot the server with a normally-saved `Superglobals.dat` — all slots load identically.
- [ ] Truncate `Superglobals.dat` mid-string or rewrite the length prefix of slot 5 to a huge value — server logs "ReadBoundedString: length ... out of range" and boots; that slot loads as `""`; subsequent slots continue parsing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)