### PR TITLE
P_VerifyAccount: close username/ban/presence enumeration oracle

### DIFF
--- a/src/Modules/MainMenu.bb
+++ b/src/Modules/MainMenu.bb
@@ -820,9 +820,12 @@ Function LogIn()
 					MNext = After M
 
 					If M\MessageType = P_VerifyAccount
-						If Left$(M\MessageData$, 1) = "N"
-							Result = -2
-						ElseIf Left$(M\MessageData$, 1) = "P"
+						; "N" is no longer emitted by the post-collapse server
+						; (P_VerifyAccount enumeration-leak fix); fold it into
+						; the same "invalid credentials" branch as "P" so the
+						; new client paired with a legacy server still shows
+						; a non-enumerating message.
+						If Left$(M\MessageData$, 1) = "N" Or Left$(M\MessageData$, 1) = "P"
 							Result = -1
 						ElseIf Left$(M\MessageData$, 1) = "B"
 							Result = 0
@@ -1145,12 +1148,19 @@ Function LogIn()
 				If AccountsEnabled = True Then GY_FreeGadget(BNew)
 				Return
 			ElseIf Result = 0
+				; Banned: only reachable after the server has verified the
+				; password (post-collapse P_VerifyAccount), so it's safe to
+				; surface ban status to the legitimate owner here.
 				GY_MessageBox("Attention!", LanguageString$(LS_YouAreBanned)) : Goto Invld
 			ElseIf Result = -1
+				; Catch-all "invalid credentials" -- absorbs no-such-account
+				; (legacy "N"), wrong-password ("P"), and the throttled path.
+				; LS_AccountDoesNotExist is intentionally never shown anymore;
+				; surfacing it would re-open the username-enumeration oracle.
 				GY_MessageBox("Attention!", LanguageString$(LS_InvalidPassword)) : Goto Invld
-			ElseIf Result = -2
-				GY_MessageBox("Attention!", LanguageString$(LS_AccountDoesNotExist)) : Goto Invld
 			Else
+				; Result = -3: already-logged-in. Same auth-before-disclosure
+				; reasoning as the banned branch above.
 				GY_MessageBox("Attention!", LanguageString$(LS_AccountAlreadyConnected)) : Goto Invld
 			EndIf
 		EndIf

--- a/src/Modules/ServerNet.bb
+++ b/src/Modules/ServerNet.bb
@@ -2203,7 +2203,19 @@ Function UpdateNetwork()
 					If FoundA = Null Or PwdLen < 1
 						LoginAttemptRecord(M\FromID, False)
 						RCE_Send(Host, M\FromID, P_VerifyAccount, "P", True)
-					ElseIf FoundA\Pass$ = "" Or Not VerifyPassword%(FoundA\Pass$, Mid$(M\MessageData$, Offset + 1, PwdLen))
+					Else
+					; Hoist password verification to a local so we can branch on
+					; it without tripping BlitzForge's parser rejection of
+					; `Or Not <call>` in an ElseIf condition. Also makes the
+					; happy-path branches read straight (no negation).
+					Local PwdOk%
+					If FoundA\Pass$ = ""
+						PwdOk = False
+					Else
+						PwdOk = VerifyPassword%(FoundA\Pass$, Mid$(M\MessageData$, Offset + 1, PwdLen))
+					EndIf
+
+					If PwdOk = False
 						; Wrong password (or stored hash is empty). Collapse to
 						; "P" regardless of banned / online status so a
 						; pre-auth attacker can't probe either.
@@ -2239,6 +2251,7 @@ Function UpdateNetwork()
 							EndIf
 						Next
 						RCE_Send(Host, M\FromID, P_VerifyAccount, Pa$, True)
+					EndIf
 					EndIf
 					EndIf
 				//EndIf

--- a/src/Modules/ServerNet.bb
+++ b/src/Modules/ServerNet.bb
@@ -2170,70 +2170,75 @@ Function UpdateNetwork()
 				Else*/
 
 					; Rate-limit failed verifications. Without this the lack of any
