### PR TITLE
Bound Instance index in BVM_CREATEZONEINSTANCE / BVM_REMOVEZONEINSTANCE

### DIFF
--- a/src/Modules/ScriptingCommands.bb
+++ b/src/Modules/ScriptingCommands.bb
@@ -317,14 +317,16 @@ End Function
 Function BVM_CREATEZONEINSTANCE%(Param1$, Instance%=0)
 	Zone.Area = FindArea(Param1$)
 	If Zone <> Null
-		; Script requests a specific ID
-		If Instance > 0
+		; Script requests a specific ID. Bound to the (Dim 0..99)
+		; Instances array; out-of-range returns 0 ("instance not
+		; created") rather than a Dim OOB write.
+		If Instance > 0 And Instance <= 99
 			If Zone\Instances[Instance] = Null
 				ServerCreateAreaInstance(Zone, Instance)
 				Result% = Instance
 			EndIf
-		; Use first free ID
-		Else
+		ElseIf Instance = 0
+			; Use first free ID
 			For i = 1 To 99
 				If Zone\Instances[i] = Null
 					ServerCreateAreaInstance(Zone, i)
@@ -332,6 +334,9 @@ Function BVM_CREATEZONEINSTANCE%(Param1$, Instance%=0)
 					Exit
 				EndIf
 			Next
+		; Instance > 99 or negative: silently return 0 (caller's
+		; if-instance-was-created check fires the same "no slot"
+		; branch).
 		EndIf
 	Else
 		WriteLog(MainLog, "Instance can not be created, Zone " + Param1$ + " does not exist.")
@@ -342,7 +347,8 @@ End Function
 Function BVM_REMOVEZONEINSTANCE(Param1$, Instance%)
 	Zone.Area = FindArea(Param1$)
 	If Zone <> Null
-		If Instance > 0
+		; Bound the script-supplied Instance index against Dim 0..99.
+		If Instance > 0 And Instance <= 99
 			If Zone\Instances[Instance] <> Null
 				; Move players to instance #0, and delete AI actor instances
 				Actor.ActorInstance = Zone\Instances[Instance]\FirstInZone


### PR DESCRIPTION
## Summary
Both BVMs only checked `If Instance > 0` — they caught 0 and negatives but **not values ≥ 100**. The subsequent `Zone\Instances[Instance]` deref walked past the `Dim 0..99` array on a script-supplied wild value.

Tighten to `If Instance > 0 And Instance <= 99`:

| BVM | Behavior on out-of-range |
|---|---|
| [`BVM_CREATEZONEINSTANCE`](src/Modules/ScriptingCommands.bb#L317) | `Result% = 0` ("instance not created"; matches the existing "already exists" no-op) |
| [`BVM_REMOVEZONEINSTANCE`](src/Modules/ScriptingCommands.bb#L342) | Silent no-op (matches the existing "doesn't exist" no-op) |

Same shape as [#173](https://github.com/RydeTec/rcce2/pull/173) (`BVM_FIRSTACTORINZONE`) and [#174](https://github.com/RydeTec/rcce2/pull/174) (`BVM_ACTORSINZONE` / `PLAYERSINZONE` / `ZONEINSTANCEEXISTS`) — completes the Instance-bounds sweep for the zone-instance BVM cluster.

## Test plan
- [x] `compile.bat -t` builds Server / Client / GUE / Project Manager cleanly.
- [ ] Script: `CREATEZONEINSTANCE("MyZone", 500)` — returns 0 cleanly; no Dim OOB.
- [ ] Script: `REMOVEZONEINSTANCE("MyZone", -1)` — no-op.
- [ ] Sanity: `CREATEZONEINSTANCE("MyZone", 5)` on a fresh slot creates instance 5 and returns 5.

🤖 Generated with [Claude Code](https://claude.com/claude-code)