### PR TITLE
After-cursor walk in BVM_REFRESHSCRIPTS ScriptSource sweep

### DIFF
--- a/src/Modules/ScriptingCommands.bb
+++ b/src/Modules/ScriptingCommands.bb
@@ -3038,10 +3038,19 @@ Function BVM_REFRESHSCRIPTS()
 	Next
 	UpdateScripts()
 
-	For SS.ScriptSource = Each ScriptSource
+	; After-cursor walk: the body Deletes SS, which would corrupt
+	; the For-Each cursor on the next iteration step (Blitz3D
+	; advances via the deleted element's "next" pointer). Established
+	; pattern from PausedScript / ThreadScript sweeps; documented in
+	; CLAUDE.md ("Iterator-during-iteration hazards", #247).
+	Local SS.ScriptSource = First ScriptSource
+	Local SSNext.ScriptSource = Null
+	While SS <> Null
+		SSNext = After SS
 		BVM_ReleaseModule(SS\hModule)
 		Delete SS
-	Next
+		SS = SSNext
+	Wend
 
 	WriteLog(MainLog, "Deleted all loaded scripts")
 	Number = LoadScripts() : WriteLog(MainLog, "Loaded " + Str$(Number) + " scripts.")


### PR DESCRIPTION
## Summary

`BVM_REFRESHSCRIPTS` contained `For SS = Each ScriptSource / Delete SS / Next` — the textbook iterator-during-iteration hazard documented in [CLAUDE.md](CLAUDE.md) (#247): Blitz3D's `For Each` advances via the deleted element's "next" pointer, so the cursor is corrupt on the next iteration.

The single-element-delete shape matches the After-cursor walk pattern from `PausedScript` / `ThreadScript` sweeps; capture `SSNext = After SS` before the Delete and resume from there.

## Impact

Triggered every `/script REFRESHSCRIPTS` (privileged-only post-#235) — previously each refresh re-loaded scripts off whatever happened to follow the freed SS in memory, occasionally crashing or silently dropping ScriptSources past the corruption point.

## Test plan

- [x] `compile.bat -t` clean
- [ ] CI green

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>