### PR TITLE
Clamp WeaponDamageType / wire DamageType index against DamageTypes$ Dim

### DIFF
--- a/src/Modules/ClientNet.bb
+++ b/src/Modules/ClientNet.bb
@@ -1060,7 +1060,12 @@ Function UpdateNetwork()
 						AnimateActorAttack(Me)
 						PlayActorSound(Me, Rand(Speech_Attack1, Speech_Attack2))
 						Damage = RCE_IntFromStr(Mid$(M\MessageData$, 4, 2)) - 1
-						DType$ = DamageTypes$(RCE_IntFromStr(Mid$(M\MessageData$, 6, 1)))
+						; DamageTypes$ is Dim'd (19); wire byte is 0..255.
+						; Clamp before indexing -- avoids Blitz Dim OOB
+						; from a malformed P_AttackUpdate "H".
+						Local DTI = RCE_IntFromStr(Mid$(M\MessageData$, 6, 1))
+						If DTI < 0 Or DTI > 19 Then DTI = 0
+						DType$ = DamageTypes$(DTI)
 						; And hit them
 						If Damage > 0
 							CombatDamageOutput(A, Damage, DType$)
@@ -1083,7 +1088,12 @@ Function UpdateNetwork()
 					; Someone else attacked me
 					ElseIf Left$(M\MessageData$, 1) = "Y"
 						Damage = RCE_IntFromStr(Mid$(M\MessageData$, 4, 2)) - 1
-						DType$ = DamageTypes$(RCE_IntFromStr(Mid$(M\MessageData$, 6, 1)))
+						; DamageTypes$ is Dim'd (19); wire byte is 0..255.
+						; Clamp before indexing -- avoids Blitz Dim OOB
+						; from a malformed P_AttackUpdate "Y".
+						Local DTI2 = RCE_IntFromStr(Mid$(M\MessageData$, 6, 1))
+						If DTI2 < 0 Or DTI2 > 19 Then DTI2 = 0
+						DType$ = DamageTypes$(DTI2)
 						PointEntity A\CollisionEN, Me\CollisionEN
 						RotateEntity A\CollisionEN, 0.0, EntityYaw#(A\CollisionEN) + 180.0, 0.0
 						; And hit me

--- a/src/Modules/Items.bb
+++ b/src/Modules/Items.bb
@@ -291,6 +291,11 @@ Function LoadItems(Filename$)
 				Case I_Weapon
 					I\WeaponDamage     = ReadShort(F)
 					I\WeaponDamageType = ReadShort(F)
+					; DamageTypes$ is Dim'd (19). WeaponDamageType is
+					; the index used to render damage in combat output
+					; (ClientNet P_AttackUpdate) and BVM_DAMAGETYPE$.
+					; ReadShort can carry -32768..32767; clamp at load.
+					If I\WeaponDamageType < 0 Or I\WeaponDamageType > 19 Then I\WeaponDamageType = 0
 					I\WeaponType       = ReadShort(F)
 					I\RangedProjectile = ReadShort(F)
 					I\Range#           = ReadFloat#(F)

--- a/src/Modules/MainMenu.bb
+++ b/src/Modules/MainMenu.bb
@@ -969,6 +969,10 @@ Function LogIn()
 										Case I_Weapon
 											It\WeaponDamage = RCE_IntFromStr(Mid$(Pa$, Offset, 2))
 											It\WeaponDamageType = RCE_IntFromStr(Mid$(Pa$, Offset + 2, 2))
+											; DamageTypes$ is Dim'd (19); wire field is 0..65535.
+											; Clamp before downstream readers (Interface3D tooltips,
+											; BVM_DAMAGETYPE$) index DamageTypes$(WeaponDamageType).
+											If It\WeaponDamageType < 0 Or It\WeaponDamageType > 19 Then It\WeaponDamageType = 0
 											It\WeaponType = RCE_IntFromStr(Mid$(Pa$, Offset + 4, 2))
 											It\Range# = RCE_FloatFromStr#(Mid$(Pa$, Offset + 6, 4))
 											Offset = Offset + 10


### PR DESCRIPTION
## Summary

`DamageTypes\$` is `Dim`'d (19). Two attack-surface paths can drive an OOB index into it:

1. `P_AttackUpdate` "H" / "Y" handlers in ClientNet.bb (~1063, ~1086) read a 1-byte damage-type index straight from the wire and pass it into `DamageTypes\$(...)`. Server byte 0..255 → OOB on any value > 19.
2. Item template loads — `LoadItems` (Items.bb:293) and the P_FetchItem handler (MainMenu.bb:971) — read `WeaponDamageType` as `ReadShort` / 2-byte-wire (-32768..32767 / 0..65535). Item tooltips (Interface3D.bb:1860/1927/1989) and `BVM_DAMAGETYPE\$` then index `DamageTypes\$(I\WeaponDamageType)` and crash.

## Pattern

\`\`\`basic
Local DTI = RCE_IntFromStr(Mid$(M\MessageData$, 6, 1))
If DTI < 0 Or DTI > 19 Then DTI = 0
DType$ = DamageTypes$(DTI)
\`\`\`

Same shape as #198–#206.

## Test plan

- [x] `compile.bat -t` clean
- [ ] CI green

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>