### PR TITLE
Loom: cross-reference nav buttons in the actor editor

### DIFF
--- a/src/GUE.bb
+++ b/src/GUE.bb
@@ -840,6 +840,9 @@ FUI_ComboBoxItem(CActorGenders, "Female only")
 FUI_ComboBoxItem(CActorGenders, "No gender")
 FUI_Label(TActorsDescription, 20, 172, "Home faction:")
 Global CActorFaction = FUI_ComboBox(TActorsDescription, 120, 170, 250, 20, 10)
+; Loom xref-nav: jump to the faction's editor on the Factions tab.
+Global BActorFactionGoto = FUI_Button(TActorsDescription, 375, 170, 22, 20, ">", "", 0, CS_BORDER)
+FUI_ToolTip(BActorFactionGoto, "Open this faction in the Factions tab")
 For i = 0 To 99
 	If FactionNames$(i) <> ""
 		Item = FUI_ComboBoxItem(CActorFaction, FactionNames$(i)) : FUI_SendMessage(Item, M_SETDATA, i)
@@ -878,8 +881,13 @@ Global BActorPlayable = FUI_CheckBox(TActorsGeneral, 20, 172, "Actor is playable
 Global BActorRideable = FUI_CheckBox(TActorsGeneral, 20, 192, "Actor can be ridden")
 FUI_Label(TActorsGeneral, 20, 222, "Male animation set:")
 Global CActorMAnim = FUI_ComboBox(TActorsGeneral, 140, 220, 150, 20, 8)
+; Loom xref-nav: jump to this anim set's editor on the Animations tab.
+Global BActorMAnimGoto = FUI_Button(TActorsGeneral, 295, 220, 22, 20, ">", "", 0, CS_BORDER)
+FUI_ToolTip(BActorMAnimGoto, "Open this animation set in the Animations tab")
 FUI_Label(TActorsGeneral, 20, 252, "Female animation set:")
 Global CActorFAnim = FUI_ComboBox(TActorsGeneral, 140, 250, 150, 20, 8)
+Global BActorFAnimGoto = FUI_Button(TActorsGeneral, 295, 250, 22, 20, ">", "", 0, CS_BORDER)
+FUI_ToolTip(BActorFAnimGoto, "Open this animation set in the Animations tab")
 For AS.AnimSet = Each AnimSet
 	Item = FUI_ComboBoxItem(CActorMAnim, AS\Name$) : FUI_SendMessage(Item, M_SETDATA, AS\ID)
 	Item = FUI_ComboBoxItem(CActorFAnim, AS\Name$) : FUI_SendMessage(Item, M_SETDATA, AS\ID)
@@ -5495,6 +5503,14 @@ Cls
 					SelectedActor\Resistances[ID] = E\EventData
 					ActorsSaved = False
 				EndIf
+
+			; Loom xref-nav: jump from this actor's bound entities to their editors.
+			Case BActorFactionGoto
+				If SelectedActor <> Null Then GUE_JumpToEntity("faction", SelectedActor\DefaultFaction)
+			Case BActorMAnimGoto
+				If SelectedActor <> Null Then GUE_JumpToEntity("animset", SelectedActor\MAnimationSet)
+			Case BActorFAnimGoto
+				If SelectedActor <> Null Then GUE_JumpToEntity("animset", SelectedActor\FAnimationSet)
 
 			; Actor navigation
 			Case CActorSelected

--- a/src/Modules/CommandPalette.bb
+++ b/src/Modules/CommandPalette.bb
@@ -293,48 +293,66 @@ End Function
 // GUE_JumpToEntity -- PUBLIC navigation primitive.
 //
 // Switches to the entity's owning tab and selects it. Reused by the palette
-// today and by PR 2-4 (conscience findings, cross-ref nav, world atlas).
+// today and by the conscience / cross-ref / atlas features.
 //
-// We programmatically set the tab index and the combobox selection, then fire
-// the corresponding FUI events so the existing tab-switch / combobox-change
-// dispatchers run their normal hide/show + UpdateXDisplay logic next frame.
-// This re-uses every line of the existing handlers instead of duplicating
-// their show/hide bookkeeping.
+// We programmatically set the tab index and the entity-picker selection, then
+// fire the corresponding FUI events so the existing tab-switch / picker-
+// change dispatchers run their normal hide/show + UpdateXDisplay logic next
+// frame. This re-uses every line of the existing handlers instead of
+// duplicating their show/hide bookkeeping.
+//
+// Supported kinds (and their entity-picker widget + data-payload convention):
+//
+//   kind     | tab | picker            | refID payload
+//   ---------+-----+-------------------+--------------------------------------
+//   actor    |  9  | CActorSelected    | Actor\ID                  (combobox)
+//   item     | 10  | CItemSelected     | Item\ID                   (combobox)
+//   spell    | 13  | CSpellSelected    | Spell\ID                  (combobox)
+//   zone     | 12  | CZone             | Handle(Area)              (combobox)
+//   faction  |  6  | LFactions         | FactionNames$ index 0..99 (listbox)
+//   animset  |  7  | LAnimSets         | AnimSet\ID                (listbox)
+//
+// Listbox and combobox share the same M_SETINDEX / M_GETSELECTED / M_GETDATA
+// shape in F-UI, so the picker-walk loop is identical.
 // =============================================================================
 Function GUE_JumpToEntity(kind$, refID)
     Local tabIdx = 0
-    Local cb = 0
+    Local picker = 0
 
     Select Lower$(kind$)
         Case "actor"
-            tabIdx = 9 : cb = CActorSelected
+            tabIdx = 9 : picker = CActorSelected
         Case "item"
-            tabIdx = 10 : cb = CItemSelected
+            tabIdx = 10 : picker = CItemSelected
         Case "spell"
-            tabIdx = 13 : cb = CSpellSelected
+            tabIdx = 13 : picker = CSpellSelected
         Case "zone"
-            tabIdx = 12 : cb = CZone
+            tabIdx = 12 : picker = CZone
+        Case "faction"
+            tabIdx = 6 : picker = LFactions
+        Case "animset"
+            tabIdx = 7 : picker = LAnimSets
     End Select
 
-    If tabIdx = 0 Or cb = 0 Then Return
+    If tabIdx = 0 Or picker = 0 Then Return
 
     // Visible tab switch + ask the dispatcher to run its leave/enter logic.
     FUI_SendMessage(TabMain, M_SETINDEX, tabIdx)
     FUI_CreateEvent(TabMain, Str(tabIdx))
 
-    // Walk the combobox items to find the one whose stored data matches.
-    // Items are 1-indexed in F-UI comboboxes.
-    Local n = FUI_SendMessage(cb, M_COUNTITEMS)
+    // Walk the picker items to find the one whose stored data matches.
+    // Items are 1-indexed in F-UI comboboxes and listboxes.
+    Local n = FUI_SendMessage(picker, M_COUNTITEMS)
     Local i = 0
-    Local cbItem = 0
-    Local cbData = 0
+    Local pItem = 0
+    Local pData = 0
     For i = 1 To n
-        FUI_SendMessage(cb, M_SETINDEX, i)
-        cbItem = FUI_SendMessage(cb, M_GETSELECTED)
-        cbData = FUI_SendMessage(cbItem, M_GETDATA)
-        If cbData = refID Then Exit
+        FUI_SendMessage(picker, M_SETINDEX, i)
+        pItem = FUI_SendMessage(picker, M_GETSELECTED)
+        pData = FUI_SendMessage(pItem, M_GETDATA)
+        If pData = refID Then Exit
     Next
 
-    // Fire the combobox-change event so the downstream handler runs.
-    FUI_CreateEvent(cb, "")
+    // Fire the picker-change event so the downstream handler runs.
+    FUI_CreateEvent(picker, "")
 End Function


### PR DESCRIPTION
## Summary

Third of four PRs porting concepts from the **Loom** GUE redesign. **Stacked on top of #273** (which is stacked on #271).

Adds three small ``>`` buttons next to the actor editor's reference fields so users can jump straight from an actor's faction / animation-set bindings to the corresponding editor tab without walking back through the tabs and dropdowns:

```
Home faction:           [combo.....] [>]   -> Factions tab + select
Male animation set:     [combo.....] [>]   -> Animations tab + select
Female animation set:   [combo.....] [>]   -> Animations tab + select
```

## Why

Editing an actor and wondering ""wait, what's actually in this faction?"" is a real workflow today. The trip is: remember the faction name → switch to Factions tab → find the faction in its listbox → click → flip back. The ``>`` button collapses it to one click.

## What's in the diff

- ``src/GUE.bb`` — three ``FUI_Button(..., ">", ...)``s placed adjacent to ``CActorFaction`` / ``CActorMAnim`` / ``CActorFAnim``, plus three matching ``Case`` clauses in the existing event-dispatch ``Select`` that call ``GUE_JumpToEntity``.
- ``src/Modules/CommandPalette.bb`` — ``GUE_JumpToEntity`` extended with two new kinds:
  - ``faction`` → Factions tab 6, ``LFactions`` listbox, ``refID`` = ``FactionNames$`` index 0..99
  - ``animset`` → Animations tab 7, ``LAnimSets`` listbox, ``refID`` = ``AnimSet\ID``

F-UI listboxes share the same ``M_SETINDEX`` / ``M_GETSELECTED`` / ``M_GETDATA`` shape as comboboxes, so the picker-walk loop is unchanged — just generalized variable names (``cb`` → ``picker``, ``cbItem`` → ``pItem``, etc.).

## Scope decision

Narrow on purpose: actor editor only, three reference fields. The pattern is now established and demonstrably tiny — future PRs can plug in item / spell / zone xrefs by adding more buttons and ``Case`` clauses, no infrastructure work needed.

## Blast radius

Three new button widgets in two existing tab pages; everything else is additive. ``Server`` / ``Client`` / ``Project Manager`` don't touch ``GUE.bb`` so they're unaffected.

## Verification

- All four engine ``.exe`` targets compile clean

## Test plan

- [ ] Open GUE, Actors tab, Description sub-tab — ``>`` button visible to the right of the faction combo
- [ ] Click ``>`` — jumps to Factions tab with that actor's home faction selected, its rename field and rating fields populated
- [ ] Back to Actors → General sub-tab — ``>`` buttons visible to the right of both anim combos
- [ ] Click male anim ``>`` — jumps to Animations tab with that anim set selected and its clip list populated
- [ ] Same for female anim

🤖 Generated with [Claude Code](https://claude.com/claude-code)