### PR TITLE
docs: note Reconnect dialog Phase 1 progress in INTENT.md

### DIFF
--- a/.claude/INTENT.md
+++ b/.claude/INTENT.md
@@ -42,7 +42,7 @@ A new RCCE developer should be able to:
 
 These are the bigger improvements still worth doing. Not every PR, but worth carrying in mind:
 
-- **Reconnect dialog** instead of `RuntimeError(LS_LostConnection)` — keep the player and their state across network blips.
+- **Reconnect dialog** instead of `RuntimeError(LS_LostConnection)` — keep the player and their state across network blips. *Phase 1 landed: all 12 `RuntimeError(LS_LostConnection)` call sites now route through a single `OnLostConnection()` helper in `ClientNet.bb` (PR #153). Phase 2 (replace the helper body with a non-fatal reconnect dialog) and phase 3 (RakNet rebind + session resume) still pending.*
 - **Modern UI dispatch tables** — replace the giant `Select Case PacketType` and BVM opcode switch with `FunctionPtr[256]` dispatch tables for clarity and extensibility.
 - **HUDPanel inheritance hierarchy** — collapse the 16 free-standing `GY_Create*` windows into typed panels using BlitzForge inheritance.
 - **AI state-machine subtypes** — turn the 180-line `If/ElseIf AIMode = ...` switch into `Type AIState` subtypes with a `Tick` method.


### PR DESCRIPTION
## Summary
[`INTENT.md`](.claude/INTENT.md) listed the Reconnect dialog as a long-horizon item without status. Phase 1 — consolidating the 12 `RuntimeError(LS_LostConnection)` call sites behind a single `OnLostConnection()` helper — landed in [#153](https://github.com/RydeTec/secce2/pull/153) and is the precondition for the substantive UI / state-resume phases to follow without re-finding every disconnect path.

Reflect that in the `INTENT` entry so a future contributor surveying the long-horizon list can see what's been done and what remains.

## Test plan
- [x] Docs-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)