### PR TITLE
Bound AI\Hair / AI\Beard against the [4]-slot Hair/Beard ID arrays

### DIFF
--- a/src/Modules/Actors3D.bb
+++ b/src/Modules/Actors3D.bb
@@ -163,6 +163,13 @@ Function SetActorHat(AI.ActorInstance, MeshID)
 		If AI\TeamID = True Then TurnEntity AI\HatEN, 0, 180, 90
 		CreateEntityEmitters(AI\HatEN)
 	Else
+		; Bound AI\Hair to the [4]-slot Hair-ID arrays (5 entries each).
+		; Hair can arrive from the wire (Asc of one byte = 0..255) or a
+		; saved character (ReadShort = 0..65535); without this guard a
+		; hostile / out-of-range value reads past MaleHairIDs/FemaleHairIDs
+		; into adjacent Actor type fields, corrupting the actor template
+		; in memory on every hair fallback for that race.
+		If AI\Hair < 0 Or AI\Hair > 4 Then Return
 		If AI\Gender = 0
 			ID = AI\Actor\MaleHairIDs[AI\Hair]
 		Else
@@ -287,8 +294,20 @@ Function LoadActorInstance3D(A.ActorInstance, Scale# = 1.0, SkipAttachments = Fa
 			UnloadTexture(A\Actor\MaleBodyIDs[BodyTex])
 		EndIf
 
-		; Beard
-		If A\Actor\BeardIDs[A\Beard] > -1 And A\Actor\BeardIDs[A\Beard] < 65535 And SkipAttachments = False
+		; Beard. Bound A\Beard against the [4]-slot BeardIDs array
+		; (5 entries). A\Beard arrives from the wire (Asc of one byte =
+		; 0..255), from a saved character (ReadShort = 0..65535), or
+		; from a script-driven SetActorBeard call; without this guard a
+		; hostile / out-of-range value reads past BeardIDs into adjacent
+		; Actor type fields. Blitz3D's And is not short-circuiting, so
+		; the bounds check has to be a separate If above the array read.
+		Local BeardOK = False
+		If A\Beard >= 0 And A\Beard <= 4
+			If A\Actor\BeardIDs[A\Beard] > -1 And A\Actor\BeardIDs[A\Beard] < 65535 And SkipAttachments = False
+				BeardOK = True
+			EndIf
+		EndIf
+		If BeardOK
 			ID = A\Actor\BeardIDs[A\Beard]
 			BeardEN = GetMesh(ID, True)
 			If BeardEN <> 0

--- a/src/Modules/ClientNet.bb
+++ b/src/Modules/ClientNet.bb
@@ -324,8 +324,15 @@ Function UpdateNetwork()
 								BeardEN = FindChild(Bonce, "Beard")
 								If BeardEN <> 0 Then FreeEntity(BeardEN)
 
-								; Apply new beard
-								If AI\Actor\BeardIDs[AI\Beard] > -1 And AI\Actor\BeardIDs[AI\Beard] < 65535
+								; Apply new beard. Same bounds + short-circuit-safe
+								; guard as the Actors3D LoadActorInstance3D path.
+								Local BeardOK = False
+								If AI\Beard >= 0 And AI\Beard <= 4
+									If AI\Actor\BeardIDs[AI\Beard] > -1 And AI\Actor\BeardIDs[AI\Beard] < 65535
+										BeardOK = True
+									EndIf
+								EndIf
+								If BeardOK
 									ID = AI\Actor\BeardIDs[AI\Beard]
 									BeardEN = GetMesh(ID, True)
 									If BeardEN <> 0


### PR DESCRIPTION
## Summary
`SetActorHat`'s hair-fallback path ([Actors3D.bb:166](src/Modules/Actors3D.bb#L166)), the `LoadActorInstance3D` beard-attach path ([Actors3D.bb:298](src/Modules/Actors3D.bb#L298)), and the `P_AppearanceUpdate "D"` beard-change handler ([ClientNet.bb:328](src/Modules/ClientNet.bb#L328)) all indexed into `[4]`-slot arrays using `AI\Hair` / `AI\Beard` values that the client / server received **unbounded**.

## Source of out-of-range values
- **Wire**: `Asc(Right$(M\MessageData$, 1))` on the appearance-update handlers gives `0..255` directly into `AI\Hair` / `AI\Beard`.
- **Persistence**: `ReadShort` gives `0..65535`.
- **Scripts**: `BVM_SETACTORBEARD` / `SETACTORHAIR` can write any `Int`.

A value > 4 reads past the `BeardIDs[4]` / `MaleHairIDs[4]` / `FemaleHairIDs[4]` arrays into adjacent `Actor` type fields, corrupting the in-memory actor template every time the broken value is used.

## Approach
Add explicit `If x >= 0 And x <= 4` bounds checks before each index. **Blitz3D's `And` is not short-circuiting**, so the bounds and array reads are split into nested `If`s (or a `Local` flag) to ensure the array read only happens with a valid index.

## Test plan
- [x] `compile.bat -t` builds Server / Client / GUE / Project Manager cleanly.
- [ ] Send a malformed `P_AppearanceUpdate "D"` with `AI\Beard = 200`: client logs nothing (silent skip), no crash on the next render tick.
- [ ] Sanity: normal beard / hair changes (`0..4`) apply as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)