### PR TITLE
reliability(mainmenu): SafeWrite migration — 4 client-side save sites

### DIFF
--- a/src/Modules/MainMenu.bb
+++ b/src/Modules/MainMenu.bb
@@ -853,11 +853,19 @@ Function LogIn()
 			Wend
 			; If successful, download Actor/Attributes lists and go to character selection
 			If Result = 1
-				; Save username/password
-				F = WriteFile("Data\Last Username.dat")
+				; Save username/password. Atomic via SafeWriteOpen/
+				; SafeWriteCommit -- a WriteFile failure mid-write would
+				; leave the cache file empty, locking the user out of
+				; pre-fill on next login. The previous cache (if any)
+				; is retained as .bak.
+				Local LUFinal$ = "Data\Last Username.dat"
+				Local LUTemp$ = SafeWriteOpen$(LUFinal$)
+				F = WriteFile(LUTemp$)
+				If F <> 0
 					WriteLine F, GY_TextFieldText$(TName)
 					WriteLine F, Encrypt$(GY_TextFieldText$(TPass), -1)
-				CloseFile F
+					SafeWriteCommit%(LUTemp$, LUFinal$, F)
+				EndIf
 				UName$ = GY_TextFieldText$(TName) : PWord$ = MD5$(GY_TextFieldText$(TPass))
 
 				; Request actors list
@@ -1496,12 +1504,20 @@ Function LogIn()
 			; Music update
 			If GY_CheckBoxDown(BUpdateMusic) <> 1 - UpdateMusic
 				UpdateMusic = 1 - GY_CheckBoxDown(BUpdateMusic)
-				; Update file
-				F = WriteFile("Data\Game Data\Misc.dat")
+				; Update file atomically. A crash mid-write would
+				; leave Misc.dat empty, which the next launch would
+				; interpret as "no game name, no version" -- locking
+				; the user out of the project. SafeWriteCommit demotes
+				; the previous Misc.dat to .bak for recovery.
+				Local MMFinal$ = "Data\Game Data\Misc.dat"
+				Local MMTemp$ = SafeWriteOpen$(MMFinal$)
+				F = WriteFile(MMTemp$)
+				If F <> 0
 					WriteLine F, GameName$
 					WriteLine F, UpdateGame$
 					WriteLine F, UpdateMusic
-				CloseFile F
+					SafeWriteCommit%(MMTemp$, MMFinal$, F)
+				EndIf
 			EndIf
 		EndIf
 				
@@ -3690,12 +3706,20 @@ Function GameOptionsMenu()
 			; Music update
 			If GY_CheckBoxDown(BUpdateMusic) <> 1 - UpdateMusic
 				UpdateMusic = 1 - GY_CheckBoxDown(BUpdateMusic)
-				; Update file
-				F = WriteFile("Data\Game Data\Misc.dat")
+				; Update file atomically. A crash mid-write would
+				; leave Misc.dat empty, which the next launch would
+				; interpret as "no game name, no version" -- locking
+				; the user out of the project. SafeWriteCommit demotes
+				; the previous Misc.dat to .bak for recovery.
+				Local MMFinal$ = "Data\Game Data\Misc.dat"
+				Local MMTemp$ = SafeWriteOpen$(MMFinal$)
+				F = WriteFile(MMTemp$)
+				If F <> 0
 					WriteLine F, GameName$
 					WriteLine F, UpdateGame$
 					WriteLine F, UpdateMusic
-				CloseFile F
+					SafeWriteCommit%(MMTemp$, MMFinal$, F)
+				EndIf
 			EndIf
 		EndIf
 
@@ -3843,8 +3867,14 @@ Function DownloadFile(URL$, SaveTo$ = "", GYProgress = 0)
 
 		If BytesToRead = 0 Then CloseTCPStream WWW : Return 0
 
-		; Create new file to write downloaded bytes into
-		Save = WriteFile(SaveTo$)
+		; Create new file to write downloaded bytes into.
+		; Atomic: write to .tmp, only promote to final on completion
+		; (BytesIn = BytesToRead). Mid-download cancellation, EOF
+		; before content-length, or any error path abort the temp
+		; without touching the prior on-disk file (if any). The prior
+		; download is retained as .bak.
+		Local DLTemp$ = SafeWriteOpen$(SaveTo$)
+		Save = WriteFile(DLTemp$)
 		If Save = 0 Then CloseTCPStream(WWW) : Return 0
 
 		; Incredibly complex download-to-file routine...
@@ -3869,8 +3899,16 @@ Function DownloadFile(URL$, SaveTo$ = "", GYProgress = 0)
 			If BytesIn = BytesToRead Then Exit
 		Forever
 
-		; Done
-		CloseFile(Save)
+		; Done. Promote to production only if the full content-length
+		; arrived; partial downloads abort the temp and leave the
+		; previous file (if any) intact. SafeWriteCommit closes Save
+		; internally on success; we close + abort on the partial path.
+		If BytesIn = BytesToRead
+			SafeWriteCommit%(DLTemp$, SaveTo$, Save)
+		Else
+			CloseFile(Save)
+			SafeWriteAbort(DLTemp$)
+		EndIf
 		CloseTCPStream(WWW)
 	EndIf
 


### PR DESCRIPTION
## Summary

Closes the client-side counterpart to PR [#279](https://github.com/RydeTec/rcce2/pull/279)'s server/editor SafeWrite sweep. 4 sites in `MainMenu.bb` that wrote directly to production files now use the established atomic SafeWriteOpen/SafeWriteCommit pair, with `.bak` retention on a 1-cycle recovery window.

### Non-technical

A crash, disk-full, or process kill during one of these client-side save operations previously left the file empty or partially-written. The user would see locked-out login pre-fill, broken project load, or a corrupted partial download. After this PR, any of those failure modes leaves the prior file intact.

## Sites migrated (4)

| File | Line | Function | Purpose |
|---|---|---|---|
| `Data\Last Username.dat` | 857 | `LogIn()` | Username/password cache for login pre-fill |
| `Data\Game Data\Misc.dat` | 1500 | `LogIn()` | Music checkbox update (in login screen settings) |
| `Data\Game Data\Misc.dat` | 3694 | `GameOptionsMenu()` | Music checkbox update (in in-game options) |
| `SaveTo$` (HTTP downloader) | 3847 | Inside `DownloadFile()` | Atomic only on `BytesIn = BytesToRead`; partial downloads abort the temp |

The downloader path (site 4) is the most-complex: it writes incrementally in a read-bytes loop and only commits if the full content-length arrived. Partial downloads (EOF before completion, TCP drop, user cancellation) abort the temp and leave the prior file (if any) intact. Same shape as RC Terrain Editor's `pad_or_optimize` site already migrated in #279.

## Acceptance criteria

- [x] All 4 sites use SafeWriteOpen/SafeWriteCommit (or SafeWriteAbort on partial-download path)
- [x] Logging.bb is included in Client.bb (verified — no new include needed)
- [x] Two `MMFinal$/MMTemp$` locals don't conflict (different functions)
- [x] `compile.bat -t` clean
- [x] All 26 tests pass (on retry; documented OnlinePlayerChainTest intermittent flake)

## Test plan

- [x] `compile.bat -t` exit 0
- [x] `test.bat` — 26/26 pass (retry needed for the documented OnlinePlayerChainTest flake; passes on second run)

## Trade-offs / deferred

- Client-side MainMenu SafeWrite is now complete. Any other client/UI saves discovered in a future per-Tools or per-MainMenu audit would land in a separate PR.
- OnlinePlayerChainTest CI flake (~30% rate per the saved memory) remains an open investigation item; not caused by this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)