### PR TITLE
Bound appearance indices in ReadActorInstance load path

### DIFF
--- a/src/Modules/Actors.bb
+++ b/src/Modules/Actors.bb
@@ -370,6 +370,16 @@ Function ReadActorInstance.ActorInstance(Stream)
 	A\Hair       = ReadShort(Stream)
 	A\Beard      = ReadShort(Stream)
 	A\BodyTex    = ReadShort(Stream)
+	; Bound the appearance indices against the [4]-slot per-Actor ID
+	; arrays. Saved characters from before PR #199's P_CreateCharacter
+	; clamp (or characters created with a misbehaving client) may have
+	; out-of-range values that would OOB on every later appearance
+	; lookup. Match the same shape as the receive-time clamps.
+	If A\Gender < 0 Or A\Gender > 1 Then A\Gender = 0
+	If A\FaceTex < 0 Or A\FaceTex > 4 Then A\FaceTex = 0
+	If A\Hair < 0 Or A\Hair > 4 Then A\Hair = 0
+	If A\Beard < 0 Or A\Beard > 4 Then A\Beard = 0
+	If A\BodyTex < 0 Or A\BodyTex > 4 Then A\BodyTex = 0
 	For i = 0 To 39
 		A\Attributes\Value[i]   = ReadShort(Stream)
 		A\Attributes\Maximum[i] = ReadShort(Stream)


### PR DESCRIPTION
## Summary
`ReadActorInstance` reads `Gender` / `FaceTex` / `Hair` / `Beard` / `BodyTex` from the saved character stream as `ReadByte` / `ReadShort`. Old saves (from before [#199](https://github.com/RydeTec/rcce2/pull/199)'s `P_CreateCharacter` clamp) or saves created with a misbehaving client may carry out-of-range values that OOB-read past the per-`Actor` `[4]`-slot appearance ID arrays on every login.

Clamp at the load site so legacy / corrupt saves get repaired in memory the moment they load. Matches the receive-time clamps in PRs [#198](https://github.com/RydeTec/rcce2/pull/198) / [#199](https://github.com/RydeTec/rcce2/pull/199).

Continues the per-character appearance-bounds sweep.

## Test plan
- [x] `compile.bat -t` builds Server / Client / GUE / Project Manager cleanly.
- [ ] Hex-edit a saved character's `Beard` field in Accounts.dat to `200`: server boots, character loads with `Beard = 0`, no OOB read on next login.
- [ ] Sanity: characters with valid 0..4 values load unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)