-					; throttle made dictionary / credential-stuffing attacks free,
-					; and the distinct "N/P/B/L" replies advertised whether each
-					; username existed (and whether it was banned or already on).
-					; LoginAttemptOk() returns False once the configured threshold
-					; for this source has been crossed; we send the same "N" reply
-					; as for an unknown account so the response itself doesn't
-					; betray why the attempt failed under attack.
+					; throttle made dictionary / credential-stuffing attacks free.
+					; Below the throttle threshold the rest of this handler now
+					; uses the "auth before disclosure" pattern: the same "P"
+					; reply for nonexistent / wrong-password / banned-without-
+					; correct-password, and the existence-revealing "L" (online)
+					; and "B" (banned) codes are sent ONLY after the password
+					; verifies. That removes the username-enumeration / presence
+					; / ban-status oracles a patient attacker could previously
+					; mine below the throttle. The throttled case keeps the same
+					; collapse (now "P", matching the canonical failure code).
 					If Not LoginAttemptOk(M\FromID)
-						RCE_Send(Host, M\FromID, P_VerifyAccount, "N", True)
+						RCE_Send(Host, M\FromID, P_VerifyAccount, "P", True)
 					Else
-					; Find account
-					Exists = False
+					; Find account (without disclosing the result yet)
+					Local FoundA.Account = Null
 					For A.Account = Each Account
 						If Upper$(A\User$) = Upper$(Username$)
-							; Account is already logged in
-							If A\LoggedOn <> -1
-								LoginAttemptRecord(M\FromID, False)
-								RCE_Send(Host, M\FromID, P_VerifyAccount, "L", True)
-							Else
-								Offset = 2 + UsernameLen
-								PwdLen = RCE_IntFromStr(Mid$(M\MessageData$, Offset, 1))
-								; Reject truncated / empty-password packets. Without
-								; this guard a 1-byte packet leaves PwdLen=0 and Mid$
-								; returns "" -- which matches any account whose Pass$
-								; was ever stored as the empty string (legacy import,
-								; corrupted accounts file tail). Treated the same as
-								; a wrong-password attempt so the response doesn't
-								; betray the cause.
-								If PwdLen < 1
-									LoginAttemptRecord(M\FromID, False)
-									RCE_Send(Host, M\FromID, P_VerifyAccount, "P", True)
-								; If password is correct, send back character list
-								ElseIf A\Pass$ <> "" And VerifyPassword%(A\Pass$, Mid$(M\MessageData$, Offset + 1, PwdLen)) And A\IsBanned = False
-									LoginAttemptRecord(M\FromID, True)
-									; Lazy-migrate to v1 on first successful login.
-									A\Pass$ = UpgradePasswordIfLegacy$(A\Pass$, Mid$(M\MessageData$, Offset + 1, PwdLen))
-									Pa$ = "Y"
-									For i = 0 To 9
-										If A\Character[i] <> Null
-											Pa$ = Pa$ + RCE_StrFromInt$(Len(A\Character[i]\Name$), 1) + A\Character[i]\Name$
-											Pa$ = Pa$ + RCE_StrFromInt$(A\Character[i]\Actor\ID, 2) + RCE_StrFromInt$(A\Character[i]\Gender, 1)
-											Pa$ = Pa$ + RCE_StrFromInt$(A\Character[i]\FaceTex, 1) + RCE_StrFromInt$(A\Character[i]\Hair, 1)
-											Pa$ = Pa$ + RCE_StrFromInt$(A\Character[i]\Beard, 1) + RCE_StrFromInt$(A\Character[i]\BodyTex, 1)
-										EndIf
-									Next
-									RCE_Send(Host, M\FromID, P_VerifyAccount, Pa$, True)
-								; Otherwise return password failure
-								Else
-									LoginAttemptRecord(M\FromID, False)
-									If A\IsBanned = False
-										RCE_Send(Host, M\FromID, P_VerifyAccount, "P", True)
-									Else
-										RCE_Send(Host, M\FromID, P_VerifyAccount, "B", True)
-									EndIf
-								EndIf
-							EndIf
-							Exists = True
+							FoundA = A
 							Exit
 						EndIf
 					Next
