### PR TITLE
Bound Quests/CharList Number walks in client P_FetchCharacter

### DIFF
--- a/src/Modules/MainMenu.bb
+++ b/src/Modules/MainMenu.bb
@@ -1544,6 +1544,11 @@ Function CharSelect()
 	; Character buttons (max of 10 characters)
 	Offset = 1 : Number = 0
 	While Offset < Len(CharList$)
+		; CharNames$/CharActors/CharGender/CharFaceTex/CharHair/CharBeard/
+		; CharBodyTex are all Dim'd (9) -- 10 slots. A malformed CharList$
+		; longer than 10 chars would Dim-OOB the client. Stop walking once
+		; the slot table is full.
+		If Number < 0 Or Number > 9 Then Exit
 		; Extract data
 		Length = RCE_IntFromStr(Mid$(CharList$, Offset, 1))
 		CharNames$(Number) = Mid$(CharList$, Offset + 1, Length)
@@ -1884,6 +1889,11 @@ Function CharSelect()
 						ElseIf Left$(M\MessageData$, 1) = "Q"
 							Offset = 2
 							While Offset < Len(M\MessageData$)
+								; QuestLog\EntryName$/EntryStatus$ are Field[499]
+								; (500 slots). A malformed P_FetchCharacter "Q"
+								; block longer than 500 quests would Field-OOB
+								; the client. Stop walking once full.
+								If Quests < 0 Or Quests > 499 Then Exit
 								NameLen = RCE_IntFromStr(Mid$(M\MessageData$, Offset, 1))
 								QuestLog\EntryName$[Quests] = Mid$(M\MessageData$, Offset + 1, NameLen)
 								Offset = Offset + 1 + NameLen


### PR DESCRIPTION
## Summary

Two more wire-walking loops on the client side could OOB-write fixed-size arrays from a malformed server payload:

1. **`P_FetchCharacter "Q"` block** (~1886) — writes `QuestLog\EntryName\$[Quests]` (Field[499]); the global `Quests` counter was incremented unchecked.
2. **`CharList\$` parsing** (~1546) — writes `CharNames\$(Number)` and sibling `CharActors`/`CharGender`/`CharFaceTex`/`CharHair`/`CharBeard`/`CharBodyTex` (all `Dim`'d (9) = 10 slots). The `Number` counter incremented unchecked.

Same shape as #224 (`AttributesDone`) and #216 (`Spells`/`Sp\ID`). Stop walking once the slot table is full.

## Test plan

- [x] `compile.bat -t` clean
- [ ] CI green

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>