### PR TITLE
Soft-fail SaveDroppedItems on stale area / null item references

### DIFF
--- a/src/Server.bb
+++ b/src/Server.bb
@@ -896,6 +896,14 @@ Function SaveDroppedItems(Filename$)
 
 		For D.DroppedItem = Each DroppedItem
 			AInstance.AreaInstance = Object.AreaInstance(D\ServerHandle)
+			; Skip dropped items whose host area instance is gone (zone
+			; unload race, freed area). Writing AInstance\Area\Name$ on
+			; a Null handle previously crashed the server during the
+			; periodic SaveDroppedItems flush -- the entire save aborts
+			; and dropped item state is lost.
+			If AInstance = Null Then Continue
+			If AInstance\Area = Null Then Continue
+			If D\Item = Null Then Continue
 			WriteString F, AInstance\Area\Name$
 			WriteByte F, AInstance\ID
 			WriteString F, ItemInstanceToString$(D\Item)


### PR DESCRIPTION
## Summary
[`SaveDroppedItems`](src/Server.bb#L888) iterates every `DroppedItem` and writes its area name + item-instance binary to disk. The host area lookup `Object.AreaInstance(D\ServerHandle)` returns Null for a stale handle (zone unload race, freed area), and the subsequent `AInstance\Area\Name$` deref would crash the entire `SaveDroppedItems` flush — not just losing that one item, but **losing every dropped item the catalog was about to persist**.

Defensive guards for the per-record path:
- `AInstance = Null`  → skip
- `AInstance\Area = Null`  → skip
- `D\Item = Null`  → skip (covers a freed but not-yet-deleted record)

`Continue` on the `For-Each` loop so the save proceeds; orphaned drops get effectively cleaned (they don't persist) and the next live save contains only resolvable items.

The atomic `SafeWriteCommit` semantics (see [Logging.bb](src/Modules/Logging.bb)) keep the prior on-disk catalog intact if anything aborts mid-write, so this strictly cannot make the on-disk file worse.

## Test plan
- [x] `compile.bat -t` builds Server / Client / GUE / Project Manager cleanly.
- [ ] Normal save / load cycle round-trips dropped items unchanged.
- [ ] Force a stale `D\ServerHandle` (e.g. via a script that calls `REMOVEZONEINSTANCE` while drops exist in that instance), then trigger `SaveDroppedItems`: server logs and persists only the resolvable drops.

🤖 Generated with [Claude Code](https://claude.com/claude-code)