### PR TITLE
Guard divide-by-zero in CharInteract create + HUD attribute displays

### DIFF
--- a/src/Modules/Interface3D.bb
+++ b/src/Modules/Interface3D.bb
@@ -2906,11 +2906,17 @@ EndIf
 	EndIf
 	;***********************************************************************************************
 
-	; Attribute displays
+	; Attribute displays. Guard divide-by-zero on Me\Attributes\Maximum
+	; -- this loop runs every frame; a single attribute with Maximum=0
+	; (mid-session stat reload, corrupted save, or a script that wrote 0)
+	; otherwise crashes the client on the next HUD update tick.
 	For i = 0 To 39
 		If AttributeDisplays(i)\Component <> 0
-			GY_UpdateProgressBar(AttributeDisplays(i)\Component, (Float#(Me\Attributes\Value[i]) / Float#(Me\Attributes\Maximum[i])) * 100.0)
-			GY_UpdateLabel(AttributeDisplayNumbers(i), Str$(Me\Attributes\Value[i]) + " / " + Str$(Me\Attributes\Maximum[i]))	
+			Local AttrMax = Me\Attributes\Maximum[i]
+			Local AttrBar# = 0.0
+			If AttrMax > 0 Then AttrBar# = (Float#(Me\Attributes\Value[i]) / Float#(AttrMax)) * 100.0
+			GY_UpdateProgressBar(AttributeDisplays(i)\Component, AttrBar#)
+			GY_UpdateLabel(AttributeDisplayNumbers(i), Str$(Me\Attributes\Value[i]) + " / " + Str$(Me\Attributes\Maximum[i]))
 		EndIf
 	Next
 
@@ -3142,9 +3148,19 @@ Function CreateCharInteractionWindow(AI.ActorInstance)
 		WCharInteract = GY_CreateWindow(Name$, 0.60, 0.03, 0.27, 0.15, True, True, False, LoadTexture("Data\Textures\GUI\PartyBG.png"))
 	EndIf
 	GY_CreateLabel(WCharInteract, 0.05, 0.1, AttributeNames$(HealthStat) + ":")
-	HealthVal = (Float#(AI\Attributes\Value[HealthStat]) / Float#(AI\Attributes\Maximum[HealthStat])) * 500.0
+	; Same divide-by-zero + faction-OOB guards as UpdateCharInteractionWindow
+	; (PR #179) -- the create path computes the initial values from the
+	; same fields and crashes on the same shape of bad input.
+	Local CharCreateHealthMax = AI\Attributes\Maximum[HealthStat]
+	If CharCreateHealthMax > 0
+		HealthVal = (Float#(AI\Attributes\Value[HealthStat]) / Float#(CharCreateHealthMax)) * 500.0
+	Else
+		HealthVal = 500.0
+	EndIf
 	SCharInteractHealth = GY_CreateProgressBar(WCharInteract, 0.3, 0.1, 0.6, 0.18, HealthVal, 500, 255, 0, 0)
-	LCharInteractFaction = GY_CreateLabel(WCharInteract, 0.05, 0.35, LanguageString$(LS_Faction) + " " + FactionNames$(AI\HomeFaction))
+	Local CharCreateFactionIdx = AI\HomeFaction
+	If CharCreateFactionIdx < 0 Or CharCreateFactionIdx > 99 Then CharCreateFactionIdx = 0
+	LCharInteractFaction = GY_CreateLabel(WCharInteract, 0.05, 0.35, LanguageString$(LS_Faction) + " " + FactionNames$(CharCreateFactionIdx))
 	LCharInteractLevel = GY_CreateLabel(WCharInteract, 0.05, 0.55, LanguageString$(LS_Level) + " " + AI\Level)
 	LCharInteractReputation = GY_CreateLabel(WCharInteract, 0.05, 0.75, LanguageString$(LS_Reputation) + " " + AI\Reputation)
 


### PR DESCRIPTION
## Summary
Two more every-frame client crashes from a zero `Maximum` attribute:

1. **`CreateCharInteractionWindow`** ([line ~3145](src/Modules/Interface3D.bb#L3145)) — same divide-by-zero + `FactionNames$` OOB shapes as the `Update` path fixed in [#179](https://github.com/RydeTec/rcce2/pull/179). The create path computes the initial bar value once when the window pops; same fields, same crash.

2. **HUD attribute display loop** ([line ~2912](src/Modules/Interface3D.bb#L2912)) — runs every frame the HUD is rendered, iterates all 40 attribute slots, and divides `Value[i] / Maximum[i]` on each. A single attribute with `Maximum=0` (mid-session stat reload, corrupted save, or a script that wrote 0) crashes the client on the next HUD tick. Fall back to a 0% bar.

Same defense-in-depth shape as #179.

## Test plan
- [x] `compile.bat -t` builds Server / Client / GUE / Project Manager cleanly.
- [ ] Set `Me\Attributes\Maximum[5] = 0` via a script: HUD shows attribute 5's bar at 0% instead of crashing.
- [ ] Right-click an actor whose `Maximum[HealthStat] = 0`: info window pops with a full bar, no crash.

🤖 Generated with [Claude Code](https://claude.com/claude-code)