### PR TITLE
Bound Num walk in client P_OpenTrading payload parser

### DIFF
--- a/src/Modules/ClientNet.bb
+++ b/src/Modules/ClientNet.bb
@@ -610,6 +610,12 @@ Function UpdateNetwork()
 							Num = 0
 							LockTextures()
 							While Offset < Len(M\MessageData$)
+								; TradeItems / TradeAmounts / ServerTradeIDs /
+								; BSlotsHis are all Dim'd (31) = 32 slots. A
+								; malformed P_OpenTrading payload longer than
+								; 32 items would Dim-OOB the client. Stop
+								; walking once the slot table is full.
+								If Num < 0 Or Num > 31 Then Exit
 								Item.ItemInstance = ItemInstanceFromString(Mid$(M\MessageData$, Offset, ItemInstanceStringLength()))
 								TradeItems(Num) = Item
 								Offset = Offset + ItemInstanceStringLength()


### PR DESCRIPTION
## Summary

`TradeItems` / `TradeAmounts` / `ServerTradeIDs` / `BSlotsHis` are all `Dim`'d (31) = 32 slots. The `P_OpenTrading "11N"` handler in ClientNet.bb (~612) walks the server's offered-items payload with `While Offset < Len(M\MessageData\$)`, incrementing `Num` unchecked.

A malformed payload longer than 32 items would Dim-OOB the client. Stop walking once full.

Same shape as #224, #225, #216 client-side wire-walk bound fixes.

## Test plan

- [x] `compile.bat -t` clean
- [ ] CI green

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>