### PR TITLE
After-cursor walks in client RCE_Message dispatchers (12 sites)

### DIFF
--- a/src/Modules/ClientNet.bb
+++ b/src/Modules/ClientNet.bb
@@ -43,10 +43,18 @@ Function Connect()
 
 	; Await reply
 	Done = 0
+	; After-cursor walk: trailing Delete M during For-Each would corrupt
+	; the cursor on the next step when multiple messages are queued
+	; (the server fans out P_StartGame plus any chat/disconnect packets
+	; that crossed the wire in the same tick).
+	Local M.RCE_Message = First RCE_Message
+	Local MNext.RCE_Message = Null
 	While Done < 13
 		Delay 10
 		; We get signal!
-		For M.RCE_Message = Each RCE_Message
+		M = First RCE_Message
+		While M <> Null
+			MNext = After M
 			If M\MessageType = P_StartGame
 				; Error message
 				If M\MessageData$ = "N" Then RuntimeError(LanguageString$(LS_AlreadyInGame))
@@ -106,11 +114,12 @@ Function Connect()
 				OnLostConnection()
 				Delete M
 			EndIf
-		Next
-		
+			M = MNext
+		Wend
+
 		RCE_Update()
 		RCE_CreateMessages()
-		
+
 		Cls
 		Flip VSync
 	Wend
@@ -125,7 +134,16 @@ End Function
 Function UpdateNetwork()
 
 	; Incoming messages
-	For M.RCE_Message = Each RCE_Message
+	; After-cursor walk: the trailing Delete M before Next would corrupt
+	; the For-Each cursor on the next step. This dispatcher runs every
+	; frame and processes the full RCE_Message backlog -- a typical tick
+	; carries many packets (per-actor updates, chat, effects, etc.), so
+	; the For-Each + Delete pattern reliably skips messages and risks a
+	; use-after-free on the cursor advance.
+	Local M.RCE_Message = First RCE_Message
+	Local MNext.RCE_Message = Null
+	While M <> Null
+		MNext = After M
 		; What happen?
 		Select M\MessageType
 
@@ -1748,9 +1766,10 @@ Function UpdateNetwork()
 
 		End Select
 		Delete M
-	Next
-	
-	
+		M = MNext
+	Wend
+
+
 	; Send update packet
 	
 	newEntityY#=EntityY#(Me\CollisionEN)

--- a/src/Modules/MainMenu.bb
+++ b/src/Modules/MainMenu.bb
@@ -185,7 +185,14 @@ Function UpdateFiles()
 	While Done = False
 		Delay 10
 		If KeyHit(1) Then RCE_Disconnect() : End
-		For M.RCE_Message = Each RCE_Message
+		; After-cursor walk: the trailing Delete M (and the inner
+		; Done = True : Exit branch) would corrupt a For-Each cursor when
+		; multiple RCE_Messages are queued; the next Next would step from
+		; the freed M's next pointer. Walk explicitly via First/After.
+		Local M.RCE_Message = First RCE_Message
+		Local MNext.RCE_Message = Null
+		While M <> Null
+			MNext = After M
 			If M\MessageType = P_FetchUpdateFiles
 				Pa$ = M\MessageData$
 				Offset = 1
@@ -233,10 +240,11 @@ Function UpdateFiles()
 				OnLostConnection()
 			EndIf
 			Delete M
-		Next
+			M = MNext
+		Wend
 		RCE_Update()
 		RCE_CreateMessages()
-		
+
 		GY_Update()
 		UpdateWorld()
 		RenderWorld()
@@ -803,7 +811,13 @@ Function LogIn()
 			While Done = False
 				Delay 10
 				If KeyHit(1) Then RCE_Disconnect() : End
-				For M.RCE_Message = Each RCE_Message
+				; After-cursor walk: trailing Delete M during For-Each would
+				; corrupt the cursor on the next step when multiple messages
+				; are queued (RCE_CreateMessages fans out everything pending).
+				Local M.RCE_Message = First RCE_Message
+				Local MNext.RCE_Message = Null
+				While M <> Null
+					MNext = After M
 
 					If M\MessageType = P_VerifyAccount
 						If Left$(M\MessageData$, 1) = "N"