-					; If account was not found, return failure
-					If Exists = False
+
+					Offset = 2 + UsernameLen
+					PwdLen = RCE_IntFromStr(Mid$(M\MessageData$, Offset, 1))
+
+					; Reject truncated / empty-password packets. Without this
+					; guard a 1-byte packet leaves PwdLen=0 and Mid$ returns ""
+					; -- which matches any account whose Pass$ was ever stored
+					; as the empty string. Same "P" as wrong-password so the
+					; response doesn't betray the cause.
+					If FoundA = Null Or PwdLen < 1
 						LoginAttemptRecord(M\FromID, False)
-						RCE_Send(Host, M\FromID, P_VerifyAccount, "N", True)
+						RCE_Send(Host, M\FromID, P_VerifyAccount, "P", True)
+					ElseIf FoundA\Pass$ = "" Or Not VerifyPassword%(FoundA\Pass$, Mid$(M\MessageData$, Offset + 1, PwdLen))
+						; Wrong password (or stored hash is empty). Collapse to
+						; "P" regardless of banned / online status so a
+						; pre-auth attacker can't probe either.
+						LoginAttemptRecord(M\FromID, False)
+						RCE_Send(Host, M\FromID, P_VerifyAccount, "P", True)
+					ElseIf FoundA\IsBanned <> False
+						; Password verified AND account is banned -- only now
+						; is it safe to tell this caller they're banned, because
+						; only the legitimate owner could have reached this
+						; branch. Count as a failed attempt for rate-limit
+						; bookkeeping so a banned user can't keep the throttle
+						; window open.
+						LoginAttemptRecord(M\FromID, False)
+						RCE_Send(Host, M\FromID, P_VerifyAccount, "B", True)
+					ElseIf FoundA\LoggedOn <> -1
+						; Password verified AND a session is already active --
+						; same "auth before disclosure" reasoning: only the
+						; legitimate owner sees the "already logged in" hint.
+						LoginAttemptRecord(M\FromID, False)
+						RCE_Send(Host, M\FromID, P_VerifyAccount, "L", True)
+					Else
+						; Success: send back character list.
+						LoginAttemptRecord(M\FromID, True)
+						; Lazy-migrate to v1 on first successful login.
+						FoundA\Pass$ = UpgradePasswordIfLegacy$(FoundA\Pass$, Mid$(M\MessageData$, Offset + 1, PwdLen))
+						Pa$ = "Y"
+						For i = 0 To 9
+							If FoundA\Character[i] <> Null
+								Pa$ = Pa$ + RCE_StrFromInt$(Len(FoundA\Character[i]\Name$), 1) + FoundA\Character[i]\Name$
+								Pa$ = Pa$ + RCE_StrFromInt$(FoundA\Character[i]\Actor\ID, 2) + RCE_StrFromInt$(FoundA\Character[i]\Gender, 1)
+								Pa$ = Pa$ + RCE_StrFromInt$(FoundA\Character[i]\FaceTex, 1) + RCE_StrFromInt$(FoundA\Character[i]\Hair, 1)
+								Pa$ = Pa$ + RCE_StrFromInt$(FoundA\Character[i]\Beard, 1) + RCE_StrFromInt$(FoundA\Character[i]\BodyTex, 1)
+							EndIf
+						Next
+						RCE_Send(Host, M\FromID, P_VerifyAccount, Pa$, True)
 					EndIf
 					EndIf
 				//EndIf

