### PR TITLE
perf(serverareas): finish ServerWater chain sweep — SaveArea + ServerUnloadArea

### DIFF
--- a/src/Modules/ServerAreas.bb
+++ b/src/Modules/ServerAreas.bb
@@ -162,16 +162,21 @@ End Function
 ; Unloads all server data for an area
 Function ServerUnloadArea(A.Area)
 
-	; After-cursor walk: the body Deletes W, which would corrupt
-	; the For-Each cursor on the next iteration. Documented in
-	; CLAUDE.md (#247).
-	Local W.ServerWater = First ServerWater
+	; Walk the per-Area chain instead of the global ServerWater
+	; collection. Capture the next link BEFORE Delete so the
+	; current node's NextWater isn't read post-free. Skipping the
+	; global For-Each here also drops the `If W\Area = A` filter,
+	; turning O(global_waters) into O(this_area_waters). The
+	; per-area chain head + NextWater links go out of scope when
+	; A is Deleted below, so no caller can observe stale links.
+	Local W.ServerWater = A\FirstWater
 	Local WNext.ServerWater = Null
 	While W <> Null
-		WNext = After W
-		If W\Area = A Then Delete(W)
+		WNext = W\NextWater
+		Delete(W)
 		W = WNext
 	Wend
+	A\FirstWater = Null
 	;For j = 0 To 99 {##}
 	;	If A\Instances[j] <> Null
 	;		For i = 0 To 499
@@ -262,12 +267,16 @@ Function ServerLoadArea.Area(Name$)
 			; SafeZone-damage loop (GameServer.bb ~773) indexes
 			; A\Resistances[SW\DamageType].
 			If W\DamageType < 0 Or W\DamageType > 19 Then W\DamageType = 0
-			; Link into A\FirstWater chain so the per-tick underwater
-			; check in GameServer.bb's UpdateActorInstances doesn't have
-			; to filter every global ServerWater by `If SW\Area = A`.
-			; Head-insert is fine -- the chain order doesn't affect
-			; semantics (the underwater check Exits on the first match
-			; and the SaveArea path still walks Each ServerWater).
+			; Link into A\FirstWater chain. With SaveArea +
+			; ServerUnloadArea also using the chain, the global
+			; `For Each ServerWater` collection still owns every
+			; record (creation and Delete are the only sites that
+			; touch the Each iterator), but no per-frame or
+			; per-save code paths have to filter it by Area.
+			; Head-insert is fine -- the underwater check Exits
+			; on first match and SaveArea writes are
+			; order-insensitive (ServerLoadArea just reads N
+			; records).
 			W\NextWater = A\FirstWater
 			A\FirstWater = W
 		Next
@@ -373,23 +382,31 @@ Function ServerSaveArea(A.Area)
 			WriteFloat(F, A\SpawnRange#[i])
 		Next
 
-		; Water areas
+		; Water areas — walk this area's chain twice (count, then
+		; write). Replaces two global For-Each loops that each
+		; filtered by `If W\Area = A`. Chain head-insert order in
+		; ServerLoadArea is the reverse of file order; chain order
+		; doesn't affect read semantics because ServerLoadArea
+		; just reads N records.
+		Local W.ServerWater
 		Count = 0
-		For W.ServerWater = Each ServerWater
-			If W\Area = A Then Count = Count + 1
-		Next
+		W = A\FirstWater
+		While W <> Null
+			Count = Count + 1
+			W = W\NextWater
+		Wend
 		WriteShort(F, Count)
-		For W.ServerWater = Each ServerWater
-			If W\Area = A
-				WriteFloat(F, W\X#)
-				WriteFloat(F, W\Y#)
-				WriteFloat(F, W\Z#)
-				WriteFloat(F, W\Width#)
-				WriteFloat(F, W\Depth#)
-				WriteShort(F, W\Damage)
-				WriteShort(F, W\DamageType)
-			EndIf
-		Next
+		W = A\FirstWater
+		While W <> Null
+			WriteFloat(F, W\X#)
+			WriteFloat(F, W\Y#)
+			WriteFloat(F, W\Z#)
+			WriteFloat(F, W\Width#)
+			WriteFloat(F, W\Depth#)
+			WriteShort(F, W\Damage)
+			WriteShort(F, W\DamageType)
+			W = W\NextWater
+		Wend
 
 	If Not SafeWriteCommit(TempPath$, FinalPath$, F) Then Return False
 


### PR DESCRIPTION
## Summary

PR #270 introduced the per-Area `ServerWater` linked-list (`Area\FirstWater` + `ServerWater\NextWater`) and converted the per-tick underwater-damage check in `GameServer.bb` to walk it, leaving the SaveArea / ServerUnloadArea sites as a deferred follow-up. This PR finishes that sweep.

Three sibling sites in `src/Modules/ServerAreas.bb` still iterated the global `For W.ServerWater = Each ServerWater` collection and filtered by `If W\Area = A`. After this change, no per-frame or per-save code path scans the global water collection to find an Area's subset.

### Non-technical

The server keeps a list of every body of water in the world. Until PR #270 every per-frame underwater check scanned that whole list and discarded the records that belonged to a different area. PR #270 fixed the per-frame check; this PR finishes the job for the area-save and area-unload paths, so neither of those has to scan every water in the world either.

## Technical changes

`src/Modules/ServerAreas.bb` only — one file, three sites:

1. **`ServerUnloadArea` (1 walk)** — replaces a global after-cursor walk filtering by `Area` with a direct chain walk over `A\FirstWater`. Body still `Delete`s the current node (legacy module — no GC), so `WNext = W\NextWater` is captured before `Delete W`. Sets `A\FirstWater = Null` after the loop for safety even though `A` is `Delete`d immediately afterward.

2. **`SaveArea` count walk** — chain walk replaces the global walk + filter. O(global_waters) → O(this_area_waters).

3. **`SaveArea` write walk** — chain walk replaces the global walk + filter. Same complexity win. Output ordering on disk may differ (head-insert is LIFO relative to file order), but `ServerLoadArea` reads N records and is order-insensitive, so the round-trip behavior is identical.

Also updates a now-stale doc comment in `ServerLoadArea` — the line "SaveArea path still walks Each ServerWater" became false.

## Acceptance criteria

- [x] Zero `For W.ServerWater = Each ServerWater` walks remain in `ServerAreas.bb` (grep-verified).
- [x] All four engine targets compile clean (Server, Client, GUE, Project Manager).
- [x] All Tools compile clean.
- [x] All 19 tests pass.
- [x] The global `Each ServerWater` collection still exists (allocation + Delete sites use it).
- [x] Round-trip semantics preserved (SaveArea writes count + N records; ServerLoadArea reads N records into the chain).

## Test plan

- [x] `compile.bat` clean (full, including Tools)
- [x] `test.bat` — 19/19 pass
- [x] grep verification: no `Each ServerWater` walks in ServerAreas.bb

Focused unit test was infeasible without substantial inline-stubbing of the `Area` type's dependencies (AreaInstance, server globals). Strongest available evidence: static (compile validates Field references; grep proves removal) plus mechanically-identical pattern reference to `GameServer.bb:736-758` shipped in PR #270.

## Trade-offs / deferred follow-ups

- File-on-disk water-record ordering changes (head-insert LIFO vs. file-order). Read path is order-insensitive so round-trip is preserved; only matters if someone diffs raw `.dat` files between pre-PR and post-PR saves. Acceptable.
- The global `For Each ServerWater` collection is still iterated at allocation (`New ServerWater` registers; `Delete` unregisters). Removing the global collection entirely would be a follow-up: it would require routing every `ServerWater` lifecycle event through `A\FirstWater`, which currently has no value (no per-water lookups exist outside the chain-walking sites covered here and in #270).
- Other deferred items from the loop's backlog still on the table: P_ChangePassword throttle (1-liner), Gubbin Tool pre-loop `DeltaTime` seed (1-liner), remaining 15 stub docs/modules/*.md files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)