### PR TITLE
Clamp I\RangedProjectile against ProjectileList Dim OOB

### DIFF
--- a/src/Modules/Items.bb
+++ b/src/Modules/Items.bb
@@ -298,6 +298,13 @@ Function LoadItems(Filename$)
 					If I\WeaponDamageType < 0 Or I\WeaponDamageType > 19 Then I\WeaponDamageType = 0
 					I\WeaponType       = ReadShort(F)
 					I\RangedProjectile = ReadShort(F)
+					; ProjectileList is Dim'd 0..5000. ReadShort can carry
+					; -32768..32767; a corrupt Items.dat would otherwise
+					; drive ProjectileList(I\RangedProjectile) OOB in the
+					; combat path (GameServer.bb ~335). Clamp to a safe
+					; sentinel (0) so the existing `If P <> Null` guard
+					; downstream catches the missing slot.
+					If I\RangedProjectile < 0 Or I\RangedProjectile > 5000 Then I\RangedProjectile = 0
 					I\Range#           = ReadFloat#(F)
 					I\RangedAnimation$ = ReadBoundedString$(F, 256)
 				Case I_Armour


### PR DESCRIPTION
## Summary

`ProjectileList` is `Dim`'d 0..5000. `LoadItems` reads `I\RangedProjectile = ReadShort(F)` which carries -32768..32767; a corrupt Items.dat would otherwise drive `ProjectileList(I\RangedProjectile)` OOB in the combat path:

\`\`\`basic
; GameServer.bb ~335
P.Projectile = ProjectileList(A1\Inventory\Items[SlotI_Weapon]\Item\RangedProjectile)
If P <> Null
    FireProjectile(P, A1, A2)
\`\`\`

The `If P <> Null` only catches the missing slot *after* a valid Dim read; an OOB index errors before reaching the Null check.

Clamp to a safe sentinel (0) at load. Same shape as the `WeaponDamageType` clamp added two lines above in the same loader (#207).

## Test plan

- [x] `compile.bat -t` clean
- [ ] CI green

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>