### PR TITLE
After-cursor walk in UpdateEnvironment3D ScriptedEmitter sweep

### DIFF
--- a/src/Modules/Environment3D.bb
+++ b/src/Modules/Environment3D.bb
@@ -237,13 +237,22 @@ End Function
 ; Updates the whole environment
 Function UpdateEnvironment3D()
 
-	; Scripted emitters
-	For SEm.ScriptedEmitter = Each ScriptedEmitter
+	; Scripted emitters.
+	; After-cursor walk: the body Deletes SEm when its lifetime
+	; expires. The original For-Each form intermittently skipped
+	; emitters or crashed on bursts of simultaneous expirations
+	; (multiple emitters scheduled for the same Length will all
+	; trigger on the same tick). Documented in CLAUDE.md (#247).
+	Local SEm.ScriptedEmitter = First ScriptedEmitter
+	Local SEmNext.ScriptedEmitter = Null
+	While SEm <> Null
+		SEmNext = After SEm
 		If MilliSecs() - SEm\StartTime >= SEm\Length
 			RP_KillEmitter(SEm\EN, True, False)
 			Delete SEm
 		EndIf
-	Next
+		SEm = SEmNext
+	Wend
 
 ;Add Animated water to options menu Cysis145
 		; Options are loaded once at startup by LoadGame() in ClientLoaders.bb


### PR DESCRIPTION
## Summary

`UpdateEnvironment3D` contained `For SEm = Each ScriptedEmitter / Delete SEm / Next` — iterator-during-iteration hazard documented in [CLAUDE.md](CLAUDE.md) (#247).

Runs every `UpdateEnvironment3D` tick on the client. Multiple emitters scheduled with the same `Length` expire on the same tick; the original loop Deleted the first and corrupted the cursor for the rest.

Symptoms: emitters that linger past their schedule, or client crash on the freed-next-pointer deref during a particle burst.

## Test plan

- [x] `compile.bat -t` clean
- [ ] CI green

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>