@@ -822,7 +836,8 @@ Function LogIn()
 						OnLostConnection()
 					EndIf
 					Delete M
-				Next
+					M = MNext
+				Wend
 				
 			
 				RCE_Update()
@@ -854,7 +869,13 @@ Function LogIn()
 				While Done = False
 					Delay 10
 					If KeyHit(1) Then RCE_Disconnect() : End
-					For M.RCE_Message = Each RCE_Message
+					; After-cursor walk (M / MNext declared above at first site).
+					; P_FetchActors streams many actor/item blocks per tick; each
+					; internal Delete M without an Exit would otherwise corrupt
+					; the For-Each cursor and silently skip subsequent blocks.
+					M = First RCE_Message
+					While M <> Null
+						MNext = After M
 						If M\MessageType = P_FetchActors
 							Pa$ = M\MessageData$
 							; Attributes block
@@ -1098,18 +1119,19 @@ Function LogIn()
 						ElseIf M\MessageType = RN_HostHasLeft Or M\MessageType = RN_Disconnected
 							OnLostConnection()
 						EndIf
-					Next
-					
+						M = MNext
+					Wend
+
 					RCE_Update()
 					RCE_CreateMessages()
-					
+
 					GY_Update()
 					UpdateWorld()
 					RenderWorld()
 					Flip(VSync)
 				Wend
-	
-	
+
+
 				; Clear window and exit
 				
 				FreeEntity(Background)
@@ -1162,7 +1184,10 @@ Function LogIn()
 			While Done = False
 				Delay 10
 				If KeyHit(1) Then RCE_Disconnect() : End
-				For M.RCE_Message = Each RCE_Message
+				; After-cursor walk (M / MNext declared above at first site).
+				M = First RCE_Message
+				While M <> Null
+					MNext = After M
 					If M\MessageType = P_CreateAccount
 						If M\MessageData$ = "Y" Then Result = True Else Result = False
 						Delete M : Done = True : Exit
@@ -1170,7 +1195,8 @@ Function LogIn()
 						OnLostConnection()
 					EndIf
 					Delete M
-				Next
+					M = MNext
+				Wend
 				
 				RCE_Update()
 				RCE_CreateMessages()
@@ -1191,14 +1217,18 @@ Function LogIn()
 		EndIf
 
 		; Check connection is still alive
-		For M.RCE_Message = Each RCE_Message
+		; After-cursor walk (M / MNext declared above at first site).
+		M = First RCE_Message
+		While M <> Null
+			MNext = After M
 			Select M\MessageType
 				Case RN_Disconnected, RN_HostHasLeft
 					OnLostConnection()
 			End Select
 			Delete M
-		Next
-		
+			M = MNext
+		Wend
+
 
 ;-------------------------------
 ;OPTIONS
@@ -1714,7 +1744,13 @@ Function CharSelect()
 				Done = False
 				While Done = False
 				;	Delay 10
-					For M.RCE_Message = Each RCE_Message
+					; After-cursor walk: the trailing Delete M (and the
+					; Goto-out branch) would corrupt the For-Each cursor on
+					; the next step when multiple messages are queued.
+					Local M.RCE_Message = First RCE_Message
+					Local MNext.RCE_Message = Null
+					While M <> Null
+						MNext = After M
 						If M\MessageType = P_DeleteCharacter
 							CharList$ = M\MessageData$
 							Delete M
@@ -1726,15 +1762,16 @@ Function CharSelect()
 							If PreviewA <> Null Then SafeFreeActorInstance(PreviewA)
 							PreviewA = Null
 							setup = False
-							
-							
-							
+
+
+
 							Goto RestartCharSelection
 						ElseIf M\MessageType = RN_HostHasLeft Or M\MessageType = RN_Disconnected
 							OnLostConnection()
 						EndIf
 						Delete M
-					Next
+						M = MNext
+					Wend
 										
 					RCE_Update()
 					RCE_CreateMessages()
@@ -1802,7 +1839,12 @@ Function CharSelect()
 			Done = False
 			While Done = False
 				Delay 10
