### PR TITLE
Drop Null-S PausedScripts at every consumer

### DIFF
--- a/src/Modules/GameServer.bb
+++ b/src/Modules/GameServer.bb
@@ -163,7 +163,13 @@ Function KillActor(A.ActorInstance, Killer.ActorInstance)
 	Local PSNext.PausedScript = Null
 	While PS <> Null
 		PSNext = After PS
-		If PS\Reason = 2
+		; Defense in depth: drop any PausedScript with Null PS\S so the
+		; deref below can't fault. The BVM_SETWAIT* setters early-return
+		; on Null SI (#228), but a stale queue entry or future code path
+		; that bypasses the SI guard would otherwise crash the server.
+		If PS\S = Null
+			Delete PS
+		ElseIf PS\Reason = 2
 			If PS\ReasonActor = Killer And PS\ReasonKillActor = A\Actor
 				PS\ReasonCount = PS\ReasonCount + 1
 				If PS\ReasonCount >= PS\ReasonAmount

--- a/src/Modules/Scripting.bb
+++ b/src/Modules/Scripting.bb
@@ -205,8 +205,15 @@ Function UpdateScripts()
 	Local PSNext.PausedScript = Null
 	While PS <> Null
 		PSNext = After PS
+		; Defense in depth: drop any PausedScript whose ScriptInstance
+		; is Null. The BVM_SETWAIT* setters now early-return on Null SI
+		; (#228), but a stale queue entry from a pre-#228 boot or a
+		; future code path that bypasses the SI guard would otherwise
+		; deref PS\S\WaitResult$ below and crash the server.
+		If PS\S = Null
+			Delete PS
 		; Check whether waited for items are available
-		If PS\Reason = 3
+		ElseIf PS\Reason = 3
 			If PS\ReasonActor <> Null
 				If InventoryHasItem(PS\ReasonActor\Inventory, PS\ReasonItem$, PS\ReasonAmount)
 					PS\S\WaitResult$ = "1"

--- a/src/Modules/ServerNet.bb
+++ b/src/Modules/ServerNet.bb
@@ -1309,7 +1309,11 @@ Function UpdateNetwork()
 							Local PSNext.PausedScript = Null
 							While PS <> Null
 								PSNext = After PS
-								If PS\Reason = 4
+								; Defense in depth: drop Null-S PausedScripts.
+								; See Scripting.bb / GameServer.bb sibling guards.
+								If PS\S = Null
+									Delete PS
+								ElseIf PS\Reason = 4
 									If PS\ReasonActor = AI And PS\ReasonContextActor = A2
 										PS\S\WaitResult$ = "1"
 										Delete PS


### PR DESCRIPTION
## Summary

Defense-in-depth pairing with #228 (`BVM_SETWAIT*` Null-SI guard). The three `PausedScript` consumers all derefed `PS\S\WaitResult\$` without checking `PS\S` first:

| Site | Trigger |
|---|---|
| Scripting.bb ~209 | per-tick wait-item check |
| GameServer.bb ~166 | WaitKill on actor death |
| ServerNet.bb ~1310 | WaitSpeak on right-click |

The setter-side guard in #228 prevents new Null-S entries from being queued, but stale queue entries from a pre-#228 boot or a future code path bypassing the SI guard would still crash the server on the next satisfying event.

## Fix

Drop Null-S entries at the top of each consumer's branch.

## Test plan

- [x] `compile.bat -t` clean
- [ ] CI green

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>