### PR TITLE
security: harden client-supplied wire parameters in P_Examine / P_Trade / P_ItemScript + InventoryAdd

### DIFF
--- a/src/Modules/Inventories.bb
+++ b/src/Modules/Inventories.bb
@@ -100,6 +100,15 @@ Function InventoryAdd(A.ActorInstance, SlotFrom, SlotTo, Amount, TellServer = Tr
 		Return False
 	EndIf
 	If ItemInstancesIdentical(A\Inventory\Items[SlotFrom], A\Inventory\Items[SlotTo]) = False Then Return False
+	; Reject negative / oversized amounts. The server-side wire
+	; bounds-check (ServerNet.bb P_InventoryUpdate "A") used
+	; `Amount <= Amounts[SlotA]`, which passes for ANY negative value
+	; (any negative is <= a non-negative count). InventoryAdd then
+	; did `Amounts[SlotTo] += Amount` and `Amounts[SlotFrom] -= Amount`
+	; unchecked, so a negative Amount inflated SlotFrom and deflated
+	; SlotTo into negative — an unbounded item-duplication path.
+	; Mirrors the partial-amount guard in InventorySwap (~line 152).
+	If Amount < 1 Or Amount > A\Inventory\Amounts[SlotFrom] Then Return False
 
 	; Do it
 	A\Inventory\Amounts[SlotTo] = A\Inventory\Amounts[SlotTo] + Amount

--- a/src/Modules/ServerNet.bb
+++ b/src/Modules/ServerNet.bb
@@ -1232,8 +1232,30 @@ Function UpdateNetwork()
 				AI.ActorInstance = FindActorInstanceFromRNID(M\FromID)
 				If AI <> Null And (Len(M\MessageData$) = 1 Or Len(M\MessageData$) = 3)
 					SlotIndex = RCE_IntFromStr(Left$(M\MessageData$, 1))
+					Local ItemScriptGateOk% = True
 					If Len(M\MessageData$) = 3
 						A2.ActorInstance = RuntimeIDList(RCE_IntFromStr(Mid$(M\MessageData$, 2)))
+						; Same-area + InteractDist gate when the item
+						; targets another actor. Mirrors P_RightClick
+						; (range) and P_AttackActor (area). Items used
+						; on self (Len = 1, A2 = Null) skip this. On
+						; cross-area or out-of-range A2, the whole
+						; handler is dropped silently (matches
+						; P_Examine / P_Trade reject semantics rather
+						; than degrading to self-cast, which could
+						; misfire an offensive item back on the user).
+						If A2 <> Null
+							AInstance.AreaInstance = Object.AreaInstance(AI\ServerArea)
+							TInstance.AreaInstance = Object.AreaInstance(A2\ServerArea)
+							If AInstance = Null Or AInstance <> TInstance
+								ItemScriptGateOk = False
+							Else
+								XDist# = Abs(AI\X# - A2\X#)
+								ZDist# = Abs(AI\Z# - A2\Z#)
+								Dist# = (XDist# * XDist#) + (ZDist# * ZDist#)
+								If Dist# >= InteractDist Then ItemScriptGateOk = False
+							EndIf
+						EndIf
 					Else
 						A2 = Null
 					EndIf
@@ -1242,7 +1264,7 @@ Function UpdateNetwork()
 					; than Slots_Inventory (45), so a crafted P_ItemScript
 					; with SlotIndex 46..49 read past the Items array
 					; (same shape as the P_EatItem fix at ~1172).
-					If SlotIndex >= 0 And SlotIndex <= Slots_Inventory
+					If ItemScriptGateOk = True And SlotIndex >= 0 And SlotIndex <= Slots_Inventory
 						If AI\Inventory\Items[SlotIndex] <> Null
 							; Bug fix: the ExclusiveClass gate originally
 							; compared Actor\Race$ against ExclusiveClass$
@@ -1335,19 +1357,38 @@ Function UpdateNetwork()
 				If AI <> Null And Len(M\MessageData$) = 2
 					A2.ActorInstance = RuntimeIDList(RCE_IntFromStr(M\MessageData$))
 					If A2 <> Null
-						If A2\Script$ <> ""
-							Running = False
+						; Same-area + InteractDist gate. Mirrors
+						; P_AttackActor (area) and P_RightClick (range).
+						; Without these, a wire-injecting client could
+						; trigger Examine scripts (default disclosure
+						; dialog, vendor inventory, quest state) on
+						; any actor anywhere on the map, defeating the
+						; implicit "you can only examine what you can
+						; see" UX contract and giving the BVM
+						; clicker-handle trap (SI\AI = Handle(clicker))
+						; a cross-area attack surface.
+						AInstance.AreaInstance = Object.AreaInstance(AI\ServerArea)
+						TInstance.AreaInstance = Object.AreaInstance(A2\ServerArea)
+						If AInstance <> Null And AInstance = TInstance
+							XDist# = Abs(AI\X# - A2\X#)
+							ZDist# = Abs(AI\Z# - A2\Z#)
+							Dist# = (XDist# * XDist#) + (ZDist# * ZDist#)
+							If Dist# < InteractDist
+								If A2\Script$ <> ""
+									Running = False
 
-							For Si.ScriptInstance = Each ScriptInstance
-								If Si\Name = A2\Script
-									If Si\AI = Handle(AI) And Si\AIContext = Handle(A2) Then Running = True : Exit
+									For Si.ScriptInstance = Each ScriptInstance
+										If Si\Name = A2\Script
+											If Si\AI = Handle(AI) And Si\AIContext = Handle(A2) Then Running = True : Exit
+										EndIf
+									Next
+									If Running = False
+										ThreadScript(A2\Script$, "Examine", Handle(AI), Handle(A2))
+									EndIf
+								Else
+									ThreadScript("Default", "Examine", Handle(AI), Handle(A2))
 								EndIf
-							Next
-							If Running = False
-								ThreadScript(A2\Script$, "Examine", Handle(AI), Handle(A2))
 							EndIf
-						Else
-							ThreadScript("Default", "Examine", Handle(AI), Handle(A2))
 						EndIf
 					EndIf
 				EndIf
@@ -1357,7 +1398,21 @@ Function UpdateNetwork()
 				If AI <> Null And Len(M\MessageData$) = 2
 					A2.ActorInstance = RuntimeIDList(RCE_IntFromStr(M\MessageData$))
 					If A2 <> Null
-						ThreadScript("Default", "Trade", Handle(AI), Handle(A2))
+						; Same-area + InteractDist gate. Without it, a
+						; wire-injecting client could pin any remote
+						; actor's IsTrading state via the Default Trade
+						; script (BVM_OPENTRADING), or trigger the script
+						; against a target in another area entirely.
+						AInstance.AreaInstance = Object.AreaInstance(AI\ServerArea)
+						TInstance.AreaInstance = Object.AreaInstance(A2\ServerArea)
+						If AInstance <> Null And AInstance = TInstance
+							XDist# = Abs(AI\X# - A2\X#)
+							ZDist# = Abs(AI\Z# - A2\Z#)
+							Dist# = (XDist# * XDist#) + (ZDist# * ZDist#)
+							If Dist# < InteractDist
+								ThreadScript("Default", "Trade", Handle(AI), Handle(A2))
+							EndIf
+						EndIf
 					EndIf
 				EndIf
 

--- a/src/Tests/Modules/WireParameterHardeningTest.bb
+++ b/src/Tests/Modules/WireParameterHardeningTest.bb
@@ -1,0 +1,172 @@
+Strict
+EnableGC
+
+; Regression test pinning the wire-parameter hardening in:
+;
+;   1. P_Examine     (ServerNet.bb ~line 1333)
+;   2. P_Trade       (ServerNet.bb ~line 1355)
+;   3. P_ItemScript  (ServerNet.bb ~line 1231, A2 path)
+;   4. InventoryAdd  (Inventories.bb ~line 105, "A" arrival branch)
+;
+; Pre-fix posture:
+;   - P_Examine, P_Trade, P_ItemScript(A2) accepted ANY actor anywhere
+;     in RuntimeIDList -- no range check, no same-area check. P_RightClick
+;     and P_AttackActor had the sibling gates (range, area) but the
+;     other three Default-script entry points did not. Combined with
+;     the BVM clicker-handle trap (SI\AI = Handle(clicker) for these
+;     script spawns), a wire-injecting client could trigger the script
+;     against a cross-area target and any BVM that's "safe in
+;     isolation" runs at attacker authority against a victim the
+;     attacker can't even see.
+;   - InventoryAdd treated Amount as unchecked: ServerNet's outer
+;     `Amount <= Amounts[SlotA]` check passes any negative value
+;     (negative <= non-negative), and the function then did
+;     Amounts[SlotTo] += Amount / Amounts[SlotFrom] -= Amount with
+;     no internal check, inflating SlotFrom and deflating SlotTo
+;     past zero -- an unbounded duplication path. InventorySwap
+;     already had the matching guard at line 152.
+;
+; Post-fix posture: all four sites validate the wire parameter
+; before any mutation/script-spawn. ServerNet.bb pulls the entire
+; network/actor/item graph and can't be included into a Strict
+; test build, so the gate predicates are replicated below following
+; the established pattern (AccountEnumerationTest, BVMPrivilegeGateTest,
+; ClampFloatTest). A behaviour change in production MUST update
+; both copies; the duplication is the trigger to refresh the test.
+
+; --- Replicated gate predicates -------------------------------------
+
+; Const InteractDist = 400 from Actors.bb (radius ~20, squared).
+; Tests use the same constant so the boundary cases align with prod.
+Const TestInteractDist% = 400
+
+; Returns True iff the same-area + InteractDist gate at the top of
+; P_Examine / P_Trade / P_ItemScript(A2) would allow the script to
+; spawn. Mirrors the production check.
+;
+;   SameArea  : True iff AInstance <> Null And AInstance = TInstance
+;   DistSq    : XDist*XDist + ZDist*ZDist (server units, squared)
+Function ScriptTriggerGateOk%(SameArea%, DistSq#)
+	If SameArea = False Then Return False
+	If DistSq >= TestInteractDist Then Return False
+	Return True
+End Function
+
+; Returns True iff InventoryAdd's new Amount bounds-check at
+; Inventories.bb ~line 105 would allow the transfer.
+;
+;   Amount       : the wire-supplied transfer count
+;   AmountsFrom  : the source slot's current stack count
+Function InventoryAddAmountOk%(Amount%, AmountsFrom%)
+	If Amount < 1 Or Amount > AmountsFrom Then Return False
+	Return True
+End Function
+
+; ====================================================================
+; Script-trigger gate -- positive cases (in-area + in-range)
+; ====================================================================
+
+Test testInAreaInRangeAllowed()
+	; Same area, distance 10^2 + 10^2 = 200, well under 400.
+	Assert(ScriptTriggerGateOk%(True, 200) = True)
+End Test
+
+Test testInAreaZeroDistanceAllowed()
+	; Standing on top of the target -- still in range.
+	Assert(ScriptTriggerGateOk%(True, 0) = True)
+End Test
+
+Test testInAreaJustInsideBoundaryAllowed()
+	; Distance squared = 399, immediately under the 400 cap.
+	Assert(ScriptTriggerGateOk%(True, 399) = True)
+End Test
+
+; ====================================================================
+; Script-trigger gate -- negative cases (cross-area or out-of-range)
+; ====================================================================
+
+Test testCrossAreaRejected()
+	; Different AreaInstance even at distance zero -- portal exploit.
+	Assert(ScriptTriggerGateOk%(False, 0) = False)
+End Test
+
+Test testCrossAreaLargeDistanceRejected()
+	; The fully-attacker-controlled case: target is in another
+	; area entirely AND not in range.
+	Assert(ScriptTriggerGateOk%(False, 1000000) = False)
+End Test
+
+Test testSameAreaTooFarRejected()
+	; Same area but well out of interaction range -- e.g. shooting
+	; an Examine packet at an NPC on the far side of the same map.
+	Assert(ScriptTriggerGateOk%(True, 10000) = False)
+End Test
+
+Test testSameAreaExactlyAtBoundaryRejected()
+	; DistSq = InteractDist exactly: the production check is
+	; `< InteractDist`, so equality rejects. Pin this boundary so
+	; a future refactor doesn't silently flip to `<=`.
+	Assert(ScriptTriggerGateOk%(True, 400) = False)
+End Test
+
+Test testStaleServerAreaRejected()
+	; AInstance = Null path (actor mid-portal / freed AreaInstance).
+	; Same as cross-area for gate purposes -- SameArea is False.
+	Assert(ScriptTriggerGateOk%(False, 50) = False)
+End Test
+
+; ====================================================================
+; InventoryAdd Amount bounds-check -- positive cases
+; ====================================================================
+
+Test testInventoryAddPositiveAmountAllowed()
+	; Standard case: move 3 of 10 in source slot.
+	Assert(InventoryAddAmountOk%(3, 10) = True)
+End Test
+
+Test testInventoryAddAmountEqualToStackAllowed()
+	; Move the whole stack -- valid.
+	Assert(InventoryAddAmountOk%(10, 10) = True)
+End Test
+
+Test testInventoryAddMinimumAmountAllowed()
+	; Move exactly one item.
+	Assert(InventoryAddAmountOk%(1, 1) = True)
+End Test
+
+; ====================================================================
+; InventoryAdd Amount bounds-check -- negative cases (exploit paths)
+; ====================================================================
+
+Test testInventoryAddZeroAmountRejected()
+	; Amount = 0 was a no-op pre-fix (Amounts[SlotTo] += 0). The
+	; new check rejects it -- callers should send a positive count
+	; or not send the packet at all. Pinned to surface UI bugs.
+	Assert(InventoryAddAmountOk%(0, 10) = False)
+End Test
+
+Test testInventoryAddNegativeOneRejected()
+	; The minimum-impact dupe: Amount = -1. Pre-fix this transferred
+	; -1 from SlotTo into SlotFrom, inflating the source by 1.
+	Assert(InventoryAddAmountOk%(-1, 5) = False)
+End Test
+
+Test testInventoryAddLargeNegativeRejected()
+	; The "give me 1000 items" exploit -- Amount = -1000.
+	; Pre-fix this passed (negative is <= AmountsFrom = 5 always)
+	; and inflated SlotFrom by 1000.
+	Assert(InventoryAddAmountOk%(-1000, 5) = False)
+End Test
+
+Test testInventoryAddOversizedAmountRejected()
+	; Amount > AmountsFrom. Pre-fix this drained SlotFrom into
+	; negative territory while inflating SlotTo past the actual
+	; available count.
+	Assert(InventoryAddAmountOk%(50, 10) = False)
+End Test
+
+Test testInventoryAddIntMinRejected()
+	; Worst case: Amount = -32768 (the minimum a 2-byte signed
+	; wire value can carry). Pre-fix: inflates SlotFrom by 32768.
+	Assert(InventoryAddAmountOk%(-32768, 1) = False)
+End Test


### PR DESCRIPTION
## Summary

Four server-side packet/primitive sites accepted client-supplied wire parameters past existing sibling protections, opening exploit paths that recent BVM-gating and float-sanitisation campaigns implicitly assumed were closed at the entry layer. This PR closes all four in one coherent pass.

### Non-technical

The server has packet handlers for examining an NPC, opening trade, and using an item. Three of them (and one inventory primitive) trusted a number sent by the client more than they should have. With careful packet crafting, a player could:
- Trigger Examine / Trade / item-use scripts against actors **in other parts of the world map**, including unreachable areas — and run BVM commands against those victims at attacker authority.
- **Duplicate inventory items** by sending a negative transfer amount on the inventory-add packet (negative arithmetic inflated the source stack and deflated the destination past zero).

After this PR, all four entry points validate the wire parameters before acting on them, matching the protections that the sibling packet handlers (P_RightClick range, P_AttackActor same-area, InventorySwap amount bounds) already had.

## Technical changes

### `src/Modules/ServerNet.bb`

**P_Examine, P_Trade**: added same-area (`AInstance = TInstance`) + InteractDist (`Dist² < InteractDist`) gate. Cross-area and out-of-range packets are silently dropped — no reply, no log flood from legitimate portal-transition retries.

**P_ItemScript**: same gate, applied only when the item targets another actor (Len=3, A2 ≠ Null). Self-cast items (Len=1, A2=Null) are unaffected. On a failed gate, the entire handler is rejected (rather than degrading A2 to Null, which could misfire an offensive item back on the user).

The pattern mirrors `P_RightClick` (range) and `P_AttackActor` (area), both of which already correctly enforce these.

### `src/Modules/Inventories.bb`

**InventoryAdd**: added `If Amount < 1 Or Amount > Amounts[SlotFrom] Then Return False` — the symmetric counterpart to InventorySwap's existing line-152 guard.

### Why the existing wire bounds-check didn't catch this

ServerNet's `P_InventoryUpdate "A"` outer check is:
```
If (AI = AIFrom Or IsPet) And (Amount = 0 Or Amount <= Amounts[SlotA])
```
`Amount <= Amounts[SlotA]` passes for ANY negative value (any negative is less than any non-negative). So negative Amount reaches InventoryAdd, which did unchecked `+=` / `-=` arithmetic. The fix is an internal guard in InventoryAdd; the wire check stays unchanged.

## Acceptance criteria

- [x] P_Examine, P_Trade, P_ItemScript(A2) reject cross-area and out-of-range targets
- [x] P_RightClick / P_AttackActor unchanged (already correctly gated)
- [x] InventoryAdd rejects `Amount < 1` and `Amount > Amounts[SlotFrom]`
- [x] InventorySwap unchanged (already correctly guarded at line 152)
- [x] Full compile clean (Server + Client + GUE + PM + 7 Tools)
- [x] All 20 tests pass (was 19 + 1 new)
- [x] New regression test pins both predicates with positive + negative cases per the established replicated-gate pattern

## Test plan

- [x] `compile.bat` (full, unfiltered, exit code 0)
- [x] `test.bat` — 20/20 passes
- [x] New `WireParameterHardeningTest.bb` has 16 cases covering both gate predicates
- [x] Manual sanity: legitimate Examine of an actor in same area, in range → still works

## Trade-offs / deferred

- Players mid-portal (their `ServerArea` not yet bound to the destination `AreaInstance`) may briefly see Examine/Trade/ItemScript packets rejected. This is the same window `P_AttackActor` already rejects today; client retries on the next packet.
- `P_RightClick` lacks the same-area gate that `P_AttackActor` has — could be a future sibling improvement (low-priority; the range gate already bounds the practical attack surface, but mid-portal cross-area right-clicks could still trigger scripts). Not in scope for this PR.
- IsTrading idempotency rejection on P_Trade (recon Agent 2 mentioned this) — deferred; would need verification that the trade state machine handles re-Trade with the same target gracefully today, and it's a behavior change that could regress legitimate UX.
- Tightening ServerNet's `Amount <= Amounts[SlotA]` check to `Amount > 0 And Amount <= ...` as defense-in-depth — deferred; the internal guard in InventoryAdd is the load-bearing fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)