### PR TITLE
Harden LoadEnvironment against corrupted Environment.dat

### DIFF
--- a/src/Modules/Environment.bb
+++ b/src/Modules/Environment.bb
@@ -69,7 +69,19 @@ Function CreateEnvironment()
 	Return SaveEnvironment(True)
 End Function
 
-; Loads all environment settings
+; Loads all environment settings.
+;
+; Defensive reads throughout:
+;   * Season/Month names go through ReadBoundedString$ (cap 256) so a
+;     corrupted file's wild length prefix can't hang the server at boot.
+;   * TimeFactor is clamped to a sane minimum (1) on load -- the comment
+;     in SaveEnvironment notes the danger ("TimeFactor=0 then triggers
+;     divide-by-zero in UpdateEnvironment"), but UpdateEnvironment itself
+;     was unguarded. Clamp here so the SaveEnvironment-partial-write
+;     defense is no longer the only line between corruption and a server
+;     crash on the first UpdateEnvironment tick.
+;   * TimeH / TimeM bounded to wall-clock ranges; Year / Day clamped to
+;     non-negative.
 Function LoadEnvironment()
 
 	F = ReadFile("Data\Server Data\Environment.dat")
@@ -80,16 +92,27 @@ Function LoadEnvironment()
 	TimeM = ReadInt(F)
 	TimeFactor = ReadInt(F)
 	For i = 0 To 11
-		SeasonName$(i) = ReadString$(F)
+		SeasonName$(i) = ReadBoundedString$(F, 256)
 		SeasonStartDay(i) = ReadInt(F)
 		SeasonDuskH(i) = ReadInt(F)
 		SeasonDawnH(i) = ReadInt(F)
 	Next
 	For i = 0 To 19
-		MonthName$(i) = ReadString$(F)
+		MonthName$(i) = ReadBoundedString$(F, 256)
 		MonthStartDay(i) = ReadInt(F)
 	Next
 	CloseFile(F)
+
+	; Clamp values that would crash or wedge UpdateEnvironment downstream.
+	If TimeFactor < 1
+		WriteLog(MainLog, "LoadEnvironment: TimeFactor was " + TimeFactor + " (would divide-by-zero); resetting to 10")
+		TimeFactor = 10
+	EndIf
+	If Year < 0 Then Year = 0
+	If Day < 0 Then Day = 0
+	If TimeH < 0 Or TimeH > 23 Then TimeH = 0
+	If TimeM < 0 Or TimeM > 59 Then TimeM = 0
+
 	TimeUpdate = MilliSecs()
 	CurrentSeason = GetSeason()
 	Return True

--- a/src/Tests/Modules/EnvironmentTest.bb
+++ b/src/Tests/Modules/EnvironmentTest.bb
@@ -1,8 +1,9 @@
 Strict
 EnableGC
 
-; Logging stubs so Environment's SafeWrite/WriteLog calls resolve without
-; pulling Modules\Logging.bb (which has its own UI/file deps).
+; Logging stubs so Environment's SafeWrite/WriteLog/ReadBoundedString$
+; calls resolve without pulling Modules\Logging.bb (which has its own
+; UI/file deps).
 Global MainLog = 0
 
 Function WriteLog(LogID%, Message$)
@@ -17,6 +18,15 @@ Function SafeWriteCommit%(TempPath$, FinalPath$, F)
 End Function
 
 Function SafeWriteAbort(TempPath$, F)
+End Function
+
+; LoadEnvironment now reads SeasonName / MonthName via ReadBoundedString$
+; (added to harden against corrupted Environment.dat). The real helper
+; lives in Logging.bb; this test doesn't exercise the load path -- only
+; TimeDelta is the unit under test below -- so a no-op stub is enough
+; to let Environment.bb compile under Strict.
+Function ReadBoundedString$(F, MaxLen)
+	Return ""
 End Function
 
 Include "Modules\Environment.bb"


### PR DESCRIPTION
## Summary
[LoadEnvironment](src/Modules/Environment.bb#L73) trusted everything it read off disk. Three concrete failure modes a corrupted / tampered `Environment.dat` could trigger:

1. **`ReadString$` length-prefix DoS** — `SeasonName` / `MonthName` reads with a wild length prefix would hang the server at boot allocating gigabytes (same shape as the recently merged [#147](https://github.com/RydeTec/rcce2/pull/147) `LoadSuperGlobals` fix and `ReadActorInstance` in `Actors.bb`). Route through `ReadBoundedString$` with a 256-byte cap.

2. **`TimeFactor=0` divide-by-zero** — [UpdateEnvironment](src/Modules/Environment.bb#L180) does `minFactor = 60000 / TimeFactor` on the next server tick. The `SaveEnvironment` comment ([Environment.bb:106-111](src/Modules/Environment.bb#L106)) acknowledged the risk and refused partial `FullSave=False` writes, but `UpdateEnvironment` itself was unguarded — so a corrupted file (or one tampered with directly) still crashed the server on boot. Clamp on load: if `TimeFactor < 1`, reset to 10 (the `CreateEnvironment` default) and log.

3. **Out-of-range TimeH / TimeM / Year / Day** — clamp to wall-clock ranges. Corrupted values otherwise propagate into `GetSeason` / `GetMonth` array indexing and the network-broadcast time packets.

## Test changes
[EnvironmentTest.bb](src/Tests/Modules/EnvironmentTest.bb) now needs a `ReadBoundedString$` stub to compile (Strict mode + included `Environment.bb` references the helper). The existing tests only exercise `TimeDelta` arithmetic, so a no-op stub is sufficient.

## Test plan
- [x] `compile.bat -t` builds Server / Client / GUE / Project Manager cleanly.
- [x] `test.bat` — all existing tests pass (`"Tests passed"`).
- [ ] Hex-edit `Environment.dat` to set `TimeFactor=0` and reboot the server: log entry `LoadEnvironment: TimeFactor was 0 (would divide-by-zero); resetting to 10`, server boots normally instead of crashing on first tick.
- [ ] Hex-edit a season name's length prefix to `-1` or `999999`: log entry from `ReadBoundedString$`, server boots with that name as `""`, subsequent fields still parse.

🤖 Generated with [Claude Code](https://claude.com/claude-code)