### PR TITLE
After-cursor walk in UpdateActorInstances ActorEffect sweep

### DIFF
--- a/src/Modules/GameServer.bb
+++ b/src/Modules/GameServer.bb
@@ -612,9 +612,19 @@ End Function
 ; Updates position, etc. of all actor instances
 Function UpdateActorInstances(Broadcast)
 
-	; Update actor effects
+	; Update actor effects.
+	;
+	; After-cursor walk: the body Deletes AE in two branches (owner gone,
+	; effect time expired). Blitz3D's For-Each advances via the deleted
+	; element's "next" pointer, so the original `For AE = Each ActorEffect
+	; / Delete AE / Next` shape intermittently skipped effects or crashed
+	; on bursts of simultaneous expirations. Documented in CLAUDE.md
+	; ("Iterator-during-iteration hazards", #247).
 	T = MilliSecs()
-	For AE.ActorEffect = Each ActorEffect
+	Local AE.ActorEffect = First ActorEffect
+	Local AENext.ActorEffect = Null
+	While AE <> Null
+		AENext = After AE
 		; Owner has gone
 		If AE\Owner = Null
 			Delete AE\Attributes
@@ -642,7 +652,8 @@ Function UpdateActorInstances(Broadcast)
 				EndIf
 			EndIf
 		EndIf
-	Next
+		AE = AENext
+	Wend
 
 	; Recharging this frame?
 	Recharge = False


### PR DESCRIPTION
## Summary

The per-tick ActorEffect update loop in `UpdateActorInstances` contained `For AE = Each ActorEffect / Delete AE / Next` — the textbook iterator-during-iteration hazard documented in [CLAUDE.md](CLAUDE.md) (#247).

Two `Delete` branches inside the body:

- `AE\Owner = Null` (orphaned effect)
- `T - AE\CreatedTime > AE\Length` (expired effect)

## Impact

Bursts of simultaneous expirations (a wave of zone enters timing the same DOT to expire on the same tick; a single owner gone with multiple stacked effects) corrupted the cursor and either:

- skipped the next effect (lingers past its `Length`), or
- crashed the server on the freed-next-pointer deref.

## Fix

Mirror the established After-cursor walk from `PausedScript` / `ThreadScript` sweeps and #248 (`BVM_REFRESHSCRIPTS`).

## Test plan

- [x] `compile.bat -t` clean
- [ ] CI green

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>