### PR TITLE
Bound LoadCEMesh string reads against corrupted .RCE files

### DIFF
--- a/src/Modules/CharacterEditorLoader.bb
+++ b/src/Modules/CharacterEditorLoader.bb
@@ -42,10 +42,14 @@ Function LoadCEMesh(ThisID, IdleStart, IdleEnd)
         Shine# = ReadFloat#(f)
         Alpha# = ReadFloat#(f)
 
-        NewTex$ = ReadString$(f)
-        NSphereMap$ = ReadString$(f)
-		Bone$ = ReadString$(F)
-		Name$ = ReadString$(F)
+        ; Bound length-prefixed strings against corrupted .RCE files.
+        ; 260 = Windows MAX_PATH covers any realistic texture / mesh / bone
+        ; name. Same shape as the broader data-loader sweep
+        ; (PRs #149 / #156 / #160 / #161 / #162 / #171).
+        NewTex$ = ReadBoundedString$(f, 260)
+        NSphereMap$ = ReadBoundedString$(f, 260)
+		Bone$ = ReadBoundedString$(F, 64)
+		Name$ = ReadBoundedString$(F, 256)
 
 		EN = GetMesh(ID)
 		If EN <> -1


### PR DESCRIPTION
## Summary
[`LoadCEMesh`](src/Modules/CharacterEditorLoader.bb#L12) walks a character-editor `.RCE` file reading 4 strings per body-part record: `NewTex$` / `NSphereMap$` (texture paths) + `Bone$` (joint name) + `Name$` (part name). All were on unguarded `ReadString$`.

A corrupted or tampered `.RCE` with a wild `ReadInt` length prefix on any string would hang the Client / GUE / Gubbin Tool at character-mesh-load time allocating gigabytes — typical trigger: a mod or update that shipped a partially-written `.RCE`.

Route through `ReadBoundedString$` with caps matching the established data-loader sweep conventions:
- **260** (Windows `MAX_PATH`) for the two texture paths.
- **64** for bone joint names (`"Head"`, `"Chest"`, etc.).
- **256** for the body-part display name.

`CharacterEditorLoader.bb` is included by `Client.bb` / `GUE.bb` / `Gubbin Tool.bb` — all three include `Logging.bb`, so `ReadBoundedString$` resolves cleanly without needing the Tools-safe local-helper pattern that `Media.bb` uses ([#157](https://github.com/RydeTec/rcce2/pull/157)).

## Test plan
- [x] Full `compile.bat` builds Server / Client / GUE / Project Manager + all Tools cleanly.
- [ ] Normal `.RCE` load (sample-project character) unchanged.
- [ ] Hex-edit a `NewTex$` length prefix to `999999`: client logs the rejection, that part loads with `NewTex$ = ""` (texture not applied), other parts still parse.

🤖 Generated with [Claude Code](https://claude.com/claude-code)