### PR TITLE
Null-guard AreaInstance lookups in BVM_SETLEADER

### DIFF
--- a/src/Modules/ScriptingCommands.bb
+++ b/src/Modules/ScriptingCommands.bb
@@ -858,31 +858,40 @@ Function BVM_SETLEADER(Param1%, Param2%)
 			If Leader <> Null
 				Actor\Leader = Leader
 				Actor\Leader\NumberOfSlaves = Actor\Leader\NumberOfSlaves + 1
-				; Make sure it no longer belongs to any spawn point
+				; Make sure it no longer belongs to any spawn point.
+				; Skip the spawn-count decrement if the actor's area
+				; lookup is Null (mid-warp / freed zone) -- the counter
+				; is already orphaned in that case.
 				If Actor\SourceSP > -1
 					AInstance.AreaInstance = Object.AreaInstance(Actor\ServerArea)
-					AInstance\Spawned[Actor\SourceSP] = AInstance\Spawned[Actor\SourceSP] - 1
+					If AInstance <> Null
+						AInstance\Spawned[Actor\SourceSP] = AInstance\Spawned[Actor\SourceSP] - 1
+					EndIf
 					Actor\SourceSP = -1
 				EndIf
 				Actor\AIMode = AI_Pet
 			; No leader!
 			Else
-				; Assign to first available waypoint
+				; Assign to first available waypoint. If the actor's
+				; area is gone, fall through to the kill path -- there's
+				; no zone to patrol in.
 				AInstance.AreaInstance = Object.AreaInstance(Actor\ServerArea)
 				Found = False
-				For i = 0 To 249
-					If AInstance\Area\PrevWaypoint[i] <> 255
-						Actor\OldX# = Actor\X#
-						Actor\OldZ# = Actor\Z#
-						Actor\AIMode = AI_Patrol
-						Actor\DestX# = AInstance\Area\WaypointX#[i] + Rnd#(-5.0, 5.0)
-						Actor\DestZ# = AInstance\Area\WaypointZ#[i] + Rnd#(-5.0, 5.0)
-						Actor\CurrentWaypoint = i
-						Found = True
-						Exit
-					EndIf
-				Next
-				; Die
+				If AInstance <> Null And AInstance\Area <> Null
+					For i = 0 To 249
+						If AInstance\Area\PrevWaypoint[i] <> 255
+							Actor\OldX# = Actor\X#
+							Actor\OldZ# = Actor\Z#
+							Actor\AIMode = AI_Patrol
+							Actor\DestX# = AInstance\Area\WaypointX#[i] + Rnd#(-5.0, 5.0)
+							Actor\DestZ# = AInstance\Area\WaypointZ#[i] + Rnd#(-5.0, 5.0)
+							Actor\CurrentWaypoint = i
+							Found = True
+							Exit
+						EndIf
+					Next
+				EndIf
+				; Die if no waypoint available (or area is gone)
 				If Found = False Then KillActor(Actor, Null)
 			EndIf
 		EndIf


### PR DESCRIPTION
## Summary
[`BVM_SETLEADER`](src/Modules/ScriptingCommands.bb#L846) derefs `Object.AreaInstance(Actor\ServerArea)` at two sites:

1. **Set-pet branch** ([line ~863](src/Modules/ScriptingCommands.bb#L863)): decrement the old spawn-count slot.
2. **Clear-leader-with-no-pet branch** ([line ~871](src/Modules/ScriptingCommands.bb#L871)): iterate waypoints to assign a patrol target.

Both fail unguarded if `Actor\ServerArea` is stale (mid-warp, freed zone). Mirror the `GameServer.bb` Null-guard pattern from PRs [#154](https://github.com/RydeTec/rcce2/pull/154) / [#155](https://github.com/RydeTec/rcce2/pull/155):

- **Spawn-count decrement**: skip if `AInstance` is Null (counter is already orphaned).
- **Waypoint patrol**: skip the waypoint search if `AInstance` / `Area` is Null. The existing "Die" fallback path then runs, which is the correct outcome for an orphaned actor.

## Test plan
- [x] `compile.bat -t` builds Server / Client / GUE / Project Manager cleanly.
- [ ] Script: `SETLEADER(actor, 0)` on an actor whose `ServerArea` is stale: no crash; the existing kill-fallback fires.
- [ ] Sanity: `SETLEADER(actor, player)` on a live actor + player still establishes the pet relationship cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)