### PR TITLE
Bound Instance index + Null-guard area in BVM_FIRSTACTORINZONE

### DIFF
--- a/src/Modules/ScriptingCommands.bb
+++ b/src/Modules/ScriptingCommands.bb
@@ -2316,6 +2316,13 @@ Function BVM_FIRSTACTORINZONE%(Param1$, Param2% = 0)
 	For Ar.Area = Each Area
 		If Upper$(Ar\Name$) = ZoneName$
 			Instance = Param2%
+			; Bound the instance index. Ar\Instances is Dim'd 0..99;
+			; a script-supplied out-of-range value would read past the
+			; array (Blitz3D's Dim has no runtime check). Also skip if
+			; the requested instance hasn't been created -- returning
+			; 0 lets the caller's iteration terminate cleanly.
+			If Instance < 0 Or Instance > 99 Then Exit
+			If Ar\Instances[Instance] = Null Then Exit
 			Actor.ActorInstance = Ar\Instances[Instance]\FirstInZone
 			If Actor <> Null Then Result% = Handle(Actor)
 			Exit


### PR DESCRIPTION
## Summary
[`BVM_FIRSTACTORINZONE`](src/Modules/ScriptingCommands.bb#L2314) accepted `Param2%` (the area instance index) without any bound, then dereferenced `Ar\Instances[Param2%]\FirstInZone`. Two crashes from a misbehaving (or buggy) script:

1. **`Instance >= 100`** walks past the `Dim 0..99 Instances` array — Blitz3D has no runtime bounds check on `Dim`, so this is arbitrary memory access.
2. **`Instance` in range `0..99` but the instance hasn't been created** (`Ar\Instances[Instance] = Null`) — the subsequent `\FirstInZone` deref is a server crash.

Both fixes: bail (`Exit` the `For Each` + `Return Result% = 0`) on either condition. Scripts iterating actors get a clean termination value instead of crashing the server.

Same shape as the [`BVM_NEXTACTORINZONE`](src/Modules/ScriptingCommands.bb#L2327) wrap-around fix ([#127](https://github.com/RydeTec/rcce2/pull/127)) — the caller's `Until iter = 0` idiom handles `Result% = 0` naturally.

## Test plan
- [x] `compile.bat -t` builds Server / Client / GUE / Project Manager cleanly.
- [ ] Script: `actor = FIRSTACTORINZONE("MyZone", 200)` — server logs nothing (silent return 0), the calling script terminates its iteration cleanly.
- [ ] Script: `actor = FIRSTACTORINZONE("MyZone", 5)` where instance 5 doesn't exist yet — same clean return.
- [ ] Sanity: live actors in instance 0 still enumerate correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)