### PR TITLE
Sanitise BVM_ANIMATEACTOR speed and BVM_CREATEEMITTER offsets

### DIFF
--- a/src/Modules/ScriptingCommands.bb
+++ b/src/Modules/ScriptingCommands.bb
@@ -1503,8 +1503,13 @@ End Function
 Function BVM_ANIMATEACTOR(Param1%, Param2$, Param3#, Param4%=0)
 	Actor.ActorInstance = Object.ActorInstance(Param1%)
 	If Actor <> Null
+		; Sanitise animation speed -- NaN broadcast to every receiving
+		; client locks up the animation timer for that actor on each
+		; receiver. ClampSaneFloat tolerates any legitimate playback
+		; rate while rejecting NaN/Inf/extreme magnitudes.
+		Local AnimSpeed# = ClampSaneFloat#(Param3#)
 		Pa$ = RCE_StrFromInt$(Actor\RuntimeID, 2) + RCE_StrFromInt$(Param4%, 1)
-		Pa$ = Pa$ + RCE_StrFromFloat$(Param3#) + Param2$
+		Pa$ = Pa$ + RCE_StrFromFloat$(AnimSpeed#) + Param2$
 		AInstance.AreaInstance = Object.AreaInstance(Actor\ServerArea)
 		If AInstance <> Null
 			A2.ActorInstance = AInstance\FirstInZone
@@ -1584,9 +1589,14 @@ Function BVM_CREATEEMITTER(Param1%, Param2$, Param3%, Param4%, Param5#=0, Param6
 	Name$ = Param2$
 	TexID = Param3%
 	Time = Param4%
-	OffsetX# = Param5#
-	OffsetY# = Param6#
-	OffsetZ# = Param7#
+	; Sanitise offset floats -- NaN broadcast to receiving clients
+	; poisons emitter positioning on each receiver. Emitter offsets
+	; are actor-relative and usually small; ClampSaneFloat is the
+	; right tool (ClampWorldCoord would also work but is sized for
+	; world-space).
+	OffsetX# = ClampSaneFloat#(Param5#)
+	OffsetY# = ClampSaneFloat#(Param6#)
+	OffsetZ# = ClampSaneFloat#(Param7#)
 	Pa$ = RCE_StrFromInt$(TexID, 2) + RCE_StrFromInt$(Time, 4) + RCE_StrFromInt(RuntimeID, 2)
 	Pa$ = Pa$ + RCE_StrFromFloat$(OffsetX#) + RCE_StrFromFloat$(OffsetY#) + RCE_StrFromFloat$(OffsetZ#) + Name$
 	Actor2.ActorInstance = Object.ActorInstance(Param8%)


### PR DESCRIPTION
## Summary

Completes the BVM float-sanitisation sweep started in #237 / #238. Two more BVM commands broadcast script-supplied floats without clamping:

| Site | Param | Use |
|---|---|---|
| `BVM_ANIMATEACTOR` | `Param3#` anim speed | `P_AnimateActor` wire — NaN locks up animation timer for that actor on each receiver |
| `BVM_CREATEEMITTER` | `Param5/6/7#` offset coords | `P_CreateEmitter` wire — NaN poisons emitter positioning |

Both use `ClampSaneFloat#` (1e9 magnitude cap with NaN/Inf rejection) since emitter offsets and anim speeds are bounded small numbers, not world-space coords.

## Test plan

- [x] `compile.bat -t` clean
- [ ] CI green

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>