### PR TITLE
Bound length-prefixed string reads in admin-editable data loaders

### DIFF
--- a/src/Modules/Animations.bb
+++ b/src/Modules/Animations.bb
@@ -133,9 +133,12 @@ Function LoadAnimSets(Filename$)
 				Exit
 			EndIf
 			AnimList(A\ID) = A
-			A\Name$ = ReadString$(F)
+			; Bound length-prefixed strings against corrupted AnimSets.dat.
+			; Set names and per-animation names are short editor labels;
+			; 256 leaves comfortable headroom.
+			A\Name$ = ReadBoundedString$(F, 256)
 			For i = 0 To 149
-				A\AnimName$[i] = ReadString$(F)
+				A\AnimName$[i] = ReadBoundedString$(F, 256)
 				A\AnimStart[i] = ReadShort(F)
 				A\AnimEnd[i] = ReadShort(F)
 				A\AnimSpeed#[i] = ReadFloat#(F)

--- a/src/Modules/Items.bb
+++ b/src/Modules/Items.bb
@@ -268,11 +268,14 @@ Function LoadItems(Filename$)
 				Exit
 			EndIf
 			ItemList(I\ID) = I
-			I\Name$            = ReadString$(F)
-			I\ExclusiveRace$   = ReadString$(F)
-			I\ExclusiveClass$  = ReadString$(F)
-			I\Script$          = ReadString$(F)
-			I\SMethod$          = ReadString$(F)
+			; Bound every length-prefixed string against corrupted Items.dat.
+			; 256 for display/restriction fields; 1024 for script paths
+			; (matches ReadActorInstance's per-character Script$ cap).
+			I\Name$            = ReadBoundedString$(F, 256)
+			I\ExclusiveRace$   = ReadBoundedString$(F, 256)
+			I\ExclusiveClass$  = ReadBoundedString$(F, 256)
+			I\Script$          = ReadBoundedString$(F, 1024)
+			I\SMethod$          = ReadBoundedString$(F, 1024)
 			I\ItemType         = ReadByte(F)
 			I\Value            = ReadInt(F)
 			I\Mass             = ReadShort(F)
@@ -291,7 +294,7 @@ Function LoadItems(Filename$)
 					I\WeaponType       = ReadShort(F)
 					I\RangedProjectile = ReadShort(F)
 					I\Range#           = ReadFloat#(F)
-					I\RangedAnimation$ = ReadString$(F)
+					I\RangedAnimation$ = ReadBoundedString$(F, 256)
 				Case I_Armour
 					I\ArmourLevel      = ReadShort(F)
 				Case I_Potion, I_Ingredient
@@ -299,7 +302,10 @@ Function LoadItems(Filename$)
 				Case I_Image
 					I\ImageID          = ReadShort(F)
 			End Select
-			I\MiscData$        = ReadString$(F)
+			; MiscData$ can carry user-defined item data (free-form strings
+			; from item scripts). Generous cap so legitimate content isn't
+			; truncated; still bounded so a corrupt file can't DoS the load.
+			I\MiscData$        = ReadBoundedString$(F, 4096)
 			Items = Items + 1
 		Wend
 
@@ -375,13 +381,14 @@ Function SaveItems(Filename$)
 
 End Function
 
-; Loads attribute names from file
+; Loads damage type names from file. Bound each name against a corrupted
+; DamageTypes.dat (same shape as the rest of the data-loader sweep).
 Function LoadDamageTypes(Filename$)
 
 	F = ReadFile(Filename$)
 	If F = 0 Then Return False
 		For i = 0 To 19
-			DamageTypes$(i) = ReadString$(F)
+			DamageTypes$(i) = ReadBoundedString$(F, 256)
 		Next
 	CloseFile(F)
 	Return True

--- a/src/Modules/Projectiles.bb
+++ b/src/Modules/Projectiles.bb
@@ -45,10 +45,15 @@ Function LoadProjectiles(Filename$)
 				Exit
 			EndIf
 			ProjectileList(P\ID) = P
-			P\Name$ = ReadString$(F)
+			; Bound length-prefixed strings against corrupted Projectiles.dat.
+			; Same shape as the Spells.bb / Items.bb / Animations.bb sweep.
+			; Name is a display field, Emitter1/2 are relative paths into
+			; Data\Emitter Configs; 256 covers either with comfortable
+			; headroom.
+			P\Name$ = ReadBoundedString$(F, 256)
 			P\MeshID = ReadShort(F)
-			P\Emitter1$ = ReadString$(F)
-			P\Emitter2$ = ReadString$(F)
+			P\Emitter1$ = ReadBoundedString$(F, 256)
+			P\Emitter2$ = ReadBoundedString$(F, 256)
 			P\Emitter1TexID = ReadShort(F)
 			P\Emitter2TexID = ReadShort(F)
 			P\Homing = ReadByte(F)

--- a/src/Modules/Spells.bb
+++ b/src/Modules/Spells.bb
@@ -56,14 +56,20 @@ Function LoadSpells(Filename$)
 				Exit
 			EndIf
 			SpellsList(S\ID) = S
-			S\Name$ = ReadString$(F)
-			S\Description$ = ReadString$(F)
+			; Bound every length-prefixed string to keep a corrupted /
+			; tampered Spells.dat from hanging the server at boot
+			; allocating gigabytes on a wild ReadInt prefix (same shape
+			; as ReadActorInstance / LoadSuperGlobals / LoadEnvironment).
+			; 256 for display names + race/class restrictions; 1024 for
+			; script paths (matches ReadActorInstance's Script$ cap).
+			S\Name$ = ReadBoundedString$(F, 256)
+			S\Description$ = ReadBoundedString$(F, 1024)
 			S\ThumbnailTexID = ReadShort(F)
-			S\ExclusiveRace$ = ReadString$(F)
-			S\ExclusiveClass$ = ReadString$(F)
+			S\ExclusiveRace$ = ReadBoundedString$(F, 256)
+			S\ExclusiveClass$ = ReadBoundedString$(F, 256)
 			S\RechargeTime = ReadInt(F)
-			S\Script$ = ReadString$(F)
-			S\SMethod$ = ReadString$(F)
+			S\Script$ = ReadBoundedString$(F, 1024)
+			S\SMethod$ = ReadBoundedString$(F, 1024)
 			Number = Number + 1
 		Wend
 

--- a/src/Tests/Modules/ItemsTest.bb
+++ b/src/Tests/Modules/ItemsTest.bb
@@ -69,6 +69,16 @@ Function LanguageString$(key$)
 	Return key
 End Function
 
+; --- ReadBoundedString$ stub -----------------------------------------------
+; LoadItems / LoadDamageTypes route every length-prefixed string through
+; ReadBoundedString$ (Logging.bb) so a corrupted Items.dat can't hang the
+; server. This test build doesn't exercise the load path -- the existing
+; tests construct items in-memory via CreateItem -- so a no-op stub is
+; sufficient to let Items.bb compile under Strict.
+Function ReadBoundedString$(F, MaxLen)
+	Return ""
+End Function
+
 Include "Modules\Items.bb"
 
 ; --- Test helpers -----------------------------------------------------------


### PR DESCRIPTION
## Summary
`LoadSpells`, `LoadProjectiles`, `LoadAnimSets`, `LoadItems`, and `LoadDamageTypes` all read length-prefixed strings (`ReadString$`) without any cap on the per-string size. A corrupted or tampered `.dat` file with a wild `ReadInt` length prefix (negative or huge) would hang the server at boot allocating gigabytes, or silently zero-pad past EOF.

Same shape and same recovery as the already-merged hardening in `ReadActorInstance`, [#147](https://github.com/RydeTec/rcce2/pull/147) (`LoadSuperGlobals`), and [#148](https://github.com/RydeTec/rcce2/pull/148) (`LoadEnvironment`); extend the discipline to the remaining admin-editable data-file loaders so the soft-fail-on-corrupted-data property is consistent across the data layer.

## Caps by field role
- **256 bytes** — short identifiers (names, race/class restrictions, relative emitter paths, animation labels).
- **1024 bytes** — script paths (matches `ReadActorInstance`'s per-char `Script$` / `DeathScript$` cap).
- **4096 bytes** — `Item.MiscData` (free-form item state set by scripts; generous so legitimate content isn't truncated, still bounded).

## Test changes
`ItemsTest.bb` needs a `ReadBoundedString$` stub so `Items.bb` compiles under Strict. The existing tests don't exercise `LoadItems` — they construct items in-memory via `CreateItem` — so a no-op stub is sufficient.

## Test plan
- [x] `compile.bat -t` builds Server / Client / GUE / Project Manager cleanly.
- [x] `test.bat` — all existing tests pass.
- [ ] Hex-edit `Items.dat` to set an item's `Name$` length prefix to `999999`: `ReadBoundedString` logs the rejection, that field loads as `""`, subsequent items still parse.

## Files
- `src/Modules/Spells.bb` — `LoadSpells`
- `src/Modules/Projectiles.bb` — `LoadProjectiles`
- `src/Modules/Animations.bb` — `LoadAnimSets`
- `src/Modules/Items.bb` — `LoadItems` + `LoadDamageTypes`
- `src/Tests/Modules/ItemsTest.bb` — `ReadBoundedString$` stub

🤖 Generated with [Claude Code](https://claude.com/claude-code)