### PR TITLE
Bound Spells/Sp\ID in client P_KnownSpellUpdate + P_FetchCharacter

### DIFF
--- a/src/Modules/ClientNet.bb
+++ b/src/Modules/ClientNet.bb
@@ -785,12 +785,24 @@ Function UpdateNetwork()
 			Case P_KnownSpellUpdate
 				; Spell added
 				If Left$(M\MessageData$, 1) = "A"
-					If Me\SpellLevels[Spells] = 0
+					; KnownSpells / SpellLevels are Field[999] (1000 slots).
+					; The global `Spells` counter grew unchecked from the
+					; previous handler; a malformed or hostile server could
+					; spam P_KnownSpellUpdate "A" past 999 and OOB-write the
+					; client. Drop further adds once the slot table is full.
+					If Spells >= 0 And Spells <= 999 And Me\SpellLevels[Spells] = 0
 						DebugLog "Spell creation entered"
 						Offset = 2
 						Me\SpellLevels[Spells] = RCE_IntFromStr(Mid$(M\MessageData$, Offset, 2))
 						Sp.Spell = New Spell
 						Sp\ID = RCE_IntFromStr(Mid$(M\MessageData$, Offset + 2, 2))
+						; SpellsList is Dim'd 65534. Wire field carries 0..65535;
+						; clamp Sp\ID before the Dim write to avoid an OOB
+						; assignment that would corrupt adjacent globals.
+						If Sp\ID < 0 Or Sp\ID > 65534
+							Delete Sp
+							Goto SkipKnownSpellAdd
+						EndIf
 						SpellsList(Sp\ID) = Sp
 						Me\KnownSpells[Spells] = Sp\ID
 						Sp\ThumbnailTexID = RCE_IntFromStr(Mid$(M\MessageData$, Offset + 4, 2))
@@ -808,6 +820,7 @@ Function UpdateNetwork()
 						EndIf
 						Spells = Spells + 1
 						SortSpells()
+						.SkipKnownSpellAdd
 					EndIf
 				; Spell removed
 				ElseIf Left$(M\MessageData$, 1) = "D"

--- a/src/Modules/MainMenu.bb
+++ b/src/Modules/MainMenu.bb
@@ -1833,9 +1833,18 @@ Function CharSelect()
 						ElseIf Left$(M\MessageData$, 1) = "S"
 							Offset = 2
 							While Offset < Len(M\MessageData$)
+								; KnownSpells / SpellLevels are Field[999]; SpellsList
+								; is Dim'd 65534. A malformed P_FetchCharacter "S"
+								; block could push past either bound -- drain the
+								; remaining bytes once full.
+								If Spells < 0 Or Spells > 999 Then Exit
 								Me\SpellLevels[Spells] = RCE_IntFromStr(Mid$(M\MessageData$, Offset, 2))
 								Sp.Spell = New Spell
 								Sp\ID = RCE_IntFromStr(Mid$(M\MessageData$, Offset + 2, 2))
+								If Sp\ID < 0 Or Sp\ID > 65534
+									Delete Sp
+									Exit
+								EndIf
 								SpellsList(Sp\ID) = Sp
 								Me\KnownSpells[Spells] = Sp\ID
 								Sp\ThumbnailTexID = RCE_IntFromStr(Mid$(M\MessageData$, Offset + 4, 2))


### PR DESCRIPTION
## Summary

Two client-side spell-load paths could OOB-write Field/Dim arrays from a malformed or hostile server payload:

1. **`P_KnownSpellUpdate "A"`** (ClientNet.bb ~785): grows the global `Spells` counter unchecked. `KnownSpells` / `SpellLevels` are `Field[999]`; spamming `"A"` past 999 OOB-writes the actor record.
2. **`P_FetchCharacter "S"` block** (MainMenu.bb ~1833): walks a wire-sourced byte string and indexes both `Spells` slots and `SpellsList(Sp\ID)`. `SpellsList` is `Dim`'d 65534; a 2-byte wire field carries 0..65535.

## Fix

Bound-check `Spells` (0..999) and `Sp\ID` (0..65534) before each write; drain the rest of the block when full or invalid.

Same shape as #208 (MemorisedSpells clamp) and #205 (HomeFaction clamp). Pattern documented in [CLAUDE.md](CLAUDE.md).

## Test plan

- [x] `compile.bat -t` clean
- [ ] CI green

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>