### PR TITLE
Test runner UX: per-file PASS/FAIL markers, summary, single-file filter

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -37,11 +37,15 @@ Always run from the repo root.
 .\compile.bat -b           # also rebuild BlitzForge (slow, MSBuild)
 .\compile.bat -e           # skip engine, build tools only
 .\test.bat                 # compile + run every Strict test under src/Tests/
+.\test.bat ItemsTest       # run only files whose basename contains "ItemsTest"
 
 # macOS (Apple Silicon, alpha)
 ./compile.sh
 ./test.sh
+./test.sh ItemsTest        # same single-file substring filter as Windows
 ```
+
+`test.bat` / `test.sh` print a `[RUN ]` / `[PASS]` / `[FAIL]` marker per file and an end-of-run `Ran N files: P passed, F failed.` summary with a bulleted list of any failing files. CI still calls the runner with no args and only checks the exit code, so the default behavior is unchanged. The positional substring filter is the documented way to reproduce the known intermittent `ItemsTest.bb` flake locally without re-running the whole suite — see the **Known intermittent flake** note under [CI](#ci-githubworkflowsciyml) below.
 
 After any change to a `.bb` file under `src/`, run `compile.bat -t` and confirm clean compile before committing. `Local`-shadowing-a-`Global`, missing field, wrong sigil — Strict mode catches all of these at compile time.
 

--- a/test.bat
+++ b/test.bat
@@ -1,5 +1,5 @@
 @echo off
-setlocal
+setlocal enabledelayedexpansion
 
 set "ROOTDIR=%~dp0"
 if "%ROOTDIR:~-1%"=="\" set "ROOTDIR=%ROOTDIR:~0,-1%"
@@ -24,17 +24,57 @@ if not defined TESTDIR (
     exit /b 1
 )
 
+REM Optional positional arg = substring filter on the test file basename.
+REM e.g. `test.bat ItemsTest` runs only files matching *ItemsTest*.bb.
+REM Useful for reproducing the documented intermittent ItemsTest flake
+REM locally without re-running the whole suite.
+set "FILTER=%~1"
+if defined FILTER (
+    set "GLOB=*!FILTER!*.bb"
+    echo Filter: only files matching !GLOB!
+) else (
+    set "GLOB=*.bb"
+)
+
 cd /d "%TESTDIR%"
 
-set FAILED=0
+set /a TOTAL=0
+set /a PASSED=0
+set /a FAILED=0
+set "FAILED_FILES="
 
-for /R %%f in (*.bb) do (
-    "%BLITZPATH%\bin\blitzcc.exe" -t -w "%ROOTDIR%\src" "%%f" || (echo "%%f failed at least one test" && SET FAILED=1)
+for /R %%f in (!GLOB!) do (
+    set /a TOTAL+=1
+    echo [RUN ] %%~nxf
+    "%BLITZPATH%\bin\blitzcc.exe" -t -w "%ROOTDIR%\src" "%%f"
+    if !errorlevel! equ 0 (
+        echo [PASS] %%~nxf
+        set /a PASSED+=1
+    ) else (
+        echo [FAIL] %%~nxf
+        set /a FAILED+=1
+        set "FAILED_FILES=!FAILED_FILES! %%~nxf"
+    )
 )
 
 cd /d "%ROOTDIR%"
 
-if %FAILED% == 1 (
+if !TOTAL! equ 0 (
+    if defined FILTER (
+        echo No test files matched filter "!FILTER!"
+    ) else (
+        echo No test files found in "%TESTDIR%"
+    )
+    endlocal
+    exit /b 1
+)
+
+echo.
+echo Ran !TOTAL! files: !PASSED! passed, !FAILED! failed.
+
+if !FAILED! gtr 0 (
+    echo Failed files:
+    for %%x in (!FAILED_FILES!) do echo   - %%x
     echo "Tests failed"
     endlocal
     exit /b 1

--- a/test.sh
+++ b/test.sh
@@ -3,6 +3,12 @@
 # Compiles every test source in src/Tests with `blitzcc -t`. Any failure marks
 # the run as failed but the loop continues so you see every broken test in one
 # pass.
+#
+# Usage:
+#   ./test.sh              run every test file
+#   ./test.sh ItemsTest    run only files whose basename contains "ItemsTest"
+#                          (useful for reproducing the documented intermittent
+#                          ItemsTest stack-overflow flake locally)
 set -uo pipefail
 
 ROOTDIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -30,19 +36,61 @@ else
   exit 1
 fi
 
+FILTER="${1:-}"
+
 cd "${TESTDIR}"
 
-FAILED=0
+# Collect matching files first so we can report TOTAL up front and detect
+# the "no files matched filter" case.
+FILES=()
 while IFS= read -r -d '' f; do
-  if ! "${BLITZCC}" -t -w "${ROOTDIR}/src" "${f}"; then
-    echo "\"${f}\" failed at least one test"
-    FAILED=1
+  if [[ -z "${FILTER}" || "$(basename "${f}")" == *"${FILTER}"* ]]; then
+    FILES+=("${f}")
   fi
 done < <(find "${TESTDIR}" -type f -name '*.bb' -print0)
 
+TOTAL="${#FILES[@]}"
+
+if [[ "${TOTAL}" -eq 0 ]]; then
+  if [[ -n "${FILTER}" ]]; then
+    echo "No test files matched filter \"${FILTER}\"" >&2
+  else
+    echo "No test files found in ${TESTDIR}" >&2
+  fi
+  exit 1
+fi
+
+if [[ -n "${FILTER}" ]]; then
+  echo "Filter: only files matching *${FILTER}*.bb"
+fi
+
+PASSED=0
+FAILED=0
+FAILED_FILES=()
+
+for f in "${FILES[@]}"; do
+  name="$(basename "${f}")"
+  echo "[RUN ] ${name}"
+  if "${BLITZCC}" -t -w "${ROOTDIR}/src" "${f}"; then
+    echo "[PASS] ${name}"
+    PASSED=$((PASSED+1))
+  else
+    echo "[FAIL] ${name}"
+    FAILED=$((FAILED+1))
+    FAILED_FILES+=("${name}")
+  fi
+done
+
 cd "${ROOTDIR}"
 
-if [[ "${FAILED}" -eq 1 ]]; then
+echo
+echo "Ran ${TOTAL} files: ${PASSED} passed, ${FAILED} failed."
+
+if [[ "${FAILED}" -gt 0 ]]; then
+  echo "Failed files:"
+  for f in "${FAILED_FILES[@]}"; do
+    echo "  - ${f}"
+  done
   echo "Tests failed"
   exit 1
 fi


### PR DESCRIPTION
## Summary (non-technical)

`test.bat` and `test.sh` now tell you which test files passed and which failed at a glance, instead of producing one giant interleaved log with the only "tests failed" signal buried in the middle. You can also run just one test file by name — useful for reproducing the documented intermittent `ItemsTest.bb` flake locally without burning a full CI minute.

## Technical summary

The previous runner walked every `.bb` under `src/Tests/` and piped raw `blitzcc` output straight to the console: ~1400 lines on a passing run (Parsing / Generating / Translating / Assembling / Executing × every file, plus every `Assert: <expr>` line — which prints identically for pass AND fail, so individual asserts are not a triagable signal). The only success marker was one trailing `"Tests passed"`. On failure, one `"<path> failed at least one test"` line was buried mid-stream per failing file. No per-file marker, no count, no failure list, no positional arg → no local single-file iteration.

Both `test.bat` and `test.sh` now:

| Behavior | Old | New |
|---|---|---|
| Per-file marker | none | `[RUN ] <name>` before invocation, `[PASS]` / `[FAIL]` after |
| End-of-run summary | none | `Ran N files: P passed, F failed.` |
| Failed-file list | grep the log | bulleted under summary on failure |
| Single-file mode | edit the script | `test.bat ItemsTest` runs only `*ItemsTest*.bb` |
| Zero-match filter | (impossible) | exits 1 with `No test files matched filter "..."` so typos don't silently pass |
| CI compatibility | — | preserved — no-arg invocation has bit-identical command surface; only echo lines added |

The substring filter is the documented reproduction path for the `ItemsTest.bb` Stack-overflow flake CLAUDE.md calls out — instead of `gh pr close && gh pr reopen` (a full CI matrix re-run), authors can run `test.bat ItemsTest` locally in ~5 seconds.

## Acceptance criteria

- [x] No-arg run: walks every test, exits 0 on success / 1 on failure (CI compatibility verified)
- [x] Output includes one `[RUN ]` and `[PASS]` or `[FAIL]` marker per file
- [x] End-of-run summary line with file counts; bulleted list of failed files on failure
- [x] `test.bat <substring>` runs only files matching `*<substring>*.bb`
- [x] `test.bat NoSuchName` exits 1 with explicit "no files matched" message (not silent exit 0)
- [x] `test.sh` mirrors all of the above for macOS / Linux
- [x] CLAUDE.md "Build and test" section documents the filter usage and CI-compatibility guarantee
- [x] No change to any `.bb` test file content; no change to `ci.yml`; no change to `compile.bat`

### Local verification matrix

| Case | Expected | Observed |
|---|---|---|
| `test.bat` | 17/17 [PASS], "Tests passed", exit 0 | ✅ |
| `test.bat ItemsTest` | 1/1 ItemsTest [PASS], exit 0 | ✅ |
| `test.bat NoSuchName` | "No test files matched filter", exit 1 | ✅ |
| `test.bat` with one synthetic always-failing probe file | [FAIL] surfaced, listed in summary, exit 1 | ✅ |

## Trade-offs / deferred

- **Skipped `-q` flag** to blitzcc. A prior recon agent suggested suppressing the per-file Parsing/Generating/Translating/Assembling/Executing prefix lines, but `-q` could conceivably hide a load-bearing diagnostic and this PR's value is already complete without it. Easy follow-up if anyone wants the extra cleanup.
- **Skipped `--retry N` flag.** Another recon angle was making the flake-retry workflow first-class via a `--retry` arg. Worth considering but separable — this PR makes the flake locally reproducible, which is the prerequisite for actually debugging it.
- **No JSON / JUnit XML output.** Strict shell-script-level improvement; structured output is a different design decision.

## Risk

- Very low. Touches two top-level scripts; no `.bb` source touched, no CI workflow change required.
- The cmd.exe `enabledelayedexpansion` switch + `for /R (!GLOB!)` syntax is the canonical pattern for runtime-substituted glob patterns in batch scripts. Confirmed working on Windows 11 / cmd.exe.
- bash's `find -print0` + `read -d ''` filter loop is the standard null-delimited file-list pattern; preserves correct behavior on paths with whitespace.

🤖 Generated with [Claude Code](https://claude.com/claude-code)