### PR TITLE
Null-guard ItemList rehydrate sites before CreateItemInstance

### DIFF
--- a/src/Modules/Actors.bb
+++ b/src/Modules/Actors.bb
@@ -933,10 +933,16 @@ Function ActorInstanceFromString.ActorInstance(Pa$)
 	ShieldID = RCE_IntFromStr(Mid$(Pa$, Offset + 20, 2))
 	HatID = RCE_IntFromStr(Mid$(Pa$, Offset + 22, 2))
 	ChestID = RCE_IntFromStr(Mid$(Pa$, Offset + 24, 2))
-	If WeaponID < 65535 Then A\Inventory\Items[SlotI_Weapon] = CreateItemInstance(ItemList(WeaponID))
-	If ShieldID < 65535 Then A\Inventory\Items[SlotI_Shield] = CreateItemInstance(ItemList(ShieldID))
-	If HatID < 65535 Then A\Inventory\Items[SlotI_Hat] = CreateItemInstance(ItemList(HatID))
-	If ChestID < 65535 Then A\Inventory\Items[SlotI_Chest] = CreateItemInstance(ItemList(ChestID))
+	; ItemList is Dim'd 65534; 65535 is the "no item" sentinel. Beyond
+	; the sentinel check, the slot itself must be non-Null -- a deleted
+	; or never-created item ID would otherwise drive CreateItemInstance
+	; with a Null Item, which faults inside the constructor on
+	; `I\Item\Attributes` deref. Range-check + Null-check at every
+	; equipped-slot rehydrate.
+	If WeaponID >= 0 And WeaponID < 65535 And ItemList(WeaponID) <> Null Then A\Inventory\Items[SlotI_Weapon] = CreateItemInstance(ItemList(WeaponID))
+	If ShieldID >= 0 And ShieldID < 65535 And ItemList(ShieldID) <> Null Then A\Inventory\Items[SlotI_Shield] = CreateItemInstance(ItemList(ShieldID))
+	If HatID >= 0 And HatID < 65535 And ItemList(HatID) <> Null Then A\Inventory\Items[SlotI_Hat] = CreateItemInstance(ItemList(HatID))
+	If ChestID >= 0 And ChestID < 65535 And ItemList(ChestID) <> Null Then A\Inventory\Items[SlotI_Chest] = CreateItemInstance(ItemList(ChestID))
 	A\HomeFaction = RCE_IntFromStr(Mid$(Pa$, Offset + 26, 1))
 	; FactionNames$ / FactionDefaultRatings are Dim'd (99) -> 0..99;
 	; FactionRatings is Field[99]. A wire byte can carry 100..255.

--- a/src/Modules/ClientNet.bb
+++ b/src/Modules/ClientNet.bb
@@ -1362,10 +1362,13 @@ Function UpdateNetwork()
 							If A\Inventory\Items[SlotI_Shield] <> Null Then FreeItemInstance(A\Inventory\Items[SlotI_Shield])
 							If A\Inventory\Items[SlotI_Chest] <> Null Then FreeItemInstance(A\Inventory\Items[SlotI_Chest])
 							If A\Inventory\Items[SlotI_Hat] <> Null Then FreeItemInstance(A\Inventory\Items[SlotI_Hat])
-							If WeaponID < 65535 Then A\Inventory\Items[SlotI_Weapon] = CreateItemInstance(ItemList(WeaponID))
-							If ShieldID < 65535 Then A\Inventory\Items[SlotI_Shield] = CreateItemInstance(ItemList(ShieldID))
-							If ChestID < 65535 Then A\Inventory\Items[SlotI_Chest] = CreateItemInstance(ItemList(ChestID))
-							If HatID < 65535 Then A\Inventory\Items[SlotI_Hat] = CreateItemInstance(ItemList(HatID))
+							; ItemList is Dim'd 65534; 65535 is the "no item" sentinel.
+							; Range-check + Null-check the slot before CreateItemInstance --
+							; the constructor faults on a Null Item (I\Item\Attributes deref).
+							If WeaponID >= 0 And WeaponID < 65535 And ItemList(WeaponID) <> Null Then A\Inventory\Items[SlotI_Weapon] = CreateItemInstance(ItemList(WeaponID))
+							If ShieldID >= 0 And ShieldID < 65535 And ItemList(ShieldID) <> Null Then A\Inventory\Items[SlotI_Shield] = CreateItemInstance(ItemList(ShieldID))
+							If ChestID >= 0 And ChestID < 65535 And ItemList(ChestID) <> Null Then A\Inventory\Items[SlotI_Chest] = CreateItemInstance(ItemList(ChestID))
+							If HatID >= 0 And HatID < 65535 And ItemList(HatID) <> Null Then A\Inventory\Items[SlotI_Hat] = CreateItemInstance(ItemList(HatID))
 							UpdateActorItems(A)
 							For i = 0 To 5
 								If RCE_IntFromStr(Mid$(M\MessageData$, 12 + i, 1)) = True
@@ -1379,6 +1382,13 @@ Function UpdateNetwork()
 					Case "G"
 						ItemID = RCE_IntFromStr(Mid$(M\MessageData$, 6, 2))
 						Amount = RCE_IntFromStr(Mid$(M\MessageData$, 8, 2))
+						; ItemList is Dim'd 65534. A wire ItemID outside
+						; 0..65534 or pointing at a Null slot would crash
+						; CreateItemInstance (I\Item\Attributes deref on a
+						; Null Item). Drop the packet on any of those.
+						If ItemID < 0 Or ItemID > 65534 Or ItemList(ItemID) = Null
+							WriteLog(MainLog, "P_InventoryUpdate G: bad ItemID " + ItemID + ", dropping")
+						Else
 						; Find free slot
 						Found = False
 						II.ItemInstance = CreateItemInstance(ItemList(ItemID))
@@ -1417,6 +1427,7 @@ Function UpdateNetwork()
 						If Found = False
 							FreeItemInstance(II)
 							RCE_Send(Connection, PeerToHost, P_InventoryUpdate, "GN" + Mid$(M\MessageData$, 2, 4), True)
+						EndIf
 						EndIf
 				End Select
 


### PR DESCRIPTION
## Summary

`CreateItemInstance(Item)` dereferences `I\Item\Attributes` inside its constructor (Items.bb:219). Passing it a Null Item — which is what every empty `ItemList` slot is — faults the process.

Three wire/persistence rehydrate sites passed `ItemList(ID)` into `CreateItemInstance` with only a `< 65535` sentinel check (the "no item" marker), no Null check on the resulting slot:

| Site | Vector |
|---|---|
| `ActorInstanceFromString` (Actors.bb ~936) | server wire receive of equipped Weapon/Shield/Hat/Chest IDs (P_NewActor body) |
| `P_AppearanceUpdate "X"` handler (ClientNet.bb ~1365) | same four slots on the client side |
| `P_InventoryUpdate "G"` handler (ClientNet.bb ~1384) | server hands the client an item to slot |

The threat: stale item ID (admin deleted the Item between sessions but a save / mid-flight packet still references it) or a malformed packet. Either was a guaranteed crash before this; now the slot stays empty / the packet is dropped with a log line.

The MySQL.bb load path (line ~698) already had the right `If ItemList(ID) = Null` guard, which is the template this PR generalizes from.

## Test plan

- [x] `compile.bat -t` clean
- [ ] CI green

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>