--- a/src/Tests/Modules/AccountEnumerationTest.bb
+++ b/src/Tests/Modules/AccountEnumerationTest.bb
@@ -1,0 +1,190 @@
+Strict
+EnableGC
+
+; Regression test pinning the "auth before disclosure" contract on
+; the P_VerifyAccount handler in ServerNet.bb.
+;
+; Pre-fix: distinct response codes were emitted before the password
+; was verified, giving an unauthenticated attacker an enumeration
+; oracle for usernames, ban state, and online state:
+;
+;   no such username                       -> "N"
+;   existing username, already logged on   -> "L"  (sent before pwd check!)
+;   existing username, wrong password      -> "P"
+;   existing username, wrong pwd, banned   -> "B"  (sent before pwd check!)
+;   existing username, correct password    -> "Y"
+;
+; Post-fix: the only response on any auth failure is "P", and the
+; existence-revealing codes ("L", "B") are emitted ONLY after the
+; supplied password verifies. This file pins that state machine so a
+; future refactor can't re-open the oracle.
+;
+; ServerNet.bb pulls the entire wire / actor / item graph and can't be
+; Included into a test build. Following the established
+; ClampFloatTest / BVMPrivilegeGateTest / SafeWriteTest pattern, the
+; decision logic is replicated verbatim below and exercised across
+; the 5 input states the handler discriminates. A behaviour change
+; in production must update both copies; the duplication is the
+; trigger to refresh the test rationale.
+
+; --- Replicated state machine -----------------------------------------
+; Inputs match the post-collapse server branch order in
+; ServerNet.bb::P_VerifyAccount (around line 2180-2240).
+;
+;   FoundA     : True iff Username matches an Account record
+;   PwdLen     : the supplied password byte count (0 = truncated packet)
+;   PwdOk      : True iff stored hash verifies against the supplied bytes
+;   IsBanned   : True iff Account\IsBanned is set
+;   LoggedOn   : True iff Account\LoggedOn <> -1 (an active session exists)
+;
+; Returns the single-byte wire code the handler would emit.
+
+Function VerifyAccountResponse$(FoundA, PwdLen, PwdOk, IsBanned, LoggedOn)
+	If FoundA = False Or PwdLen < 1 Then Return "P"
+	If PwdOk = False Then Return "P"
+	If IsBanned <> False Then Return "B"
+	If LoggedOn <> False Then Return "L"
+	Return "Y"
+End Function
+
+; ======================================================================
+; Pre-auth failure paths -- the unauthenticated attacker probes.
+; All MUST collapse to the same "P" response so the wire stream
+; reveals nothing about which precondition failed.
+; ======================================================================
+
+Test testResponseUnknownUsernameIsP()
+	; The historical "N" leak. Attacker scans usernames against a
+	; throwaway password; must get "P" indistinguishable from a real
+	; account they happened to guess wrong on.
+	Assert(VerifyAccountResponse$(False, 16, False, False, False) = "P")
+End Test
+
+Test testResponseTruncatedPasswordPacketIsP()
+	; A 1-byte packet leaves PwdLen=0 and Mid$ returns "" -- the empty
+	; string would match any account whose Pass$ was historically
+	; stored empty. Collapse to "P" so the response doesn't betray
+	; this special case.
+	Assert(VerifyAccountResponse$(True, 0, False, False, False) = "P")
+End Test
+
+Test testResponseWrongPasswordIsP()
+	Assert(VerifyAccountResponse$(True, 16, False, False, False) = "P")
+End Test
+
+Test testResponseWrongPasswordOnBannedAccountIsP()
+	; The historical "B" leak. Attacker discovers ban status without
+	; ever proving they own the account. Must collapse to "P".
+	Assert(VerifyAccountResponse$(True, 16, False, True, False) = "P")
+End Test
+
+Test testResponseWrongPasswordOnLoggedInAccountIsP()
+	; The historical "L" leak. Attacker probes for active sessions
+	; ("is this user online right now?") without auth. Must collapse
+	; to "P".
+	Assert(VerifyAccountResponse$(True, 16, False, False, True) = "P")
+End Test
+
+Test testResponseWrongPasswordOnBannedAndLoggedInIsP()
+	; Both side-channels at once; collapse to "P" regardless.
+	Assert(VerifyAccountResponse$(True, 16, False, True, True) = "P")
+End Test
+
+; ======================================================================
+; Post-auth disclosure paths -- only emitted after PwdOk=True, so
+; only the legitimate account owner can reach them.
+; ======================================================================
+
+Test testResponseCorrectPasswordBannedIsB()
+	; Banned takes precedence over LoggedOn because the engine refuses
+	; the session entirely; no point telling the user "you're already
+	; logged on" when the ban will block the new session anyway.
+	Assert(VerifyAccountResponse$(True, 16, True, True, False) = "B")
+End Test
+
+Test testResponseCorrectPasswordBannedAndLoggedInIsB()
+	; Banned still takes precedence even with a stale-looking active
+	; session.
+	Assert(VerifyAccountResponse$(True, 16, True, True, True) = "B")
+End Test
+
+Test testResponseCorrectPasswordLoggedInIsL()
+	; Not banned, but a session exists -- legitimate user gets the
+	; "already logged on elsewhere" hint they can act on.
+	Assert(VerifyAccountResponse$(True, 16, True, False, True) = "L")
+End Test
+
+Test testResponseCorrectPasswordSuccessIsY()
+	; The happy path.
+	Assert(VerifyAccountResponse$(True, 16, True, False, False) = "Y")
+End Test
+
+; ======================================================================
+; Negative-space sanity checks -- ensure NO input combination produces
+; the historical "N" code (which the new server never emits), and
+; "L" / "B" only ever fire on the PwdOk=True path.
+; ======================================================================
+
+Test testResponseNeverEmitsLegacyN()
+	; Brute-force the 32-cell input grid; assert "N" is never the answer.
+	Local foundA, pwdLen, pwdOk, banned, loggedOn
+	For foundA = 0 To 1
+		For pwdLen = 0 To 1
+			For pwdOk = 0 To 1
+				For banned = 0 To 1
+					For loggedOn = 0 To 1
+						Local r$ = VerifyAccountResponse$(foundA, pwdLen, pwdOk, banned, loggedOn)
+						Assert(r$ <> "N")
+					Next
+				Next
+			Next
+		Next
+	Next
+End Test
+
+Test testResponseLOnlyOnSuccessfulAuth()
+	; "L" must require PwdOk=True. Any False/PwdOk combination must
+	; not be able to produce "L".
+	Local foundA, pwdLen, banned, loggedOn
+	For foundA = 0 To 1
+		For pwdLen = 0 To 1
+			For banned = 0 To 1
+				For loggedOn = 0 To 1
+					Local r$ = VerifyAccountResponse$(foundA, pwdLen, False, banned, loggedOn)
+					Assert(r$ <> "L")
+				Next
+			Next
+		Next
+	Next
+End Test
+
+Test testResponseBOnlyOnSuccessfulAuth()
+	; Same for "B" -- ban disclosure requires the user to have proven
+	; ownership first.
+	Local foundA, pwdLen, banned, loggedOn
+	For foundA = 0 To 1
+		For pwdLen = 0 To 1
+			For banned = 0 To 1
+				For loggedOn = 0 To 1
+					Local r$ = VerifyAccountResponse$(foundA, pwdLen, False, banned, loggedOn)
+					Assert(r$ <> "B")
+				Next
+			Next
+		Next
+	Next
+End Test
+
+Test testResponseYOnlyOnSuccessfulAuth()
+	; "Y" requires PwdOk=True AND not banned AND not logged on.
+	Local foundA, pwdLen, banned, loggedOn
+	For foundA = 0 To 1
+		For pwdLen = 0 To 1
+			For banned = 0 To 1
+				For loggedOn = 0 To 1
+					Local r$ = VerifyAccountResponse$(foundA, pwdLen, False, banned, loggedOn)
+					Assert(r$ <> "Y")
+				Next
+			Next
+		Next
+	Next
+End Test

