### PR TITLE
Bound appearance indices at P_CreateCharacter server-side receive

### DIFF
--- a/src/Modules/ServerNet.bb
+++ b/src/Modules/ServerNet.bb
@@ -2468,6 +2468,21 @@ Function UpdateNetwork()
 									C\Hair = RCE_IntFromStr(Mid$(M\MessageData$, Offset + 4, 1))
 									C\Beard = RCE_IntFromStr(Mid$(M\MessageData$, Offset + 5, 1))
 									C\BodyTex = RCE_IntFromStr(Mid$(M\MessageData$, Offset + 6, 1))
+									; Bound the appearance indices at the receive
+									; site. Wire bytes are 0..255 but the per-Actor
+									; Face/Body/Hair/Beard ID arrays are Field [4].
+									; Persisting out-of-range values is the long-
+									; tail bug -- the client clamps on receipt
+									; (PR #198) but storing the bad value means
+									; every login round-trip re-emits it. Clamp
+									; here so the persisted character has a valid
+									; appearance from creation. Gender clamps to
+									; 0/1; Face/Body/Hair/Beard clamp to 0..4.
+									If C\Gender < 0 Or C\Gender > 1 Then C\Gender = 0
+									If C\FaceTex < 0 Or C\FaceTex > 4 Then C\FaceTex = 0
+									If C\Hair < 0 Or C\Hair > 4 Then C\Hair = 0
+									If C\Beard < 0 Or C\Beard > 4 Then C\Beard = 0
+									If C\BodyTex < 0 Or C\BodyTex > 4 Then C\BodyTex = 0
 									C\Area$ = C\Actor\StartArea$
 									C\Gold = StartGold
 									C\Reputation = StartReputation


### PR DESCRIPTION
## Summary
`P_CreateCharacter` reads 5 single-byte appearance fields from the wire: `Gender`, `FaceTex`, `Hair`, `Beard`, `BodyTex`. Each gets stored in the new character record **unbounded** (0..255 from the byte).

The corresponding `Actor` template arrays are `Field [4]` (5 slots each for `Hair`/`Beard`/`Face`/`Body`); a stored value > 4 reads past the array when the character later logs in and the client renders or processes their appearance. [#198](https://github.com/RydeTec/rcce2/pull/198) added the **client-side** receive clamp, but the **server** stored the bad value in the persistent character record — every login round-trip re-emits it.

Clamp at the server receive site so the persisted character has a valid appearance from creation:
- `Gender` → clamp to 0..1
- `FaceTex` / `BodyTex` / `Hair` / `Beard` → clamp to 0..4

Continues the wire-input bounds discipline ([#132](https://github.com/RydeTec/rcce2/pull/132) / [#133](https://github.com/RydeTec/rcce2/pull/133) / [#197](https://github.com/RydeTec/rcce2/pull/197) / [#198](https://github.com/RydeTec/rcce2/pull/198)).

## Test plan
- [x] `compile.bat -t` builds Server / Client / GUE / Project Manager cleanly.
- [ ] Hand-craft a `P_CreateCharacter` packet with `Beard = 200`: character created with `Beard = 0` instead of stored 200; downstream login + appearance updates use the clamped value.
- [ ] Sanity: normal character creation with valid 0..4 values stores them as-is.

🤖 Generated with [Claude Code](https://claude.com/claude-code)