### PR TITLE
Bound AttributesDone walk in client P_StatUpdate B1 handler

### DIFF
--- a/src/Modules/MainMenu.bb
+++ b/src/Modules/MainMenu.bb
@@ -1815,6 +1815,12 @@ Function CharSelect()
 								If Me\HomeFaction < 0 Or Me\HomeFaction > 99 Then Me\HomeFaction = 0
 								Offset = 16
 								While Offset < Len(M\MessageData$)
+									; Me\Attributes\Value/Maximum are Field[39]
+									; (40 slots). A malformed P_StatUpdate "B1"
+									; payload longer than the legitimate 40
+									; attribute pairs would Field-OOB the
+									; client. Stop walking once full.
+									If AttributesDone < 0 Or AttributesDone > 39 Then Exit
 									Me\Attributes\Value[AttributesDone] = RCE_IntFromStr(Mid$(M\MessageData$, Offset, 2))
 									Me\Attributes\Maximum[AttributesDone] = RCE_IntFromStr(Mid$(M\MessageData$, Offset + 2, 2))
 									AttributesDone = AttributesDone + 1


### PR DESCRIPTION
## Summary

`Me\Attributes\Value/Maximum` are `Field[39]` (40 slots). The `P_StatUpdate "B1"` handler walks attribute pairs from the wire buffer with `While Offset < Len(M\MessageData\$)`, incrementing `AttributesDone` unchecked.

A malformed payload longer than the legitimate 40 attribute pairs (160 bytes after the 16-byte header) would Field-OOB the client.

Same shape as #208 (MemorisedSpells), #216 (Spells), #217 (It\ID): bound the index counter before each Field write.

## Test plan

- [x] `compile.bat -t` clean
- [ ] CI green

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>