### PR TITLE
Null-guard AreaInstance lookups in combat / death broadcasts

### DIFF
--- a/src/Modules/GameServer.bb
+++ b/src/Modules/GameServer.bb
@@ -127,16 +127,21 @@ End Function
 
 Function KillActor(A.ActorInstance, Killer.ActorInstance)
 
-	; Tell players in the same area if it was an AI actor dying
+	; Tell players in the same area if it was an AI actor dying. If the
+	; actor's ServerArea is stale (warp-in-progress, freed area, or any
+	; cleanup race), Object.AreaInstance returns Null -- skip the
+	; broadcast rather than crash on AInstance\FirstInZone.
 	If A\RNID < 0
 		Pa$ = RCE_StrFromInt$(A\RuntimeID, 2)
 		If Killer <> Null Then Pa$ = Pa$ + RCE_StrFromInt$(Killer\RuntimeID, 2)
 		AInstance.AreaInstance = Object.AreaInstance(A\ServerArea)
-		A2.ActorInstance = AInstance\FirstInZone
-		While A2 <> Null
-			If A2\RNID > 0 Then RCE_Send(Host, A2\RNID, P_ActorDead, Pa$, True)
-			A2 = A2\NextInZone
-		Wend
+		If AInstance <> Null
+			A2.ActorInstance = AInstance\FirstInZone
+			While A2 <> Null
+				If A2\RNID > 0 Then RCE_Send(Host, A2\RNID, P_ActorDead, Pa$, True)
+				A2 = A2\NextInZone
+			Wend
+		EndIf
 	EndIf
 
 	If Killer <> Null
@@ -187,23 +192,31 @@ Function KillActor(A.ActorInstance, Killer.ActorInstance)
 			Params$ = Params$ + "," + A\ScriptGlobals$[i]
 		Next
 		If A\DeathScript$ <> "" Then ThreadScript(A\DeathScript$, "Main", Handle(Killer), 0, Params$)
-		; Remove from zone linked list
+		; Remove from zone linked list. If the area instance is already
+		; gone (zone unload race, mid-warp), there's nothing to detach
+		; from and the existing NextInZone pointers will be dangling
+		; anyway -- skip rather than crash.
 		If A\NextInZone <> Null
 			AInstance.AreaInstance = Object.AreaInstance(A\ServerArea)
-			A2.ActorInstance = AInstance\FirstInZone
-			If A2 = A
-				AInstance\FirstInZone = A\NextInZone
-			Else
-				While A2\NextInZone <> A
-					A2 = A2\NextInZone
-				Wend
-				A2\NextInZone = A\NextInZone
+			If AInstance <> Null
+				A2.ActorInstance = AInstance\FirstInZone
+				If A2 = A
+					AInstance\FirstInZone = A\NextInZone
+				Else
+					While A2\NextInZone <> A
+						A2 = A2\NextInZone
+					Wend
+					A2\NextInZone = A\NextInZone
+				EndIf
 			EndIf
 		EndIf
-		; Remove from spawn point if attached to one
+		; Remove from spawn point if attached to one. Same Null guard --
+		; if AInstance is gone, the Spawned counter is already orphaned.
 		If A\SourceSP > -1
 			AInstance.AreaInstance = Object.AreaInstance(A\ServerArea)
-			AInstance\Spawned[A\SourceSP] = AInstance\Spawned[A\SourceSP] - 1
+			If AInstance <> Null
+				AInstance\Spawned[A\SourceSP] = AInstance\Spawned[A\SourceSP] - 1
+			EndIf
 		EndIf
 		FreeActorScripts(A)
 		FreeActorInstance(A)
@@ -220,16 +233,22 @@ Function FireProjectile(P.Projectile, A1.ActorInstance, A2.ActorInstance)
 	; Check faction ratings
 	If A1\FactionRatings[A2\HomeFaction] > 150 Then Return
 
-	; Tell all players about the projectile so they can display it
+	; Tell all players about the projectile so they can display it. If
+	; the source's area lookup fails (stale ServerArea after a warp),
+	; skip the broadcast -- mid-flight projectiles whose source actor
+	; is in transit just don't get a visual ping; the damage logic
+	; below still resolves authoritatively on the server.
 	Pa$ = RCE_StrFromInt$(A1\RuntimeID, 2) + RCE_StrFromInt$(A2\RuntimeID, 2) + RCE_StrFromInt$(P\MeshID, 2)
 	Pa$ = Pa$ + RCE_StrFromInt$(P\Emitter1TexID, 2) + RCE_StrFromInt$(P\Emitter2TexID, 2) + RCE_StrFromInt$(P\Homing, 1) + RCE_StrFromInt$(P\Speed, 1)
 	Pa$ = Pa$ + RCE_StrFromInt$(Len(P\Emitter1$), 1) + P\Emitter1$ + P\Emitter2$
 	AInstance.AreaInstance = Object.AreaInstance(A1\ServerArea)
-	A3.ActorInstance = AInstance\FirstInZone
-	While A3 <> Null
-		If A3\RNID > 0 Then RCE_Send(Host, A3\RNID, P_Projectile, Pa$, True)
-		A3 = A3\NextInZone
-	Wend
+	If AInstance <> Null
+		A3.ActorInstance = AInstance\FirstInZone
+		While A3 <> Null
+			If A3\RNID > 0 Then RCE_Send(Host, A3\RNID, P_Projectile, Pa$, True)
+			A3 = A3\NextInZone
+		Wend
+	EndIf
 
 	; Does the projectile hit the target?
 	ToHit = Rand(100)
@@ -298,16 +317,19 @@ Function ActorAttack(A1.ActorInstance, A2.ActorInstance)
 					CheckDist# = A1\Inventory\Items[SlotI_Weapon]\Item\Range# + A1\Actor\Radius# + A2\Actor\Radius#
 					If Dist# > CheckDist# * CheckDist# Then Return False
 
