### PR TITLE
Bound ID in SetMesh{Scale,Offset,Shader} and GetMeshNameClean$

### DIFF
--- a/src/Modules/Media.bb
+++ b/src/Modules/Media.bb
@@ -673,6 +673,12 @@ End Function
 ; Changes the scale for a mesh
 Function SetMeshScale(ID, Scale#)
 
+	; LoadedMeshScales# is Dim'd 0..65534. Mirror GetMesh's bound check
+	; (line 756) -- editor-supplied IDs from MediaDialogs can land here
+	; via the Architect's mesh-config flow; a typo or sentinel would
+	; otherwise OOB-write into adjacent globals.
+	If ID < 0 Or ID > 65534 Then Return False
+
 	LoadedMeshScales#(ID) = Scale#
 
 	; Open index file
@@ -702,6 +708,9 @@ End Function
 
 ; Changes the offset for a mesh
 Function SetMeshOffset(ID, X#, Y#, Z#)
+
+	; LoadedMeshX#/Y#/Z# are Dim'd 0..65534. Same bound as SetMeshScale.
+	If ID < 0 Or ID > 65534 Then Return False
 
 	LoadedMeshX#(ID) = X#
 	LoadedMeshY#(ID) = Y#
@@ -736,6 +745,9 @@ End Function
 
 ; Changes the shader for a mesh
 Function SetMeshShader(ID, Shader)
+
+	; LoadedMeshShaders is Dim'd 0..65534. Same bound as SetMeshScale.
+	If ID < 0 Or ID > 65534 Then Return False
 
 	LoadedMeshShaders(ID) = Shader
 
@@ -1090,6 +1102,9 @@ End Function
 
 ;Bump mapping
 Function GetMeshNameClean$(ID)
+; Same bound as GetMeshName$ -- ID seeks into the 4-byte-per-entry
+; mesh index table; a sentinel like -1 would SeekFile to -4.
+If ID < 0 Or ID > 65534 Then Return ""
 If LockedMeshes = 0
    F = OpenFile("Data\Game Data\Meshes.dat")
    If F = 0 Then Return ""


### PR DESCRIPTION
## Summary

Completes the Media.bb bound-check sweep started in #231:

| Site | What's unguarded |
|---|---|
| `SetMeshScale` (~673) | writes `LoadedMeshScales#[ID]` |
| `SetMeshOffset` (~687) | writes `LoadedMeshX#/Y#/Z#[ID]` |
| `SetMeshShader` (~721) | writes `LoadedMeshShaders[ID]` |
| `GetMeshNameClean\$` (~1092) | `SeekFile F, ID * 4` |

All four index 0..65534-sized `Dim` arrays / 4-byte-per-entry file tables without an ID check. Editor-supplied IDs (MediaDialogs, RC Architect mesh-config flow) or a sentinel like `-1` would OOB-write into adjacent globals / `SeekFile` to negative offset.

Same shape as `GetMesh` / `GetTexture` / `GetSound` (already guarded) and #231 (`GetMeshName\$` / `GetTextureName\$` / `GetSoundName\$` / `GetMusicName\$`).

## Test plan

- [x] Full `compile.bat` clean
- [ ] CI green

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>