### PR TITLE
Null-guard P_SpellUpdate cast against stale SpellsList slot

### DIFF
--- a/src/Modules/ServerNet.bb
+++ b/src/Modules/ServerNet.bb
@@ -1060,6 +1060,20 @@ Function UpdateNetwork()
 											RCE_Send(Host, AI\RNID, P_ChatMessage, Chr$(253) + LanguageString$(LS_AbilityNotRecharged), True)
 										Else
 											Sp.Spell = SpellsList(SpellID)
+											; SpellsList is sparse; a stale character save
+											; (admin deleted the spell between sessions)
+											; or a corrupted KnownSpells slot would otherwise
+											; deref Null below. P_FetchCharacter already
+											; prunes stale entries at character-select but
+											; defense-in-depth at the cast site means a
+											; race or future code path that bypasses the
+											; prune can't take down the server.
+											If Sp = Null
+												WriteLog(MainLog, "P_SpellUpdate F: SpellID " + SpellID + " in KnownSpells but not in SpellsList (stale slot); dropping cast")
+												AI\KnownSpells[Num] = 0
+												AI\SpellLevels[Num] = 0
+												Goto SkipSpellCast
+											EndIf
 											; Race / class restriction check.
 											; The Spell type has ExclusiveRace$/ExclusiveClass$
 											; (persisted by SaveSpells / loaded by
@@ -1087,6 +1101,7 @@ Function UpdateNetwork()
 									EndIf
 								EndIf
 							EndIf
+							.SkipSpellCast
 					End Select
 				EndIf
 


### PR DESCRIPTION
## Summary
[`P_SpellUpdate "F"`](src/Modules/ServerNet.bb#L1062) reads `Sp.Spell = SpellsList(SpellID)` and immediately dereferences `Sp\ExclusiveRace$` for the race/class restriction check. `SpellsList` is sparse — a player's saved character with a `KnownSpells` slot referencing a spell ID that was deleted between sessions would read back a Null `Spell` and crash the server.

`P_FetchCharacter` already prunes stale character spell slots at character-select time, but defense in depth at the cast site closes:
- Any future code path that bypasses the `FetchCharacter` prune.
- A race between `FetchCharacter` completion and the player's first cast on a stale slot.
- Script-driven mutations of `KnownSpells` that don't validate the ID.

## Recovery
- Log the stale slot (`MainLog`).
- Zero `AI\KnownSpells[Num]` + `AI\SpellLevels[Num]` (idempotent: subsequent casts hit the cleaned slot and skip).
- `Goto SkipSpellCast` past the cast body.

Same shape as other Null-deref soft-fail PRs in the series ([#138](https://github.com/RydeTec/secce2/pull/138)–[#164](https://github.com/RydeTec/rcce2/pull/164)).

## Test plan
- [x] `compile.bat -t` builds Server / Client / GUE / Project Manager cleanly.
- [ ] Save a character with a known spell, delete the spell in GUE between sessions, then cast it on the resaved character: server logs the rejection and continues, slot is cleared, no crash.
- [ ] Sanity: normal cast against a live spell unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)