### PR TITLE
Clamp MAnimationSet/FAnimationSet at every load site

### DIFF
--- a/src/Modules/Actors.bb
+++ b/src/Modules/Actors.bb
@@ -659,6 +659,14 @@ Function LoadActors(Filename$)
 			A\StartPortal$ = ReadBoundedString$(F, 256)
 			A\MAnimationSet = ReadShort(F)
 			A\FAnimationSet = ReadShort(F)
+			; AnimList is Dim'd 0..999. A ReadShort returns -32768..32767;
+			; either side of 0..999 is a Blitz Dim OOB at every PlayAnimation
+			; call (Animations.bb:44, Actors3D.bb:210, ClientNet.bb:683).
+			; A missing-set slot is already tolerated via `If A = Null Then
+			; Return`, but only after the index is in-range; clamp at load
+			; so the downstream Null check is reachable.
+			If A\MAnimationSet < 0 Or A\MAnimationSet > 999 Then A\MAnimationSet = 0
+			If A\FAnimationSet < 0 Or A\FAnimationSet > 999 Then A\FAnimationSet = 0
 			A\Scale# = ReadFloat(F)
 			A\Radius# = ReadFloat(F)
 			For i = 0 To 7  : A\MeshIDs[i] = ReadShort(F) : Next

--- a/src/Modules/MainMenu.bb
+++ b/src/Modules/MainMenu.bb
@@ -1044,6 +1044,11 @@ Function LogIn()
 									A\InventorySlots = RCE_IntFromStr(Mid$(Pa$, Offset + 7, 2))
 									A\MAnimationSet  = RCE_IntFromStr(Mid$(Pa$, Offset + 9, 2))
 									A\FAnimationSet  = RCE_IntFromStr(Mid$(Pa$, Offset + 11, 2))
+									; AnimList is Dim'd 0..999. The 2-byte wire
+									; field carries 0..65535 -- clamp before any
+									; AnimList(A\MAnimationSet) read.
+									If A\MAnimationSet < 0 Or A\MAnimationSet > 999 Then A\MAnimationSet = 0
+									If A\FAnimationSet < 0 Or A\FAnimationSet > 999 Then A\FAnimationSet = 0
 									A\Scale#         = RCE_FloatFromStr#(Mid$(Pa$, Offset + 13, 4))
 									A\DefaultFaction = RCE_IntFromStr(Mid$(Pa$, Offset + 17, 1))
 									; DefaultFaction propagates to HomeFaction


### PR DESCRIPTION
## Summary

`AnimList` is `Dim`'d 0..999. The Actor template's animation-set IDs are read as `ReadShort` (signed 16-bit, -32768..32767) on the server side and 2 bytes (0..65535) on the client wire side. Out-of-range values bypass the existing `If A = Null Then Return` soft-fail in `PlayAnimation` because the Blitz Dim OOB read errors out *before* the Null check is reached.

`PlayAnimation` runs from every-frame actor render / movement code (Animations.bb:44, Actors3D.bb:210, ClientNet.bb:683), so a single corrupt Actor template = next-frame crash.

## Sites clamped

| Site | Vector |
|---|---|
| `LoadActors` (Actors.bb ~660) | Actors.dat / on-disk template |
| `P_NewActor` handler (MainMenu.bb ~1045) | client wire receive |

## Pattern

\`\`\`basic
If A\MAnimationSet < 0 Or A\MAnimationSet > 999 Then A\MAnimationSet = 0
\`\`\`

Same shape as #198–#205.

## Test plan

- [x] `compile.bat -t` clean
- [ ] CI green

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>