### PR TITLE
Guard divide-by-zero on ProgressBar Max in GY_UpdateProgressBar

### DIFF
--- a/src/Modules/Gooey.bb
+++ b/src/Modules/Gooey.bb
@@ -2022,7 +2022,15 @@ Function GY_UpdateProgressBar(GHandle, Value)
 
 	If Value > P\Max Then Value = P\Max
 	P\Value = Value
-	ScaleEntity(P\BarEN, Float#(Value) / Float#(P\Max) - 0.02, 1.0, 1.0) ; DEFINITION OF STUPID.......
+	; Guard divide-by-zero on Max. A caller can create a bar with Max=0
+	; (placeholder UI, dynamic re-cap) and any later UpdateProgressBar
+	; call would crash on this every-frame ScaleEntity. Pin to an empty
+	; bar (-0.02 matches the original 0-Value rendering offset).
+	If P\Max > 0
+		ScaleEntity(P\BarEN, Float#(Value) / Float#(P\Max) - 0.02, 1.0, 1.0) ; DEFINITION OF STUPID.......
+	Else
+		ScaleEntity(P\BarEN, -0.02, 1.0, 1.0)
+	EndIf
 
 	Return True
 


### PR DESCRIPTION
## Summary
[`GY_UpdateProgressBar`](src/Modules/Gooey.bb#L2015) scales the bar entity by `Value / Max` on every call. A caller that creates a progress bar with `Max=0` (placeholder UI, dynamic re-cap that left `Max` unset, or a UI authoring bug) would crash the client every time the update is invoked — e.g. an attribute bar tied to a stat whose `Maximum` got zeroed.

Pin to an empty bar (`-0.02` matches the original 0-Value rendering offset) when `Max <= 0`. Better than a crash; UI shows the bar empty until `Max` is fixed.

Same defense-in-depth shape as the per-frame `Maximum` guards in PRs [#179](https://github.com/RydeTec/rcce2/pull/179) / [#180](https://github.com/RydeTec/rcce2/pull/180) / [#181](https://github.com/RydeTec/rcce2/pull/181) / [#190](https://github.com/RydeTec/rcce2/pull/190).

## Test plan
- [x] Full `compile.bat` builds Server / Client / GUE / Project Manager + all Tools cleanly.
- [ ] Create a progress bar with `GY_CreateProgressBar(..., Value=0, Max=0)` and call `GY_UpdateProgressBar(handle, 5)`: bar renders empty instead of crashing.
- [ ] Sanity: normal progress-bar updates with Max>0 unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)