### PR TITLE
Guard RP_SetParticleFrame against zero TexAcross / TexDown

### DIFF
--- a/src/Modules/RottParticles.bb
+++ b/src/Modules/RottParticles.bb
@@ -408,6 +408,21 @@ End Function
 ; Sets the texture frame for a particle
 Function RP_SetParticleFrame(P.RP_Particle, Frame)
 
+	; Guard divide-by-zero / mod-by-zero on TexAcross and TexDown.
+	; A misconfigured .rpc emitter config (or one corrupted in transit)
+	; with TexAcross = 0 would crash this every-frame particle update
+	; on the Frame Mod call below, and again on the Float# divides used
+	; to compute UV coordinates. Bail to a 0,0 frame so the particle
+	; still renders (full-texture UV space) but does no math.
+	If P\E\Config\TexAcross <= 0 Or P\E\Config\TexDown <= 0
+		VertexTexCoords GetSurface(P\E\MeshEN, 1), P\FirstVertex, 0.0, 1.0
+		VertexTexCoords GetSurface(P\E\MeshEN, 1), P\FirstVertex + 1, 0.0, 0.0
+		VertexTexCoords GetSurface(P\E\MeshEN, 1), P\FirstVertex + 2, 1.0, 0.0
+		VertexTexCoords GetSurface(P\E\MeshEN, 1), P\FirstVertex + 3, 1.0, 1.0
+		P\TexFrame = Frame
+		Return
+	EndIf
+
 	X = Frame Mod P\E\Config\TexAcross
 	If Frame > P\E\Config\TexAcross - 1
 		If P\E\Config\TexAcross > 1


### PR DESCRIPTION
## Summary
[`RP_SetParticleFrame`](src/Modules/RottParticles.bb#L409) computes texture UV coordinates as `1.0 / TexAcross` and `1.0 / TexDown` — both pulled from emitter config (`.rpc` files). A misconfigured config with `TexAcross = 0` (or `TexDown = 0`) crashes the particle render on every frame:
- First via `Frame Mod TexAcross` (integer mod-by-zero).
- Then via the `Float#` divides at lines 422–425.

Reachable via custom emitter content or update-channel-shipped config. Particle rendering is per-tick, so a single bad emitter is a continuous crash loop on every client that comes within view.

Early-return with a degenerate-but-rendering 0,0 UV layout (full texture space). Particle still renders; just doesn't animate the texture frame. Better than the crash.

Same defense-in-depth shape as the `Maximum`-divide guards in PRs [#179](https://github.com/RydeTec/rcce2/pull/179) / [#180](https://github.com/RydeTec/rcce2/pull/180) / [#181](https://github.com/RydeTec/rcce2/pull/181) / [#190](https://github.com/RydeTec/rcce2/pull/190) / [#191](https://github.com/RydeTec/rcce2/pull/191).

## Test plan
- [x] Full `compile.bat` builds all targets cleanly.
- [ ] Create a `.rpc` emitter config with `TexAcross = 0`: spawn one in a zone — client renders the particle in full-UV mode instead of crashing.
- [ ] Sanity: normal animated emitters (`TexAcross > 1`) animate frames correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)