### PR TITLE
Bound It\ID in client P_FetchItem loader

### DIFF
--- a/src/Modules/MainMenu.bb
+++ b/src/Modules/MainMenu.bb
@@ -936,6 +936,17 @@ Function LogIn()
 									It.Item = New Item
 									It\Attributes = New Attributes
 									It\ID = RCE_IntFromStr(Mid$(Pa$, Offset, 2))
+									; ItemList is Dim'd 65534. A 2-byte wire field
+									; carries 0..65535 -- clamp before the Dim
+									; write to avoid corrupting the adjacent
+									; global. Same shape as #209's read-side
+									; bound check on the P_AppearanceUpdate "X"
+									; / P_InventoryUpdate "G" / ActorInstance
+									; rehydrate paths.
+									If It\ID < 0 Or It\ID > 65534
+										Delete It\Attributes : Delete It
+										Exit
+									EndIf
 									ItemList(It\ID) = It
 									It\ItemType = RCE_IntFromStr(Mid$(Pa$, Offset + 2, 1))
 									It\TakesDamage = RCE_IntFromStr(Mid$(Pa$, Offset + 3, 1))


### PR DESCRIPTION
## Summary

`ItemList` is `Dim`'d 65534. The `P_FetchItem` handler in `MainMenu.bb` (line ~938) reads a 2-byte wire field (0..65535) into `It\ID` then immediately writes `ItemList(It\ID) = It` — a value of `65535` OOB-writes into adjacent globals.

Mirrors the spell-loader fix in #216 and the read-side guard in #209. Same shape as the `LoadItems` server-disk loader in `Items.bb` (line ~266), which is the template this PR generalizes from.

## Test plan

- [x] `compile.bat -t` clean
- [ ] CI green

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>