### PR TITLE
Guard divide-by-zero on SpeedStat Maximum in client + server movement

### DIFF
--- a/src/Client.bb
+++ b/src/Client.bb
@@ -556,8 +556,16 @@ Function UpdateActorInstances()
 ;						EndIf
 ;					EndIf
 
-					; Calculate speed
-					Speed# = 1.5 * (Float#(AI\Attributes\Value[SpeedStat]) / Float#(AI\Attributes\Maximum[SpeedStat])) * Delta#  ; the delta makes the character move at the same speed when the fps rate drops
+					; Calculate speed. Guard divide-by-zero on SpeedStat
+					; Maximum (misconfigured actor template, mid-session
+					; cap zeroing, corrupted save). Fall back to a full-
+					; speed ratio so the actor still moves; same shape as
+					; the GameServer.bb authoritative-move guard.
+					If AI\Attributes\Maximum[SpeedStat] > 0
+						Speed# = 1.5 * (Float#(AI\Attributes\Value[SpeedStat]) / Float#(AI\Attributes\Maximum[SpeedStat])) * Delta#  ; the delta makes the character move at the same speed when the fps rate drops
+					Else
+						Speed# = 1.5 * Delta#
+					EndIf
 					If AI\IsRunning = True
 						Speed# = Speed# * 2.0
 					ElseIf AI\WalkingBackward = True

--- a/src/Modules/GameServer.bb
+++ b/src/Modules/GameServer.bb
@@ -670,12 +670,25 @@ Function UpdateActorInstances(Broadcast)
 				Next
 			EndIf
 
-			; Move (except mounts)
+			; Move (except mounts). Guard divide-by-zero on SpeedStat
+			; Maximum: a misconfigured actor template (or a script that
+			; zeroed the cap mid-session) would otherwise crash the
+			; per-tick movement update for every actor in the world.
+			; Fall back to a full-speed ratio (1.0) so the actor still
+			; moves; speed-tuning content is a softer failure mode.
 			If AI\Rider = Null
 				If AI\Mount = Null
-					Speed# = 1.5 * (Float#(AI\Attributes\Value[SpeedStat]) / Float#(AI\Attributes\Maximum[SpeedStat]))
+					If AI\Attributes\Maximum[SpeedStat] > 0
+						Speed# = 1.5 * (Float#(AI\Attributes\Value[SpeedStat]) / Float#(AI\Attributes\Maximum[SpeedStat]))
+					Else
+						Speed# = 1.5
+					EndIf
 				Else
-					Speed# = 1.5 * (Float#(AI\Mount\Attributes\Value[SpeedStat]) / Float#(AI\Mount\Attributes\Maximum[SpeedStat]))
+					If AI\Mount\Attributes\Maximum[SpeedStat] > 0
+						Speed# = 1.5 * (Float#(AI\Mount\Attributes\Value[SpeedStat]) / Float#(AI\Mount\Attributes\Maximum[SpeedStat]))
+					Else
+						Speed# = 1.5
+					EndIf
 				EndIf
 				If AI\WalkingBackward = True Then Speed# = Speed# / 2.0
 				If AI\IsRunning = True


### PR DESCRIPTION
## Summary
`Client.bb`'s render-tick mover and `GameServer.bb`'s authoritative `UpdateActorInstances` both compute `Speed# = 1.5 * Value / Maximum` on `SpeedStat`. If `Maximum` is 0 (misconfigured actor template, mid-session cap zeroing, corrupted save), **both crash per-frame on the divide**.

| Site | When |
|---|---|
| [`Client.bb:560`](src/Client.bb#L560) | Per-frame render-side actor movement |
| [`GameServer.bb:676`](src/Modules/GameServer.bb#L676) | Authoritative AI movement (regular actor) |
| [`GameServer.bb:678`](src/Modules/GameServer.bb#L678) | Authoritative AI movement (mount) |

Mirror the existing guard pattern from [`ServerNet.bb`'s P_StandardUpdate speed-hack clamp](src/Modules/ServerNet.bb#L1592) (which already had this check from [#142](https://github.com/RydeTec/rcce2/pull/142)'s neighborhood). Fall back to a full-speed ratio (`Speed# = 1.5 [* Delta#]`) so the actor still moves — speed tuning is a softer failure mode than a crash loop.

Same defense-in-depth shape as PRs [#179](https://github.com/RydeTec/rcce2/pull/179) / [#180](https://github.com/RydeTec/rcce2/pull/180) (CharInteract divide-by-zero / faction OOB).

## Test plan
- [x] `compile.bat -t` builds Server / Client / GUE / Project Manager cleanly.
- [ ] Spawn an actor with `Attributes\Maximum[SpeedStat] = 0` in GUE: actor moves at base speed instead of crashing the per-tick update.
- [ ] Sanity: actors with normal Maximum (typical ~100) move at expected speeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)