### PR TITLE
Clamp MemorisedSpells at load against KnownSpells[999] OOB

### DIFF
--- a/src/Modules/Actors.bb
+++ b/src/Modules/Actors.bb
@@ -427,6 +427,14 @@ Function ReadActorInstance.ActorInstance(Stream)
 	Next
 	For i = 0 To 9
 		A\MemorisedSpells[i] = ReadShort(Stream)
+		; MemorisedSpells stores an index into KnownSpells (Field[999])
+		; or the sentinel 5000 ("no spell memorised"). ReadShort returns
+		; -32768..32767; a corrupt slot bypassed the `<> 5000` guards in
+		; ClientNet / Interface3D and indexed KnownSpells[OOB] -- Blitz
+		; field-array OOB crashes the client every frame an action-bar
+		; redraw walks the memorised list.
+		If A\MemorisedSpells[i] < 0 Then A\MemorisedSpells[i] = 5000
+		If A\MemorisedSpells[i] > 999 And A\MemorisedSpells[i] <> 5000 Then A\MemorisedSpells[i] = 5000
 	Next
 
 	; v1: LastPortal triad. Older saves (no magic header in

--- a/src/Modules/MySQL.bb
+++ b/src/Modules/MySQL.bb
@@ -823,6 +823,11 @@ Function My_LoadActorInstance.ActorInstance(ActID, Q.Questlog, C.ActionBarData, 
 		
 		If i = 0 Then A\Memorised_ID		= ReadSQLField(MemSpellRow, "id")
 		A\MemorisedSpells[i] = ReadSQLField(MemSpellRow, "mem")
+		; KnownSpells is Field[999]; sentinel is 5000 ("no spell").
+		; Clamp at load so a corrupt SQL row can't drive an OOB read
+		; into KnownSpells[A\MemorisedSpells[i]] on the client.
+		If A\MemorisedSpells[i] < 0 Then A\MemorisedSpells[i] = 5000
+		If A\MemorisedSpells[i] > 999 And A\MemorisedSpells[i] <> 5000 Then A\MemorisedSpells[i] = 5000
 		
 		; Clean up
 		FreeSQLRow(ScriptRow)


### PR DESCRIPTION
## Summary

`MemorisedSpells[9]` stores an index into `KnownSpells` (`Field[999]`) or the sentinel `5000` ("no spell memorised"). The `<> 5000` guards in `ClientNet.bb` (~70, ~827) and `Interface3D.bb` (~1057, ~1127, ~1169, ~1366) are the only thing standing between `Me\KnownSpells[Me\MemorisedSpells[j]]` and a Blitz Field-array OOB.

A corrupt save row (`ReadShort` returns -32768..32767; `ReadSQLField` is uncapped) bypasses that guard with any value other than 5000 that lies outside 0..999, and the action-bar redraw / memorised-spell-walk crashes the client every frame.

## Sites clamped

| Site | Vector |
|---|---|
| `ReadActorInstance` (Actors.bb ~429) | save file |
| `LoadCharacter` (MySQL.bb ~825) | SQL row |

## Pattern

\`\`\`basic
If A\MemorisedSpells[i] < 0 Then A\MemorisedSpells[i] = 5000
If A\MemorisedSpells[i] > 999 And A\MemorisedSpells[i] <> 5000 Then A\MemorisedSpells[i] = 5000
\`\`\`

## Test plan

- [x] `compile.bat -t` clean
- [ ] CI green

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>