### PR TITLE
Null-guard DialogOutput against stale dialog handles

### DIFF
--- a/src/Modules/Interface3D.bb
+++ b/src/Modules/Interface3D.bb
@@ -103,6 +103,11 @@ End Function
 Function DialogOutput(Han, T$, R = 255, G = 255, B = 255, Opt = 0)
 
 	D.Dialog = Object.Dialog(Han)
+	; Stale dialog handle: server can send P_Dialog "T" / "O" against
+	; a dialog the client has already freed (window-close race, dialog
+	; reuse). The unguarded D\TextLines[0] deref below was a crash on
+	; the next message in that flow.
+	If D = Null Then Return
 
 	; Word wrap
 	Gad.GY_Gadget = Object.GY_Gadget(D\TextLines[0])


### PR DESCRIPTION
## Summary

`DialogOutput`'s bottom branch wraps the write in `If D <> Null`, but the word-wrap branch at line 108 derefs `D\TextLines[0]` before that guard.

A stale dialog handle (server sends `P_Dialog "T"` / `"O"` against a dialog the client already freed — window-close race, dialog reuse) faults the client on the next message in the flow.

## Fix

Early-return on Null at the top of the function so both branches are protected. Same `Object.X(handle)` discipline documented in [CLAUDE.md](CLAUDE.md).

## Test plan

- [x] `compile.bat -t` clean
- [ ] CI green

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>