### PR TITLE
P_ChangePassword: close username-enumeration oracle (sibling of #264)

### DIFF
--- a/src/Modules/ServerNet.bb
+++ b/src/Modules/ServerNet.bb
@@ -2293,8 +2293,18 @@ Function UpdateNetwork()
 					EndIf
 				Next
 
-				; If account was not found, return failure
-				If Exists = False Then RCE_Send(Host, M\FromID, P_ChangePassword, "N", True)
+				; If account was not found, return failure.
+				; Auth-before-disclosure: emit the same "P" code as the
+				; "found-account-but-fail" path on line ~2289 so the wire
+				; response can't be used to enumerate registered usernames.
+				; Same shape PR #264 closed for P_VerifyAccount; the same
+				; "patient attacker sends throwaway-password probes to map
+				; the account list" oracle exists here. RequesterOwns-
+				; AccountSession() makes the legitimate path session-gated,
+				; but an unauthenticated peer could still send P_Change-
+				; Password with any username + any password and (pre-fix)
+				; observe "N" vs "P" to discriminate existence.
+				If Exists = False Then RCE_Send(Host, M\FromID, P_ChangePassword, "P", True)
 
 			; Request to fetch character data
 			Case P_FetchCharacter ; :)

--- a/src/Tests/Modules/ChangePasswordEnumerationTest.bb
+++ b/src/Tests/Modules/ChangePasswordEnumerationTest.bb
@@ -1,0 +1,143 @@
+Strict
+EnableGC
+
+; Regression test pinning the "auth before disclosure" contract on
+; the P_ChangePassword handler in ServerNet.bb.
+;
+; Same enumeration-oracle threat model as PR #264 closed for
+; P_VerifyAccount, applied to the sibling handler:
+;
+; Pre-fix: an unauthenticated peer could send P_ChangePassword with
+; any username + any password and distinguish:
+;   no such username                        -> "N"
+;   account exists, wrong password / non-   -> "P"
+;     session-owner
+;   account exists, correct pwd, session    -> "Y"
+;     owner (successful change)
+;
+; The session-owner gate (RequesterOwnsAccountSession) blocks the
+; actual change but does NOT block the response-code probe, so
+; usernames could still be harvested with no auth at all.
+;
+; Post-fix: every failure path collapses to "P"; "Y" is reachable
+; only when the caller proves both (a) correct password AND
+; (b) ownership of the current session for that account. This file
+; pins that state machine.
+;
+; ServerNet.bb can't be Included into a test build; following the
+; established ClampFloatTest / BVMPrivilegeGateTest / SafeWriteTest /
+; AccountEnumerationTest pattern, the decision logic is replicated
+; verbatim and exercised across the input states the handler
+; discriminates. A behaviour change in production must update both
+; copies.
+
+; --- Replicated state machine -----------------------------------------
+; Inputs match the post-collapse server branch order in
+; ServerNet.bb::P_ChangePassword (around line 2260-2300):
+;
+;   FoundA       : True iff Username matches an Account record
+;   PwdLen       : the supplied password byte count (0 = truncated packet)
+;   PwdOk        : True iff stored hash verifies against supplied bytes
+;                  AND the stored Pass$ is non-empty (production
+;                  short-circuits an empty stored Pass$ via the same
+;                  AND chain as the verify call)
+;   SessionOwner : True iff RequesterOwnsAccountSession(A, M\FromID)
+;
+; Returns the single-byte wire code the handler would emit.
+
+Function ChangePasswordResponse$(FoundA, PwdLen, PwdOk, SessionOwner)
+	If FoundA = False Then Return "P"
+	If PwdLen < 1 Then Return "P"
+	If PwdOk = False Then Return "P"
+	If SessionOwner = False Then Return "P"
+	Return "Y"
+End Function
+
+; ======================================================================
+; Pre-auth failure paths -- every probe the unauthenticated attacker
+; can mount must collapse to "P".
+; ======================================================================
+
+Test testChangePasswordUnknownUsernameIsP()
+	; The historical "N" leak: attacker scans usernames against any
+	; throwaway password. Pre-fix yielded "N" for nonexistent and "P"
+	; for everything else; post-fix the response is "P" either way.
+	Assert(ChangePasswordResponse$(False, 16, False, False) = "P")
+End Test
+
+Test testChangePasswordTruncatedPacketIsP()
+	Assert(ChangePasswordResponse$(True, 0, False, False) = "P")
+End Test
+
+Test testChangePasswordWrongPasswordIsP()
+	; Account exists, wrong password.
+	Assert(ChangePasswordResponse$(True, 16, False, False) = "P")
+End Test
+
+Test testChangePasswordWrongPasswordIsPEvenIfSessionOwner()
+	; Pathological: session-owner replays with a bad password. Still
+	; "P" so an attacker who hijacks a connection's RakNet id can't
+	; distinguish "right session, wrong password" from any other failure.
+	Assert(ChangePasswordResponse$(True, 16, False, True) = "P")
+End Test
+
+Test testChangePasswordCorrectPasswordNonSessionOwnerIsP()
+	; The session-owner gate is the actual protection against account
+	; takeover. Verifies it short-circuits to "P" without distinguishing
+	; from a normal wrong-password failure on the wire.
+	Assert(ChangePasswordResponse$(True, 16, True, False) = "P")
+End Test
+
+; ======================================================================
+; Success path -- requires all four preconditions True.
+; ======================================================================
+
+Test testChangePasswordSuccessRequiresAllFour()
+	Assert(ChangePasswordResponse$(True, 16, True, True) = "Y")
+End Test
+
+; ======================================================================
+; Negative-space sweep -- every input combination short of full
+; success MUST collapse to "P", and "N" must never appear in the
+; output of the new handler.
+; ======================================================================
+
+Test testChangePasswordNeverEmitsLegacyN()
+	; Brute-force the 16-cell input grid (4 booleans). Assert "N" is
+	; never the answer post-collapse.
+	Local foundA, pwdLen, pwdOk, sessionOwner
+	For foundA = 0 To 1
+		For pwdLen = 0 To 1
+			For pwdOk = 0 To 1
+				For sessionOwner = 0 To 1
+					Local r$ = ChangePasswordResponse$(foundA, pwdLen, pwdOk, sessionOwner)
+					Assert(r$ <> "N")
+				Next
+			Next
+		Next
+	Next
+End Test
+
+Test testChangePasswordYOnlyOnAllConditionsTrue()
+	; "Y" must require ALL of (FoundA, PwdLen>=1, PwdOk, SessionOwner).
+	; Any one False/zero input must produce "P", never "Y". This is the
+	; structural guarantee that account takeover requires both
+	; credential knowledge AND session ownership.
+	Local foundA, pwdLen, pwdOk, sessionOwner
+	For foundA = 0 To 1
+		For pwdLen = 0 To 1
+			For pwdOk = 0 To 1
+				For sessionOwner = 0 To 1
+					Local r$ = ChangePasswordResponse$(foundA, pwdLen, pwdOk, sessionOwner)
+					; Only the (1, 1, 1, 1) corner is allowed to be "Y".
+					If r$ = "Y"
+						Assert(foundA = 1)
+						Assert(pwdLen = 1)
+						Assert(pwdOk = 1)
+						Assert(sessionOwner = 1)
+					EndIf
+				Next
+			Next
+		Next
+	Next
+End Test


