### PR TITLE
Atomic-write the RC Terrain Editor area saves and BVM core ROM

### DIFF
--- a/src/Modules/ClientAreasTE.bb
+++ b/src/Modules/ClientAreasTE.bb
@@ -793,9 +793,17 @@ Function LoadAreaTE(Name$)
 End Function
 
 ; Saves the current area back to file
+; Routes through SafeWriteOpen / SafeWriteCommit so a crash mid-flush
+; doesn't leave the previous (good) area dat truncated. RC Terrain
+; Editor authors hand-build areas over hours; without the atomic
+; wrapper a single mistimed crash loses every waypoint, spawn, and
+; portal in the zone. Mirrors the canonical GUE SaveArea migration
+; in ClientAreas.bb (PR audit at line ~817 there).
 Function SaveAreaTE(Name$)
-	
-	F = WriteFile("Data\Areas\" + Name$ + ".dat")
+
+	Local FinalPath$ = "Data\Areas\" + Name$ + ".dat"
+	Local TempPath$ = SafeWriteOpen(FinalPath$)
+	F = WriteFile(TempPath$)
 	If F = 0 Then Return False
 	
 		; Loading screen
@@ -915,17 +923,21 @@ Function SaveAreaTE(Name$)
 		WriteInt F, SZ\RepeatTime
 		WriteByte F, SZ\Volume
 	Next
-	
-	CloseFile(F)
-	Return True
-	
+
+	Return SafeWriteCommit(TempPath$, FinalPath$, F)
+
 End Function
 
 
 ; Saves the current area back to file
+; Atomic-write parity with SaveAreaTE above and the canonical
+; ClientAreas.bb SaveArea. Same threat model: hand-authored area
+; dat lost on a crash mid-write.
 Function SaveArea(Name$)
 
-	F = WriteFile("Data\Areas\" + Name$ + ".dat")
+	Local FinalPath$ = "Data\Areas\" + Name$ + ".dat"
+	Local TempPath$ = SafeWriteOpen(FinalPath$)
+	F = WriteFile(TempPath$)
 	If F = 0 Then Return False
 
 		; Loading screen
@@ -1069,8 +1081,7 @@ Function SaveArea(Name$)
 			WriteByte F, SZ\Volume
 		Next
 
-	CloseFile(F)
-	Return True
+	Return SafeWriteCommit(TempPath$, FinalPath$, F)
 
 End Function
 

--- a/src/Modules/Scripting.bb
+++ b/src/Modules/Scripting.bb
@@ -623,15 +623,23 @@ End Function
 Function CreateCore()
 ;Consider also generating Core.rcm (Core.bvm)
 filename$ = RCScripts$ + "RC_Core.rcm"
+	; Route through SafeWriteOpen / SafeWriteCommit. The previous
+	; DeleteFile-then-WriteFile sequence opened the exact truncate-
+	; then-crash window Logging.bb's SafeWrite helpers exist to close:
+	; a crash between Delete and CloseFile leaves no RC_Core.rcm, and
+	; the engine fails to compile any script on next launch. Atomic
+	; wrapper demotes the existing copy to .bak first, so even a
+	; promote-failure leaves a recoverable copy.
+	Local TempPath$ = SafeWriteOpen(filename)
 	Restore Core
-	DeleteFile(filename)
-	W = WriteFile(filename)
+	W = WriteFile(TempPath$)
+	If W = 0 Then Return
 	Read count
 	For i = 1 To count
 		Read Dat
 		WriteByte(W, Dat)
 	Next
-	CloseFile(W)
+	SafeWriteCommit(TempPath$, filename, W)
 End Function
 
 

--- a/src/Tests/Modules/SafeWriteTest.bb
+++ b/src/Tests/Modules/SafeWriteTest.bb
@@ -116,6 +116,41 @@ Test testSafeWriteCommitRefusesEmptyTemp()
 	CleanupTestFiles()
 End Test
 
+; Successive commits cycle the .bak: after three saves A -> B -> C,
+; .bak must hold B (the immediately previous version), not A. This pins
+; the behaviour at Logging.bb's `If FileType(Bak$) = 1 Then DeleteFile(Bak$)`
+; line -- without that delete, the second CopyFile into an existing
+; .bak target either fails silently or appends, and the .bak content
+; diverges from the most-recent-pre-save state. The RC Terrain Editor
+; SaveAreaTE migration (and the GUE SaveArea before it) saves on every
+; build-cycle hotkey; an author hitting Save twice in a row must be able
+; to recover the *previous* save, not the original empty area.
+Test testSafeWriteCommitCyclesBakOnSuccessiveSaves()
+	CleanupTestFiles()
+
+	; Save A (no prior file -> no .bak)
+	Local tempA$ = SafeWriteOpen$(ProductionPath$)
+	SeedFile(tempA$, "save A")
+	Assert(SafeWriteCommit%(tempA$, ProductionPath$, 0) = True)
+	Assert(FileType(BakPath$) <> 1)
+
+	; Save B (A demoted to .bak)
+	Local tempB$ = SafeWriteOpen$(ProductionPath$)
+	SeedFile(tempB$, "save B")
+	Assert(SafeWriteCommit%(tempB$, ProductionPath$, 0) = True)
+	Assert(ReadFileString$(ProductionPath$) = "save B")
+	Assert(ReadFileString$(BakPath$) = "save A")
+
+	; Save C (B demoted to .bak, displacing A)
+	Local tempC$ = SafeWriteOpen$(ProductionPath$)
+	SeedFile(tempC$, "save C")
+	Assert(SafeWriteCommit%(tempC$, ProductionPath$, 0) = True)
+	Assert(ReadFileString$(ProductionPath$) = "save C")
+	Assert(ReadFileString$(BakPath$) = "save B")
+
+	CleanupTestFiles()
+End Test
+
 ; SafeWriteAbort cleans up the temp when the caller decides not to commit
 ; (e.g. a serialization error mid-write).
 Test testSafeWriteAbortRemovesTemp()


### PR DESCRIPTION
## Summary (non-technical)

If RC Terrain Editor crashes (or the user's power goes out) while saving a zone, the previous save is now preserved as a `.bak` recovery file instead of being silently truncated. Same protection for the BVM core script ROM — a crash during its regeneration no longer leaves the engine unable to compile any script on next launch.

## Technical summary

Three persistent-write sites still used the pre-audit pattern (bare `WriteFile(final_path)` or `DeleteFile + WriteFile`) that [Logging.bb](src/Modules/Logging.bb)'s `SafeWriteOpen` / `SafeWriteCommit` helpers exist to close:

| Site | What it writes | Threat |
|---|---|---|
| [ClientAreasTE.bb::SaveAreaTE](src/Modules/ClientAreasTE.bb) | `Data\Areas\<Name>.dat` | Author-built zone (triggers, waypoints, spawns, portals) lost on crash mid-write |
| [ClientAreasTE.bb::SaveArea](src/Modules/ClientAreasTE.bb) (TE variant) | Same | Same |
| [Scripting.bb::CreateCore](src/Modules/Scripting.bb) | `RC_Core.rcm` (BVM script ROM) | A crash between `DeleteFile` and `CloseFile` leaves the engine unable to compile any script on next launch |

Each site now follows the canonical migration pattern from [ClientAreas.bb::SaveArea](src/Modules/ClientAreas.bb) (already audited in an earlier PR): `SafeWriteOpen` produces the temp path, the body writes to temp, `SafeWriteCommit` demotes the prior production file to `.bak` before promoting the temp. A crash mid-commit leaves either the `.bak` (recovery) or the `.tmp` (manual promote) usable.

Each migrated site carries an in-place audit comment explaining the threat model and pointing back to the canonical migration so future readers don't second-guess the choice.

## Tests

Added one test to [SafeWriteTest.bb](src/Tests/Modules/SafeWriteTest.bb): `testSafeWriteCommitCyclesBakOnSuccessiveSaves`. The pre-existing tests cover first-save (no `.bak`), second-save (production → `.bak`), refusal to promote an empty temp, and abort. They did NOT cover the third+ save — where SafeWriteCommit's `If FileType(Bak$) = 1 Then DeleteFile(Bak$)` line has to fire so the new `CopyFile` doesn't trip over the existing `.bak`. The newly-migrated area-save paths invoke `SafeWriteCommit` on every author hotkey press, so authors will hit this case constantly. The new test pins `A → B → C → .bak = B` so a future helper refactor can't silently break successive-save recovery.

## Acceptance criteria

- [x] All three sites use `SafeWriteOpen` + `SafeWriteCommit` (or equivalent atomic-rename), matching the canonical migration shape in `ClientAreas.bb::SaveArea`
- [x] Full `compile.bat` (not `-t`) succeeds — touches both Server (`Scripting.bb`) and the RC Terrain Editor / RC Architect Tools targets that include `ClientAreasTE.bb`
- [x] `test.bat` green including the new successive-save regression
- [x] No remaining bare-`WriteFile(final_path)` pattern for area `.dat` files or `RC_Core.rcm`
- [x] Audit comment on each site cites the threat model and the canonical migration

## Out of scope / deferred

- **Other `WriteFile(...)` sites the recon agents enumerated**: `MainMenu.bb` login cache + Misc.dat saves; `Language.bb::RestoreLanguage`; `Logging.bb::StartLog` log creation; `AccountsServer.bb` initial empty `Accounts.dat` creation. These are different threat models (cache files are regenerable; log files are append-only and tolerate truncation; the empty Accounts.dat first-launch case is intentional cold-start state, not a data-loss risk). A separate iteration can audit each on its own merits — bundling them here would conflate different decisions.
- **`ClientAreas_FE.bb::SaveArea`**: appears unreferenced from Client.exe. Flagged for a dead-code follow-up, not fixed here.
- The `SafeWriteTest` doesn't simulate a *process crash* between operations (Blitz3D can't fork or assert atomicity at the OS level); the new test exercises the explicit code path that the crash-recovery contract depends on, which is the strongest available evidence under the test framework.

## Risk

- **Tools-target compile risk**: confirmed all four engine targets and all seven editor tools build clean.
- **Behavior change**: a successful save now leaves a `<Name>.dat.bak` next to the production file. This is the documented and intended posture (same as every other audited save site); editors and external tools should treat `.bak` as a recovery artifact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)