### PR TITLE
refactor: consolidate 12 RuntimeError(LS_LostConnection) sites behind OnLostConnection()

### DIFF
--- a/src/Modules/ClientNet.bb
+++ b/src/Modules/ClientNet.bb
@@ -9,6 +9,21 @@ Global oldEntityX#,oldEntityY#,oldEntityZ#
 Global CurrentMusicSound = 0
 Global CurrentMusicChannel = 0
 
+; Single entry point for "we lost the server connection" outcomes.
+;
+; Today this is the same `RuntimeError(LS_LostConnection)` that the 12
+; previous in-line callers had -- a controlled crash with a localized
+; message. Consolidating to one function gives a single place to swap
+; in a reconnect dialog (the long-horizon INTENT item) without having
+; to find and modify every disconnect path again.
+;
+; Callers should branch to this immediately on detecting
+; RN_HostHasLeft / RN_Disconnected / PeerToHostNotFound and similar
+; RakNet conditions. The function does not return.
+Function OnLostConnection()
+	RuntimeError(LanguageString$(LS_LostConnection))
+End Function
+
 ; Connects to the server
 Function Connect()
 
@@ -88,7 +103,7 @@ Function Connect()
 				EndIf
 				Delete M : Done = Done + 1
 			ElseIf M\MessageType = PeerToHostHasLeft
-				RuntimeError(LanguageString$(LS_LostConnection))
+				OnLostConnection()
 				Delete M
 			EndIf
 		Next
@@ -1627,7 +1642,7 @@ Function UpdateNetwork()
 			; Host disconnected
 			Case P_KickedPlayer
 				RCE_Disconnect()
-				RuntimeError(LanguageString$(LS_LostConnection))
+				OnLostConnection()
 
 		End Select
 		Delete M

--- a/src/Modules/MainMenu.bb
+++ b/src/Modules/MainMenu.bb
@@ -230,7 +230,7 @@ Function UpdateFiles()
 				Wend
 				If CreatedFiles = RequiredFiles Then Delete M : Done = True : Exit
 			ElseIf M\MessageType = RN_HostHasLeft Or M\MessageType = RN_Disconnected
-				RuntimeError(LanguageString$(LS_LostConnection))
+				OnLostConnection()
 			EndIf
 			Delete M
 		Next
@@ -819,7 +819,7 @@ Function LogIn()
 						EndIf
 						Delete M : Done = True : Exit
 					ElseIf M\MessageType = RN_HostHasLeft Or M\MessageType = RN_Disconnected
-						RuntimeError(LanguageString$(LS_LostConnection))
+						OnLostConnection()
 					EndIf
 					Delete M
 				Next
@@ -1072,7 +1072,7 @@ Function LogIn()
 								EndIf
 							EndIf
 						ElseIf M\MessageType = RN_HostHasLeft Or M\MessageType = RN_Disconnected
-							RuntimeError(LanguageString$(LS_LostConnection))
+							OnLostConnection()
 						EndIf
 					Next
 					
@@ -1143,7 +1143,7 @@ Function LogIn()
 						If M\MessageData$ = "Y" Then Result = True Else Result = False
 						Delete M : Done = True : Exit
 					ElseIf M\MessageType = RN_HostHasLeft Or M\MessageType = RN_Disconnected
-						RuntimeError(LanguageString$(LS_LostConnection))
+						OnLostConnection()
 					EndIf
 					Delete M
 				Next
@@ -1170,7 +1170,7 @@ Function LogIn()
 		For M.RCE_Message = Each RCE_Message
 			Select M\MessageType
 				Case RN_Disconnected, RN_HostHasLeft
-					RuntimeError(LanguageString$(LS_LostConnection))
+					OnLostConnection()
 			End Select
 			Delete M
 		Next
@@ -1702,7 +1702,7 @@ Function CharSelect()
 							
 							Goto RestartCharSelection
 						ElseIf M\MessageType = RN_HostHasLeft Or M\MessageType = RN_Disconnected
-							RuntimeError(LanguageString$(LS_LostConnection))
+							OnLostConnection()
 						EndIf
 						Delete M
 					Next
@@ -1861,7 +1861,7 @@ Function CharSelect()
 							Done = True : Exit
 						EndIf
 					ElseIf M\MessageType = RN_HostHasLeft Or M\MessageType = RN_Disconnected
-						RuntimeError(LanguageString$(LS_LostConnection))
+						OnLostConnection()
 						Delete M
 					EndIf
 				Next
@@ -1963,7 +1963,7 @@ Function CharSelect()
 		For M.RCE_Message = Each RCE_Message
 			Select M\MessageType
 				Case RN_Disconnected, RN_HostHasLeft
-					RuntimeError(LanguageString$(LS_LostConnection))
+					OnLostConnection()
 			End Select
 			Delete M
 		Next
@@ -2256,7 +2256,7 @@ Function CreateChar()
 								EndIf
 								Delete(M) : Done = True : Exit
 							ElseIf M\MessageType = RN_HostHasLeft Or M\MessageType = RN_Disconnected
-								RuntimeError(LanguageString$(LS_LostConnection))
+								OnLostConnection()
 							EndIf
 							Delete(M)
 						Next
@@ -2616,7 +2616,7 @@ Function CreateChar()
        For M.RCE_Message = Each RCE_Message 
           Select M\MessageType 
              Case RN_Disconnected, RN_HostHasLeft 
-                RuntimeError(LanguageString$(LS_LostConnection)) 
+                OnLostConnection() 
           End Select 
           Delete M 
        Next


### PR DESCRIPTION
## Summary
[INTENT.md](.claude/INTENT.md) lists "Reconnect dialog instead of `RuntimeError(LS_LostConnection)` — keep the player and their state across network blips" as a long-horizon item.

**Phase 1**: collapse the 12 in-line `RuntimeError(LanguageString$(LS_LostConnection))` callers down to a single function so future phases (reconnect UI, state preservation) only have to touch one place.

Pure refactor — behavior unchanged. `OnLostConnection()` in [ClientNet.bb](src/Modules/ClientNet.bb#L23) wraps the original `RuntimeError` call. The 12 callers across `ClientNet.bb` and `MainMenu.bb` now call the helper.

A function-pointer or state-machine swap-in later can replace the helper body without re-finding every disconnect path:

```basic
Function OnLostConnection()
    RuntimeError(LanguageString$(LS_LostConnection))  ; <-- replace this body in phase 2
End Function
```

## Sites consolidated (12 total)
- `ClientNet.bb` × 2 — `PeerToHostHasLeft` connect-time handler, `P_KickedPlayer`.
- `MainMenu.bb` × 10 — every wait-for-server loop in connect / login / character-list / fetch-character / disconnect paths.

## Test plan
- [x] `compile.bat -t` builds Server / Client / GUE / Project Manager cleanly.
- [ ] Disconnect the server while a client is mid-login: client still shows the "Lost connection" error and exits cleanly, identical to before.

## Roadmap (future phases, separate PRs)
- **Phase 2**: convert `OnLostConnection()` to a non-fatal handler — pause the current game state, show a reconnect dialog with retry / cancel.
- **Phase 3**: wire actual reconnect logic (RakNet rebind, session resume, state replay).

🤖 Generated with [Claude Code](https://claude.com/claude-code)