### PR TITLE
docs: three BVM privilege-gate categories in CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -176,6 +176,14 @@ Test files under [src/Tests/](src/Tests/) use `Strict` + `EnableGC` at the top. 
 
 BVM functions that mutate global server state (`BVM_BANPLAYER`, `BVM_SETGOLD`, `BVM_WARP`, faction mutators) must guard with `If Not BVM_RequirePrivileged() Then Return` at the top. Functions that take an actor handle but are safe when targeting the script's own actor use `BVM_RequireSelfOrPrivileged(handle)` instead. Without these, any NPC's right-click script can ban its own clicker.
 
+Three categories beyond the obvious mutator gate, all of which also need `BVM_RequirePrivileged()`:
+
+1. **Anything that opens a host-side resource.** UDP sockets (PR #233 — `BVM_CreateUDPStream` / `SendUDPMsg` / `RecvUDPMsg` / etc.), file system (`BVM_DELETEFILE` / `BVM_WRITEFILE` / `BVM_OPENFILE` / `BVM_APPENDFILE` / `BVM_CREATEDIR`), and arbitrary SQL (`BVM_MYSQLQUERY`). Without the gate, any NPC's right-click script could open sockets, write arbitrary files, or run arbitrary SQL using the server's permissions.
+2. **Handle-walking helpers for those resources.** Once an entry-point that creates a handle is gated, the row/free family that walks the same handle space (PR #234 — `BVM_MYSQLNUMROWS` / `MYSQLFETCHROW` / `MYSQLGETVAR` / `MYSQLFREEQUERY` / `MYSQLFREEROW`) must be gated too. Otherwise a non-priv script can receive a handle via `SCRIPTGLOBAL`/`SUPERGLOBAL` passing and walk privileged data, or free a handle the server itself is using (LoadCharacter, SaveActor) by guessing the integer.
+3. **Fatal-failure entry points.** `BVM_RUNTIMEERROR` (PR series, see audit comment in the function) lets the caller `RuntimeError()` the entire server process. Gate it so non-priv scripts log + return instead.
+
+The compound rule: if the function reaches out to a resource the host owns (kernel handle, file descriptor, socket, database connection) or can terminate the server, it's privileged.
+
 ## Workflow
 
 ### Branching + PRs


### PR DESCRIPTION
## Summary

Extends the existing "Privilege gating in BVM commands" section in [CLAUDE.md](CLAUDE.md) to capture the pattern surfaced by #233 (UDP family) and #234 (MySQL row/free walkers):

1. **Host-side resource opens** (UDP, FS, SQL) — all gated
2. **Handle-walking helpers for those resources** — also gated, so a non-priv script can't receive a handle via `SCRIPTGLOBAL` passing and walk privileged data or free server-owned handles
3. **Fatal-failure entry points** (`BVM_RUNTIMEERROR`) — gated so non-priv scripts log + return instead of crashing the server

The compound rule: if the function touches a host-owned resource (kernel handle, FD, socket, database connection) or can terminate the server, it's privileged.

## Test plan

- [x] Documentation-only; CI compile is a no-op for `.md`
- [ ] CI green

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>