### PR TITLE
Bound A\ID in LoadActors against ActorList Dim OOB

### DIFF
--- a/src/Modules/Actors.bb
+++ b/src/Modules/Actors.bb
@@ -654,6 +654,14 @@ Function LoadActors(Filename$)
 			A.Actor = New Actor
 			A\Attributes = New Attributes
 			A\ID = ReadShort(F)
+			; ActorList is Dim'd 0..65535. ReadShort returns -32768..32767
+			; (signed); a negative or any other out-of-range A\ID OOB-writes
+			; into adjacent globals. Stop loading the rest of the file on
+			; the first bad ID -- the partial state is still consistent.
+			If A\ID < 0 Or A\ID > 65535
+				Delete A\Attributes : Delete A
+				Exit
+			EndIf
 			ActorList(A\ID) = A
 			; Bound every length-prefixed string against a corrupted
 			; Actors.dat (same shape as the data-loader sweep in PR #149).


### PR DESCRIPTION
## Summary

`ActorList` is `Dim`'d 0..65535. `LoadActors` reads `A\ID = ReadShort(F)` which returns -32768..32767 (signed); a negative or out-of-range `A\ID` OOB-writes into adjacent globals when `ActorList(A\ID) = A` runs at line ~657.

Same pattern as `LoadItems` (Items.bb:266), `LoadSpells`, and the client `P_FetchItem` / `P_FetchActor` fixes in #209/#216/#217. Exit cleanly on first bad ID — the partial state is consistent.

## Test plan

- [x] `compile.bat -t` clean
- [ ] CI green

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>