### PR TITLE
Guard divide-by-zero on Sun PathLength in per-tick render

### DIFF
--- a/src/Modules/Environment3D.bb
+++ b/src/Modules/Environment3D.bb
@@ -467,13 +467,22 @@ Next
 				UnloadTexture(S\TexID[S\CurrentPhase])	
 			EndIf
 					
-			; Sun position
+			; Sun position. Guard divide-by-zero on PathLength: a sun
+			; configured with the same Start and End time for the
+			; current season (zero-duration phase, often a placeholder
+			; in custom content) would otherwise crash the client on
+			; every render tick. Treat zero-duration as "no path" and
+			; pin the sun at its start position.
 			ShowEntity(S\EN)
 			PathLength = TimeDelta(S\StartH[CurrentSeason], S\StartM[CurrentSeason], S\EndH[CurrentSeason], S\EndM[CurrentSeason])
 			DoneLengthM = TimeDelta(S\StartH[CurrentSeason], S\StartM[CurrentSeason], TimeH, TimeM)
 			AmountOfMinuteDone# = Float#(MilliSecs() - TimeUpdate) / Float#(60000 / TimeFactor)
 			DoneLength# = Float#(DoneLengthM) + AmountOfMinuteDone#
-			Pitch# = (DoneLength# / Float#(PathLength)) * 220.0 ;180
+			If PathLength > 0
+				Pitch# = (DoneLength# / Float#(PathLength)) * 220.0 ;180
+			Else
+				Pitch# = 0.0
+			EndIf
 			PositionEntity(S\EN, EntityX#(Cam), EntityY#(Cam) + 100, EntityZ#(Cam))
 			RotateEntity(S\EN, -Pitch#, S\PathAngle#, 0)
 			MoveEntity(S\EN, 0, 0, 100.0)


### PR DESCRIPTION
## Summary
The sun-render tick in [`Environment3D.bb`](src/Modules/Environment3D.bb#L470) computes `Pitch# = (DoneLength# / Float#(PathLength)) * 220.0`. `PathLength` is the `TimeDelta` between the sun's Start and End times for the current season. If a custom-content sun has `Start==End` for that season (a zero-duration phase, often a placeholder while the content author was setting up multi-season suns), **`PathLength = 0` and the divide crashes the client on every render tick**.

Pin `Pitch# = 0.0` (start position) when `PathLength` is 0 — the sun just doesn't move during that season-slot for that sun.

Same defense-in-depth shape as the recent `Maximum`-divide guards (PRs [#179](https://github.com/RydeTec/rcce2/pull/179) / [#180](https://github.com/RydeTec/rcce2/pull/180) / [#181](https://github.com/RydeTec/rcce2/pull/181)).

## Test plan
- [x] `compile.bat -t` builds Server / Client / GUE / Project Manager cleanly.
- [ ] Configure a sun in GUE with `StartH=12 StartM=0 EndH=12 EndM=0` for season 0, then enter the world during season 0: client renders the sun at its start position without crashing.
- [ ] Sanity: normal sun arcs render unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)