-				For M.RCE_Message = Each RCE_Message
+				; After-cursor walk (M / MNext declared above at first site).
+				; P_FetchCharacter streams many blocks in one tick -- iterator
+				; corruption here would silently skip character data on login.
+				M = First RCE_Message
+				While M <> Null
+					MNext = After M
 					If M\MessageType = P_FetchCharacter
 						; Character information
 						If Left$(M\MessageData$, 1) = "C"
@@ -1918,11 +1960,12 @@ Function CharSelect()
 						OnLostConnection()
 						Delete M
 					EndIf
-				Next
-				
+					M = MNext
+				Wend
+
 				RCE_Update()
 				RCE_CreateMessages()
-				
+
 				GY_Update()
 				UpdateWorld(Delta#)
 				RenderWorld()
@@ -2014,18 +2057,22 @@ Function CharSelect()
 		EndIf		
 
 		; Check connection is still alive
-		For M.RCE_Message = Each RCE_Message
+		; After-cursor walk (M / MNext declared above at first site).
+		M = First RCE_Message
+		While M <> Null
+			MNext = After M
 			Select M\MessageType
 				Case RN_Disconnected, RN_HostHasLeft
 					OnLostConnection()
 			End Select
 			Delete M
-		Next
+			M = MNext
+		Wend
 
 		; Update everything
 		RCE_Update()
 		RCE_CreateMessages()
-		
+
 		GY_Update()
 		RP_Update()
 		UpdateWorld(delta#)
@@ -2313,7 +2360,13 @@ Function CreateChar()
 					Done = False : Result = 0
 					While Done = False
 						Delay 10
-						For M.RCE_Message = Each RCE_Message
+						; After-cursor walk: trailing Delete M during For-Each
+						; would corrupt the cursor on the next step when
+						; multiple messages are queued.
+						Local M.RCE_Message = First RCE_Message
+						Local MNext.RCE_Message = Null
+						While M <> Null
+							MNext = After M
 							If M\MessageType = P_CreateCharacter
 								If M\MessageData$ = "Y"
 									Result = 2
@@ -2325,7 +2378,8 @@ Function CreateChar()
 								OnLostConnection()
 							EndIf
 							Delete(M)
-						Next
+							M = MNext
+						Wend
 
 						RCE_Update()
 						RCE_CreateMessages()
@@ -2678,14 +2732,18 @@ Function CreateChar()
        PointEntity Cam, GPP 
        MoveEntity Cam, 10.0, 0.0, 0.0 
 
-       ; Check connection is still alive 
-       For M.RCE_Message = Each RCE_Message 
-          Select M\MessageType 
-             Case RN_Disconnected, RN_HostHasLeft 
-                OnLostConnection() 
-          End Select 
-          Delete M 
-       Next
+       ; Check connection is still alive
+       ; After-cursor walk (M / MNext declared above at first site).
+       M = First RCE_Message
+       While M <> Null
+          MNext = After M
+          Select M\MessageType
+             Case RN_Disconnected, RN_HostHasLeft
+                OnLostConnection()
+          End Select
+          Delete M
+          M = MNext
+       Wend
 
 		; Update everything
 		RCE_Update()


### PR DESCRIPTION
## Summary (non-technical)

Twelve places on the client side were walking the inbound network-message list while deleting messages from it — the same iterator-during-iteration hazard documented in [CLAUDE.md](https://github.com/RydeTec/rcce2/blob/develop/CLAUDE.md). When a tick carried multiple messages (common during login, character data streaming, and every frame of normal play), the iterator advanced from a freed pointer. Symptoms range from silently dropped messages (skipped actor / item / spell data on login) to a hard crash on the cursor step.

This PR sweeps the entire client RCE_Message processing path: all four MainMenu phases (file update, login, character select, character creation) and both ClientNet dispatchers (P_StartGame handshake and the per-frame UpdateNetwork loop).

## Summary (technical)

### Sites converted

`src/Modules/MainMenu.bb` (10 sites across 4 functions):

| Function | Sites | Purpose |
|---|---|---|
| `UpdateFiles` | 1 | initial file-update wait (P_FetchUpdateFiles) |
| `LogIn` | 4 | P_VerifyAccount, P_CreateAccount, connection-alive, P_FetchActors (streams attributes / damage types / environment / actor / item blocks) |
| `CharSelect` | 3 | P_DeleteCharacter, P_FetchCharacter (streams stat / inventory / spell / quest blocks), connection-alive |
| `CreateChar` | 2 | P_CreateCharacter, connection-alive |

`src/Modules/ClientNet.bb` (2 sites across 2 functions):

| Function | Purpose |
|---|---|
| `Connect` | P_StartGame handshake wait |
| `UpdateNetwork` | per-frame packet dispatcher (~1620-line `Select Case` on packet type) |

### Pattern

Before:
```basic
For M.RCE_Message = Each RCE_Message
    ; ... body, often with intermediate Delete M / Exit ...
    Delete M
Next
```

After:
```basic
Local M.RCE_Message = First RCE_Message
Local MNext.RCE_Message = Null
While M <> Null
    MNext = After M
    ; ... body ...
    Delete M
    M = MNext
Wend
```

The `MNext = After M` capture happens *before* the body touches M, so the next-pointer is always live regardless of whether the body deletes M, `Exit`s, or `Goto`s out.

### Per-function Local declarations

BlitzForge will reject duplicate `Local M.RCE_Message` declarations within the same function and will collide if a `Local M` is added while another `For M = Each` still implicitly declares M. So each function declares `Local M.RCE_Message` and `Local MNext.RCE_Message` exactly once at its first converted site; subsequent sites reuse the same locals. This is recorded as the *Local + For-Each collision* feedback memory.

### Highest-impact sites

- `UpdateNetwork` (ClientNet.bb:125) runs every frame and dispatches the full backlog. A typical tick carries many packets (per-actor updates, chat, effects, projectiles, spells, area changes) — corruption here is per-frame.
- `P_FetchActors` (MainMenu.bb LogIn, ~line 872) and `P_FetchCharacter` (CharSelect, ~line 1805) stream many blocks in one tick — iterator corruption silently drops attributes, inventory, spells, quest log entries on login.
- Connection-alive checks (MainMenu lines 1194, 2017, 2682) run every menu frame.

### Tests / verification

- Full engine compile (`compile.bat -t`): clean across Server / Client / GUE / Project Manager. Tools don't include MainMenu or ClientNet.
- `test.bat` suite continues to pass.
- No `Continue` or `Exit For` keywords inside any of the converted bodies (verified with grep) so `Exit` semantics are preserved when `For` becomes `While`.

### Related history

Continues the iterator-during-iteration hazard sweep documented in CLAUDE.md and previously executed for [#258](https://github.com/RydeTec/rcce2/pull/258) (Logging.StopLog), [#257](https://github.com/RydeTec/rcce2/pull/257) (BVM_REMOVEZONEINSTANCE), [#256](https://github.com/RydeTec/rcce2/pull/256) (ClientNet area-change cleanup), [#255](https://github.com/RydeTec/rcce2/pull/255) / [#254](https://github.com/RydeTec/rcce2/pull/254) (UnloadArea family), [#252](https://github.com/RydeTec/rcce2/pull/252) (UpdateEnvironment3D), [#251](https://github.com/RydeTec/rcce2/pull/251) (ServerUnloadArea), [#250](https://github.com/RydeTec/rcce2/pull/250) (Interface3D), [#249](https://github.com/RydeTec/rcce2/pull/249) (UpdateActorInstances), [#248](https://github.com/RydeTec/rcce2/pull/248) (BVM_REFRESHSCRIPTS), and [#246](https://github.com/RydeTec/rcce2/pull/246) (FreeActorInstanceSlaves restart-on-Delete).

### Out of scope / deferred

- Server-side `For M.RCE_Message = Each RCE_Message` in `ServerNet.bb:85` — server-side dispatcher uses a similar pattern but with very different cleanup semantics; deserves its own PR with the threat-model audit.
- Other server-side iterator hazards surfaced by the scan (`QueuedPacket` flush at `ServerNet.bb:69`, `FreeActorScripts` interaction at `Scripting.bb:391`) — separate audits, separate PRs.

## Test plan

- [x] `compile.bat -t` clean
- [x] `test.bat` green
- [x] No remaining `For M.RCE_Message = Each` in either file (verified)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)