### PR TITLE
Null-guard AreaInstance in UpdateAttribute / UpdateAttributeMax / UpdateReputation

### DIFF
--- a/src/Server.bb
+++ b/src/Server.bb
@@ -933,14 +933,16 @@ Function UpdateAttribute(AI.ActorInstance, Att, Value)
 	If AI\Attributes\Value[Att] > AI\Attributes\Maximum[Att]
 		AI\Attributes\Value[Att] = AI\Attributes\Maximum[Att]
 	EndIf
-	If AI\RNID > 0 Or AI\RNID = -1 
+	If AI\RNID > 0 Or AI\RNID = -1
 		Pa$ = "A" + RCE_StrFromInt$(AI\RuntimeID, 2) + RCE_StrFromInt$(Att, 1) + RCE_StrFromInt$(AI\Attributes\Value[Att], 2)
 		AInstance.AreaInstance = Object.AreaInstance(AI\ServerArea)
-		A2.ActorInstance = AInstance\FirstInZone
-		While A2 <> Null
-			If A2\RNID > 0 Then RCE_Send(Host, A2\RNID, P_StatUpdate, Pa$, True)
-			A2 = A2\NextInZone
-		Wend
+		If AInstance <> Null
+			A2.ActorInstance = AInstance\FirstInZone
+			While A2 <> Null
+				If A2\RNID > 0 Then RCE_Send(Host, A2\RNID, P_StatUpdate, Pa$, True)
+				A2 = A2\NextInZone
+			Wend
+		EndIf
 	EndIf
 End Function
 
@@ -948,14 +950,16 @@ End Function
 Function UpdateAttributeMax(AI.ActorInstance, Att, Value)
 	AI\Attributes\Maximum[Att] = Value
 
-	If AI\RNID > 0 Or AI\RNID = -1 
+	If AI\RNID > 0 Or AI\RNID = -1
 		Pa$ = "M" + RCE_StrFromInt$(AI\RuntimeID, 2) + RCE_StrFromInt$(Att, 1) + RCE_StrFromInt$(Value, 2)
 		AInstance.AreaInstance = Object.AreaInstance(AI\ServerArea)
-		A2.ActorInstance = AInstance\FirstInZone
-		While A2 <> Null
-			If A2\RNID > 0 Then RCE_Send(Host, A2\RNID, P_StatUpdate, Pa$, True)
-			A2 = A2\NextInZone
-		Wend
+		If AInstance <> Null
+			A2.ActorInstance = AInstance\FirstInZone
+			While A2 <> Null
+				If A2\RNID > 0 Then RCE_Send(Host, A2\RNID, P_StatUpdate, Pa$, True)
+				A2 = A2\NextInZone
+			Wend
+		EndIf
 	EndIf
 End Function
 
@@ -966,10 +970,12 @@ Function UpdateReputation(AI.ActorInstance, Value)
 	If AI\RNID > 0
 		Pa$ = "R" + RCE_StrFromInt$(AI\RuntimeID, 2) + RCE_StrFromInt$(Value, 2)
 		AInstance.AreaInstance = Object.AreaInstance(AI\ServerArea)
-		A2.ActorInstance = AInstance\FirstInZone
-		While A2 <> Null
-			If A2\RNID > 0 Then RCE_Send(Host, A2\RNID, P_StatUpdate, Pa$, True)
-			A2 = A2\NextInZone
-		Wend
+		If AInstance <> Null
+			A2.ActorInstance = AInstance\FirstInZone
+			While A2 <> Null
+				If A2\RNID > 0 Then RCE_Send(Host, A2\RNID, P_StatUpdate, Pa$, True)
+				A2 = A2\NextInZone
+			Wend
+		EndIf
 	EndIf
 End Function


### PR DESCRIPTION
## Summary
Three server-side broadcast helpers in `Server.bb` propagate stat changes to everyone in an actor's zone:

| Helper | Packet |
|---|---|
| [`UpdateAttribute`](src/Server.bb#L931) | `P_StatUpdate "A"` |
| [`UpdateAttributeMax`](src/Server.bb#L948) | `P_StatUpdate "M"` |
| [`UpdateReputation`](src/Server.bb#L963) | `P_StatUpdate "R"` |

Each was the same unguarded `AInstance.AreaInstance = ...` then immediate `A2 = AInstance\FirstInZone` pattern. Triggered from any state mutator (combat XP, script-driven stat changes, buff expiry, etc.) — if the affected actor's `ServerArea` is stale (mid-warp, freed zone), the broadcast loop crashes the server.

Same recovery: skip the broadcast on Null. The state mutation already happened in-memory; only the network propagation drops.

Continues the AInstance-Null sweep across rcce2.

## Test plan
- [x] `compile.bat -t` builds Server / Client / GUE / Project Manager cleanly.
- [ ] Trigger a stat mutation on an actor mid-warp (e.g. script-driven `SETATTRIBUTE` immediately after `WARP`) — state change applies in-memory, no broadcast crash.
- [ ] Sanity: in-zone players still receive `P_StatUpdate` packets correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)