### PR TITLE
After-cursor walk in F-UI listbox M_RESET handler

### DIFF
--- a/src/Modules/F-UI.bb
+++ b/src/Modules/F-UI.bb
@@ -3562,14 +3562,28 @@ Function FUI_SendMessage$( ID, Message, Param1$="", Param2$="" )
 					EndIf
 				Next
 			Case M_RESET
-				For lsti.ListBoxItem = Each ListBoxItem
-					If lsti\Owner = lst
-						FreeEntity lsti\IconMesh
-						FreeEntity lsti\Mesh
-						Delete lsti
-;						FUI_DeleteGadget Handle( lsti )
+				; After-cursor walk: the body Deletes the iter, which
+				; would corrupt the For-Each cursor on the next
+				; iteration. A listbox with multiple items would Delete
+				; the first match and either skip the rest (orphan
+				; ListBoxItems leak) or crash on freed-next-pointer
+				; deref. Documented in CLAUDE.md (#247).
+				; Local renamed to lstiR / lstiRNext to avoid collision
+				; with the implicitly-declared lsti from sibling
+				; `For lsti.ListBoxItem = Each ListBoxItem` loops at
+				; the function scope above.
+				Local lstiR.ListBoxItem = First ListBoxItem
+				Local lstiRNext.ListBoxItem = Null
+				While lstiR <> Null
+					lstiRNext = After lstiR
+					If lstiR\Owner = lst
+						FreeEntity lstiR\IconMesh
+						FreeEntity lstiR\Mesh
+						Delete lstiR
+;						FUI_DeleteGadget Handle( lstiR )
 					EndIf
-				Next
+					lstiR = lstiRNext
+				Wend
 				lst\CY = 0
 			Case M_ENABLE
 				FUI_EnableGadget Handle( lst )


### PR DESCRIPTION
## Summary

F-UI's listbox `M_RESET` case contained `For lsti = Each ListBoxItem / Delete lsti / Next` — iterator-during-iteration hazard documented in [CLAUDE.md](CLAUDE.md) (#247).

Triggered on every listbox reset (refresh of GUE editor item list, dropdown clearing, etc.). A listbox with multiple items would Delete the first match and either skip the rest (orphan ListBoxItems leak) or crash on freed-next-pointer deref.

## Naming

Locals renamed to `lstiR` / `lstiRNext` to avoid collision with the implicitly-declared `lsti` from sibling `For lsti = Each ListBoxItem` loops at the function scope above — the initial fix attempt with `Local lsti` produced a "Duplicate variable name" compile error.

## Test plan

- [x] Full `compile.bat` clean (F-UI is shared with the Tools build)
- [ ] CI green

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>