### PR TITLE
Exit-after-Delete in Logging.StopLog For-Each

### DIFF
--- a/src/Modules/Logging.bb
+++ b/src/Modules/Logging.bb
@@ -152,8 +152,18 @@ End Function
 ; Closes a log file
 Function StopLog(LogHandle)
 
+	; Exit immediately after the matching Delete -- For-Each
+	; iteration with a Delete in the body corrupts the cursor
+	; (documented in CLAUDE.md, #247). Each LogHandle has at
+	; most one matching LogFile, so the loop should never need
+	; to continue after the Delete; the original `Next` was a
+	; latent crash waiting for a future caller that might
+	; re-enter the loop body before the Delete settled.
 	For L.LogFile = Each LogFile
-		If L\File = LogHandle Then Delete L
+		If L\File = LogHandle
+			Delete L
+			Exit
+		EndIf
 	Next
 	CloseFile(LogHandle)
 


### PR DESCRIPTION
## Summary

`StopLog` walked `For L = Each LogFile / If L\File = LogHandle Then Delete L / Next` — iterator-during-iteration hazard documented in [CLAUDE.md](CLAUDE.md) (#247).

Each `LogHandle` has at most one matching `LogFile`, so the loop body never needs to continue past the Delete. Exit immediately after the Delete is the lightest safe fix.

The original `Next` was a latent crash waiting for a future caller that might cause iteration to continue after the Delete.

## Test plan

- [x] `compile.bat -t` clean
- [x] `test.bat` passes (Logging.bb has dedicated tests in ReadBoundedStringTest)
- [ ] CI green

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>