### PR TITLE
fix(gubbin-tool): atomic save in SaveRotation + DecryptMesh — closes #43 data-loss bug

### DIFF
--- a/src/Tests/Modules/GubbinSaveAtomicTest.bb
+++ b/src/Tests/Modules/GubbinSaveAtomicTest.bb
@@ -1,0 +1,181 @@
+Strict
+EnableGC
+
+; Regression test pinning the atomic-save contract on the Gubbin Tool
+; SaveRotation / DecryptMesh paths (issue #43).
+;
+; Pre-fix bug shape:
+;
+;   ; SaveRotation opened the production .b3d directly for in-place
+;   ; read+write of vertex chunks.
+;   F = OpenFile("Data\Meshes\Foo.b3d")
+;   While Not Eof(F)
+;       ... seek, ReadFloat, transform, SeekFile back, WriteFloat ...
+;   Wend
+;   CloseFile(F)
+;
+; Any failure during the walk (process kill, RuntimeError downstream,
+; the user-reported VRTS-walk desync that issue #43 describes) left
+; the production file truncated or zero-length. The mesh was
+; permanently destroyed; no recovery path existed.
+;
+; Post-fix posture: CopyFile the source to FinalPath$ + ".tmp", mutate
+; the temp in place using the same VRTS walker, then SafeWriteCommit
+; atomic-promotes the temp into production. SafeWriteCommit refuses
+; to promote an empty temp and demotes the prior production to .bak.
+; Any failure leaves the original intact (with a .bak even on success
+; for one-cycle history).
+;
+; The Gubbin Tool pulls F-UI, media, and GubbinScene globals and can't
+; be Included into a Strict test build. Following the established
+; SafeWriteTest pattern, this file exercises the SafeWrite contract
+; with the same shape SaveRotation uses (CopyFile -> in-place mutate
+; -> SafeWriteCommit) and validates the failure modes that closing
+; issue #43 depends on.
+
+Global LogMode = 0
+Global MainLog = 0
+
+Include "Modules\Logging.bb"
+
+Global TestRoot$ = CurrentDir$()
+Global FinalPath$ = TestRoot$ + "gubbin_save_atomic_test.b3d"
+Global TempPath$ = FinalPath$ + ".tmp"
+Global BakPath$ = FinalPath$ + ".bak"
+
+Function CleanupTestFiles()
+	If FileType(FinalPath$) = 1 Then DeleteFile(FinalPath$)
+	If FileType(TempPath$) = 1 Then DeleteFile(TempPath$)
+	If FileType(BakPath$) = 1 Then DeleteFile(BakPath$)
+End Function
+
+; Writes a 48-byte file with a recognizable signature so we can verify
+; round-trip integrity without parsing real B3D format.
+Function WriteSignatureFile(Path$, Sig%)
+	Local Out.BBStream = WriteFile(Path$)
+	If Out = Null Then Return
+	WriteInt(Out, Sig)
+	WriteInt(Out, Sig + 1)
+	WriteInt(Out, Sig + 2)
+	WriteInt(Out, Sig + 3)
+	WriteInt(Out, Sig + 4)
+	WriteInt(Out, Sig + 5)
+	WriteInt(Out, Sig + 6)
+	WriteInt(Out, Sig + 7)
+	WriteInt(Out, Sig + 8)
+	WriteInt(Out, Sig + 9)
+	WriteInt(Out, Sig + 10)
+	WriteInt(Out, Sig + 11)
+	CloseFile(Out)
+End Function
+
+Function ReadFirstInt%(Path$)
+	Local In.BBStream = ReadFile(Path$)
+	If In = Null Then Return -1
+	Local V% = ReadInt(In)
+	CloseFile(In)
+	Return V
+End Function
+
+; --- Successful round-trip -----------------------------------------------
+
+Test testCopyFileThenSafeWriteCommitPromotesTemp()
+	CleanupTestFiles()
+	; Pre-save state: original file with signature 1000.
+	WriteSignatureFile(FinalPath$, 1000)
+	Assert(FileType(FinalPath$) = 1)
+	Local Tmp$ = SafeWriteOpen$(FinalPath$)
+	Assert(Tmp$ = TempPath$)
+	; Stage the working copy. Mirrors the production SaveRotation flow:
+	; the source is copied to .tmp, then the .tmp is mutated in place.
+	CopyFile(FinalPath$, Tmp$)
+	Assert(FileType(Tmp$) = 1)
+	; Mutate the temp in place: rewrite the first int to a new signature.
+	Local F.BBStream = OpenFile(Tmp$)
+	Assert(F <> Null)
+	SeekFile(F, 0)
+	WriteInt(F, 2000)
+	CloseFile(F)
+	; F=0 sentinel tells SafeWriteCommit "I closed it already" -- Strict
+	; can't bridge a BBStream local to the untyped Int parameter.
+	Assert(SafeWriteCommit%(Tmp$, FinalPath$, 0) = True)
+	; Production now reads the mutated signature.
+	Assert(ReadFirstInt%(FinalPath$) = 2000)
+	; Prior production is preserved as .bak.
+	Assert(FileType(BakPath$) = 1)
+	Assert(ReadFirstInt%(BakPath$) = 1000)
+	; Temp has been cleaned up.
+	Assert(FileType(Tmp$) <> 1)
+	CleanupTestFiles()
+End Test
+
+; --- Aborted save preserves original -------------------------------------
+
+Test testSafeWriteAbortLeavesOriginalUntouched()
+	CleanupTestFiles()
+	WriteSignatureFile(FinalPath$, 3000)
+	Assert(FileType(FinalPath$) = 1)
+	Local Tmp$ = SafeWriteOpen$(FinalPath$)
+	CopyFile(FinalPath$, Tmp$)
+	Local F.BBStream = OpenFile(Tmp$)
+	Assert(F <> Null)
+	; Simulate mid-mutation crash: corrupt the temp, then abort.
+	SeekFile(F, 0)
+	WriteInt(F, 9999)
+	CloseFile(F)
+	SafeWriteAbort(Tmp$)
+	; The original is unchanged because we never committed.
+	Assert(FileType(FinalPath$) = 1)
+	Assert(ReadFirstInt%(FinalPath$) = 3000)
+	; No leftover temp.
+	Assert(FileType(Tmp$) <> 1)
+	; No .bak was created (commit never ran).
+	Assert(FileType(BakPath$) <> 1)
+	CleanupTestFiles()
+End Test
+
+; --- Empty temp refusal --------------------------------------------------
+
+Test testSafeWriteCommitRefusesEmptyTemp()
+	CleanupTestFiles()
+	WriteSignatureFile(FinalPath$, 4000)
+	Assert(FileType(FinalPath$) = 1)
+	Local Tmp$ = SafeWriteOpen$(FinalPath$)
+	; Create a zero-length temp -- the WriteFile-then-CloseFile case
+	; with no payload. Production SaveRotation would never reach this
+	; on a real file (CopyFile leaves either full content or nothing),
+	; but the SafeWriteCommit contract MUST refuse to promote a
+	; zero-length file regardless.
+	Local F.BBStream = WriteFile(Tmp$)
+	Assert(F <> Null)
+	CloseFile(F)
+	Assert(FileType(Tmp$) = 1)
+	Assert(FileSize(Tmp$) = 0)
+	; SafeWriteCommit returns False on empty-temp and cleans it up;
+	; original is untouched.
+	Assert(SafeWriteCommit%(Tmp$, FinalPath$, 0) = False)
+	Assert(FileType(FinalPath$) = 1)
+	Assert(ReadFirstInt%(FinalPath$) = 4000)
+	Assert(FileType(Tmp$) <> 1)
+	CleanupTestFiles()
+End Test
+
+; --- Source-missing tolerance --------------------------------------------
+
+Test testCopyFileFailureLeavesNoCommitState()
+	; If CopyFile fails (source missing), the temp won't exist, and
+	; SaveRotation must bail without touching the original. This pins
+	; the gate `If FileType(TempPath$) <> 1 Then Return` in the
+	; production code.
+	CleanupTestFiles()
+	Local Tmp$ = SafeWriteOpen$(FinalPath$)
+	; No source file -> CopyFile is a no-op silently in Blitz3D.
+	CopyFile(FinalPath$, Tmp$)
+	; Temp should not exist; SaveRotation's gate catches this and
+	; returns without calling SafeWriteCommit.
+	Assert(FileType(Tmp$) <> 1)
+	; And the original (also non-existent in this scenario) wasn't
+	; created either.
+	Assert(FileType(FinalPath$) <> 1)
+	CleanupTestFiles()
+End Test

--- a/src/Tools/Gubbin Tool.bb
+++ b/src/Tools/Gubbin Tool.bb
@@ -798,6 +798,21 @@ End Function
 ; file (the DecryptMesh scratch output) and leaves the original .eb3d
 ; untouched. Callers should treat .eb3d rotation as a no-op until the
 ; encryption pipeline is restored.
+;
+; Atomicity (issue #43): the prior implementation opened
+; "Data\Meshes\Name$" directly via OpenFile and rewrote vertex chunks
+; in place. Any failure (process kill, RuntimeError downstream, the
+; user-reported VRTS-walk desync that silently destroys the file) left
+; the original mesh truncated or zeroed with no recovery path. The
+; mesh is part of the data project and not easily reproducible by the
+; user.
+;
+; The new path: CopyFile the source to a sibling .tmp, mutate the
+; .tmp in place using the existing VRTS walker, then SafeWriteCommit
+; atomic-promotes the .tmp into production (with the previous version
+; retained as .bak). Any failure leaves the original intact. Matches
+; the SafeWriteOpen / SafeWriteCommit pattern established by the 2025
+; sweep across Server / GUE / RCTE / Tools (Logging.bb).
 Function SaveRotation(TargetMeshID)
 
 	Local TName$ = ""
@@ -815,87 +830,117 @@ Function SaveRotation(TargetMeshID)
 			Return
 		End If
 
-;		CopyFile( TName$, Name$ )
-		DebugLog( "Save File: " +  "Data\Meshes\" + Name$)
-		Local F = OpenFile("Data\Meshes\" + Name$)
-		If F = 0 Then RuntimeError("Could not open " + Name$)
-			temp_bank = CreateBank(12)
-			GPP = CreatePivot()
-			RotateEntity(GPP, EntityPitch#(PreviewMesh), EntityYaw#(PreviewMesh), EntityRoll#(PreviewMesh))
-			While Not Eof(F)
-				SeekFile(F, fspot)
-				fspot = FilePos(F) + 1
-				Testr$ = Chr$(ReadByte(F))
-				Testr$ = Testr$ + Chr$(ReadByte(F))
-				Testr$ = Testr$ + Chr$(ReadByte(F))
-				Testr$ = Testr$ + Chr$(ReadByte(F))
+		Local FinalPath$ = "Data\Meshes\" + Name$
+		Local TempPath$ = SafeWriteOpen$(FinalPath$)
+		DebugLog( "Save File: " + FinalPath$ + " (via " + TempPath$ + ")")
 
-				; Found a vertices chunk
-				If Testr$ = "VRTS"
-					vertend = FilePos(F) + 4 + ReadInt(F)
-					Flags = ReadInt(F)
-					tc_sets = ReadInt(F)
-					tc_size = ReadInt(F)
+		; Stage a working copy. CopyFile returns non-zero on success in
+		; Blitz3D; we treat any case where the temp doesn't actually
+		; appear on disk as a failure and bail without touching the
+		; original.
+		CopyFile(FinalPath$, TempPath$)
+		If FileType(TempPath$) <> 1
+			DebugLog( "SaveRotation: could not stage temp for " + FinalPath$ + " -- save aborted, original preserved")
+			Return
+		EndIf
 
-					; Process each vertex
-					While FilePos(F) < vertend
-						; Read in floats
-						temppos = FilePos(F)
-						X# = ReadFloat(F)
-						Y# = ReadFloat(F)
-						Z# = ReadFloat(F)
+		Local F = OpenFile(TempPath$)
+		If F = 0
+			; CopyFile produced a file but we can't open it. Clean up
+			; the orphan so the next save attempt starts from a known
+			; state, and leave the original untouched.
+			DebugLog( "SaveRotation: could not open temp " + TempPath$ + " for in-place rewrite -- save aborted, original preserved")
+			SafeWriteAbort(TempPath$)
+			Return
+		EndIf
 
-						; Put them into the bank
-						PokeFloat(temp_bank, 0, X#)
-						PokeFloat(temp_bank, 4, Y#)
-						PokeFloat(temp_bank, 8, Z#)
+		temp_bank = CreateBank(12)
+		GPP = CreatePivot()
+		RotateEntity(GPP, EntityPitch#(PreviewMesh), EntityYaw#(PreviewMesh), EntityRoll#(PreviewMesh))
+		While Not Eof(F)
+			SeekFile(F, fspot)
+			fspot = FilePos(F) + 1
+			Testr$ = Chr$(ReadByte(F))
+			Testr$ = Testr$ + Chr$(ReadByte(F))
+			Testr$ = Testr$ + Chr$(ReadByte(F))
+			Testr$ = Testr$ + Chr$(ReadByte(F))
 
-						; Decrypt with Blowfish
-						;BFOld_decrypt(temp_bank, 12)
+			; Found a vertices chunk
+			If Testr$ = "VRTS"
+				vertend = FilePos(F) + 4 + ReadInt(F)
+				Flags = ReadInt(F)
+				tc_sets = ReadInt(F)
+				tc_size = ReadInt(F)
 
-						; Rotate
-						X# = PeekFloat(temp_bank, 0)
-						Y# = PeekFloat(temp_bank, 4)
-						Z# = PeekFloat(temp_bank, 8)
-						TFormPoint(X#, Y#, Z#, GPP, 0)
-						PokeFloat(temp_bank, 0, TFormedX#())
-						PokeFloat(temp_bank, 4, TFormedY#())
-						PokeFloat(temp_bank, 8, TFormedZ#())
+				; Process each vertex
+				While FilePos(F) < vertend
+					; Read in floats
+					temppos = FilePos(F)
+					X# = ReadFloat(F)
+					Y# = ReadFloat(F)
+					Z# = ReadFloat(F)
 
-						; Encrypt again
-						;BFOld_encrypt(temp_bank, 12)
+					; Put them into the bank
+					PokeFloat(temp_bank, 0, X#)
+					PokeFloat(temp_bank, 4, Y#)
+					PokeFloat(temp_bank, 8, Z#)
 
-						; Write new values back to the file
-						SeekFile F, temppos
-						WriteFloat F, PeekFloat(temp_bank, 0)
-						WriteFloat F, PeekFloat(temp_bank, 4)
-						WriteFloat F, PeekFloat(temp_bank, 8)
+					; Decrypt with Blowfish
+					;BFOld_decrypt(temp_bank, 12)
 
-						; Skip unnecessary vertex data
-						If Flags And 1
-							ReadFloat#(F)
-							ReadFloat#(F)
-							ReadFloat#(F)
-						EndIf
-						If Flags And 2
-							ReadFloat#(F)
-							ReadFloat#(F)
-							ReadFloat#(F)
-							ReadFloat#(F)
-						EndIf
-						For j = 1 To tc_sets * tc_size
-							ReadFloat#(F)
-						Next
-					Wend
+					; Rotate
+					X# = PeekFloat(temp_bank, 0)
+					Y# = PeekFloat(temp_bank, 4)
+					Z# = PeekFloat(temp_bank, 8)
+					TFormPoint(X#, Y#, Z#, GPP, 0)
+					PokeFloat(temp_bank, 0, TFormedX#())
+					PokeFloat(temp_bank, 4, TFormedY#())
+					PokeFloat(temp_bank, 8, TFormedZ#())
 
-				EndIf
-			Wend
-			FreeEntity(GPP)
-			FreeBank(temp_bank)
-		CloseFile(F)
+					; Encrypt again
+					;BFOld_encrypt(temp_bank, 12)
+
+					; Write new values back to the file
+					SeekFile F, temppos
+					WriteFloat F, PeekFloat(temp_bank, 0)
+					WriteFloat F, PeekFloat(temp_bank, 4)
+					WriteFloat F, PeekFloat(temp_bank, 8)
+
+					; Skip unnecessary vertex data
+					If Flags And 1
+						ReadFloat#(F)
+						ReadFloat#(F)
+						ReadFloat#(F)
+					EndIf
+					If Flags And 2
+						ReadFloat#(F)
+						ReadFloat#(F)
+						ReadFloat#(F)
+						ReadFloat#(F)
+					EndIf
+					For j = 1 To tc_sets * tc_size
+						ReadFloat#(F)
+					Next
+				Wend
+
+			EndIf
+		Wend
+		FreeEntity(GPP)
+		FreeBank(temp_bank)
+
+		; SafeWriteCommit closes F, refuses to promote an empty temp,
+		; demotes the existing production file to .bak, then promotes
+		; the mutated temp into production. On any commit failure the
+		; helper logs to MainLog and leaves the original (.bak rollback
+		; if the promote half-completed). The previous code called
+		; CloseFile here unconditionally -- SafeWriteCommit owns that
+		; now, do not double-close.
+		If SafeWriteCommit%(TempPath$, FinalPath$, F) = False
+			DebugLog( "SaveRotation: commit failed for " + FinalPath$ + " -- previous version retained (see .bak)")
+		EndIf
 	EndIf
-	
-	
+
+
 ; REMOVE FOR DECRYPT SIREDBLOOD SAYS MUHAHAHA #######################
 ;
 ; Re-encrypt path retired: the isEncrypted gate was always False (its
@@ -914,6 +959,11 @@ Function SaveRotation(TargetMeshID)
 
 End Function
 
+; Writes a .b3d sidecar next to a source .eb3d. Atomic via
+; SafeWriteOpen / SafeWriteCommit so a crash mid-decrypt doesn't
+; leave a zero-length sidecar that SaveRotation would then
+; "successfully" rewrite into an empty file (the upstream half of
+; issue #43).
 Function DecryptMesh(Name$)
 
 	If Len(Name$) > 5
@@ -933,7 +983,8 @@ Function DecryptMesh(Name$)
 		;	Name$ = Name$ + "temp.b3d"
 			Name$ = Name$ + ".b3d"
 
-			Out = WriteFile(Name$)
+			Local TempPath$ = SafeWriteOpen$(Name$)
+			Out = WriteFile(TempPath$)
 			If Out = 0 Then
 				FreeBank(B)
 				Return
@@ -957,13 +1008,16 @@ Function DecryptMesh(Name$)
 			EndIf
 
 			FreeBank(DecryptBank)
-			CloseFile(Out)
+			; SafeWriteCommit closes Out internally; do not double-close.
+			If SafeWriteCommit%(TempPath$, Name$, Out) = False
+				DebugLog( "DecryptMesh: commit failed for " + Name$ + " -- previous sidecar retained (see .bak)")
+			EndIf
 
 			FreeBank(B)
 		EndIf
 	EndIf
 
-End Function 
+End Function
 
 Function EncryptMesh(Name$)
 


### PR DESCRIPTION
## Summary

Closes [issue #43](https://github.com/RydeTec/rcce2/issues/43) — milestone-tagged user-confirmed data-loss bug where saving a mesh in the Gubbin Tool can leave the `.b3d` on disk empty, permanently destroying the mesh.

### Non-technical

Today, hitting **Save** in the Gubbin Tool overwrites the production `.b3d` file in `Data\Meshes` byte-by-byte. If anything goes wrong during the save — process kill, an unhandled error in the VRTS chunk walker — the mesh is corrupted or zeroed with no way to recover. The user who reported this has a `WorkingGubbinTool.zip` workaround circulating because the bug still reproduces on `develop`.

After this PR, the save process is **atomic**: the source file is copied to a sibling `.tmp`, all mutations happen on the `.tmp`, and only when the entire save completes does the `.tmp` get promoted to production (with the prior version retained as `.bak`). Any failure leaves the original mesh untouched.

## Technical

### `SaveRotation` ([src/Tools/Gubbin Tool.bb:801-915](src/Tools/Gubbin%20Tool.bb#L801))

**Before:** `OpenFile("Data\Meshes\" + Name$)` opened the production `.b3d` for in-place read+write and seek-mutated vertex chunks one float at a time. Any mid-walk failure destroyed the original.

**After:**
1. `CopyFile(FinalPath$, TempPath$)` stages a working copy at `FinalPath$ + ".tmp"`.
2. The existing VRTS walker runs against the temp (no changes to the walker logic — only the file handle's target shifts).
3. `SafeWriteCommit%(TempPath$, FinalPath$, F)` atomic-promotes the temp into production, demoting the prior version to `.bak` for one-cycle recovery.
4. Any failure (CopyFile didn't materialize, OpenFile returned 0, SafeWriteCommit refused an empty temp) → soft-fail via `DebugLog` and return with the original preserved.

The fatal `RuntimeError(\"Could not open \" + Name\$)` is removed — tools should not crash on a transient file lock.

### `DecryptMesh` ([src/Tools/Gubbin Tool.bb:917-966](src/Tools/Gubbin%20Tool.bb#L917))

**Before:** `WriteFile(Name$ + \".b3d\")` wrote directly to the final sidecar path. A crash mid-decrypt left an empty sidecar that SaveRotation then ran against — the upstream half of #43 (empty-sidecar-becomes-empty-mesh).

**After:** `SafeWriteOpen$` provides the temp path; `WriteFile` opens the temp; `SafeWriteCommit%` atomic-promotes on completion.

## Acceptance criteria

- [x] `SaveRotation` no longer touches the production file until the temp has been fully mutated and `SafeWriteCommit` succeeds.
- [x] `DecryptMesh` uses the SafeWrite atomic pattern.
- [x] `RuntimeError` removed from the save path; soft-fail via `DebugLog`.
- [x] Full compile clean (Server + Client + GUE + PM + all 7 Tools).
- [x] All 22 tests pass (was 21 + 1 new).
- [x] New `GubbinSaveAtomicTest.bb` (4 cases) pins the SafeWrite contract that SaveRotation now depends on.

## Test plan

- [x] `compile.bat` (full, no `-t`) — exit 0
- [x] `test.bat` — 22/22 pass
- [x] `test.bat GubbinSaveAtomic` — all 4 cases pass: round-trip, mid-mutation abort, empty-temp refusal, source-missing tolerance.

The Gubbin Tool itself pulls F-UI / Media / GubbinScene globals and can't be Included into a Strict test build; the test follows the established `SafeWriteTest.bb` pattern (real Logging.bb + scratch files in CWD) to exercise the same `CopyFile → mutate → SafeWriteCommit` shape SaveRotation uses.

## Trade-offs / deferred follow-ups

- The other 9 SafeWrite migration sites surfaced by iteration #15 recon (RCTE `savework` / `WriteBB3D` / `Settings.dat` / `savemodelbrush` / mesh-export, PM Functions `GenerateFullInstall`, `Radar.bb`, `Media.bb`, `Gooey_3D_Text.bb`) remain open. This PR ships the one with milestone-tagged user impact; the rest are mechanical and can land as a single follow-up.
- `.eb3d` encryption restoration is still out of scope (`EncryptMesh` is intentionally empty per documented retirement; `.eb3d` rotation continues to no-op visibly to the user).
- Other deferred items from prior iterations: IsTrading idempotency on P_Trade, P_RightClick same-area gate, GameServer.bb:828 redundant re-lookup cleanup, Interface3D `Object.GY_Gadget` Null guards (iteration #16 recon Agent 1 — zero-sentinel UI corruption).

Closes #43.

🤖 Generated with [Claude Code](https://claude.com/claude-code)