### PR TITLE
docs: note that Tools-shared modules need full compile.bat (not -t)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -47,6 +47,8 @@ After any change to a `.bb` file under `src/`, run `compile.bat -t` and confirm 
 
 The compile target (`Server.exe`, `Client.exe`, `GUE.exe`, `Project Manager.exe`) depends on which top-level `.bb` includes the file. Most modules are included by Server *and* Client, so check both compile.
 
+**Run full `compile.bat` (no `-t`) when touching modules that the Tools also include.** `-t` skips `src/Tools/*.bb` for speed (~10× faster), but several utility modules are shared between the engine and the Tools — `src/Modules/Media.bb`, `src/Modules/b3dfile.bb`, `src/Modules/MD5.bb`, and others. CI runs the full compile, so a change that adds an unresolved reference inside `Media.bb` (e.g. calling a helper from `Logging.bb` that the Tools don't include) will pass `-t` locally but fail CI on the Tools target. Quick rule of thumb: if you touched anything in `src/Modules/` that doesn't have `Server`/`Client` in the filename, prefer the full compile.
+
 ## Repo layout
 
 ```


### PR DESCRIPTION
## Summary
[#157](https://github.com/RydeTec/rcce2/pull/157) hit a CI failure that `compile.bat -t` had not caught: `Media.bb` called a helper (`ReadBoundedString$`) that lived in `Logging.bb`, which `Server.bb` / `Client.bb` / `GUE.bb` include but [`src/Tools/RC Architect.bb`](src/Tools/RC%20Architect.bb) does not. The `-t` build skipped the Tools so the missing reference only surfaced on CI's full compile.

Capture the rule of thumb in [CLAUDE.md](CLAUDE.md) so the next contributor doesn't have to rediscover it: shared utility modules (`Media`, `b3dfile`, `MD5`, etc.) are included by Tools too, and any new external reference in those needs a full `compile.bat` verification before push, not `-t`.

## Test plan
- [x] Docs-only.
- [ ] Re-read the orientation section from a cold context; the new sentence routes correctly to the "shared module" case without contradicting the existing `-t` default for engine-only changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)