### PR TITLE
Cap b3dReadString$ at 4096 bytes to bound O(N²) concat blowup

### DIFF
--- a/src/Modules/b3dfile.bb
+++ b/src/Modules/b3dfile.bb
@@ -25,12 +25,21 @@ Function b3dReadFloat#()
 	Return ReadFloat( b3d_file )
 End Function
 
+; Reads a NUL-terminated string with a hard upper bound. A corrupted or
+; tampered .b3d with no NUL terminator before EOF would otherwise grow t$
+; one byte at a time -- Blitz string concatenation is O(N) per concat, so
+; an unbounded loop is O(N^2) and can stall the loader for minutes on a
+; megabyte-class string of garbage. 4096 bytes covers any realistic mesh
+; tag, material name, or animation name in a legitimate .b3d.
 Function b3dReadString$()
-Local t$
+	Local t$
+	Local n
 	Repeat
 		ch=b3dReadByte()
 		If ch=0 Return t$
 		t$=t$+Chr$(ch)
+		n=n+1
+		If n >= 4096 Return t$
 	Forever
 End Function
 


### PR DESCRIPTION
## Summary
[`b3dReadString$`](src/Modules/b3dfile.bb#L28) reads a NUL-terminated string by repeatedly appending one byte at a time to `t$`. Blitz string concatenation is **O(N) per concat** (the runtime copies the entire string each time), so an unbounded loop is **O(N²)**. A corrupted or tampered `.b3d` with no NUL terminator before EOF (or one carefully crafted by a hostile update channel) could stall the loader for minutes on a megabyte-class string of garbage.

`ReadByte` at EOF does return `0` so the loop eventually terminates, but the wall-clock cost of getting there is the DoS.

Cap at **4096 bytes** — comfortably above any realistic mesh tag, material name, or animation name in a legitimate `.b3d` file.

## Test plan
- [x] Full `compile.bat` builds all targets cleanly.
- [ ] Normal `.b3d` mesh loads identically (BB3D / TEXS / BRUS / NODE / etc. tags are 4 chars, names are typically <64).
- [ ] Hand-craft a `.b3d` whose name field is a multi-megabyte byte stream with no NUL: the cap kicks in at 4096 and the load proceeds (or fails cleanly downstream), instead of stalling the editor for several minutes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)