### PR TITLE
Null-guard A\Character[Number] in P_FetchCharacter

### DIFF
--- a/src/Modules/ServerNet.bb
+++ b/src/Modules/ServerNet.bb
@@ -2247,7 +2247,12 @@ Function UpdateNetwork()
 						If PwdLen >= 1 And A\Pass$ <> "" And VerifyPassword%(A\Pass$, Mid$(M\MessageData$, Offset + 1, PwdLen)) And A\IsBanned = False
 							Offset = Offset + 1 + PwdLen
 							Number = Asc(Mid$(M\MessageData$, Offset, 1))
-							If Number > -1 And Number < 10
+							; Mirror P_StartGame's guard (line ~1848): an
+							; authenticated client can still send a Number for
+							; an empty slot, and dereferencing A\Character[Number]
+							; without the Null check below was a one-packet
+							; server crash. Refuse cleanly with "N" instead.
+							If Number > -1 And Number < 10 And A\Character[Number] <> Null
 								; Send character data
 								Pa$ = RCE_StrFromInt$(A\Character[Number]\Gold, 4) + RCE_StrFromInt$(A\Character[Number]\Reputation, 2)
 								Pa$ = Pa$ + RCE_StrFromInt$(A\Character[Number]\Level, 2) + RCE_StrFromInt$(A\Character[Number]\XP, 4)


### PR DESCRIPTION
## Summary
An authenticated client could send `P_FetchCharacter` with a `Number` byte pointing at an empty character slot (`0..9` range, slot is `Null`). The unguarded deref `A\Character[Number]\Gold` at the start of the data encode ([ServerNet.bb:2252](src/Modules/ServerNet.bb#L2252)) then crashes the server, taking every connected player down.

[P_StartGame](src/Modules/ServerNet.bb#L1848) already has this check:
```basic
If Number > -1 And Number < 10 And A\Character[Number] <> Null
```

Mirror that guard in `P_FetchCharacter` so a misbehaving (or malicious) client can't take down the world via a custom packet. Failure path matches the existing "Number out of range" branch — send back `"N"` so the client treats this as a normal fetch failure.

## Reachability
- Client UI prevents this — the character-select screen only lets the user click slots that exist.
- A modified client (or someone hand-crafting `P_FetchCharacter` packets) can trivially send a slot index whose `A\Character[i]` is `Null`. Any authenticated user can therefore crash the server.

## Test plan
- [x] `compile.bat -t` builds Server / Client / GUE / Project Manager cleanly.
- [ ] Connect with the normal client and fetch real characters — flow unchanged.
- [ ] Send a hand-crafted `P_FetchCharacter` with `Number=5` for an account that only has characters in slots 0–2: server logs (well, doesn't crash) and the client receives `"N"` instead of taking down the world.

🤖 Generated with [Claude Code](https://claude.com/claude-code)