--- a/src/Tests/Modules/AccountEnumerationTest.bb
+++ b/src/Tests/Modules/AccountEnumerationTest.bb
@@ -29,13 +29,17 @@ EnableGC
 
 ; --- Replicated state machine -----------------------------------------
 ; Inputs match the post-collapse server branch order in
-; ServerNet.bb::P_VerifyAccount (around line 2180-2240).
+; ServerNet.bb::P_VerifyAccount (around line 2180-2255). The integer
+; sentinel values mirror production exactly so a future contributor
+; can diff the helper against the handler without translating
+; abstractions:
 ;
 ;   FoundA     : True iff Username matches an Account record
 ;   PwdLen     : the supplied password byte count (0 = truncated packet)
 ;   PwdOk      : True iff stored hash verifies against the supplied bytes
-;   IsBanned   : True iff Account\IsBanned is set
-;   LoggedOn   : True iff Account\LoggedOn <> -1 (an active session exists)
+;   IsBanned   : Account\IsBanned int field (production: <> False -> banned)
+;   LoggedOn   : Account\LoggedOn int field (production: -1 = logged out,
+;                anything else = active session)
 ;
 ; Returns the single-byte wire code the handler would emit.
 
@@ -43,7 +47,7 @@ Function VerifyAccountResponse$(FoundA, PwdLen, PwdOk, IsBanned, LoggedOn)
 	If FoundA = False Or PwdLen < 1 Then Return "P"
 	If PwdOk = False Then Return "P"
 	If IsBanned <> False Then Return "B"
