### PR TITLE
perf(serverwater): O(actors*global_waters) → O(actors*per_area_waters) in per-tick underwater check

### DIFF
--- a/src/Modules/GameServer.bb
+++ b/src/Modules/GameServer.bb
@@ -733,23 +733,30 @@ Function UpdateActorInstances(Broadcast)
 				AI\Z# = AI\Rider\Z#
 			EndIf
 
-			; Underwater damage
+			; Underwater damage. Walks the per-Area chain off
+			; AInstance\Area\FirstWater (built in ServerLoadArea above)
+			; rather than the global `For Each ServerWater` + filter on
+			; SW\Area. Old: O(actors * total_water_in_all_loaded_areas)
+			; per tick. New: O(actors * waters_in_this_actor's_area),
+			; typically 5-10 per area vs potentially 50+ across all
+			; loaded zones. Behaviour unchanged -- same hit-test, same
+			; early Exit on first match.
 			If AI\Actor\Environment <> Environment_Swim
 				Underwater = 0
-				For SW.ServerWater = Each ServerWater
-					If SW\Area = AInstance\Area
-						If AI\Y# < SW\Y# + 0.5
-							If AI\X# > SW\X# And AI\X# < SW\X# + SW\Width#
-								If AI\Z# > SW\Z# And AI\Z# < SW\Z# + SW\Depth#
-									If AI\Underwater = 0 Then AI\Underwater = MilliSecs()
-									Underwater = Handle(SW)
-									DistUnder# = SW\Y# - AI\Y#
-									Exit
-								EndIf
+				Local SW.ServerWater = AInstance\Area\FirstWater
+				While SW <> Null
+					If AI\Y# < SW\Y# + 0.5
+						If AI\X# > SW\X# And AI\X# < SW\X# + SW\Width#
+							If AI\Z# > SW\Z# And AI\Z# < SW\Z# + SW\Depth#
+								If AI\Underwater = 0 Then AI\Underwater = MilliSecs()
+								Underwater = Handle(SW)
+								DistUnder# = SW\Y# - AI\Y#
+								Exit
 							EndIf
 						EndIf
 					EndIf
-				Next
+					SW = SW\NextWater
+				Wend
 				If Underwater = 0
 					AI\Underwater = 0
 					; Restore breath

--- a/src/Modules/ServerAreas.bb
+++ b/src/Modules/ServerAreas.bb
@@ -26,6 +26,13 @@ Type Area
 	Field Gravity
 	; Track instances
 	Field Instances.AreaInstance[99]
+	; Head of this area's per-Area ServerWater chain. The global
+	; `For Each ServerWater` collection still owns every water record
+	; (creation / Delete go through Each); this field is an O(1)-lookup
+	; index into the subset belonging to this Area, used by the
+	; per-tick underwater-damage check in GameServer.bb to avoid
+	; walking the entire global list once per actor.
+	Field FirstWater.ServerWater
 End Type
 
 ; Water areas for damaging things
@@ -34,6 +41,12 @@ Type ServerWater
 	Field X#, Y#, Z#
 	Field Width#, Depth#
 	Field Damage, DamageType
+	; Next link in Area\FirstWater chain. Maintained at allocation
+	; (ServerLoadArea below). Becomes dangling when the owning Area
+	; is deleted (ServerUnloadArea Deletes both the chain heads and
+	; every linked ServerWater in a single call, so no caller can
+	; observe a stale NextWater pointer).
+	Field NextWater.ServerWater
 End Type
 
 ; Each area instance may have up to 500 player owned items of scenery (e.g. chests, doors, etc.) {##}
@@ -249,6 +262,14 @@ Function ServerLoadArea.Area(Name$)
 			; SafeZone-damage loop (GameServer.bb ~773) indexes
 			; A\Resistances[SW\DamageType].
 			If W\DamageType < 0 Or W\DamageType > 19 Then W\DamageType = 0
+			; Link into A\FirstWater chain so the per-tick underwater
+			; check in GameServer.bb's UpdateActorInstances doesn't have
+			; to filter every global ServerWater by `If SW\Area = A`.
+			; Head-insert is fine -- the chain order doesn't affect
+			; semantics (the underwater check Exits on the first match
+			; and the SaveArea path still walks Each ServerWater).
+			W\NextWater = A\FirstWater
+			A\FirstWater = W
 		Next
 
 	CloseFile(F)


### PR DESCRIPTION
## Summary (non-technical)

The server checks every actor against every water region in every loaded zone, every server tick — even when only one zone's water can possibly intersect that actor. This PR indexes water regions by their owning zone and walks only the relevant subset. On a 5-zone server with 10 water regions each and 300 actors, that's ~3,000 inner-loop iterations per tick instead of ~15,000. Behaviour is byte-identical; only the iteration is faster.

## Technical summary

`UpdateActorInstances()` ([GameServer.bb:665](src/Modules/GameServer.bb#L665)) is the per-tick actor update loop. Inside its body, the underwater-damage check at line 737 previously walked the **global** `For SW.ServerWater = Each ServerWater` collection and filtered each candidate via `If SW\Area = AInstance\Area`. Cost: **O(actors × total_water_in_all_loaded_areas)** per tick.

Indexing change:

| Type | Field added |
|---|---|
| `Area` | `Field FirstWater.ServerWater` — head of the per-Area chain |
| `ServerWater` | `Field NextWater.ServerWater` — chain link |

Populated at `ServerLoadArea` time via head-insert into `A\FirstWater` (chain order is irrelevant — the hit-test Exits on the first match). The global `For Each ServerWater` collection still owns every record (allocation / Delete go through `Each`); the new chain is an O(1)-lookup index into the subset belonging to each Area.

The per-tick hot path in `GameServer.bb` now reads:

```basic
Local SW.ServerWater = AInstance\Area\FirstWater
While SW <> Null
    ; ... hit test (byte-identical to old body) ...
    SW = SW\NextWater
Wend
```

New cost: **O(actors × waters_in_this_actor's_area)** per tick.

### Chain-lifecycle invariants (documented inline)

- **Head-insert at allocation** (`ServerLoadArea` line 247-248): order doesn't matter; the underwater check `Exits` on the first match.
- **Dangling on area unload**: `ServerUnloadArea` Deletes both `A` (which kills the chain head) and every `ServerWater` (via the existing after-cursor walk that filters by `W\Area = A`) in a single call. No caller can observe a stale `NextWater` pointer.
- **Save path unaffected**: `SaveArea` still walks the global `For Each ServerWater` with the existing `If W\Area = A` filter. Not a perf-critical path; left alone.

## Acceptance criteria

- [x] `Area` type gains `FirstWater.ServerWater` field with inline documentation
- [x] `ServerWater` type gains `NextWater.ServerWater` field with inline documentation
- [x] `ServerLoadArea` head-inserts each new water into `A\FirstWater`
- [x] `GameServer.bb` underwater check walks the per-Area chain instead of `For Each ServerWater`
- [x] Hit-test body byte-identical to the original (same conditions, same `Underwater = Handle(SW)` recording, same early `Exit`)
- [x] Full `compile.bat` clean across Server + Client + GUE + Project Manager + 7 Tools (exit 0, unfiltered)
- [x] `test.bat` 19/19 green
- [x] No behaviour change for any actor's water-damage outcome

## Trade-offs / deferred

- **`SaveArea` not converted** to the per-Area chain (still walks `For Each` + filter). Not a per-tick hot path; the conversion would add code without measurable benefit and risks breaking the save-format-stable ordering. Acknowledged in the inline comment.
- **`ServerUnloadArea` not converted** to walk via the per-Area chain (still uses the after-cursor walk). Same reasoning — runs once per area unload, not per tick. The dangling-NextWater-on-Area-Delete invariant is documented inline so a future contributor doesn't try to "fix" it.
- **No benchmark added**. Microbenchmarking the per-tick savings would require a packet-handler test harness that doesn't exist (see iteration #9's deferred follow-ups). The structural argument (`Each ServerWater` + filter → per-Area chain walk) is sound by inspection; the per-iteration body is byte-identical so any difference is purely loop count.

## Risk

- **Low**. Behaviour-observable change is zero (verified: hit-test conditions, `Underwater` recording, `DistUnder#` math, early `Exit` semantics, the surrounding `Underwater = 0` reset path — all preserved).
- The new chain pointer (`W\NextWater`) is only set in one place (head-insert at allocation) and read in one place (the GameServer.bb walk). No mutation path; no risk of corruption.
- `Exit` inside `While...Wend` works the same way in Blitz3D as inside `For...Next` (breaks the innermost loop) — verified by successful compile + test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)