-					; Tell other players in the same area
+					; Tell other players in the same area. Skip if
+					; the attacker's area lookup is Null (warp race).
 					Pa$ = "O" + RCE_StrFromInt$(A1\RuntimeID, 2) + RCE_StrFromInt$(A2\RuntimeID, 2)
 					AInstance.AreaInstance = Object.AreaInstance(A1\ServerArea)
-					A3.ActorInstance = AInstance\FirstInZone
-					While A3 <> Null
-						If A3\RNID > 0
-							If A3 <> A1 And A3 <> A2 Then RCE_Send(Host, A3\RNID, P_AttackActor, Pa$, True)
-						EndIf
-						A3 = A3\NextInZone
-					Wend
+					If AInstance <> Null
+						A3.ActorInstance = AInstance\FirstInZone
+						While A3 <> Null
+							If A3\RNID > 0
+								If A3 <> A1 And A3 <> A2 Then RCE_Send(Host, A3\RNID, P_AttackActor, Pa$, True)
+							EndIf
+							A3 = A3\NextInZone
+						Wend
+					EndIf
 
 					; Launch projectile
 					P.Projectile = ProjectileList(A1\Inventory\Items[SlotI_Weapon]\Item\RangedProjectile)
@@ -540,17 +562,20 @@ Function ActorAttack(A1.ActorInstance, A2.ActorInstance)
 		RCE_Send(Host, A2\RNID, P_AttackActor, "Y" + RCE_StrFromInt$(A1\RuntimeID, 2) + Pa$, True)
 	EndIf
 
-	; Tell other players in the same area
+	; Tell other players in the same area. Skip if the attacker's
+	; area lookup is Null (warp race / freed area).
 	Pa$ = "O" + RCE_StrFromInt$(A1\RuntimeID, 2) + RCE_StrFromInt$(A2\RuntimeID, 2)
 
 	AInstance.AreaInstance = Object.AreaInstance(A1\ServerArea)
-	A3.ActorInstance = AInstance\FirstInZone
-	While A3 <> Null
-		If A3\RNID > 0
-			If A3 <> A1 And A3 <> A2 Then RCE_Send(Host, A3\RNID, P_AttackActor, Pa$, True)
-		EndIf
-		A3 = A3\NextInZone
-	Wend
+	If AInstance <> Null
+		A3.ActorInstance = AInstance\FirstInZone
+		While A3 <> Null
+			If A3\RNID > 0
+				If A3 <> A1 And A3 <> A2 Then RCE_Send(Host, A3\RNID, P_AttackActor, Pa$, True)
+			EndIf
+			A3 = A3\NextInZone
+		Wend
+	EndIf
 
 	.SkipAttackNet
 


### PR DESCRIPTION
## Summary
Six sites in [GameServer.bb](src/Modules/GameServer.bb) resolved `Object.AreaInstance(actor\ServerArea)` and immediately dereferenced `AInstance\FirstInZone` / `AInstance\Spawned` without checking the lookup succeeded. `Object.X(handle)` returns Null on a stale handle — typical trigger here is an actor mid-warp whose `ServerArea` was cleared before `SetArea` fully settled the new zone, or a zone-unload race against a script-spawned attack.

## Sites

| Site | Function | Behavior |
|---|---|---|
| [KillActor:130-140](src/Modules/GameServer.bb#L130) | AI-death broadcast loop | Tell players in zone the AI died |
| [KillActor:191-202](src/Modules/GameServer.bb#L191) | Zone linked-list removal | Detach the dead AI from `FirstInZone` chain |
| [KillActor:204-207](src/Modules/GameServer.bb#L204) | Spawn-point counter | Decrement `Spawned[SourceSP]` |
| [FireProjectile:227](src/Modules/GameServer.bb#L227) | Visual broadcast for ranged shots | Tell players to render the in-flight projectile |
| [ActorAttack:303](src/Modules/GameServer.bb#L303) | Ranged-attack broadcast (`CombatFormula <> 4`) | Tell area about the ranged attack |
| [ActorAttack:546](src/Modules/GameServer.bb#L546) | Melee-attack broadcast | Tell area about the melee attack |

All six follow the same recovery: **if `AInstance` is Null, skip the loop / counter update**. The orphaned `NextInZone` pointers from a freed zone are dangling anyway — there's nothing to detach from, and no one to broadcast to. Authoritative damage / kill state still resolves on the server; only the visual / network broadcast is skipped.

## Pattern reference
Established by the rcce2-packet-handler skill and recently documented in [CLAUDE.md](CLAUDE.md) under "Handle-lookup Null discipline" (PR [#145](https://github.com/RydeTec/secce2/pull/145)). This is the server-side application of the same `Object.X(handle)` guard pattern the client-side [PR #144](https://github.com/RydeTec/rcce2/pull/144) added for `PlayerTarget`.

## Out of scope (follow-up)
[`UpdateActorInstances`](src/Modules/GameServer.bb#L625) at line 625+ has the same `AInstance` pattern at higher fanout (per-actor per-tick `AInstance` access for water damage, etc.). That surface needs a different shape of fix — skip the actor's entire tick, not just one broadcast — and lands in a separate PR.

## Test plan
- [x] `compile.bat -t` builds Server / Client / GUE / Project Manager cleanly.
- [ ] Force a kill of an actor whose `ServerArea` has been cleared mid-warp (e.g. a BVM script that calls `KILLACTOR` on an actor immediately after `WARP`). Server logs (well, doesn't crash) and the kill cleanup proceeds without the broadcast.
- [ ] Sanity: normal in-area combat still propagates attack and death packets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)