-	If LoggedOn <> False Then Return "L"
+	If LoggedOn <> -1 Then Return "L"
 	Return "Y"
 End Function
 
@@ -57,7 +61,7 @@ Test testResponseUnknownUsernameIsP()
 	; The historical "N" leak. Attacker scans usernames against a
 	; throwaway password; must get "P" indistinguishable from a real
 	; account they happened to guess wrong on.
-	Assert(VerifyAccountResponse$(False, 16, False, False, False) = "P")
+	Assert(VerifyAccountResponse$(False, 16, False, False, -1) = "P")
 End Test
 
 Test testResponseTruncatedPasswordPacketIsP()
@@ -65,29 +69,29 @@ Test testResponseTruncatedPasswordPacketIsP()
 	; string would match any account whose Pass$ was historically
 	; stored empty. Collapse to "P" so the response doesn't betray
 	; this special case.
-	Assert(VerifyAccountResponse$(True, 0, False, False, False) = "P")
+	Assert(VerifyAccountResponse$(True, 0, False, False, -1) = "P")
 End Test
 
 Test testResponseWrongPasswordIsP()
-	Assert(VerifyAccountResponse$(True, 16, False, False, False) = "P")
+	Assert(VerifyAccountResponse$(True, 16, False, False, -1) = "P")
 End Test
 
 Test testResponseWrongPasswordOnBannedAccountIsP()
 	; The historical "B" leak. Attacker discovers ban status without
 	; ever proving they own the account. Must collapse to "P".
-	Assert(VerifyAccountResponse$(True, 16, False, True, False) = "P")
+	Assert(VerifyAccountResponse$(True, 16, False, True, -1) = "P")
 End Test
 
 Test testResponseWrongPasswordOnLoggedInAccountIsP()
 	; The historical "L" leak. Attacker probes for active sessions
 	; ("is this user online right now?") without auth. Must collapse
 	; to "P".
-	Assert(VerifyAccountResponse$(True, 16, False, False, True) = "P")
+	Assert(VerifyAccountResponse$(True, 16, False, False, 0) = "P")
 End Test
 
 Test testResponseWrongPasswordOnBannedAndLoggedInIsP()
 	; Both side-channels at once; collapse to "P" regardless.
-	Assert(VerifyAccountResponse$(True, 16, False, True, True) = "P")
+	Assert(VerifyAccountResponse$(True, 16, False, True, 0) = "P")
 End Test
 
 ; ======================================================================
@@ -99,24 +103,24 @@ Test testResponseCorrectPasswordBannedIsB()
 	; Banned takes precedence over LoggedOn because the engine refuses
 	; the session entirely; no point telling the user "you're already
 	; logged on" when the ban will block the new session anyway.
-	Assert(VerifyAccountResponse$(True, 16, True, True, False) = "B")
+	Assert(VerifyAccountResponse$(True, 16, True, True, -1) = "B")
 End Test
 
 Test testResponseCorrectPasswordBannedAndLoggedInIsB()
 	; Banned still takes precedence even with a stale-looking active
 	; session.
