### PR TITLE
Bound LoadActors / LoadAttributes / LoadFactions string reads

### DIFF
--- a/src/Modules/Actors.bb
+++ b/src/Modules/Actors.bb
@@ -630,11 +630,16 @@ Function LoadActors(Filename$)
 			A\Attributes = New Attributes
 			A\ID = ReadShort(F)
 			ActorList(A\ID) = A
-			A\Race$ = ReadString$(F)
-			A\Class$ = ReadString$(F)
-			A\Description$ = ReadString$(F)
-			A\StartArea$ = ReadString$(F)
-			A\StartPortal$ = ReadString$(F)
+			; Bound every length-prefixed string against a corrupted
+			; Actors.dat (same shape as the data-loader sweep in PR #149).
+			; Race / Class / area names are short identifiers; Description
+			; is editor-authored flavor text; StartArea/StartPortal are
+			; area + portal names.
+			A\Race$ = ReadBoundedString$(F, 256)
+			A\Class$ = ReadBoundedString$(F, 256)
+			A\Description$ = ReadBoundedString$(F, 4096)
+			A\StartArea$ = ReadBoundedString$(F, 256)
+			A\StartPortal$ = ReadBoundedString$(F, 256)
 			A\MAnimationSet = ReadShort(F)
 			A\FAnimationSet = ReadShort(F)
 			A\Scale# = ReadFloat(F)
@@ -743,7 +748,9 @@ Function LoadAttributes(Filename$)
 
 		AttributeAssignment = ReadByte(F)
 		For i = 0 To 39
-			AttributeNames$(i) = ReadString$(F)
+			; Bound attribute display names against a corrupted
+			; Attributes.dat (same shape as the data-loader sweep).
+			AttributeNames$(i) = ReadBoundedString$(F, 256)
 			AttributeIsSkill(i) = ReadByte(F)
 			AttributeHidden(i) = ReadByte(F)
 		Next
@@ -918,7 +925,8 @@ Function LoadFactions(Filename$)
 	If F = 0 Then Return -1
 
 		For i = 0 To 99
-			FactionNames$(i) = ReadString$(F)
+			; Bound faction names against a corrupted Factions.dat.
+			FactionNames$(i) = ReadBoundedString$(F, 256)
 			If Len(FactionNames$(i)) > 0 Then Factions = Factions + 1
 		Next
 


### PR DESCRIPTION
## Summary
Three more admin-editable data loaders in [Actors.bb](src/Modules/Actors.bb) were on unguarded `ReadString$`:

| Loader | Strings per record | Total |
|---|---|---|
| `LoadActors` | Race, Class, Description, StartArea, StartPortal | 5 × N actors |
| `LoadAttributes` | name per slot | 40 |
| `LoadFactions` | faction name per slot | 100 |

Each was a length-prefix DoS waiting on a corrupted `.dat`. Route every read through `ReadBoundedString$` with caps matching the established conventions:
- **256** for short identifiers (Race / Class / StartArea / StartPortal, attribute names, faction names).
- **4096** for `Description` (editor-authored flavor text; generous so real content isn't truncated).

Same shape as [#149](https://github.com/RydeTec/rcce2/pull/149)'s data-loader sweep, [#156](https://github.com/RydeTec/rcce2/pull/156)'s `ServerLoadArea` hardening, and [#160](https://github.com/RydeTec/rcce2/pull/160)'s `ClientAreas` variants.

## Test plan
- [x] Full `compile.bat` builds Server / Client / GUE / Project Manager + all Tools cleanly.
- [ ] Normal `Actors.dat` / `Attributes.dat` / `Factions.dat` loads identically.
- [ ] Hex-edit any name length prefix to a large value: server/client/GUE/Gubbin Tool/RC Terrain Editor all log the rejection and continue loading subsequent entries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)