### PR TITLE
Bound Money.dat currency name reads

### DIFF
--- a/src/Modules/ClientLoaders.bb
+++ b/src/Modules/ClientLoaders.bb
@@ -67,15 +67,17 @@ Function LoadGame()
 		ShadowR = ReadByte(F)
 	CloseFile(F)
 
-	; Money settings
+	; Money settings. Bound currency name reads -- Money.dat is a 4-line
+	; admin-edited config; a wild length prefix would hang the client at
+	; startup. Same shape as the other admin-editable data loaders.
 	F = ReadFile("Data\Game Data\Money.dat")
 	If F = 0 Then RuntimeError("Could not open Data\Game Data\Money.dat!")
-		Money1$ = ReadString$(F)
-		Money2$ = ReadString$(F)
+		Money1$ = ReadBoundedString$(F, 64)
+		Money2$ = ReadBoundedString$(F, 64)
 		Money2x = ReadShort(F)
-		Money3$ = ReadString$(F)
+		Money3$ = ReadBoundedString$(F, 64)
 		Money3x = ReadShort(F)
-		Money4$ = ReadString$(F)
+		Money4$ = ReadBoundedString$(F, 64)
 		Money4x = ReadShort(F)
 	CloseFile(F)
 


### PR DESCRIPTION
## Summary
`LoadMisc`'s [Money.dat parse](src/Modules/ClientLoaders.bb#L71) uses 4 unguarded `ReadString$` calls for the currency-unit display names. `Money.dat` is admin-editable; a corrupted or hand-edited file with a wild length prefix would hang the client at startup allocating gigabytes on the first name read.

Same shape as the broader data-loader sweep ([#147](https://github.com/RydeTec/rcce2/pull/147) / [#148](https://github.com/RydeTec/rcce2/pull/148) / [#149](https://github.com/RydeTec/rcce2/pull/149) / [#156](https://github.com/RydeTec/rcce2/pull/156)). **64-byte cap** is comfortably above any realistic currency display name (typical content uses "Gold" / "Silver" / etc.).

## Test plan
- [x] `compile.bat` (full build including tools) — all targets clean.
- [ ] Normal `Money.dat` loads identically.
- [ ] Hex-edit a name length prefix to a large value — client logs the rejection and boots with that name as `""`; subsequent fields parse.

🤖 Generated with [Claude Code](https://claude.com/claude-code)