### PR DESCRIPTION
## Summary (non-technical)

The password-change request leaked the same "is this username registered?" oracle that the just-fixed login request did. An unauthenticated attacker could send password-change probes with throwaway passwords and read off the registered account list from the response code. This PR collapses the no-account reply into the same generic "failed" code as a wrong-password / wrong-session reply.

## Technical summary

Same shape as merged PR [#264](https://github.com/RydeTec/rcce2/pull/264), applied to [`P_ChangePassword`](src/Modules/ServerNet.bb) (handler at ~line 2260-2297):

| Pre-fix | Condition | Issue |
|---|---|---|
| `N` | no such account | username enumeration |
| `P` | account exists, wrong password / wrong session | canonical failure |
| `Y` | account exists, correct password, session-owner | success |

The handler is structurally safer than `P_VerifyAccount` was — actual password mutation is session-gated via `RequesterOwnsAccountSession()`, so the worst-case exploit is enumeration-only (not takeover). But enumeration is the same primitive PR #264 closed for the login surface, and it shouldn't be open here either.

### Fix

One-line server change at [ServerNet.bb:2297](src/Modules/ServerNet.bb#L2297): change `"N"` → `"P"`. Audit comment block names PR #264 as the precedent and explains the threat model so the next reader doesn't have to derive it.

### Client decode

`Packets.bb` defines `P_ChangePassword = 6` but **no in-tree client code sends or receives this packet** (verified by grep across `src/`). The post-collapse server emits `"P"` for the no-account case where it previously emitted `"N"`; any custom client / external tool that parses the reply sees a semantically-equivalent "password change failed" response. No client decode to keep in sync.

### Tests

New [ChangePasswordEnumerationTest.bb](src/Tests/Modules/ChangePasswordEnumerationTest.bb) — 8 tests across two layers, mirroring `AccountEnumerationTest.bb`:

1. **Per-input-state cases (5)**: unknown username, truncated packet, wrong password, wrong password + session owner (pathological replay scenario), correct password + non-session-owner — all must collapse to `"P"`. The success case (all four conditions true) returns `"Y"`.
2. **Negative-space sweep (2)**: brute-force the 16-cell input grid (4 booleans). Assert `"N"` never produced and `"Y"` requires ALL FOUR conditions true (the structural guarantee that takeover requires both credential knowledge AND session ownership — session-gate is the real protection, not the password verify alone).

## Acceptance criteria

- [x] No-account path emits `"P"` instead of `"N"`
- [x] Wrong-password / wrong-session paths unchanged (still `"P"`)
- [x] Success path unchanged (still `"Y"` with no precondition relaxation)
- [x] Full `compile.bat` clean (exit code 0, verified unfiltered — lesson from PR #264 review applied)
- [x] `test.bat` green (19/19 incl. new test)
- [x] Brute-force sweep over 16-cell input grid: `"N"` never emitted; `"Y"` reaches only `(FoundA=1, PwdLen=1, PwdOk=1, SessionOwner=1)`
- [x] Audit comment names PR #264 as precedent

## Trade-offs / deferred

- **`P_StartGame`, `P_FetchCharacter`, `P_CreateCharacter`, `P_DeleteCharacter`**: verified during recon — these handlers already emit a uniform `"N"` for ALL failure paths (no mixed N/P shape), so they have no enumeration leak to fix. Documented for the next auditor.
- **`VerifyPassword%` timing oracle** (still): SHA-256 hex equality is not constant-time and the no-account path skips hashing entirely. Constant-time compare + dummy hash on the no-account path remains a separate iteration.

## Risk

- **Server-only**, single-line response-code swap. No wire-format change that breaks in-tree client decode (no such decode exists).
- **External tool compatibility**: any custom tool that distinguishes `"N"` ("account not found") from `"P"` ("password wrong") will now see `"P"` in both cases. Semantically still "password change failed." Documented as a behaviour change in the audit comment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)