### PR TITLE
Bound LoadDroppedItems string reads

### DIFF
--- a/src/Server.bb
+++ b/src/Server.bb
@@ -843,7 +843,10 @@ Function LoadDroppedItems(Filename$)
 
 		While Eof(F) = False
 			D.DroppedItem = New DroppedItem
-			Zone$ = ReadString$(F)
+			; Bound Zone$ (area name) -- corrupted DroppedItems.dat with
+			; a wild length prefix would hang the server at boot. Same
+			; shape as the broader data-loader sweep.
+			Zone$ = ReadBoundedString$(F, 256)
 			Instance = ReadByte(F)
 			; AreaInstance Instances is Dim'd 0..99. ReadByte returns 0..255;
 			; a corrupted DroppedItems.dat with Instance >= 100 triggers OOB
@@ -857,7 +860,10 @@ Function LoadDroppedItems(Filename$)
 					Exit
 				EndIf
 			Next
-			D\Item = ItemInstanceFromString(ReadString$(F))
+			; Item-instance binary is 83 bytes today (ItemInstanceStringLength);
+			; cap to 256 to cover the current format with comfortable
+			; headroom and still reject a wild length prefix.
+			D\Item = ItemInstanceFromString(ReadBoundedString$(F, 256))
 			D\Amount = ReadShort(F)
 			D\X# = ReadFloat#(F)
 			D\Y# = ReadFloat#(F)


### PR DESCRIPTION
## Summary
[LoadDroppedItems](src/Server.bb#L837) walks `DroppedItems.dat` reading a `Zone$` (area name) + an `ItemInstance` binary per record via unguarded `ReadString$`. A corrupted `DroppedItems.dat` with a wild `ReadInt` length prefix would hang the server at boot allocating gigabytes on the first record.

Route both reads through `ReadBoundedString$`:
- **256 bytes** for `Zone$` (area name).
- **256 bytes** for the item-instance binary (currently 83 bytes per `ItemInstanceStringLength`; cap provides comfortable headroom for future format growth while still bounding malformed input).

Same shape as the broader data-loader sweep.

## Test plan
- [x] Full `compile.bat` builds Server / Client / GUE / Project Manager + all Tools cleanly.
- [ ] Normal `DroppedItems.dat` loads identically; existing dropped items appear in the right zones on boot.
- [ ] Hex-edit a record's `Zone$` length prefix to `999999`: server logs the rejection, that record is skipped (no item ends up in the world), subsequent records still parse.

🤖 Generated with [Claude Code](https://claude.com/claude-code)