### PR TITLE
Clamp HomeFaction/DefaultFaction at every load site

### DIFF
--- a/src/Modules/Actors.bb
+++ b/src/Modules/Actors.bb
@@ -408,6 +408,13 @@ Function ReadActorInstance.ActorInstance(Stream)
 		A\NumberOfSlaves = 0
 	EndIf
 	A\HomeFaction    = ReadByte(Stream)
+	; FactionNames$ / FactionDefaultRatings are Dim'd (99) -> 0..99.
+	; A byte-wide HomeFaction can hold 100..255 (corrupt or stale save).
+	; That value flows into FactionRatings[A\HomeFaction] and
+	; FactionNames$(Actor\HomeFaction) at runtime -- both Blitz Dim
+	; reads, neither bounds-checked. Clamp at the load site so every
+	; downstream consumer can deref freely.
+	If A\HomeFaction < 0 Or A\HomeFaction > 99 Then A\HomeFaction = 0
 	For i = 0 To 99
 		A\FactionRatings[i] = ReadByte(Stream)
 	Next
@@ -683,6 +690,12 @@ Function LoadActors(Filename$)
 			A\InventorySlots = ReadInt(F)
 			A\DefaultDamageType = ReadByte(F)
 			A\DefaultFaction = ReadByte(F)
+			; DefaultFaction propagates to ActorInstance\HomeFaction
+			; (CreateActorInstance line ~510). FactionNames$ /
+			; FactionDefaultRatings are Dim'd (99). Clamp at load
+			; so a malformed Actors.dat can't poison every new
+			; ActorInstance with an OOB HomeFaction.
+			If A\DefaultFaction < 0 Or A\DefaultFaction > 99 Then A\DefaultFaction = 0
 			A\XPMultiplier = ReadInt(F)
 			A\PolyCollision = ReadByte(F)
 			Actors = Actors + 1
@@ -909,6 +922,10 @@ Function ActorInstanceFromString.ActorInstance(Pa$)
 	If HatID < 65535 Then A\Inventory\Items[SlotI_Hat] = CreateItemInstance(ItemList(HatID))
 	If ChestID < 65535 Then A\Inventory\Items[SlotI_Chest] = CreateItemInstance(ItemList(ChestID))
 	A\HomeFaction = RCE_IntFromStr(Mid$(Pa$, Offset + 26, 1))
+	; FactionNames$ / FactionDefaultRatings are Dim'd (99) -> 0..99;
+	; FactionRatings is Field[99]. A wire byte can carry 100..255.
+	; Clamp before downstream readers index either array.
+	If A\HomeFaction < 0 Or A\HomeFaction > 99 Then A\HomeFaction = 0
 	Offset = Offset + 27
 	For i = 0 To 99
 		A\FactionRatings[i] = RCE_IntFromStr(Mid$(Pa$, Offset + i, 1))

--- a/src/Modules/MainMenu.bb
+++ b/src/Modules/MainMenu.bb
@@ -1046,6 +1046,10 @@ Function LogIn()
 									A\FAnimationSet  = RCE_IntFromStr(Mid$(Pa$, Offset + 11, 2))
 									A\Scale#         = RCE_FloatFromStr#(Mid$(Pa$, Offset + 13, 4))
 									A\DefaultFaction = RCE_IntFromStr(Mid$(Pa$, Offset + 17, 1))
+									; DefaultFaction propagates to HomeFaction
+									; on every new ActorInstance. FactionNames$
+									; / FactionDefaultRatings are Dim'd (99).
+									If A\DefaultFaction < 0 Or A\DefaultFaction > 99 Then A\DefaultFaction = 0
 									Offset = Offset + 18
 									For i = 0 To 39
 										A\Attributes\Value[i] = RCE_IntFromStr(Mid$(Pa$, Offset, 2))
@@ -1784,6 +1788,11 @@ Function CharSelect()
 								Me\Level = RCE_IntFromStr(Mid$(M\MessageData$, 9, 2))
 								Me\XP = RCE_IntFromStr(Mid$(M\MessageData$, 11, 4))
 								Me\HomeFaction = RCE_IntFromStr(Mid$(M\MessageData$, 15, 1))
+								; Client-side faction tables are Dim'd (99).
+								; Wire byte can hold 100..255 -- clamp before
+								; any read of FactionRatings[Me\HomeFaction]
+								; or FactionNames$(Me\HomeFaction).
+								If Me\HomeFaction < 0 Or Me\HomeFaction > 99 Then Me\HomeFaction = 0
 								Offset = 16
 								While Offset < Len(M\MessageData$)
 									Me\Attributes\Value[AttributesDone] = RCE_IntFromStr(Mid$(M\MessageData$, Offset, 2))

--- a/src/Modules/MySQL.bb
+++ b/src/Modules/MySQL.bb
@@ -645,6 +645,11 @@ Function My_LoadActorInstance.ActorInstance(ActID, Q.Questlog, C.ActionBarData, 
 	A\Gold				= ReadSQLField(Row, "gold")
 	A\NumberOfslaves	= ReadSQLField(Row, "slaves")
 	A\HomeFaction		= ReadSQLField(Row, "homefaction")
+	; FactionNames$ / FactionDefaultRatings are Dim'd (99) and
+	; FactionRatings is Field[99]. A corrupt SQL row could carry an
+	; OOB HomeFaction; clamp at load so downstream readers can deref
+	; without bounds-checking.
+	If A\HomeFaction < 0 Or A\HomeFaction > 99 Then A\HomeFaction = 0
 	; Column is `xpbarlev` on the SaveActor side (above); the read here
 	; used to look up `xbbarlev`, which silently returned 0 on every load
 	; and made the XP bar reset to empty on relog.


### PR DESCRIPTION
## Summary

`FactionNames\$` and `FactionDefaultRatings` are `Dim`'d (99). The `ActorInstance\FactionRatings[99]` field is sized the same. The faction index that selects into those is loaded as a single byte from disk, wire, and SQL — range 0..255.

Values 100..255 silently propagate into every combat-rating decision (GameServer.bb engagement gates, NPC aggression, `BVM_HOMEFACTION\$`, `BVM_FACTIONRATING%`) and crash the server with a Blitz Dim OOB. The threat path is a malformed character save, a corrupted Actors.dat, or a hostile P_StatUpdate / P_NewActor (client side).

## Sites clamped

| Site | What's loaded | Vector |
|---|---|---|
| `ReadActorInstance` (Actors.bb ~410) | `HomeFaction` from save | local FS |
| `ActorInstanceFromString` (Actors.bb ~918) | `HomeFaction` from wire | server wire |
| `LoadActors` (Actors.bb ~692) | `DefaultFaction` on Actor template | Actors.dat (propagates to every spawned instance) |
| `MainMenu.bb ~1786` | `Me\HomeFaction` from P_StatUpdate \"B\" Block 1 | client wire |
| `MainMenu.bb ~1048` | `A\DefaultFaction` from P_NewActor | client wire |
| `MySQL.bb ~647` | `HomeFaction` from rc_characters row | SQL |

Pattern (same shape as the appearance-index clamps in #198–#203):

\`\`\`basic
If A\HomeFaction < 0 Or A\HomeFaction > 99 Then A\HomeFaction = 0
\`\`\`

## Test plan

- [x] \`compile.bat -t\` clean
- [ ] CI green

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>