### PR TITLE
Null-guard AreaInstance in Server.bb players-list + portals/triggers per-tick

### DIFF
--- a/src/Server.bb
+++ b/src/Server.bb
@@ -355,7 +355,7 @@ Repeat
 					For AI.ActorInstance = Each ActorInstance
 						If AI\RNID > 0
 							AInstance.AreaInstance = Object.AreaInstance(AI\ServerArea)
-							If AInstance\Area = GameArea
+							If AInstance <> Null And AInstance\Area = GameArea
 								If AI\Name$ + " (" + AInstance\ID + ")" = Name$
 									DataAux$ = RCE_StrFromInt(AI\RNID)
 									RCE_FSend(0, RCE_PlayerKicked, DataAux$, True, Len(DataAux$))
@@ -397,7 +397,7 @@ Repeat
 				For AI.ActorInstance = Each ActorInstance
 					If AI\RNID > 0
 						AInstance.AreaInstance = Object.AreaInstance(AI\ServerArea)
-						If AInstance\Area = GameArea
+						If AInstance <> Null And AInstance\Area = GameArea
 							AddListBoxItem(Game\PlayersList, AI\Name$ + " (" + AInstance\ID + ")")
 						EndIf
 					EndIf
@@ -570,7 +570,7 @@ Repeat
 				For AI.ActorInstance = Each ActorInstance
 					If AI\RuntimeID > -1 And AI\RNID > 0
 						AInstance.AreaInstance = Object.AreaInstance(AI\ServerArea)
-						If AInstance\Area = UpdateArea
+						If AInstance <> Null And AInstance\Area = UpdateArea
 							; Portals
 							For i = 0 To 99
 								If Len(UpdateArea\PortalName$[i]) > 0


### PR DESCRIPTION
## Summary
Three more sites in `Server.bb` dereferenced `AInstance\Area` without checking `AInstance` for Null:

| Site | Trigger |
|---|---|
| [Line ~357](src/Server.bb#L357) — Players list "Kick" button | Iterating live players to match against a clicked list entry |
| [Line ~399](src/Server.bb#L399) — Players list refresh | Same iteration |
| [Line ~572](src/Server.bb#L572) — Per-area portal + trigger update loop | Every-tick iteration of all actors in every area |

All three crash the server when an actor's `ServerArea` is stale (mid-warp, freed zone). The portal/trigger one is the worst — it's an every-tick world-update loop, so a single stale `ServerArea` is a one-tick server-wide crash.

All three: `And AInstance <> Null` short-circuited before the `\Area` deref. The actor's per-tick work still gets covered the next tick once `SetArea` re-establishes the zone link.

Continues the AInstance-Null sweep ([#154](https://github.com/RydeTec/secce2/pull/154) / [#155](https://github.com/RydeTec/secce2/pull/155) / [#176](https://github.com/RydeTec/secce2/pull/176) / [#182](https://github.com/RydeTec/secce2/pull/182) / [#183](https://github.com/RydeTec/secce2/pull/183) / [#184](https://github.com/RydeTec/secce2/pull/184) / [#185](https://github.com/RydeTec/secce2/pull/185) / [#186](https://github.com/RydeTec/secce2/pull/186) / [#187](https://github.com/RydeTec/secce2/pull/187)).

## Test plan
- [x] `compile.bat -t` builds Server / Client / GUE / Project Manager cleanly.
- [ ] Force a `SetArea`-in-progress race condition on a player and click "Kick" in the server window — server logs (well, doesn't crash); the kick either fires on the next tick or the player completes their warp.
- [ ] Sanity: normal kicks and players-list refresh work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)