### PR TITLE
Tighten P_ItemScript slot bound to Slots_Inventory

### DIFF
--- a/src/Modules/ServerNet.bb
+++ b/src/Modules/ServerNet.bb
@@ -1237,7 +1237,12 @@ Function UpdateNetwork()
 					Else
 						A2 = Null
 					EndIf
-					If SlotIndex >= 0 And SlotIndex < 50
+					; Tighten upper bound to the actual inventory size.
+					; Previous limit was the unrelated literal 50 -- larger
+					; than Slots_Inventory (45), so a crafted P_ItemScript
+					; with SlotIndex 46..49 read past the Items array
+					; (same shape as the P_EatItem fix at ~1172).
+					If SlotIndex >= 0 And SlotIndex <= Slots_Inventory
 						If AI\Inventory\Items[SlotIndex] <> Null
 							; Bug fix: the ExclusiveClass gate originally
 							; compared Actor\Race$ against ExclusiveClass$


### PR DESCRIPTION
## Summary

`P_ItemScript` guarded `SlotIndex` with `>= 0 And < 50` — `50` is the unrelated literal that pre-dates the rcce2 `Slots_Inventory` constant (45). `AI\Inventory\Items` is `Field[45]` = 46 slots (0..45), so `SlotIndex` 46..49 read past the array.

Same bug, same fix as the merged `P_EatItem` hardening at line ~1172: tighten to `<= Slots_Inventory`.

## Crafted-packet impact

A client could trigger the equip / use-item script for whatever object happens to follow `Inventory\Items` in the `ActorInstance` Type layout (subsequent `Field[N]` arrays, which include `Resistances[19]` reinterpreted as item-instance pointers). Most likely produces a crash; with sympathetic memory layout, could trigger script execution against an attacker-controlled "item".

## Test plan

- [x] `compile.bat -t` clean
- [ ] CI green

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>