### PR TITLE
Clamp Gender wire byte in P_AppearanceUpdate "G" handler

### DIFF
--- a/src/Modules/ClientNet.bb
+++ b/src/Modules/ClientNet.bb
@@ -292,6 +292,14 @@ Function UpdateNetwork()
 						; Gender
 						Case "G"
 							AI\Gender = Asc(Right$(M\MessageData$, 1))
+							; Wire byte arrives 0..255 but Gender is a 0/1
+							; selector for Male/Female mesh + hair + face +
+							; body lookups in LoadActorInstance3D below.
+							; Clamp at the receive site -- the server's
+							; P_CreateCharacter handler already clamps on
+							; persistence (#199); this mirrors that for the
+							; in-session P_AppearanceUpdate path.
+							If AI\Gender < 0 Or AI\Gender > 1 Then AI\Gender = 0
 							X# = EntityX#(AI\CollisionEN)
 							Y# = EntityY#(AI\CollisionEN)
 							Z# = EntityZ#(AI\CollisionEN)


### PR DESCRIPTION
## Summary

`P_AppearanceUpdate "G"` (ClientNet.bb ~294) took `AI\Gender = Asc(...)` without clamping the wire byte. Subsequent `LoadActorInstance3D` selects Male vs Female mesh / hair / face / body lookups based on this value; out-of-range (2..255) drives the unsupported "neither branch" through whichever `Else` fell out.

The Beard / Hair / Face cases in the same Select already clamp (PR #198). The Gender case was the holdout.

Mirror the same guard so the in-session appearance flow matches the `P_CreateCharacter` persistence-side clamp (#199).

## Test plan

- [x] `compile.bat -t` clean
- [ ] CI green

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>