### PR TITLE
Bound appearance indices in ActorInstanceFromString (P_NewActor / P_FetchCharacter)

### DIFF
--- a/src/Modules/Actors.bb
+++ b/src/Modules/Actors.bb
@@ -886,6 +886,16 @@ Function ActorInstanceFromString.ActorInstance(Pa$)
 	A\Hair    = RCE_IntFromStr(Mid$(Pa$, Offset + 4, 2))
 	A\BodyTex = RCE_IntFromStr(Mid$(Pa$, Offset + 6, 2))
 	A\Beard   = RCE_IntFromStr(Mid$(Pa$, Offset + 8, 2))
+	; Bound the wire-derived appearance indices. Per-Actor Face/Body/
+	; Hair/Beard ID arrays are Field [4]; an out-of-range value (server
+	; sent an unbounded byte or short, or local data drift) walks past
+	; the array. Same shape as PRs #198 / #199 / #200 for the other
+	; per-character receive sites.
+	If A\Gender < 0 Or A\Gender > 1 Then A\Gender = 0
+	If A\FaceTex < 0 Or A\FaceTex > 4 Then A\FaceTex = 0
+	If A\Hair < 0 Or A\Hair > 4 Then A\Hair = 0
+	If A\BodyTex < 0 Or A\BodyTex > 4 Then A\BodyTex = 0
+	If A\Beard < 0 Or A\Beard > 4 Then A\Beard = 0
 	A\Attributes\Value[SpeedStat] = RCE_IntFromStr(Mid$(Pa$, Offset + 10, 2))
 	A\Attributes\Maximum[SpeedStat] = RCE_IntFromStr(Mid$(Pa$, Offset + 12, 2))
 	A\Attributes\Value[HealthStat] = RCE_IntFromStr(Mid$(Pa$, Offset + 14, 2))


### PR DESCRIPTION
## Summary
`ActorInstanceFromString` parses an actor record off the wire (used by `P_NewActor` and the `P_FetchCharacter` character-list reply). It reads 2-byte fields for `FaceTex` / `Hair` / `BodyTex` / `Beard` (0..65535) and a 1-byte `Gender`. Per-`Actor` Face/Body/Hair/Beard ID arrays are `Field [4]`; an out-of-range value reads past the array on every later appearance lookup.

Add receive-time clamps matching the rest of the per-character appearance-bounds sweep (PRs [#198](https://github.com/RydeTec/rcce2/pull/198) / [#199](https://github.com/RydeTec/rcce2/pull/199) / [#200](https://github.com/RydeTec/rcce2/pull/200)). Same `Gender` 0..1, Face/Body/Hair/Beard 0..4 shape.

## Test plan
- [x] `compile.bat -t` builds Server / Client / GUE / Project Manager cleanly.
- [ ] Have a server send a `P_NewActor` with `Beard = 200` (e.g. via a hostile-server test rig): client renders the actor with `Beard = 0` instead of crashing on the next render tick.
- [ ] Sanity: normal `P_NewActor` packets with valid 0..4 values render unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)