### PR TITLE
Clamp XDivs/ZDivs floor in CreateSubdividedPlane to avoid divide-by-zero

### DIFF
--- a/src/Modules/ClientAreas.bb
+++ b/src/Modules/ClientAreas.bb
@@ -91,6 +91,15 @@ End Type
 ; Creates a subdivided plane (used for water)
 Function CreateSubdividedPlane(XDivs, ZDivs, UScale# = 1.0, VScale# = 1.0, Parent = 0)
 
+	; Clamp divisions to a sane minimum. A water with ScaleX or ScaleZ
+	; below the Ceil/15.0 threshold (or a misconfigured area data file)
+	; would arrive here with XDivs / ZDivs = 1, then divide-by-zero on
+	; the XPos / ZPos normalization below. Below 2 there's no actual
+	; subdivision; force at least a 2x2 grid so the mesh has a real
+	; surface and the normalization divisor is non-zero.
+	If XDivs < 2 Then XDivs = 2
+	If ZDivs < 2 Then ZDivs = 2
+
 	EN = CreateMesh(Parent)
 	Surf = CreateSurface(EN)
 

--- a/src/Modules/ClientAreasTE.bb
+++ b/src/Modules/ClientAreasTE.bb
@@ -80,6 +80,12 @@ End Type
 ; Creates a subdivided plane (used for water)
 Function CreateSubdividedPlane(XDivs, ZDivs, UScale# = 1.0, VScale# = 1.0, Parent = 0)
 
+	; Clamp divisions to a sane minimum (see ClientAreas.bb for the
+	; full reasoning). XDivs/ZDivs of 1 would divide-by-zero on the
+	; XPos/ZPos normalization. Below 2 has no actual subdivision.
+	If XDivs < 2 Then XDivs = 2
+	If ZDivs < 2 Then ZDivs = 2
+
 	EN = CreateMesh(Parent)
 	Surf = CreateSurface(EN)
 

--- a/src/Modules/ClientAreas_FE.bb
+++ b/src/Modules/ClientAreas_FE.bb
@@ -101,6 +101,12 @@ End Type
 ; Creates a subdivided plane (used for water)
 Function CreateSubdividedPlane(XDivs, ZDivs, UScale# = 1.0, VScale# = 1.0, Parent = 0)
 
+	; Clamp divisions to a sane minimum (see ClientAreas.bb for the
+	; full reasoning). XDivs/ZDivs of 1 would divide-by-zero on the
+	; XPos/ZPos normalization. Below 2 has no actual subdivision.
+	If XDivs < 2 Then XDivs = 2
+	If ZDivs < 2 Then ZDivs = 2
+
 	EN = CreateMesh(Parent)
 	Surf = CreateSurface(EN)
 


### PR DESCRIPTION
## Summary
Three sibling water-plane builders (`ClientAreas.bb`, `ClientAreas_FE.bb`, `ClientAreasTE.bb`) compute mesh vertex positions with `Float#(x) / Float#(XDivs - 1)`. The callers compute `XDivs` / `ZDivs` as `Ceil(ScaleX / 15.0)` which can produce `1` for a water with `ScaleX` / `ScaleZ ≤ 15`. **`XDivs = 1` → `XDivs - 1 = 0` → divide-by-zero at area load**.

Clamp `XDivs` / `ZDivs` to at least 2 inside `CreateSubdividedPlane`. Below 2 has no actual subdivision anyway (you need 4 vertices to form a quad), so this is the right semantic floor.

**Affects**: water tiles smaller than 15 units in any dimension. Reachable content (small ponds, decorative water).

## Test plan
- [x] Full `compile.bat` builds Server / Client / GUE / Project Manager + all Tools cleanly.
- [ ] Configure a water tile in GUE with `ScaleX=5, ScaleZ=5`: client/editor renders the water (now at the minimum 2x2 subdivision) instead of crashing on area load.
- [ ] Sanity: normal-sized water tiles (`ScaleX > 15`) render unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)