### PR TITLE
Bound length-prefixed strings in ClientAreas variants

### DIFF
--- a/src/Modules/ClientAreas.bb
+++ b/src/Modules/ClientAreas.bb
@@ -319,9 +319,11 @@ Function LoadArea(Name$, CameraEN, DisplayItems = False, UpdateRottNet = False)
 			
 			
 			Collides = ReadByte(F)
-			; Lightmap information and RCTE data
-			S\Lightmap$ = ReadString$(F)
-			S\RCTE$ = ReadString$(F)
+			; Lightmap information and RCTE data. Bound the asset paths
+			; so a corrupted Area data file can't hang the loader on a
+			; wild ReadInt length prefix (260 = Windows MAX_PATH).
+			S\Lightmap$ = ReadBoundedString$(F, 260)
+			S\RCTE$ = ReadBoundedString$(F, 260)
 			
 			;v1.104 options cysis145 [010]
 			S\CastShadow = ReadByte(F)
@@ -637,8 +639,8 @@ Function LoadArea(Name$, CameraEN, DisplayItems = False, UpdateRottNet = False)
 				E\EN = CreatePivot()
 			EndIf
 								
-			; Read in emitter data
-			E\ConfigName$ = ReadString$(F)
+			; Read in emitter data. Same length-prefix DoS hardening.
+			E\ConfigName$ = ReadBoundedString$(F, 260)
 			E\TexID = ReadShort(F)
 			Texture = GetTexture(E\TexID)
 			X# = ReadFloat#(F) : Y# = ReadFloat#(F) : Z# = ReadFloat#(F)

--- a/src/Modules/ClientAreasTE.bb
+++ b/src/Modules/ClientAreasTE.bb
@@ -280,9 +280,11 @@ Function LoadArea(Name$, CameraEN, DisplayItems = False, UpdateRottNet = False)
 			; Collision/picking
 			S\CatchRain = ReadByte(F)
 			Collides = ReadByte(F)
-			; Lightmap information and RCTE data
-			S\Lightmap$ = ReadString$(F)
-			S\RCTE$ = ReadString$(F)
+			; Lightmap information and RCTE data. Bound the asset paths
+			; so a corrupted Area data file can't hang the loader on a
+			; wild ReadInt length prefix (260 = Windows MAX_PATH).
+			S\Lightmap$ = ReadBoundedString$(F, 260)
+			S\RCTE$ = ReadBoundedString$(F, 260)
 
 			If S\EN <> 0
 				; Toolbox extras
@@ -501,8 +503,8 @@ Function LoadArea(Name$, CameraEN, DisplayItems = False, UpdateRottNet = False)
 			Else
 				E\EN = CreatePivot()
 			EndIf
-			; Read in emitter data
-			E\ConfigName$ = ReadString$(F)
+			; Read in emitter data. Same length-prefix DoS hardening.
+			E\ConfigName$ = ReadBoundedString$(F, 260)
 			E\TexID = ReadShort(F)
 			Texture = GetTexture(E\TexID)
 			X# = ReadFloat#(F) : Y# = ReadFloat#(F) : Z# = ReadFloat#(F)
@@ -703,8 +705,9 @@ Function LoadAreaTE(Name$)
 		dm\TextureID = ReadShort(F)
 		dm\CatchRain = ReadByte(F)
 		dm\Collides = ReadByte(F)
-		dm\Lightmap$ = ReadString$(F)
-		dm\rcTe$ = ReadString$(F)
+		; Bound the asset paths (260 = Windows MAX_PATH).
+		dm\Lightmap$ = ReadBoundedString$(F, 260)
+		dm\rcTe$ = ReadBoundedString$(F, 260)
 		
 		If Left$(dm\rcTe$,5)<>"_TRRN"
 			dm\ent = GetMesh(dm\id)
@@ -755,7 +758,7 @@ Function LoadAreaTE(Name$)
 	Emitters = ReadShort(F)
 	For i = 1 To Emitters
 		E.Emitter = New Emitter
-		E\ConfigName$ = ReadString$(F)
+		E\ConfigName$ = ReadBoundedString$(F, 260)
 		E\TexID = ReadShort(F)
 		E\X# = ReadFloat#(F) : E\Y# = ReadFloat#(F) : E\Z# = ReadFloat#(F)
 		E\Pitch# = ReadFloat#(F) : E\Yaw# = ReadFloat#(F) : E\Roll# = ReadFloat#(F)

--- a/src/Modules/ClientAreas_FE.bb
+++ b/src/Modules/ClientAreas_FE.bb
@@ -456,9 +456,11 @@ Function LoadArea(Name$, CameraEN, DisplayItems = False, UpdateRottNet = False)
 			
 			
 			Collides = ReadByte(F)
-			; Lightmap information and RCTE data
-			S\Lightmap$ = ReadString$(F)
-			S\RCTE$ = ReadString$(F)
+			; Lightmap information and RCTE data. Bound the asset paths
+			; so a corrupted Area data file can't hang the loader on a
+			; wild ReadInt length prefix (260 = Windows MAX_PATH).
+			S\Lightmap$ = ReadBoundedString$(F, 260)
+			S\RCTE$ = ReadBoundedString$(F, 260)
 			
 			;v1.104 options cysis145 [010]
 			S\CastShadow = ReadByte(F)
@@ -818,8 +820,8 @@ Function LoadArea(Name$, CameraEN, DisplayItems = False, UpdateRottNet = False)
 				E\EN = CreatePivot()
 			EndIf
 								
-			; Read in emitter data
-			E\ConfigName$ = ReadString$(F)
+			; Read in emitter data. Same length-prefix DoS hardening.
+			E\ConfigName$ = ReadBoundedString$(F, 260)
 			E\TexID = ReadShort(F)
 			Texture = GetTexture(E\TexID)
 			X# = ReadFloat#(F) : Y# = ReadFloat#(F) : Z# = ReadFloat#(F)


### PR DESCRIPTION
## Summary
Three sibling client-area loaders all parse scenery / decoration / emitter asset paths via unguarded `ReadString$`:

| File | Included by | Sites |
|---|---|---|
| [`ClientAreas.bb`](src/Modules/ClientAreas.bb) | `GUE.bb` | Lightmap, RCTE, ConfigName |
| [`ClientAreas_FE.bb`](src/Modules/ClientAreas_FE.bb) | `Client.bb` | Lightmap, RCTE, ConfigName |
| [`ClientAreasTE.bb`](src/Modules/ClientAreasTE.bb) | `RC Terrain Editor.bb` | Lightmap, RCTE, dm/Lightmap, dm/rcTe, two ConfigName sites |

A corrupted or tampered Area scene file with a wild `ReadInt` length prefix on any of these paths would hang the loader at allocation.

Same shape as the `ServerLoadArea` hardening in [#156](https://github.com/RydeTec/rcce2/pull/156) (server side) and the broader data-loader sweep in [#149](https://github.com/RydeTec/rcce2/pull/149).

All sites routed through `ReadBoundedString$` with a **260-byte cap** (Windows `MAX_PATH`).

## Test plan
- [x] Full `compile.bat` builds Server / Client / GUE / Project Manager + all 8 Tool targets cleanly.
- [ ] Normal area loads unchanged across Client, GUE, and RC Terrain Editor.
- [ ] Hex-edit a `Lightmap$` length prefix in an area file to `999999`: client logs the rejection, that path loads as `""`, subsequent scenery still parses.

🤖 Generated with [Claude Code](https://claude.com/claude-code)