### PR TITLE
Null+LoggedOn guard BVM quest commands

### DIFF
--- a/src/Modules/ScriptingCommands.bb
+++ b/src/Modules/ScriptingCommands.bb
@@ -1954,6 +1954,12 @@ Function BVM_NEWQUEST(Param1%, Param2$, Param3$, Param4%=255, Param5%=255, Param
 	If Actor <> Null
 		If Actor\RNID > 0
 			A.Account = Object.Account(Actor\Account)
+			; Object.Account returns Null for stale handles; A\LoggedOn
+			; is -1 between login states and 0..9 once logged in.
+			; QuestLog is Field[9]; either condition would crash the
+			; server with a Blitz Field OOB or Null deref during a
+			; script-triggered quest mutation.
+			If A = Null Or A\LoggedOn < 0 Or A\LoggedOn > 9 Then Return
 			Name$ = Param2$
 			; Check it doesn't already exist
 			FreeSpace = -1
@@ -1986,6 +1992,7 @@ Function BVM_UPDATEQUEST(Param1%, Param2$, Param3$, Param4%=255, Param5%=255, Pa
 	If Actor <> Null
 		If Actor\RNID > 0
 			A.Account = Object.Account(Actor\Account)
+			If A = Null Or A\LoggedOn < 0 Or A\LoggedOn > 9 Then Return
 			Name$ = Upper$(Param2$)
 			Status$ = RCE_StrFromInt$(Param4%, 1)
 			Status$ = Status$ + RCE_StrFromInt$(Param5%, 1)
@@ -2010,6 +2017,7 @@ Function BVM_COMPLETEQUEST(Param1%, Param2$)
 	If Actor <> Null
 		If Actor\RNID > 0
 			A.Account = Object.Account(Actor\Account)
+			If A = Null Or A\LoggedOn < 0 Or A\LoggedOn > 9 Then Return
 			Name$ = Upper$(Param2$)
 			Status$ = Chr$(255) + Chr$(225) + Chr$(100) + Chr$(254)
 			For i = 0 To 499
@@ -2030,6 +2038,7 @@ Function BVM_DELETEQUEST(Param1%, Param2$)
 	If Actor <> Null
 		If Actor\RNID > 0
 			A.Account = Object.Account(Actor\Account)
+			If A = Null Or A\LoggedOn < 0 Or A\LoggedOn > 9 Then Return
 			Name$ = Upper$(Param2$)
 			For i = 0 To 499
 				If Upper$(A\QuestLog[A\LoggedOn]\EntryName$[i]) = Name$
@@ -2048,6 +2057,7 @@ Function BVM_QUESTSTATUS$(Param1%, Param2$)
 	If Actor <> Null
 		If Actor\RNID > 0
 			A.Account = Object.Account(Actor\Account)
+			If A = Null Or A\LoggedOn < 0 Or A\LoggedOn > 9 Then Return ""
 			Name$ = Upper$(Param2$)
 			For i = 0 To 499
 				If Upper$(A\QuestLog[A\LoggedOn]\EntryName$[i]) = Name$
@@ -2065,6 +2075,7 @@ Function BVM_QUESTCOMPLETE%(Param1%, Param2$)
 	If Actor <> Null
 		If Actor\RNID > 0
 			A.Account = Object.Account(Actor\Account)
+			If A = Null Or A\LoggedOn < 0 Or A\LoggedOn > 9 Then Return 0
 			Name$ = Upper$(Param2$)
 			For i = 0 To 499
 				If Upper$(A\QuestLog[A\LoggedOn]\EntryName$[i]) = Name$


### PR DESCRIPTION
## Summary

Six BVM quest commands derefed `A\QuestLog[A\LoggedOn]\EntryName\$[i]` from `A.Account = Object.Account(Actor\Account)` without checking either `A` or `A\LoggedOn`:

- `BVM_NEWQUEST`
- `BVM_UPDATEQUEST`
- `BVM_COMPLETEQUEST`
- `BVM_DELETEQUEST`
- `BVM_QUESTSTATUS\$`
- `BVM_QUESTCOMPLETE%`

Two crash paths each:

1. `Object.Account` returns Null for stale handles (mid-logout, account-pool reset) — bare `A\LoggedOn` Null-derefs the server.
2. `A\LoggedOn` is `-1` between login states (set in `AccountsServer.bb:200`, `:331`, `MySQL.bb:247`) and `0..9` once logged in. `QuestLog` is `Field[9]` — `A\QuestLog[-1]` is a Blitz Field OOB.

A script firing a quest mutation during the brief window where the player's account/character is in transition would crash the server for every connected player.

## Fix

Early-return on either condition:

\`\`\`basic
If A = Null Or A\LoggedOn < 0 Or A\LoggedOn > 9 Then Return
\`\`\`

(Returns the empty / 0 / nothing value appropriate to each function signature.)

## Test plan

- [x] `compile.bat -t` clean
- [ ] CI green

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>