### PR TITLE
Null-guard PlayerIgnoring against stale Account handles

### DIFF
--- a/src/Modules/AccountsServer.bb
+++ b/src/Modules/AccountsServer.bb
@@ -413,9 +413,15 @@ End Function
 Function PlayerIgnoring(A1.ActorInstance, A2.ActorInstance)
 
 	; Is the player ignoring anyone?
+	; Object.Account returns Null for stale handles -- bare \Ignore$ or
+	; \User$ on a Null crashes the server. Called from /me, /yell,
+	; /pmsay, /trade, /partysay, etc., so the deref runs on every chat
+	; message from every connected player.
 	Ac1.Account = Object.Account(A1\Account)
+	If Ac1 = Null Then Return 0
 	If Ac1\Ignore$ <> ""
 		Ac2.Account = Object.Account(A2\Account)
+		If Ac2 = Null Then Return 0
 
 		; Loop through every ignored account and check
 		OldPos = 1


### PR DESCRIPTION
## Summary

`PlayerIgnoring` derefs `Ac1\Ignore\$` and `Ac2\User\$` from `Object.Account` lookups. The lookup returns Null for stale or freed Account handles (mid-logout, account-pool reset).

The function is called from every chat handler that respects ignore lists — `/me`, `/yell`, `/pmsay`, `/trade`, `/partysay`, `/unignore`, `/ignore`, `/invite`, regular area chat — so the deref runs on every chat message from every connected player. One stale handle = a chat-line server crash.

Fix follows the same `Object.X(handle)` discipline already documented in [CLAUDE.md](CLAUDE.md): bound + Null-check, return early on Null.

## Test plan

- [x] `compile.bat -t` clean
- [ ] CI green

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>