-	Assert(VerifyAccountResponse$(True, 16, True, True, True) = "B")
+	Assert(VerifyAccountResponse$(True, 16, True, True, 0) = "B")
 End Test
 
 Test testResponseCorrectPasswordLoggedInIsL()
 	; Not banned, but a session exists -- legitimate user gets the
 	; "already logged on elsewhere" hint they can act on.
-	Assert(VerifyAccountResponse$(True, 16, True, False, True) = "L")
+	Assert(VerifyAccountResponse$(True, 16, True, False, 0) = "L")
 End Test
 
 Test testResponseCorrectPasswordSuccessIsY()
 	; The happy path.
-	Assert(VerifyAccountResponse$(True, 16, True, False, False) = "Y")
+	Assert(VerifyAccountResponse$(True, 16, True, False, -1) = "Y")
 End Test
 
 ; ======================================================================
@@ -126,13 +130,16 @@ End Test
 ; ======================================================================
 
 Test testResponseNeverEmitsLegacyN()
-	; Brute-force the 32-cell input grid; assert "N" is never the answer.
+	; Brute-force the 32-cell logical input grid (5 inputs x 2 states).
+	; LoggedOn iterates {-1, 0}: -1 = logged out, 0 = active session,
+	; matching the production `<> -1` test (any non-(-1) value branches
+	; the same way). Asserts "N" is never the answer.
 	Local foundA, pwdLen, pwdOk, banned, loggedOn
 	For foundA = 0 To 1
 		For pwdLen = 0 To 1
 			For pwdOk = 0 To 1
 				For banned = 0 To 1
-					For loggedOn = 0 To 1
+					For loggedOn = -1 To 0
 						Local r$ = VerifyAccountResponse$(foundA, pwdLen, pwdOk, banned, loggedOn)
 						Assert(r$ <> "N")
 					Next
@@ -149,7 +156,7 @@ Test testResponseLOnlyOnSuccessfulAuth()
 	For foundA = 0 To 1
 		For pwdLen = 0 To 1
 			For banned = 0 To 1
-				For loggedOn = 0 To 1
+				For loggedOn = -1 To 0
 					Local r$ = VerifyAccountResponse$(foundA, pwdLen, False, banned, loggedOn)
 					Assert(r$ <> "L")
 				Next
@@ -165,7 +172,7 @@ Test testResponseBOnlyOnSuccessfulAuth()
 	For foundA = 0 To 1
 		For pwdLen = 0 To 1
 			For banned = 0 To 1
-				For loggedOn = 0 To 1
+				For loggedOn = -1 To 0
 					Local r$ = VerifyAccountResponse$(foundA, pwdLen, False, banned, loggedOn)
 					Assert(r$ <> "B")
 				Next
@@ -180,7 +187,7 @@ Test testResponseYOnlyOnSuccessfulAuth()
 	For foundA = 0 To 1
 		For pwdLen = 0 To 1
 			For banned = 0 To 1
-				For loggedOn = 0 To 1
+				For loggedOn = -1 To 0
 					Local r$ = VerifyAccountResponse$(foundA, pwdLen, False, banned, loggedOn)
 					Assert(r$ <> "Y")
 				Next


### PR DESCRIPTION
## Summary (non-technical)

The login response used to tell an unauthenticated attacker different things depending on whether the username existed, was banned, or was currently logged in — even when the password was wrong. A patient (or distributed) scanner could harvest the full account list, map ban status, and probe live sessions without ever proving they owned an account. This PR collapses all auth-failure responses into a single "invalid credentials" code, and only surfaces ban / already-logged-in messages after the password has been verified.

## Technical summary

[ServerNet.bb::P_VerifyAccount](src/Modules/ServerNet.bb) emitted 5 distinct response codes that leaked account state pre-auth:

