### PR TITLE
Privilege-gate BVM MySQL row/query walkers

### DIFF
--- a/src/Modules/ScriptingCommands.bb
+++ b/src/Modules/ScriptingCommands.bb
@@ -2703,26 +2703,41 @@ Function BVM_MYSQLQUERY$(Param1$)
 Return Result$
 End Function
 
+; MySQL row/query walkers -- privileged-only, matching BVM_MYSQLQUERY.
+; Param1 is a server-side SQL query handle. Without the gate, a
+; non-privileged script could:
+;   - Walk rows of a SQL handle obtained via SCRIPTGLOBAL passing from
+;     a privileged script (read e.g. account data the privileged script
+;     queried but didn't want to expose to the calling NPC script).
+;   - Free SQL queries the server itself is using (LoadCharacter,
+;     SaveActor) by guessing handle values -- the underlying SQL
+;     library doesn't validate "this query belongs to this caller".
+; Privileged scripts retain full access for legitimate admin queries.
 Function BVM_MYSQLNUMROWS%(Param1%)
+	If Not BVM_RequirePrivileged() Then Return 0
 	If MySQL = True Then Result% = SQLRowCount(Param1%)
 Return Result%
 End Function
 
 Function BVM_MYSQLFETCHROW$(Param1%)
+	If Not BVM_RequirePrivileged() Then Return ""
 	If MySQL = True Then Result$ = SQLFetchRow(Param1%)
 Return Result$
 End Function
 
 Function BVM_MYSQLGETVAR$(Param1%,Param2$)
+	If Not BVM_RequirePrivileged() Then Return ""
 	If MySQL = True Then Result$ = ReadSQLField(Param1%, Param2$)
 	Return Result$
 End Function
 
 Function BVM_MYSQLFREEQUERY(Param1%)
+	If Not BVM_RequirePrivileged() Then Return
 	If MySQL = True Then FreeSQLQuery(Param1%)
 End Function
 
 Function BVM_MYSQLFREEROW(Param1%)
+	If Not BVM_RequirePrivileged() Then Return
 	If MySQL = True Then FreeSQLRow(Param1%)
 End Function
 


### PR DESCRIPTION
## Summary

`BVM_MYSQLNUMROWS`, `BVM_MYSQLFETCHROW`, `BVM_MYSQLGETVAR`, `BVM_MYSQLFREEQUERY`, `BVM_MYSQLFREEROW` had no privilege gate. `BVM_MYSQLQUERY` (the only entry-point that creates SQL handles) was already privileged, but the walkers and FREE family were exposed to any non-privileged NPC script.

Two attack paths:

1. Walk rows of a SQL handle obtained via `SCRIPTGLOBAL` passing from a privileged script (read e.g. account data the privileged script queried but didn't want to expose to the non-priv NPC that called it).
2. Free SQL queries the server itself is using (`LoadCharacter`, `SaveActor`) by guessing handle values — the underlying SQL library doesn't validate "this query belongs to this caller".

## Fix

Same posture as the UDP family (#233) and the file-system family. Privileged scripts retain full access for legitimate admin queries.

## Test plan

- [x] `compile.bat -t` clean
- [ ] CI green

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>