### PR TITLE
Guard UpdateCharInteractionWindow divide-by-zero + faction index OOB

### DIFF
--- a/src/Modules/Interface3D.bb
+++ b/src/Modules/Interface3D.bb
@@ -3158,11 +3158,25 @@ End Function
 
 Function UpdateCharInteractionWindow()
 	If CharInteract = Null Then Return
-	
+
 	Local AI.ActorInstance = CharInteract
-	HealthVal = (Float#(AI\Attributes\Value[HealthStat]) / Float#(AI\Attributes\Maximum[HealthStat])) * 500.0
+	; Guard divide-by-zero. An actor with HealthStat\Maximum = 0
+	; (misconfigured template, ghost / immortal NPC, or a target whose
+	; Maximum got zeroed mid-session) would otherwise crash the client
+	; the moment its info window updates -- this runs every frame the
+	; window is open. Fall back to a full bar so the UI stays usable.
+	Local HealthMax = AI\Attributes\Maximum[HealthStat]
+	If HealthMax > 0
+		HealthVal = (Float#(AI\Attributes\Value[HealthStat]) / Float#(HealthMax)) * 500.0
+	Else
+		HealthVal = 500.0
+	EndIf
 	GY_UpdateProgressBar( SCharInteractHealth, HealthVal )
-	GY_UpdateLabel( LCharInteractFaction, LanguageString$(LS_Faction) + " " + FactionNames$(AI\HomeFaction) )
+	; HomeFaction is Dim'd 0..99; bound the array read so a misconfigured
+	; HomeFaction value can't read past the end into adjacent memory.
+	Local FactionIdx = AI\HomeFaction
+	If FactionIdx < 0 Or FactionIdx > 99 Then FactionIdx = 0
+	GY_UpdateLabel( LCharInteractFaction, LanguageString$(LS_Faction) + " " + FactionNames$(FactionIdx) )
 	GY_UpdateLabel( LCharInteractLevel, LanguageString$(LS_Level) + " " + AI\Level )
 	GY_UpdateLabel( LCharInteractReputation, LanguageString$(LS_Reputation) + " " + AI\Reputation )
 


### PR DESCRIPTION
## Summary
[`UpdateCharInteractionWindow`](src/Modules/Interface3D.bb#L3159) runs every frame the target info window is open. Two failure modes crashed the client on a misconfigured or corrupted target actor:

1. **`AI\Attributes\Maximum[HealthStat] = 0`** — divide-by-zero in the health-bar percentage calculation. Triggered by ghost / immortal NPCs, mid-session stat zeroing, or a corrupted actor template. Fall back to a full bar so the UI stays usable.
2. **`AI\HomeFaction` outside `0..99`** — read past the `FactionNames$` array (`Dim`'d `0..99`) into adjacent memory. Triggered by a corrupted character save or a script that wrote an out-of-range faction value. Clamp to `0` (the default faction) for the display.

Same defense-in-depth shape as other every-frame client hot-path guards (PRs [#144](https://github.com/RydeTec/rcce2/pull/144) / [#169](https://github.com/RydeTec/rcce2/pull/169)).

## Test plan
- [x] `compile.bat -t` builds Server / Client / GUE / Project Manager cleanly.
- [ ] Target an actor with `Maximum[HealthStat] = 0` (via GUE Actor editor): info window shows a full bar instead of crashing.
- [ ] Target an actor with `HomeFaction = 250`: info window shows faction 0's name instead of crashing on the array OOB.

🤖 Generated with [Claude Code](https://claude.com/claude-code)