### PR TITLE
Skip races with unloadable meshes in CharCreation initial preview

### DIFF
--- a/src/Modules/MainMenu.bb
+++ b/src/Modules/MainMenu.bb
@@ -2143,16 +2143,28 @@ Function CreateChar()
 		EndIf
 	Next
 
-	; Set preview to first playable actor
+	; Set preview to first playable actor whose mesh loads. Walk the
+	; Actor list looking for a candidate; if a race's mesh fails to
+	; load (corrupt mesh file, missing asset, hostile content update),
+	; skip it and try the next playable race rather than crash the
+	; entire character-creation flow on a single bad race. Only bail
+	; with a RuntimeError if NO playable race has a loadable mesh --
+	; an unrecoverable project state.
 	A.Actor = First Actor
 	If A = Null Then RuntimeError("No actors in project!")
-	While A\Playable = False
+	Preview.ActorInstance = Null
+	While A <> Null
+		If A\Playable = True
+			Preview = CreateActorInstance(A)
+			Result = LoadActorInstance3D(Preview, 1.0, False, False)
+			If Result <> False Then Exit
+			WriteLog(MainLog, "CharCreation: skipping race '" + A\Race$ + "' (mesh load failed)")
+			SafeFreeActorInstance(Preview)
+			Preview = Null
+		EndIf
 		A = After A
-		If A = Null Then RuntimeError("No playable actors in project!")
 	Wend
-	Preview.ActorInstance = CreateActorInstance(A)
-	Result = LoadActorInstance3D(Preview, 1.0, False, False)
-	If Result = False Then RuntimeError("Could not load actor mesh for " + A\Race$ + "!")
+	If Preview = Null Then RuntimeError("No playable race with a loadable mesh!")
 	PlayAnimation(Preview, 1, 0.003, Anim_Idle)
 	PositionEntity Preview\CollisionEN, 30, -(35.0 + EntityY#(Preview\EN, True)), 100
 	;HideEntity Preview\ShadowEN [###]


### PR DESCRIPTION
## Summary
[CharCreation](src/Modules/MainMenu.bb)'s "set preview to first playable actor" path crashed with `RuntimeError` if the first playable race's mesh failed to load. Triggered by:
- Corrupt mesh file shipped via update channel
- Missing asset (mesh ID points at deleted `Meshes.dat` entry)
- Race-specific mesh format incompatibility on the player's machine

Walk the `Actor` list looking for a candidate: if a race's mesh fails, log + free the partial instance + try the next playable race. Only `RuntimeError` if **no** playable race has a loadable mesh (an unrecoverable project state).

Continues the soft-fail / skip-and-recover discipline from the rest of the rcce2 hardening series.

## Follow-up
The `CRace` combo box and `BNextClass` / `BPrevClass` paths (~lines 2334, 2386, 2418) still `RuntimeError` on mesh failure — those are runtime race-switches where the right recovery is to keep the previous selection. Separate follow-up PR.

## Test plan
- [x] `compile.bat -t` builds Server / Client / GUE / Project Manager cleanly.
- [ ] Configure a playable race whose mesh ID points at a missing/corrupt mesh, place it first in `Actors.dat`: character creation skips it to the next playable race instead of crashing.
- [ ] Sanity: normal character creation with the first race's mesh loading cleanly unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)