### PR TITLE
After-cursor walks in ClientAreas_FE.bb and ClientAreasTE.bb UnloadArea

### DIFF
--- a/src/Modules/ClientAreasTE.bb
+++ b/src/Modules/ClientAreasTE.bb
@@ -1084,46 +1084,75 @@ Function UnloadArea()
 
 	UnloadTrees(False)
 
-	For S.Scenery = Each Scenery
+	; Six After-cursor walks; same bug class as #254 (GUE
+	; ClientAreas.bb sibling). RC Terrain Editor's UnloadArea
+	; ran six For-Each + Delete loops in sequence -- the
+	; original shape corrupted the cursor for any multi-element
+	; resource type. Documented in CLAUDE.md (#247).
+	Local S.Scenery = First Scenery
+	Local SNext.Scenery = Null
+	While S <> Null
+		SNext = After S
 		If S\TextureID < 65535 Then UnloadTexture(S\TextureID)
 		UnloadMesh(S\MeshID)
 		FreeEntity(S\EN)
 		Delete(S)
-	Next
+		S = SNext
+	Wend
 
-	For W.Water = Each Water
+	Local W.Water = First Water
+	Local WNext.Water = Null
+	While W <> Null
+		WNext = After W
 		UnloadTexture(W\TexID)
 		FreeTexture(W\TexHandle)
 		FreeEntity(W\EN)
 		Delete(W)
-	Next
+		W = WNext
+	Wend
 
-	For C.ColBox = Each ColBox
+	Local C.ColBox = First ColBox
+	Local CNext.ColBox = Null
+	While C <> Null
+		CNext = After C
 		FreeEntity(C\EN)
 		Delete(C)
-	Next
+		C = CNext
+	Wend
 
-	For E.Emitter = Each Emitter
+	Local E.Emitter = First Emitter
+	Local ENext.Emitter = Null
+	While E <> Null
+		ENext = After E
 		RP_FreeEmitter(GetChild(E\EN, 1), True, False)
 		UnloadTexture(E\TexID)
 		FreeEntity(E\EN)
 		Delete(E)
-	Next
+		E = ENext
+	Wend
 
-	For SZ.SoundZone = Each SoundZone
+	Local SZ.SoundZone = First SoundZone
+	Local SZNext.SoundZone = Null
+	While SZ <> Null
+		SZNext = After SZ
 		If SZ\Channel <> 0 Then StopChannel(SZ\Channel)
 		If SZ\SoundID > 0 And SZ\SoundID < 65535 Then UnloadSound(SZ\SoundID)
 		FreeEntity(SZ\EN)
 		Delete(SZ)
-	Next
+		SZ = SZNext
+	Wend
 
-	For T.Terrain = Each Terrain
+	Local T.Terrain = First Terrain
+	Local TNext.Terrain = Null
+	While T <> Null
+		TNext = After T
 		FreeEntity T\EN
 		UnloadTexture(T\BaseTexID)
 		If T\DetailTex <> 0 Then FreeTexture(T\DetailTex)
 		If T\DetailTexID < 65535 Then UnloadTexture(T\DetailTexID)
 		Delete(T)
-	Next
+		T = TNext
+	Wend
 
 	Delete Each CatchPlane
 

--- a/src/Modules/ClientAreas_FE.bb
+++ b/src/Modules/ClientAreas_FE.bb
@@ -1157,53 +1157,83 @@ Function UnloadArea()
 
 ;	UnloadTrees(False) [~@~]
 
-	For S.Scenery = Each Scenery
+	; Six After-cursor walks; same bug class as #254 (the GUE
+	; ClientAreas.bb sibling). Every zone transition on the
+	; client unloads area resources via these loops, each
+	; Deleting the current iter -- the original For-Each shape
+	; corrupted the cursor for multi-element types. Documented
+	; in CLAUDE.md (#247).
+	Local S.Scenery = First Scenery
+	Local SNext.Scenery = Null
+	While S <> Null
+		SNext = After S
 		;Shadow
 		FreeShadowCaster% (S\EN)
 		;FreeShadowReceiver% (S\EN)
-	
+
 		If S\TextureID < 65535 Then UnloadTexture(S\TextureID)
 		UnloadMesh(S\MeshID)
 		FreeEntity(S\EN)
 		Delete(S)
-	Next
+		S = SNext
+	Wend
 
-	For W.Water = Each Water
+	Local W.Water = First Water
+	Local WNext.Water = Null
+	While W <> Null
+		WNext = After W
 		UnloadTexture(W\TexID)
 		FreeTexture(W\TexHandle)
 		FreeEntity(W\EN)
-		
-		;FreeTexture(W\BumpTexA)
-		
-		Delete(W)
-	Next
 
-	For C.ColBox = Each ColBox
+		;FreeTexture(W\BumpTexA)
+
+		Delete(W)
+		W = WNext
+	Wend
+
+	Local C.ColBox = First ColBox
+	Local CNext.ColBox = Null
+	While C <> Null
+		CNext = After C
 		FreeEntity(C\EN)
 		Delete(C)
-	Next
+		C = CNext
+	Wend
 
-	For E.Emitter = Each Emitter
+	Local E.Emitter = First Emitter
+	Local ENext.Emitter = Null
+	While E <> Null
+		ENext = After E
 		RP_FreeEmitter(GetChild(E\EN, 1), True, False)
 		UnloadTexture(E\TexID)
 		FreeEntity(E\EN)
 		Delete(E)
-	Next
+		E = ENext
+	Wend
 
-	For SZ.SoundZone = Each SoundZone
+	Local SZ.SoundZone = First SoundZone
+	Local SZNext.SoundZone = Null
+	While SZ <> Null
+		SZNext = After SZ
 		If SZ\Channel <> 0 Then StopChannel(SZ\Channel)
 		If SZ\SoundID > 0 And SZ\SoundID < 65535 Then UnloadSound(SZ\SoundID)
 		FreeEntity(SZ\EN)
 		Delete(SZ)
-	Next
+		SZ = SZNext
+	Wend
 
-	For T.Terrain = Each Terrain
+	Local T.Terrain = First Terrain
+	Local TNext.Terrain = Null
+	While T <> Null
+		TNext = After T
 		FreeEntity T\EN
 		UnloadTexture(T\BaseTexID)
 		If T\DetailTex <> 0 Then FreeTexture(T\DetailTex)
 		If T\DetailTexID < 65535 Then UnloadTexture(T\DetailTexID)
 		Delete(T)
-	Next
+		T = TNext
+	Wend
 	
 	;For AI.ActorInstance = Each ActorInstance
 	;		FreeShadowCaster% (AI\EN)


### PR DESCRIPTION
## Summary

Sibling `UnloadArea` functions in two other ClientAreas variants had the same six iterator-during-iteration hazards as the GUE build (fixed in #254):

- `src/Client.bb` uses `ClientAreas_FE.bb` (the live game client)
- `src/Tools/RC Terrain Editor.bb` uses `ClientAreasTE.bb`

Both files run six For-Each + Delete loops in sequence on every zone transition (Scenery / Water / ColBox / Emitter / SoundZone / Terrain). The original For-Each shape corrupted the cursor for any multi-element resource type — **the live client was affected on every zone change**, not just GUE.

Mirror the established After-cursor walk pattern documented in [CLAUDE.md](CLAUDE.md) (#247).

## Why a multi-file PR

These three `UnloadArea` implementations diverged from a common ancestor; the bug class is identical in all three. Splitting into three PRs would just be churn for review.

## Test plan

- [x] Full `compile.bat` clean (all binaries that include these modules)
- [ ] CI green

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>