### PR TITLE
Path-traversal guard on BVM_FILESIZE / BVM_FILETYPE

### DIFF
--- a/src/Modules/ScriptingCommands.bb
+++ b/src/Modules/ScriptingCommands.bb
@@ -1804,11 +1804,18 @@ Return Result%
 End Function
 
 Function BVM_FILESIZE%(Param1$)
+	; Stat is non-mutating, same posture as BVM_READFILE -- leave the
+	; privilege gate off but enforce path safety. Without the
+	; traversal check a non-priv script could probe metadata on host
+	; files outside RCScriptFiles$ (recon for further attacks even if
+	; no read access).
+	If Not BVM_ScriptPathIsSafe(Param1$) Then Return 0
 	Result% = FileSize(RCScriptFiles$ + Param1$)
 Return Result%
 End Function
 
 Function BVM_FILETYPE%(Param1$)
+	If Not BVM_ScriptPathIsSafe(Param1$) Then Return 0
 	Result% = FileType(RCScriptFiles$ + Param1$)
 Return Result%
 End Function


### PR DESCRIPTION
## Summary

Both filesystem-metadata BVMs concatenated `Param1\$` onto `RCScriptFiles\$` and stat'd the result without the `BVM_ScriptPathIsSafe` check the sibling `BVM_READFILE` applies.

A non-priv NPC script with `..\..\..\windows\system32\hosts` or similar could probe metadata on arbitrary host files outside the scripts directory. Not a content disclosure — but recon information for further attacks (which files exist, how large they are).

## Fix

Mirror the `BVM_READFILE` posture: stat is non-mutating, so leave the privilege gate off but enforce path safety. This matches the established three-category privilege model documented in [CLAUDE.md](CLAUDE.md) (#235).

## Test plan

- [x] `compile.bat -t` clean
- [ ] CI green

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>