### PR TITLE
Null-guard click-to-pickup DroppedItem lookup

### DIFF
--- a/src/Modules/Interface3D.bb
+++ b/src/Modules/Interface3D.bb
@@ -823,19 +823,25 @@ Function UpdateInterface()
 						UsedClick = True
 
 						DItem.DroppedItem = Object.DroppedItem(EntityName$(Result))
+						; Stale handle: the dropped-item entity was picked but
+						; its Object lookup resolved to Null (entity name lost,
+						; server-side cleanup race). Skip the pickup flow rather
+						; than crash on DItem\Item below. The sibling scenery
+						; path at ~line 854 already has this guard.
 						FoundSlot = -1
-
-						For i = 0 To Slots_Inventory
-							If Me\Inventory\Items[i] = Null
-								If DItem\Item <> Null
-									If SlotsMatch(DItem\Item\Item, i) And ActorHasSlot(Me\Actor, i, DItem\Item\Item) Then FoundSlot = i : Exit
+						If DItem <> Null
+							For i = 0 To Slots_Inventory
+								If Me\Inventory\Items[i] = Null
+									If DItem\Item <> Null
+										If SlotsMatch(DItem\Item\Item, i) And ActorHasSlot(Me\Actor, i, DItem\Item\Item) Then FoundSlot = i : Exit
+									EndIf
+								ElseIf (ItemInstancesIdentical(DItem\Item, Me\Inventory\Items[i]) And  DItem\Item <> Null And i >= SlotI_Backpack)
+									If DItem\Item\Item\Stackable = True
+										If SlotsMatch(DItem\Item\Item, i) And ActorHasSlot(Me\Actor, i, DItem\Item\Item) Then FoundSlot = i : Exit
+									EndIf
 								EndIf
-							ElseIf (ItemInstancesIdentical(DItem\Item, Me\Inventory\Items[i]) And  DItem\Item <> Null And i >= SlotI_Backpack)
-								If DItem\Item\Item\Stackable = True
-									If SlotsMatch(DItem\Item\Item, i) And ActorHasSlot(Me\Actor, i, DItem\Item\Item) Then FoundSlot = i : Exit
-								EndIf
-							EndIf
-						Next
+							Next
+						EndIf
 						; Room, request it from server
 						If FoundSlot > -1
 							RCE_Send(Connection, PeerToHost, P_InventoryUpdate, "P" + RCE_StrFromInt$(DItem\ServerHandle, 4) + RCE_StrFromInt$(FoundSlot, 1), True)


### PR DESCRIPTION
## Summary
The click-to-interact handler at [Interface3D.bb:825](src/Modules/Interface3D.bb#L825) picks an entity labeled `"D"` (dropped item) and resolves the `DroppedItem` via `Object.DroppedItem(EntityName$(Result))`. `Object.X(handle)` returns Null on a stale handle (entity picked but its Object label resolved to nothing — typical when the server cleaned up the drop but the client still has the entity around for one tick), and the `For-Each` loop below derefs `DItem\Item` unconditionally.

The sibling scenery-click path 30 lines down already has the `If Sc <> Null` guard; mirror it here. On Null, `FoundSlot` stays at `-1` so the existing "No room!" branch fires — a minor UX falsehood for a rare race, but no crash.

Same shape as the broader `Object.X(handle)` discipline doc'd in [CLAUDE.md](CLAUDE.md) (PR [#145](https://github.com/RydeTec/secce2/pull/145)).

## Test plan
- [x] `compile.bat -t` builds Server / Client / GUE / Project Manager cleanly.
- [ ] Normal click-to-pickup unchanged.
- [ ] Pick up an item one tick after another player grabbed it (server already deleted, client EN lingering): "No room!" toast instead of a crash; next click finds the world in its post-pickup state.

🤖 Generated with [Claude Code](https://claude.com/claude-code)