### PR TITLE
After-cursor walk in ServerUnloadArea ServerWater sweep

### DIFF
--- a/src/Modules/ServerAreas.bb
+++ b/src/Modules/ServerAreas.bb
@@ -149,9 +149,16 @@ End Function
 ; Unloads all server data for an area
 Function ServerUnloadArea(A.Area)
 
-	For W.ServerWater = Each ServerWater
+	; After-cursor walk: the body Deletes W, which would corrupt
+	; the For-Each cursor on the next iteration. Documented in
+	; CLAUDE.md (#247).
+	Local W.ServerWater = First ServerWater
+	Local WNext.ServerWater = Null
+	While W <> Null
+		WNext = After W
 		If W\Area = A Then Delete(W)
-	Next
+		W = WNext
+	Wend
 	;For j = 0 To 99 {##}
 	;	If A\Instances[j] <> Null
 	;		For i = 0 To 499


### PR DESCRIPTION
## Summary

`ServerUnloadArea` contained `For W = Each ServerWater / If W\Area = A Then Delete(W) / Next` — iterator-during-iteration hazard documented in [CLAUDE.md](CLAUDE.md) (#247).

Triggered when an area is unloaded server-side (admin tool refresh or shutdown sweep). An area with multiple `ServerWater` records would Delete the first matching record, corrupt the cursor, and either skip the next match (orphaned ServerWater leaks) or crash on the freed-next-pointer deref.

Mirror the established After-cursor walk pattern from `PausedScript` / `ThreadScript` / ActorEffect (#249) / Interface3D (#250) sweeps.

## Test plan

- [x] `compile.bat -t` clean
- [ ] CI green

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>