### PR TITLE
Clamp DamageType on Projectile/Weather loads against Resistances[19]

### DIFF
--- a/src/Modules/Projectiles.bb
+++ b/src/Modules/Projectiles.bb
@@ -60,6 +60,12 @@ Function LoadProjectiles(Filename$)
 			P\HitChance = ReadByte(F)
 			P\Damage = ReadShort(F)
 			P\DamageType = ReadShort(F)
+			; DamageTypes$ is Dim'd (19); A\Resistances field is [19].
+			; ReadShort returns -32768..32767; clamp before downstream
+			; readers (GameServer combat at line ~257/265, Resistances
+			; indexing) crash on Field/Dim OOB. Same shape as #207's
+			; WeaponDamageType clamp.
+			If P\DamageType < 0 Or P\DamageType > 19 Then P\DamageType = 0
 			P\Speed = ReadByte(F)
 
 			Projectiles = Projectiles + 1

--- a/src/Modules/ServerAreas.bb
+++ b/src/Modules/ServerAreas.bb
@@ -237,6 +237,11 @@ Function ServerLoadArea.Area(Name$)
 			W\Depth#     = ReadFloat#(F)
 			W\Damage     = ReadShort(F)
 			W\DamageType = ReadShort(F)
+			; A\Resistances is Field[19]; DamageTypes$ is Dim'd (19).
+			; ReadShort can carry -32768..32767; clamp before the runtime
+			; SafeZone-damage loop (GameServer.bb ~773) indexes
+			; A\Resistances[SW\DamageType].
+			If W\DamageType < 0 Or W\DamageType > 19 Then W\DamageType = 0
 		Next
 
 	CloseFile(F)


### PR DESCRIPTION
## Summary

`A\Resistances` is `Field[19]`; `DamageTypes\$` is `Dim`'d (19). Two server-side data-file loaders read DamageType as `ReadShort` (-32768..32767) without clamping:

- `LoadProjectiles` (Projectiles.bb ~62): `P\DamageType` flows into GameServer combat at ~257/265 (`A2\Resistances[P\DamageType]`) on every projectile hit.
- `LoadServerAreas` SafeZone weather (ServerAreas.bb ~239): `W\DamageType` flows into the SafeZone damage loop at ~773 (`AI\Resistances[SW\DamageType]`).

Either OOB index is a Blitz Field-OOB crash on the server tick.

Pattern matches #207's `WeaponDamageType` clamp; documented in [CLAUDE.md](CLAUDE.md).

## Test plan

- [x] `compile.bat -t` clean
- [ ] CI green

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>