### PR TITLE
After-cursor walks in ClientNet area-change cleanup loops

### DIFF
--- a/src/Modules/ClientNet.bb
+++ b/src/Modules/ClientNet.bb
@@ -1653,16 +1653,30 @@ Function UpdateNetwork()
 					If OldAreaName$ <> "" Then Save_Radar_Fog(RadarPath$ + Me\Name$ + "-" + OldAreaName$ + ".rdr")
 
 					; Remove old actor instances
-					For A.ActorInstance = Each ActorInstance
-						If A <> Me Then SafeFreeActorInstance(A)
-					Next
+					; After-cursor walk: SafeFreeActorInstance Deletes A
+					; via FreeActorInstance. The original For-Each form
+					; corrupted the cursor for any zone with multiple
+					; remote actors (which is every populated zone).
+					; Documented in CLAUDE.md (#247).
+					Local Acac.ActorInstance = First ActorInstance
+					Local AcacNext.ActorInstance = Null
+					While Acac <> Null
+						AcacNext = After Acac
+						If Acac <> Me Then SafeFreeActorInstance(Acac)
+						Acac = AcacNext
+					Wend
 				EndIf
 
-				; Remove dropped loot
-				For DItem.DroppedItem = Each DroppedItem
-					FreeEntity DItem\EN
-					Delete DItem
-				Next
+				; Remove dropped loot -- After-cursor walk for the same
+				; reason as above.
+				Local DItemR.DroppedItem = First DroppedItem
+				Local DItemRNext.DroppedItem = Null
+				While DItemR <> Null
+					DItemRNext = After DItemR
+					FreeEntity DItemR\EN
+					Delete DItemR
+					DItemR = DItemRNext
+				Wend
 
 				; Unload old and load new zone if necessary
 				If AreaName$ <> OldAreaName$


### PR DESCRIPTION
## Summary

Two more iterator-during-iteration hazards documented in [CLAUDE.md](CLAUDE.md) (#247), both in the `P_ChangeArea` / area-change reception path:

| Site | Trigger |
|---|---|
| ActorInstance sweep (~1656) | `For A = Each ActorInstance / If A <> Me Then SafeFreeActorInstance(A) / Next` — fires on every zone change for every remote actor (which is every populated zone) |
| DroppedItem sweep (~1662) | `For DItem = Each DroppedItem / Delete DItem / Next` — same hazard for the area's loot |

Both Locals renamed with `R` / `Next` suffixes (`Acac`, `DItemR`) to avoid the BlitzForge `Local X` vs `For X = Each` collision trap (saved to memory after PR #253 hit it).

## Test plan

- [x] `compile.bat -t` clean
- [ ] CI green

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>