| Pre-fix code | Condition | Leak |
|---|---|---|
| `N` | no such account | username enumeration |
| `L` | account exists + already logged on (**sent BEFORE pwd check**) | presence oracle |
| `P` | account exists + wrong password | canonical failure |
| `B` | account exists + banned + wrong pwd (**sent BEFORE pwd check**) | ban-status oracle |
| `Y` | account exists + correct password | success |

The existing `LoginAttemptOk()` rate-limiter only collapsed throttled traffic to `N`; everything below the threshold still leaked. The author's audit comment at lines 2174-2179 acknowledged the issue but the mitigation was incomplete.

### Auth-before-disclosure restructure

1. Look up account by username (no response emitted yet).
2. If not found OR password wrong (regardless of banned/online status): emit `P` — the single canonical failure code.
3. Only after password verifies:
   - `B` if banned (legitimate owner learns of the ban)
   - `L` if active session elsewhere (legitimate owner can act)
   - `Y` + character list on success.

Throttled path now emits `P` (was `N`) to match. Banned users count as failed-attempt for rate-limit bookkeeping so a banned account can't keep the throttle window open indefinitely.

### Client decode + UX

[MainMenu.bb](src/Modules/MainMenu.bb) updates:
- Decode at line 822: `N` and `P` both map to `Result=-1` — defense-in-depth so a new client paired with an unmigrated legacy server still renders a non-enumerating message.
- UX at line 1147: `LS_AccountDoesNotExist` path now dead-code with inline doc that surfacing it would re-open the enumeration oracle on the client side.

### Tests

New [AccountEnumerationTest.bb](src/Tests/Modules/AccountEnumerationTest.bb) — 14 cases across two layers:

1. **Per-input-state cases (6 + 4)**: each historical leak shape (unknown username, truncated packet, wrong+banned, wrong+logged-in, wrong+both) must collapse to `P`; each post-auth disclosure path (correct+banned, correct+banned+logged-in, correct+logged-in, correct+normal) reaches its expected code.
2. **Negative-space sweep (4)**: brute-force the full 32-cell input grid to assert `N` is never produced and `L`/`B`/`Y` cannot be reached without `PwdOk=True`.

Replication pattern matches established [BVMPrivilegeGateTest.bb](src/Tests/Modules/BVMPrivilegeGateTest.bb) / [SafeWriteTest.bb](src/Tests/Modules/SafeWriteTest.bb) — production handler can't be Included (drags the entire wire/actor/item graph), so the decision logic is replicated verbatim with the file header naming the replication as the trigger to refresh both copies on future changes.

## Acceptance criteria

- [x] No pre-auth response distinguishes "account exists" from "account doesn't exist"
- [x] `L` and `B` emitted only after the password verifies
- [x] Rate-limited path also returns `P` (no `N` anywhere)
- [x] Full compile.bat clean across Server + Client + GUE + Tools
- [x] test.bat green (18/18 incl. new test)
- [x] Brute-force sweep over the 32-cell input grid never produces `N` and never produces `L`/`B`/`Y` without `PwdOk=True`

## Trade-offs / deferred

- **Typoed-username UX becomes "invalid credentials"** instead of "account does not exist". Standard auth-vs-UX tradeoff every modern login surface makes.
- **`P_StartGame` and `P_ChangePassword`** have similar shapes (lines 1948 and 2279 respectively) and likely leak the same way. Deliberately out of scope — each needs its own threat-model review before bundling.
- **Timing oracle in `VerifyPassword%`** (PasswordHash.bb:226): SHA-256 hex equality is not constant-time, and the no-account path skips the hash entirely. A constant-time compare + dummy hash on the no-account path would close the timing side-channel that remains under this fix. Out of scope; separate iteration.
- **`LS_AccountDoesNotExist` / unused language strings** stay in Language.dat — pruning is a separate concern.

## Risk

- **Wire format change**: server stops emitting `N`. Client is shipped in-repo and updated in the same PR, so no compatibility surface for first-party clients.
- **UX**: banned users now have to enter their correct password to see the "you are banned" message. Mild regression for legitimate banned users; significant security improvement against unauthenticated probing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)