### PR TITLE
Bound LoadGubbinNames joint name reads

### DIFF
--- a/src/Modules/Actors3D.bb
+++ b/src/Modules/Actors3D.bb
@@ -20,7 +20,10 @@ Function LoadGubbinNames()
 	F = ReadFile("Data\Game Data\Gubbins.dat")
 	If F = 0 Then RuntimeError("File not found: " + "Data\Game Data\Gubbins.dat!")
 		For i = 0 To 5
-			GubbinJoints$(i) = ReadString$(F)
+			; Bound joint names against a corrupted Gubbins.dat. Joints are
+			; short identifiers like "Head", "Hand"; 64 covers any realistic
+			; mesh joint label.
+			GubbinJoints$(i) = ReadBoundedString$(F, 64)
 		Next
 	CloseFile(F)
 


### PR DESCRIPTION
## Summary
[`LoadGubbinNames`](src/Modules/Actors3D.bb#L18) reads 6 joint names from `Gubbins.dat` via unguarded `ReadString$`. A corrupted `Gubbins.dat` with a wild length prefix would hang the client / GUE / Gubbin Tool at boot allocating gigabytes on the first joint.

**64-byte cap** covers any realistic joint label (`"Head"`, `"Hand"`, etc.). Same defensive shape as the rest of the data-loader sweep.

## Test plan
- [x] Full `compile.bat` builds Server / Client / GUE / Project Manager + all Tools cleanly.
- [ ] Normal `Gubbins.dat` loads identically.
- [ ] Hex-edit a joint name length prefix to a large value: client logs the rejection and continues; that joint loads as `""`, which downstream `FindChild` calls handle gracefully (`Bonce = 0` triggers the existing missing-joint soft-fail in Actors3D).

🤖 Generated with [Claude Code](https://claude.com/claude-code)