### PR TITLE
Null-guard actor selection / right-click paths

### DIFF
--- a/src/Modules/Interface3D.bb
+++ b/src/Modules/Interface3D.bb
@@ -685,22 +685,28 @@ Function UpdateInterface()
 		; Talk to button was clicked
 		If ControlHit(Key_TalkTo) And TradingVisible = False And MilliSecs() - RightDownTime < 500
 			ClickedTarget = False
-			; Selected target actor, show interaction window
+			; Selected target actor, show interaction window.
+			; Stale PlayerTarget handle: clear and fall through to the
+			; click-target-pick branch below rather than crash on
+			; AI\CollisionEN.
 			If PlayerTarget > 0
 				AI.ActorInstance = Object.ActorInstance(PlayerTarget)
-				
-				If CharInteractVisible
-					UpdateCharInteractionWindow()
+				If AI = Null
+					PlayerTarget = 0
 				Else
-					CreateCharInteractionWindow( AI )
-					;CysisLibs Outline
-					;Outline ActorSelectEN
+					If CharInteractVisible
+						UpdateCharInteractionWindow()
+					Else
+						CreateCharInteractionWindow( AI )
+						;CysisLibs Outline
+						;Outline ActorSelectEN
+					EndIf
+					If EntityDistance#(AI\CollisionEN, Me\CollisionEN) < InteractRange
+						RCE_Send(Connection, PeerToHost, P_RightClick, RCE_StrFromInt$(AI\RuntimeID, 2), True)
+					EndIf
+					QuitActive = False
+					ClickedTarget = True
 				EndIf
-				If EntityDistance#(AI\CollisionEN, Me\CollisionEN) < InteractRange
-					RCE_Send(Connection, PeerToHost, P_RightClick, RCE_StrFromInt$(AI\RuntimeID, 2), True)
-				EndIf
-				QuitActive = False
-				ClickedTarget = True
 			EndIf
 			If ClickedTarget = False
 				SetPickModes(-1, 3, True)
@@ -711,22 +717,29 @@ Function UpdateInterface()
 					If Target$ = "A"
 						PlayerTarget = EntityName$(Result)
 						AI.ActorInstance = Object.ActorInstance(PlayerTarget)
-						MaxLength# = MeshWidth#(AI\EN)
-						If MeshDepth#(AI\EN) > MaxLength# Then MaxLength# = (MeshDepth#(AI\EN) + MeshWidth#(AI\EN)) / 2.0
-						ScaleEntity(ActorSelectEN, MaxLength# * 0.03, 1.0, MaxLength# * 0.03)
-						ShowEntity(ActorSelectEN)
-						If CharInteractVisible
-							UpdateCharInteractionWindow()
-						ElseIf CharInteract = Null
-							CreateCharInteractionWindow(AI)
-							;CysisLibs Outline
-							;Outline ActorSelectEN
+						; EntityName$ resolved to a non-actor handle, or
+						; the actor was freed between pick and now. Drop
+						; the selection rather than crash on AI\EN.
+						If AI = Null
+							PlayerTarget = 0
+						Else
+							MaxLength# = MeshWidth#(AI\EN)
+							If MeshDepth#(AI\EN) > MaxLength# Then MaxLength# = (MeshDepth#(AI\EN) + MeshWidth#(AI\EN)) / 2.0
+							ScaleEntity(ActorSelectEN, MaxLength# * 0.03, 1.0, MaxLength# * 0.03)
+							ShowEntity(ActorSelectEN)
+							If CharInteractVisible
+								UpdateCharInteractionWindow()
+							ElseIf CharInteract = Null
+								CreateCharInteractionWindow(AI)
+								;CysisLibs Outline
+								;Outline ActorSelectEN
+							EndIf
+							; If friendly and in range, close interact window and execute right click
+							If AI\FactionRatings[Me\HomeFaction] > 99 And EntityDistance#(AI\CollisionEN, Me\CollisionEN) < InteractRange
+								RCE_Send(Connection, PeerToHost, P_RightClick, RCE_StrFromInt$(AI\RuntimeID, 2), True)
+							EndIf
+							QuitActive = False
 						EndIf
-						; If friendly and in range, close interact window and execute right click
-						If AI\FactionRatings[Me\HomeFaction] > 99 And EntityDistance#(AI\CollisionEN, Me\CollisionEN) < InteractRange
-							RCE_Send(Connection, PeerToHost, P_RightClick, RCE_StrFromInt$(AI\RuntimeID, 2), True)
-						EndIf
-						QuitActive = False
 					EndIf
 				EndIf
 			EndIf
@@ -759,6 +772,13 @@ Function UpdateInterface()
 					OldTarget = PlayerTarget
 					PlayerTarget = EntityName$(Result)
 					AI.ActorInstance = Object.ActorInstance(PlayerTarget)
+					; Stale Object lookup (actor picked but freed before
+					; we resolved). Drop the selection rather than crash
+					; on AI\EN / AI\Actor / AI\FactionRatings below.
+					If AI = Null
+						PlayerTarget = 0
+						Goto SkipActorSelect
+					EndIf
 					MaxLength# = MeshWidth#(AI\EN)
 					If MeshDepth#(AI\EN) > MaxLength# Then MaxLength# = (MeshDepth#(AI\EN) + MeshWidth#(AI\EN)) / 2.0
 					ScaleEntity(ActorSelectEN, MaxLength# * 0.03, 1.0, MaxLength# * 0.03)
@@ -815,6 +835,7 @@ Function UpdateInterface()
 
 						AttackTarget = False
 					EndIf
+					.SkipActorSelect
 					;HideEntity(ClickMarkerEN) ;{@@@~}
 				; Target is a dropped item
 				ElseIf Target$ = "D"


### PR DESCRIPTION
## Summary
Three sites in `Interface3D.bb`'s input handling resolved an actor handle via `Object.ActorInstance(PlayerTarget)` or `Object.ActorInstance(EntityName$(Result))` and then dereferenced the result without a Null check:

| Site | Trigger | Crash on |
|---|---|---|
| [~line 690](src/Modules/Interface3D.bb#L690) | Talk-to-button (Key_TalkTo) with a stale `PlayerTarget` | `CreateCharInteractionWindow(AI)` / `AI\CollisionEN` |
| [~line 712](src/Modules/Interface3D.bb#L712) | Right-click on the world while PlayerTarget=0 picks a target | `MeshWidth#(AI\EN)` |
| [~line 774](src/Modules/Interface3D.bb#L774) | Click-select picks an actor | `MeshWidth#(AI\EN)` and downstream `AI\Actor`, `AI\FactionRatings`, context-menu construction |

All three follow the established "clear `PlayerTarget` + bail" pattern from [#144](https://github.com/RydeTec/rcce2/pull/144) (every-frame `PlayerTarget` cluster). The fourth such site in the click-to-pickup `DroppedItem` path landed in [#168](https://github.com/RydeTec/rcce2/pull/168).

## Trigger
`EntityName$(Result)` returns whatever string was set on the picked entity. A freed actor that hasn't been despawned from the client yet (one tick of lag) returns a string that no longer maps to a live `ActorInstance` via `Object.ActorInstance`.

## Test plan
- [x] `compile.bat -t` builds Server / Client / GUE / Project Manager cleanly.
- [ ] Normal Talk / right-click / click-select against live actors unchanged.
- [ ] Race-test: kill a targeted actor server-side, then immediately try to right-click or talk: client clears the selection silently instead of crashing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)