### PR TITLE
Sanitise BVM_MOVEACTOR / BVM_ROTATEACTOR float params

### DIFF
--- a/src/Modules/ScriptingCommands.bb
+++ b/src/Modules/ScriptingCommands.bb
@@ -714,7 +714,10 @@ Function BVM_ROTATEACTOR(Param1%, Param2#)
 	If Not BVM_RequireSelfOrPrivileged(Param1%) Then Return
 	Actor.ActorInstance = Object.ActorInstance(Param1%)
 	If Actor <> Null
-		Actor\Yaw# = Param2#
+		; ClampSaneFloat catches NaN/Inf/extreme magnitudes -- a
+		; script-supplied NaN yaw poisons rotation matrices on
+		; every receiver.
+		Actor\Yaw# = ClampSaneFloat#(Param2#)
 		Pa$ = "R" + RCE_StrFromInt$(Actor\RuntimeID, 2) + RCE_StrFromFloat$(Actor\Yaw#)
 		AInstance.AreaInstance = Object.AreaInstance(Actor\ServerArea)
 		If AInstance <> Null
@@ -731,9 +734,14 @@ Function BVM_MOVEACTOR(Param1%, Param2#, Param3#, Param4#, Param5%=0, Param6%=0)
 	If Not BVM_RequireSelfOrPrivileged(Param1%) Then Return
 	Actor.ActorInstance = Object.ActorInstance(Param1%)
 	If Actor <> Null
-		Actor\X# = Param2#
-		Actor\Y# = Param3#
-		Actor\Z# = Param4#
+		; Sanitise positions before they're persisted into the actor
+		; record and broadcast. A script supplying NaN/Inf would
+		; poison every receiving client's spatial code (collision,
+		; LOD culling, EntityDistance#). Mirrors the P_InventoryUpdate
+		; "D" drop-item flow (ServerNet.bb ~1467).
+		Actor\X# = ClampWorldCoord#(Param2#)
+		Actor\Y# = ClampWorldCoord#(Param3#)
+		Actor\Z# = ClampWorldCoord#(Param4#)
 		Actor\DestX# = Actor\X#
 		Actor\DestZ# = Actor\Z#
 		Pa$ = "M" + RCE_StrFromInt$(Actor\RuntimeID, 2) + RCE_StrFromFloat$(Actor\X#) + RCE_StrFromFloat$(Actor\Y#) + RCE_StrFromFloat$(Actor\Z#)


### PR DESCRIPTION
## Summary

A script-supplied NaN/Inf X/Y/Z or Yaw would otherwise be persisted into the actor record and broadcast on `P_RepositionActor` to every receiving client. NaN positions poison spatial code (collision, LOD culling, `EntityDistance#`); NaN yaw poisons rotation matrices.

Mirror the `P_InventoryUpdate "D"` drop-item flow (ServerNet.bb ~1467) which already applies `ClampWorldCoord#` to `AI\X/Y/Z` before persisting into a DroppedItem.

## Fix

- `BVM_MOVEACTOR`: `ClampWorldCoord#` on X/Y/Z
- `BVM_ROTATEACTOR`: `ClampSaneFloat#` on Yaw (the WorldCoord clamp would reject legitimate >2pi yaws since `WorldCoordMax` is set for world-space distances; `ClampSaneFloat` is permissive enough for any valid yaw but still rejects NaN/Inf/extreme magnitudes)

## Test plan

- [x] `compile.bat -t` clean
- [ ] CI green

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>