### PR TITLE
Bound ActorList index in BVM_SPAWN and BVM_ACTORXPMULTIPLIER

### DIFF
--- a/src/Modules/ScriptingCommands.bb
+++ b/src/Modules/ScriptingCommands.bb
@@ -666,7 +666,11 @@ End Function
 Function BVM_SPAWN%(Param1%, Param2$, Param3#, Param4#, Param5#, Param6$ = "", Param7$ = "", Param8%=0)
 	; Find actor
 	ID = Param1%
-	If ID > -1
+	; ActorList is Dim'd 0..65535. Bound-check both sides before the
+	; Null check -- Blitz3D does not bounds-check Dim accesses, so a
+	; script-supplied ID of 99999 or -1 would read off the end of the
+	; array and crash the server. Same shape as P_KillActor handler.
+	If ID >= 0 And ID <= 65535
 		If ActorList(ID) <> Null
 			; Find zone
 			Name$ = Upper$(Param2$)
@@ -1871,8 +1875,13 @@ End Function
 
 Function BVM_ACTORXPMULTIPLIER%(Param1%)
 	ID = Param1%
-	If ActorList(ID) <> Null
-		Result% = ActorList(ID)\XPMultiplier
+	; ActorList is Dim'd 0..65535. Bound-check before the Null check;
+	; otherwise a script-supplied ID of -1 / 99999 would read off the
+	; end of the Dim and crash. Same shape as P_KillActor / BVM_SPAWN.
+	If ID >= 0 And ID <= 65535
+		If ActorList(ID) <> Null
+			Result% = ActorList(ID)\XPMultiplier
+		EndIf
 	EndIf
 Return Result%
 End Function


### PR DESCRIPTION
## Summary

`ActorList` is `Dim`'d 0..65535. Blitz3D does **not** bounds-check `Dim` accesses, so a script-supplied actor ID of `-1` or `99999` reads off the end and either corrupts an adjacent global or crashes the server.

Two BVM commands index `ActorList(ID)` directly from a script-supplied `Param1%`:

- `BVM_SPAWN` (line ~670) — had a `If ID > -1` lower bound but no upper bound.
- `BVM_ACTORXPMULTIPLIER` (line ~1874) — had **neither** bound.

Apply the same `>= 0 And <= 65535` pattern that the already-merged `P_KillActor` handler (`BVM_SETWAITINFO_KILL`, line ~2805) uses — its audit comment block was the template.

## Test plan

- [x] `compile.bat -t` clean
- [ ] CI green

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>