### PR TITLE
docs: fill out Projectiles.bb and Spells.bb module references

### DIFF
--- a/docs/modules/projectiles.md
+++ b/docs/modules/projectiles.md
@@ -1,1 +1,122 @@
 <!-- body { color:black background-color:white } a:link{ color:#0070FF } a:visited{ color:#0070FF } --> RealmCrafter: Community Edition Documentation
+
+**Projectiles.bb**
+
+This module defines the catalog of projectile templates used by ranged weapons and spell effects. Projectile records describe the mesh, particle emitters, damage profile, and homing behavior for in-flight objects the runtime spawns from these templates. The visual / 3D side lives in [Projectiles3D.bb](projectiles3d.md).
+
+This module contains the following globals:
+
+*   [ProjectileList.Projectile(5000)](#GProjectileList)
+
+This module contains the following types:
+
+*   [Projectile](#TProjectile)
+
+This module contains the following functions:
+
+*   [CreateProjectile](#FCreateProjectile)
+*   [LoadProjectiles](#FLoadProjectiles)
+*   [SaveProjectiles](#FSaveProjectiles)
+*   [FindProjectile](#FFindProjectile)
+
+  
+
+* * *
+
+  
+
+**ProjectileList.Projectile(5000) (global)**
+
+This global array indexes every Projectile object, with the array index being the ID for that object. It thus provides fast non-sequential access to any Projectile object. Indices outside `0..5000` are rejected at load time to prevent `Dim` out-of-range writes from a corrupted `Projectiles.dat`.
+
+  
+
+* * *
+
+  
+
+**Projectile (type)**
+
+This type represents a projectile template. It stores:
+
+*   `ID` — server-side identifier and array index into `ProjectileList`.
+*   `Name$` — display name; matched by `FindProjectile`.
+*   `MeshID` — mesh ID into the project's mesh table.
+*   `Emitter1$`, `Emitter2$` — paths into `Data\Emitter Configs` (.rpc) for the two particle emitters attached to the projectile.
+*   `Emitter1TexID`, `Emitter2TexID` — texture IDs the emitters bind at runtime.
+*   `Homing` — boolean; if true the projectile tracks its target each frame.
+*   `HitChance` — accuracy modifier (0-100).
+*   `Damage`, `DamageType` — combat resolution data; `DamageType` indexes the global `DamageTypes$` table.
+*   `Speed` — base travel speed.
+
+  
+
+* * *
+
+  
+  
+  
+
+**CreateProjectile.Projectile()**
+
+Return value: A new `Projectile` reference, or `Null` if `ProjectileList` is full.
+
+Parameters: None
+
+This function allocates the next free slot in `ProjectileList`, assigns the slot's index as the new projectile's `ID`, and returns the new template for the caller to populate.
+
+  
+
+* * *
+
+  
+
+**LoadProjectiles(Filename$)**
+
+Return value: Number of projectiles loaded, or `-1` if the file could not be opened.
+
+Parameters:
+
+*   _Filename$_ — Path to the projectile data file (typically `Data\Server Data\Projectiles.dat`).
+
+Reads projectile templates from disk and registers each one in `ProjectileList`. Each record carries a 2-byte `ID` followed by the projectile's fields; an out-of-range `ID` or a malformed length-prefixed string aborts the load defensively rather than crashing the server. String fields go through `ReadBoundedString$` (see [Logging.bb](logging.md)) with a 256-byte cap.
+
+  
+
+* * *
+
+  
+
+**SaveProjectiles(Filename$)**
+
+Return value: `True` on success, `False` if the file could not be opened.
+
+Parameters:
+
+*   _Filename$_ — Path to write the projectile data file.
+
+Writes every loaded `Projectile` to disk via the atomic temp+rename helper in [Logging.bb](logging.md), so a crash or power loss mid-write cannot truncate the catalog.
+
+  
+
+* * *
+
+  
+
+**FindProjectile(Name$)**
+
+Return value: The `ID` of the matching projectile, or `-1` if none was found.
+
+Parameters:
+
+*   _Name$_ — Case-insensitive name to look up.
+
+Linear scan of `Projectile` records by name. Used by spell and weapon scripts to resolve a designer-supplied projectile name to an `ID` at runtime.
+
+  
+
+* * *
+
+  
+  
+  

--- a/docs/modules/spells.md
+++ b/docs/modules/spells.md
@@ -1,1 +1,133 @@
 <!-- body { color:black background-color:white } a:link{ color:#0070FF } a:visited{ color:#0070FF } --> RealmCrafter: Community Edition Documentation
+
+**Spells.bb**
+
+This module defines the catalog of spells (general-purpose actor abilities, not just magic). A spell binds a name, icon, restrictions, recharge timer, and a script entry point that runs when the spell is cast. The cast dispatch lives in [ServerNet.bb](servernet.md) (`P_SpellUpdate`); this module owns the data model and the load/save format.
+
+> **Naming note**: the original RealmCrafter codebase uses "Spells" and "Abilities" interchangeably. Engine code and data files use *Spell*; the user-facing scripting API ([ScriptingCommands.bb](scripting.md)) names the BVM commands `BVM_ADDABILITY`, `BVM_ABILITYKNOWN`, etc. The two terms refer to the same thing.
+
+This module contains the following globals:
+
+*   [SpellsList.Spell(65534)](#GSpellsList)
+*   [Spells](#GSpells)
+
+This module contains the following types:
+
+*   [Spell](#TSpell)
+*   [MemorisingSpell](#TMemorisingSpell)
+
+This module contains the following functions:
+
+*   [CreateSpell](#FCreateSpell)
+*   [LoadSpells](#FLoadSpells)
+*   [SaveSpells](#FSaveSpells)
+
+  
+
+* * *
+
+  
+
+**SpellsList.Spell(65534) (global)**
+
+Sparse index of every loaded `Spell`, keyed by `ID`. Slots not yet assigned are `Null`; readers must guard with `If SpellsList(id) <> Null` before dereferencing, since admins can delete spells in the editor and stale references can persist in a character's `KnownSpells[]` save data. The [`P_FetchCharacter` handler](servernet.md) prunes stale entries on character-select to keep `Me\KnownSpells[]` consistent before the player enters the world.
+
+  
+
+* * *
+
+  
+
+**Spells (global)**
+
+The number of currently-loaded spells. Set by `LoadSpells` and incremented by `CreateSpell`.
+
+  
+
+* * *
+
+  
+
+**Spell (type)**
+
+A single ability definition:
+
+*   `ID` — server-side identifier and index into `SpellsList`.
+*   `Name$` — display name (used by the spellbook UI and the scripting `ABILITY*` BVM commands for lookups).
+*   `Description$` — flavor text shown in the spellbook tooltip.
+*   `ThumbnailTexID` — icon texture ID.
+*   `ExclusiveRace$`, `ExclusiveClass$` — restriction strings. Empty = no restriction. The cast path in [ServerNet.bb's P_SpellUpdate "F"](servernet.md) enforces these (mirrors the item-eat gate in `P_EatItem`).
+*   `RechargeTime` — cooldown between casts, in milliseconds.
+*   `Script$`, `SMethod$` — script entry point. `Script$` is a path into `Data\Scripts`; `SMethod$` is the method name (empty = `Main`).
+
+  
+
+* * *
+
+  
+
+**MemorisingSpell (type)**
+
+Tracks an in-progress memorisation when the server runs in `RequireMemorise` mode:
+
+*   `AI.ActorInstance` — the actor learning the spell.
+*   `KnownNum` — the spell slot being filled (0..9).
+*   `CreatedTime` — `MilliSecs()` at start; used to compute progress against the memorise timer.
+
+The server consumes the record once the memorise timer elapses; until then, the player can cancel.
+
+  
+
+* * *
+
+  
+  
+  
+
+**CreateSpell.Spell()**
+
+Return value: A new `Spell` reference, or `Null` if `SpellsList` is full.
+
+Parameters: None
+
+Allocates the next free slot in `SpellsList`, assigns the slot's index as the new spell's `ID`, and returns the template seeded with `Name$ = "New ability"` and `RechargeTime = 2000`.
+
+  
+
+* * *
+
+  
+
+**LoadSpells(Filename$)**
+
+Return value: Number of spells loaded, or `-1` if the file could not be opened.
+
+Parameters:
+
+*   _Filename$_ — Path to the spell data file (typically `Data\Server Data\Spells.dat`).
+
+Reads spell templates from disk into `SpellsList`. Each record carries a 2-byte `ID` followed by the spell's fields. An out-of-range `ID` aborts the load defensively (preserving any spells already parsed) rather than corrupt memory via a `Dim` out-of-range write. String fields go through `ReadBoundedString$` ([Logging.bb](logging.md)): 256 bytes for `Name$` / `ExclusiveRace$` / `ExclusiveClass$`, 1024 for `Description$` and 1024 for `Script$` / `SMethod$`.
+
+  
+
+* * *
+
+  
+
+**SaveSpells(Filename$)**
+
+Return value: `True` on success, `False` if the file could not be opened.
+
+Parameters:
+
+*   _Filename$_ — Path to write the spell data file.
+
+Writes every loaded `Spell` to disk via the atomic temp+rename helper in [Logging.bb](logging.md), so a crash or power loss mid-write cannot truncate the catalog.
+
+  
+
+* * *
+
+  
+  
+  


### PR DESCRIPTION
## Summary
[`docs/modules/projectiles.md`](docs/modules/projectiles.md) and [`docs/modules/spells.md`](docs/modules/spells.md) existed only as the boilerplate HTML-comment header — 0 lines of actual content. Both modules are user-facing surface (designers configure projectiles and spells in the editor, and BVM scripts call into the spell APIs every day) so the empty stubs were a real gap.

Backfilled in the same style as [`animations.md`](docs/modules/animations.md) / [`environment.md`](docs/modules/environment.md):
- Module purpose paragraph.
- Surface index (globals, types, functions).
- Per-symbol reference with parameters, return value, and a note on the **soft-fail / bounded-read** behavior introduced by [PRs #138–#149](https://github.com/RydeTec/rcce2/pull/149) (sparse `Null` slots, `ReadBoundedString$` caps, atomic save through `SafeWriteOpen` / `SafeWriteCommit`).

Also called out the **Spell/Ability naming duality** (engine code and data files say *Spell*; the BVM script API says *Ability*) since it's a perennial confusion point for content authors. Cross-linked to [`ScriptingCommands.bb`](docs/modules/scripting.md) and [`ServerNet.bb`'s `P_SpellUpdate` handler](docs/modules/servernet.md).

## Test plan
- [x] Docs-only change, no compile or tests needed.
- [ ] Skim the rendered output to confirm formatting matches the rest of `docs/modules/`.

## Out of scope (follow-ups)
[`docs/modules/items.md`](docs/modules/items.md) and [`docs/modules/scripting.md`](docs/modules/scripting.md) are also empty stubs. They're larger surfaces (Items.bb has ~30 functions, ScriptingCommands.bb has 100+ BVM commands) and warrant their own focused docs PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)