### PR TITLE
fix(ux): /help string drift — 9 commands had wrong syntax or wrong gate

### DIFF
--- a/docs/protocol/packets/P_ChatMessage.md
+++ b/docs/protocol/packets/P_ChatMessage.md
@@ -66,8 +66,8 @@ The dispatch is a single `Select Command$` keyed on `LanguageString$(LS_SC*)` ([
 | `/trade <name>` | none | Player→player trade offer. |
 | `/players` / `/allplayers` | none | Counter — current area vs. server-wide. |
 | `/time` / `/date` / `/season` | none | Game-clock report. |
-| `/warp <area>, <x>, <z>` | DM | Server-side warp. |
-| `/warpother <name>, <area>, <x>, <z>` | DM | Warp another player. |
+| `/warp <area>[,<instance>]` | DM | Self-warp to the area's first defined portal (the `Instance` arg picks the area-instance, not coordinates). |
+| `/warpother <name>, <area>[,<instance>]` | DM | Warp another player to the area's first defined portal. |
 | `/xp <amount>` | DM | `GiveXP(AI, n)`. |
 | `/gold <amount>` | DM | Direct gold adjustment + `P_GoldChange`. |
 | `/setattribute <attr>, <n>` / `/setattributemax <attr>, <n>` | DM | Calls `UpdateAttribute` / `UpdateAttributeMax` for Health/Speed/Energy, otherwise writes through and broadcasts `P_StatUpdate`. |

--- a/src/Modules/ServerNet.bb
+++ b/src/Modules/ServerNet.bb
@@ -51,11 +51,11 @@ Function SendChatHelp(AI.ActorInstance, Topic$)
 	; Social
 	RCE_Send(Host, AI\RNID, P_ChatMessage, Chr$(254) + "Social: /ignore /unignore /players /allplayers /trade", True)
 	; Info
-	RCE_Send(Host, AI\RNID, P_ChatMessage, Chr$(254) + "Info: /time /date /season /warp", True)
+	RCE_Send(Host, AI\RNID, P_ChatMessage, Chr$(254) + "Info: /time /date /season", True)
 
 	; DM commands -- only listed for DMs
 	If IsDM = True
-		RCE_Send(Host, AI\RNID, P_ChatMessage, Chr$(254) + "DM-only: /kick /xp /gold /setattribute /setattributemax /script /gm /warpother /ability /give /weather /netdump", True)
+		RCE_Send(Host, AI\RNID, P_ChatMessage, Chr$(254) + "DM-only: /kick /xp /gold /setattribute /setattributemax /script /gm /warp /warpother /ability /give /weather /netdump", True)
 	EndIf
 End Function
 
@@ -66,7 +66,7 @@ Function SendChatHelpDetail(AI.ActorInstance, T$, IsDM%)
 	Local Line$ = ""
 	; Built-in non-DM commands
 	If T = "ME" Then Line = "/me <action> -- emote action in current area"
-	If T = "YELL" Then Line = "/yell <text> -- shout to your entire area"
+	If T = "YELL" Then Line = "/yell <text> -- shout to every online player on the server"
 	If T = "PM" Then Line = "/pm <player>,<text> -- private message"
 	If T = "G" Then Line = "/g <text> -- guild chat"
 	If T = "P" Then Line = "/p <text> -- party chat"
@@ -82,22 +82,25 @@ Function SendChatHelpDetail(AI.ActorInstance, T$, IsDM%)
 	If T = "TIME" Then Line = "/time -- show in-world clock time"
 	If T = "DATE" Then Line = "/date -- show in-world date"
 	If T = "SEASON" Then Line = "/season -- show current season"
-	If T = "WARP" Then Line = "/warp <area>[,<x>,<y>,<z>] -- warp to an area"
 	If T = "HELP" Or T = "?" Then Line = "/help [<command>] -- list commands, or detail on one"
 
-	; DM-only commands -- only describe when caller has DM rights
+	; DM-only commands -- only describe when caller has DM rights.
+	; All "grant" commands target self -- the handlers in this file
+	; uniformly call GiveXP/AddSpell/etc. on AI, never on a Params-named
+	; player. /warpother is the sole exception that takes a target.
 	If IsDM = True
 		If T = "KICK" Then Line = "/kick <player> -- disconnect a player"
-		If T = "XP" Then Line = "/xp <player>,<amount> -- grant XP"
-		If T = "GOLD" Then Line = "/gold <player>,<amount> -- grant gold"
-		If T = "SETATTRIBUTE" Then Line = "/setattribute <player>,<attr>,<value> -- set attribute"
-		If T = "SETATTRIBUTEMAX" Then Line = "/setattributemax <player>,<attr>,<value> -- set max attribute"
+		If T = "XP" Then Line = "/xp <amount> -- grant XP to self"
+		If T = "GOLD" Then Line = "/gold <amount> -- adjust own gold (negative to deduct)"
+		If T = "SETATTRIBUTE" Then Line = "/setattribute <attr>,<value> -- set own attribute"
+		If T = "SETATTRIBUTEMAX" Then Line = "/setattributemax <attr>,<value> -- set own max attribute"
 		If T = "SCRIPT" Then Line = "/script <name>,<func> -- run script's function as self"
-		If T = "GM" Then Line = "/gm <text> -- broadcast as GM to all players"
-		If T = "WARPOTHER" Then Line = "/warpother <player>,<area>[,<x>,<y>,<z>] -- warp another player"
-		If T = "ABILITY" Then Line = "/ability <player>,<ability> -- grant ability"
-		If T = "GIVE" Then Line = "/give <player>,<item>[,<amount>] -- grant item"
-		If T = "WEATHER" Then Line = "/weather <type> -- set weather"
+		If T = "GM" Then Line = "/gm <text> -- broadcast as GM to all DMs"
+		If T = "WARP" Then Line = "/warp <area>[,<instance>] -- warp self to area's first portal"
+		If T = "WARPOTHER" Then Line = "/warpother <player>,<area>[,<instance>] -- warp another player"
+		If T = "ABILITY" Then Line = "/ability <ability>,<level> -- grant own ability at level"
+		If T = "GIVE" Then Line = "/give <item> -- spawn item into own inventory"
+		If T = "WEATHER" Then Line = "/weather <type> -- set weather in current area"
 		If T = "NETDUMP" Then Line = "/netdump -- start a network packet log"
 	EndIf
 

--- a/src/Modules/ServerNet.bb
+++ b/src/Modules/ServerNet.bb
@@ -87,7 +87,7 @@ Function SendChatHelpDetail(AI.ActorInstance, T$, IsDM%)
 	; DM-only commands -- only describe when caller has DM rights.
 	; All "grant" commands target self -- the handlers in this file
 	; uniformly call GiveXP/AddSpell/etc. on AI, never on a Params-named
-	; player. /warpother is the sole exception that takes a target.
+	; player. /kick and /warpother are the exceptions that take a target.
 	If IsDM = True
 		If T = "KICK" Then Line = "/kick <player> -- disconnect a player"
 		If T = "XP" Then Line = "/xp <amount> -- grant XP to self"


### PR DESCRIPTION
## Summary

Audit of `SendChatHelp` + `SendChatHelpDetail` ([ServerNet.bb:31-109](src/Modules/ServerNet.bb#L31)) against the actual `Case` dispatch in `UpdateNetwork` found **9 in-game help strings** that misdescribed their command. Players running `/help <cmd>` would learn the wrong syntax, type something the parser silently rejects, and lose several seconds figuring out what's wrong.

The recon trigger was [PR #290](https://github.com/RydeTec/rcce2/pull/290)'s reviewer, who spotted that `/script <name>[,<params>]` was actually `/script <name>,<func>` (handler splits to `Name + Func` and ignores any 3rd arg). That fix went in last PR; this PR is the comprehensive sweep of every remaining drift.

## Defects fixed

| Command | Old help | What handler actually does | New help |
|---|---|---|---|
| `/warp` | `<area>[,<x>,<y>,<z>]` (non-DM **Info** category) | DM-gated; 2nd arg is `Instance`, not coordinates; warps to area's first `PortalName$[i]` | `<area>[,<instance>] -- warp self to area's first portal` (moved to **DM-only**) |
| `/warpother` | `<player>,<area>[,<x>,<y>,<z>]` | Same — 3rd arg is Instance, not coords | `<player>,<area>[,<instance>] -- warp another player` |
| `/yell` | "shout to your entire area" | Walks `FirstOnlinePlayer` engine-wide chain ([:408-414](src/Modules/ServerNet.bb#L408)) | "shout to every online player on the server" |
| `/xp` | `<player>,<amount>` | `GiveXP(AI, Int(Params$))` — single arg, self ([:335](src/Modules/ServerNet.bb#L335)) | `<amount> -- grant XP to self` |
| `/gold` | `<player>,<amount>` | `AI\Gold = AI\Gold + Int(Params$)` ([:340](src/Modules/ServerNet.bb#L340)) | `<amount> -- adjust own gold (negative to deduct)` |
| `/setattribute` | `<player>,<attr>,<value>` | 2-arg comma split; targets `AI` ([:354](src/Modules/ServerNet.bb#L354)) | `<attr>,<value> -- set own attribute` |
| `/setattributemax` | `<player>,<attr>,<value>` | Same shape | `<attr>,<value> -- set own max attribute` |
| `/ability` | `<player>,<ability>` | `Name,Level` 2-arg; `AddSpell(AI, ...)` ([:577-580](src/Modules/ServerNet.bb#L577)) | `<ability>,<level> -- grant own ability at level` |
| `/give` | `<player>,<item>[,<amount>]` | `Upper$(Params$)` whole-string item-name match; assigns to `AI` ([:588-602](src/Modules/ServerNet.bb#L588)) | `<item> -- spawn item into own inventory` |
| `/gm` | "broadcast as GM to all players" | Walks `FirstOnlinePlayer` but re-checks `A2\Account.IsDM` ([:422-427](src/Modules/ServerNet.bb#L422)) — DM-to-DM only | "broadcast as GM to all DMs" |

`/warp` also moved out of the non-DM **Info** summary line into the DM-only summary line, since its handler at [:531](src/Modules/ServerNet.bb#L531) requires `Account\IsDM`.

## Block comment added

Above the DM-only `If` block in `SendChatHelpDetail`, a comment now records the self-target invariant for future contributors:

> All `grant` commands target self — the handlers in this file uniformly call `GiveXP`/`AddSpell`/etc. on `AI`, never on a Params-named player. `/warpother` is the sole exception that takes a target.

This keeps the next reviewer from re-introducing the `<player>,...` mistake when they add a new DM command.

## Doc follow-up

Two stale entries in [`docs/protocol/packets/P_ChatMessage.md`](docs/protocol/packets/P_ChatMessage.md) (the catalogue I just merged in #290) had the same `<x>,<z>` mistake copied from the broken help text. Corrected.

## Test plan

- [x] `compile.bat -t` clean (Server + Client + GUE + Project Manager)
- [x] All 9 help strings cross-checked against their `Case` handler at the line range cited in the table above
- [x] Doc catalogue (`docs/protocol/packets/P_ChatMessage.md`) updated for `/warp` and `/warpother`
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)