### PR TITLE
Bound id in ItemInstanceFromString against ItemList Dim OOB

### DIFF
--- a/src/Modules/Items.bb
+++ b/src/Modules/Items.bb
@@ -91,6 +91,23 @@ Function ItemInstanceFromString.ItemInstance(Pa$)
 
 	Local I.ItemInstance = Null
 	Local id% = RCE_IntFromStr(Left$(Pa$, 2))
+	; ItemList is Dim'd 0..65534; 65535 is the "no item" sentinel
+	; that WriteItemInstance emits for Null items. A 2-byte wire
+	; field carries 0..65535 -- without the upper bound, id=65535
+	; Dim-OOB reads ItemList(65535) before the `<> Null` branch
+	; can run. Same shape as the read-side guard in #209.
+	If id < 0 Or id > 65534
+		; Still consume the trailing bytes so the caller's offset
+		; math stays in sync (matches the existing Null-fallback
+		; branch below).
+		Offset = 3
+		For j = 0 To 39
+			RCE_IntFromStr(Mid$(Pa$, Offset, 2))
+			Offset = Offset + 2
+		Next
+		RCE_IntFromStr(Mid$(Pa$, Offset, 1))
+		Return Null
+	EndIf
 	If ItemList(id) <> Null
 		I.ItemInstance = CreateItemInstance(ItemList(id))
 		Offset = 3


### PR DESCRIPTION
## Summary

`ItemList` is `Dim`'d 0..65534; `65535` is the "no item" sentinel that `WriteItemInstance` emits for Null items. A 2-byte wire field carries 0..65535. Without an upper bound, `id=65535` Dim-OOB-reads `ItemList(65535)` before the existing `<> Null` branch can run.

`ItemInstanceFromString` is called from:

| Site | Trigger |
|---|---|
| `ClientNet.bb` `P_OpenTrading` (~525, ~619) | NPC trade and player-trade inventory broadcasts |
| `ClientNet.bb` `P_InventoryUpdate "D"` drop-broadcast (~1345) | item drops from any actor |
| `MainMenu.bb` `P_FetchCharacter` inventory block (~1844) | login |

Every wire path that quotes an item across the network was a Dim-OOB-read trigger from a single crafted byte. Fix at the source so all callers are protected uniformly. Same shape as the read-side guard in #209.

Drain the trailing 40 attribute pairs + health byte from `Pa\$` on the rejected path so the caller's offset math stays in sync (matches the existing Null-fallback branch's behaviour).

## Test plan

- [x] `compile.bat -t` clean
- [x] `test.bat` passes (includes the existing `ItemInstanceFromString` round-trip test in `ItemsTest.bb`)
- [ ] CI green

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>