### PR TITLE
fix(bvm): SCENERYOWNER stack-imbalance — push 0 sentinel; document dead-BVM trap

### DIFF
--- a/src/Modules/RC_Standard_Invoker.bb
+++ b/src/Modules/RC_Standard_Invoker.bb
@@ -93,15 +93,20 @@ Function BVM_InitStringConst_BVM_MAIN_CMD_SET_DEF_$()
 	s = s + "Function ACTORUNDERWATER<BVM_ACTORUNDERWATER>%(PARAM1%)"+Chr(10)
 	s = s + "Function ACTORGENDER<BVM_ACTORGENDER>%(PARAM1%)"+Chr(10)
 	; DEAD-API: SetOwner / SceneryOwner are permanently disabled. The
-	; underlying OwnedScenery type was removed from ServerAreas.bb:53
-	; and these BVM impls are commented out at ScriptingCommands.bb:1046
-	; / :1071. Both contract entries stay alive because removing them
-	; would shift opcodes for every BVM alphabetically after
-	; SCENERYOWNER and SETOWNER, breaking the fixed-Case dispatch at
-	; lines 1363 / 1494 below. The dispatch cases push a 0 sentinel
-	; (SCENERYOWNER) or no-op (SETOWNER) so scripts that still call
-	; these don't corrupt the stack. Do not remove without an opcode-
-	; renumber audit of every Case >= 501.
+	; underlying OwnedScenery type was removed from ServerAreas.bb
+	; (the `Type OwnedScenery` and `Field OwnedScenery[]` declarations
+	; are commented out) and these BVM impls are commented out in
+	; ScriptingCommands.bb (grep `;Function BVM_SETOWNER` /
+	; `;Function BVM_SCENERYOWNER`). Both contract entries stay alive
+	; -- removing them would shift opcodes for every BVM alphabetically
+	; after SCENERYOWNER and SETOWNER, breaking the fixed-Case dispatch
+	; for Case 501 (SCENERYOWNER) and Case 530 (SETOWNER) below. The
+	; dispatch cases push a 0 sentinel (SCENERYOWNER) or no-op
+	; (SETOWNER) so scripts that still call these don't corrupt the
+	; stack. Do not remove without an opcode-renumber audit of every
+	; Case >= 501. Mirror entries live in src/RC_Standard.bcs (the
+	; compile-time twin of this runtime contract string).
+	; Contract entries (next two lines):
 	s = s + "Function SETOWNER<BVM_SETOWNER>(PARAM1%, PARAM2$, PARAM3%, PARAM4% = 0)"+Chr(10)
 	s = s + "Function SCENERYOWNER<BVM_SCENERYOWNER>%(PARAM1$, PARAM2%, PARAM3%=0)"+Chr(10)
 	s = s + "Function ACTORID<BVM_ACTORID>%(PARAM1$, PARAM2$)"+Chr(10)
@@ -1380,10 +1385,11 @@ Function BVM_Invoke%(withTimeOut% = 0)
 				iparam1% = BVM_PopInt()
 				sparam0$ = BVM_PopString()
 				; BVM_SCENERYOWNER is permanently disabled -- the underlying
-				; OwnedScenery type was commented out in
-				; ServerAreas.bb:53 alongside its supporting code. The impl
-				; in ScriptingCommands.bb:1071 has been commented out as
-				; well. The contract entry above at line ~95 stays alive to
+				; OwnedScenery type was commented out in ServerAreas.bb
+				; alongside its supporting code, and the impl was
+				; commented out in ScriptingCommands.bb (grep
+				; `;Function BVM_SCENERYOWNER`). The contract entry near
+				; the top of this file (grep "DEAD-API") stays alive to
 				; preserve opcode stability for every BVM alphabetically
 				; after SCENERYOWNER, so this dispatch case still gets
 				; reached when a script calls SceneryOwner(...).
@@ -1523,8 +1529,9 @@ Function BVM_Invoke%(withTimeOut% = 0)
 				; the 4-arg pop is stack-balanced on its own and no
 				; sentinel push is needed; the case becomes a silent no-op
 				; for scripts that call SetOwner(...). The contract entry
-				; above at line ~95 stays alive for opcode stability;
-				; impl at ScriptingCommands.bb:1046 is commented out.
+				; near the top of this file (grep "DEAD-API") stays alive
+				; for opcode stability; impl in ScriptingCommands.bb is
+				; commented out (grep `;Function BVM_SETOWNER`).
 			Case 531
 				iparam1% = BVM_PopInt()
 				iparam0% = BVM_PopInt()

--- a/src/Modules/RC_Standard_Invoker.bb
+++ b/src/Modules/RC_Standard_Invoker.bb
@@ -92,6 +92,16 @@ Function BVM_InitStringConst_BVM_MAIN_CMD_SET_DEF_$()
 	s = s + "Function ACTORDESTINATIONZ<BVM_ACTORDESTINATIONZ>#(PARAM1%)"+Chr(10)
 	s = s + "Function ACTORUNDERWATER<BVM_ACTORUNDERWATER>%(PARAM1%)"+Chr(10)
 	s = s + "Function ACTORGENDER<BVM_ACTORGENDER>%(PARAM1%)"+Chr(10)
+	; DEAD-API: SetOwner / SceneryOwner are permanently disabled. The
+	; underlying OwnedScenery type was removed from ServerAreas.bb:53
+	; and these BVM impls are commented out at ScriptingCommands.bb:1046
+	; / :1071. Both contract entries stay alive because removing them
+	; would shift opcodes for every BVM alphabetically after
+	; SCENERYOWNER and SETOWNER, breaking the fixed-Case dispatch at
+	; lines 1363 / 1494 below. The dispatch cases push a 0 sentinel
+	; (SCENERYOWNER) or no-op (SETOWNER) so scripts that still call
+	; these don't corrupt the stack. Do not remove without an opcode-
+	; renumber audit of every Case >= 501.
 	s = s + "Function SETOWNER<BVM_SETOWNER>(PARAM1%, PARAM2$, PARAM3%, PARAM4% = 0)"+Chr(10)
 	s = s + "Function SCENERYOWNER<BVM_SCENERYOWNER>%(PARAM1$, PARAM2%, PARAM3%=0)"+Chr(10)
 	s = s + "Function ACTORID<BVM_ACTORID>%(PARAM1$, PARAM2$)"+Chr(10)
@@ -1369,7 +1379,19 @@ Function BVM_Invoke%(withTimeOut% = 0)
 				iparam2% = BVM_PopInt()
 				iparam1% = BVM_PopInt()
 				sparam0$ = BVM_PopString()
-				;BVM_PushInt(BVM_SCENERYOWNER(sparam0$, iparam1%, iparam2%)) {##}
+				; BVM_SCENERYOWNER is permanently disabled -- the underlying
+				; OwnedScenery type was commented out in
+				; ServerAreas.bb:53 alongside its supporting code. The impl
+				; in ScriptingCommands.bb:1071 has been commented out as
+				; well. The contract entry above at line ~95 stays alive to
+				; preserve opcode stability for every BVM alphabetically
+				; after SCENERYOWNER, so this dispatch case still gets
+				; reached when a script calls SceneryOwner(...).
+				; Push 0 (sentinel "no owner") so the caller's stack stays
+				; balanced -- without this push, the int the caller
+				; expected back is missing and every subsequent BVM
+				; operation in that expression pops the wrong slot.
+				BVM_PushInt(0)
 			Case 502
 				iparam6% = BVM_PopInt()
 				iparam5% = BVM_PopInt()
@@ -1496,7 +1518,13 @@ Function BVM_Invoke%(withTimeOut% = 0)
 				iparam2% = BVM_PopInt()
 				sparam1$ = BVM_PopString()
 				iparam0% = BVM_PopInt()
-				;BVM_SETOWNER(iparam0%, sparam1$, iparam2%, iparam3%) {##}
+				; BVM_SETOWNER is permanently disabled -- same context as
+				; the SCENERYOWNER no-op at Case 501. SetOwner is void, so
+				; the 4-arg pop is stack-balanced on its own and no
+				; sentinel push is needed; the case becomes a silent no-op
+				; for scripts that call SetOwner(...). The contract entry
+				; above at line ~95 stays alive for opcode stability;
+				; impl at ScriptingCommands.bb:1046 is commented out.
 			Case 531
 				iparam1% = BVM_PopInt()
 				iparam0% = BVM_PopInt()

--- a/src/Modules/ScriptingCommands.bb
+++ b/src/Modules/ScriptingCommands.bb
@@ -1043,6 +1043,14 @@ Function BVM_ACTORGENDER%(Param1%)
 Return Result%
 End Function
 
+; DEAD-API: BVM_SETOWNER permanently disabled. The underlying
+; OwnedScenery type was removed from ServerAreas.bb:53; the public
+; contract entry in RC_Standard_Invoker.bb:~95 stays alive for opcode
+; stability (removing it would renumber every BVM alphabetically after
+; SCENERYOWNER/SETOWNER and break the fixed-Case dispatch). Dispatch
+; case at RC_Standard_Invoker.bb:1494 is a silent no-op. Sibling
+; BVM_SCENERYOWNER below has the same treatment but with a 0-sentinel
+; push to keep its return-value caller stack-balanced.
 ;Function BVM_SETOWNER(Param1%, Param2$, Param3%, Param4% = 0) {##}
 ;	Actor.ActorInstance = Object.ActorInstance(Param1%)
 ;	Zone.Area = FindArea(Param2$)
@@ -1068,6 +1076,13 @@ End Function
 
 ;End Function
 
+; DEAD-API: BVM_SCENERYOWNER permanently disabled. See the audit
+; comment above BVM_SETOWNER for the OwnedScenery feature removal and
+; the opcode-stability rationale. The dispatch case at
+; RC_Standard_Invoker.bb:1363 now pushes 0 (sentinel "no owner") so the
+; caller's stack stays balanced -- before that fix, the case popped 3
+; args and pushed nothing, corrupting every subsequent BVM operation
+; in the calling expression.
 ;Function BVM_SCENERYOWNER%(Param1$, Param2%, Param3%=0) {##}
 ;	Zone.Area = FindArea(Param1$)
 ;	If Zone <> Null

--- a/src/Modules/ScriptingCommands.bb
+++ b/src/Modules/ScriptingCommands.bb
@@ -1044,13 +1044,13 @@ Return Result%
 End Function
 
 ; DEAD-API: BVM_SETOWNER permanently disabled. The underlying
-; OwnedScenery type was removed from ServerAreas.bb:53; the public
-; contract entry in RC_Standard_Invoker.bb:~95 stays alive for opcode
-; stability (removing it would renumber every BVM alphabetically after
-; SCENERYOWNER/SETOWNER and break the fixed-Case dispatch). Dispatch
-; case at RC_Standard_Invoker.bb:1494 is a silent no-op. Sibling
-; BVM_SCENERYOWNER below has the same treatment but with a 0-sentinel
-; push to keep its return-value caller stack-balanced.
+; OwnedScenery type was removed from ServerAreas.bb; the public
+; contract entry in RC_Standard_Invoker.bb (grep "DEAD-API") stays
+; alive for opcode stability (removing it would renumber every BVM
+; alphabetically after SCENERYOWNER/SETOWNER and break the fixed-Case
+; dispatch). Dispatch case for SETOWNER (Case 530) is a silent no-op.
+; Sibling BVM_SCENERYOWNER below has the same treatment but with a
+; 0-sentinel push to keep its return-value caller stack-balanced.
 ;Function BVM_SETOWNER(Param1%, Param2$, Param3%, Param4% = 0) {##}
 ;	Actor.ActorInstance = Object.ActorInstance(Param1%)
 ;	Zone.Area = FindArea(Param2$)
@@ -1078,11 +1078,11 @@ End Function
 
 ; DEAD-API: BVM_SCENERYOWNER permanently disabled. See the audit
 ; comment above BVM_SETOWNER for the OwnedScenery feature removal and
-; the opcode-stability rationale. The dispatch case at
-; RC_Standard_Invoker.bb:1363 now pushes 0 (sentinel "no owner") so the
-; caller's stack stays balanced -- before that fix, the case popped 3
-; args and pushed nothing, corrupting every subsequent BVM operation
-; in the calling expression.
+; the opcode-stability rationale. The dispatch case for SCENERYOWNER
+; (Case 501 in RC_Standard_Invoker.bb) now pushes 0 (sentinel
+; "no owner") so the caller's stack stays balanced -- before that fix,
+; the case popped 3 args and pushed nothing, corrupting every
+; subsequent BVM operation in the calling expression.
 ;Function BVM_SCENERYOWNER%(Param1$, Param2%, Param3%=0) {##}
 ;	Zone.Area = FindArea(Param1$)
 ;	If Zone <> Null

--- a/src/RC_Standard.bcs
+++ b/src/RC_Standard.bcs
@@ -111,6 +111,14 @@ Function ACTORDESTINATIONX<BVM_ACTORDESTINATIONX>#(PARAM1%)
 Function ACTORDESTINATIONZ<BVM_ACTORDESTINATIONZ>#(PARAM1%)
 Function ACTORUNDERWATER<BVM_ACTORUNDERWATER>%(PARAM1%)
 Function ACTORGENDER<BVM_ACTORGENDER>%(PARAM1%)
+; DEAD-API: SetOwner / SceneryOwner are permanently disabled. The
+; underlying OwnedScenery type was removed from src/Modules/ServerAreas.bb
+; and the BVM impls are commented out in src/Modules/ScriptingCommands.bb
+; (grep "DEAD-API"). Both entries stay alive here -- removing them would
+; shift opcodes for every BVM alphabetically after SCENERYOWNER and
+; SETOWNER, breaking the fixed-Case dispatch in
+; src/Modules/RC_Standard_Invoker.bb. Mirror of the audit comment in
+; that file.
 Function SETOWNER<BVM_SETOWNER>(PARAM1%, PARAM2$, PARAM3%, PARAM4% = 0)
 Function SCENERYOWNER<BVM_SCENERYOWNER>%(PARAM1$, PARAM2%, PARAM3%=0)
 Function ACTORID<BVM_ACTORID>%(PARAM1$, PARAM2$)


### PR DESCRIPTION
## Summary

Applied the just-learned [doc-audits-find-source-bugs](https://github.com/RydeTec/rcce2/pull/291) recon pattern to a sibling area: the **invoker-contract vs. BVM-impl drift**. There's known precedent — the audit-comment at [ScriptingCommands.bb:2780](src/Modules/ScriptingCommands.bb#L2780) records that `BVM_OUTPUT`'s `Param3 = 0` impl default mismatched the invoker contract's `255`, causing every 2-arg `Output(player, \"hi\")` call to print black-on-black. If one was wrong, others likely were too.

Sweep: 220 contract entries (`<BVM_*>` in `RC_Standard_Invoker.bb`) vs. 222 active impls (`^Function BVM_*` in `ScriptingCommands.bb`), case-insensitive. Two contract-without-impl orphans: **`BVM_SETOWNER`** and **`BVM_SCENERYOWNER`**. The 4 impl-without-contract entries (`RequirePrivileged` / `RequireSelfOrPrivileged` / `ScriptPathIsSafe` / `SetWaitResult`) are correctly-private internal helpers.

## The bug

The underlying `OwnedScenery` Type was disabled long ago in [ServerAreas.bb:53](src/Modules/ServerAreas.bb#L53), and both BVM impls were commented out in [ScriptingCommands.bb:1046](src/Modules/ScriptingCommands.bb#L1046) / [:1071](src/Modules/ScriptingCommands.bb#L1071). The dispatch cases in [RC_Standard_Invoker.bb:1363](src/Modules/RC_Standard_Invoker.bb#L1363) / [:1494](src/Modules/RC_Standard_Invoker.bb#L1494) were also commented out. But the **public contract entries at lines ~95-96 were left active**, so the BlitzForge compiler still accepts `SetOwner(...)` / `SceneryOwner(...)` calls from scripts.

The dispatch cases pop args from the BVM stack but the (commented-out) impl calls never happen:

| Case | Pops | Pushes | Stack delta |
|---|---|---|---|
| 501 SCENERYOWNER (returns `%`) | 3 | **0** ← was supposed to push the int return value | **-3 + caller-expects-+1 = -4 off** |
| 530 SETOWNER (void) | 4 | 0 | balanced |

So **SETOWNER** is silently no-op (annoying but safe). **SCENERYOWNER** is a real silent-corruption bug: the caller's expression expects an int on the stack after the call, gets a stack underflow instead, and every subsequent BVM operation in that expression pops the wrong slot.

## Fix

1. **`RC_Standard_Invoker.bb:501`** — push `BVM_PushInt(0)` so SCENERYOWNER's stack stays balanced. 0 reads as \"no owner\" — the closest defined sentinel given the storage is gone.
2. **5 audit comments** cross-linking all dead-API sites:
   - Contract entries at `RC_Standard_Invoker.bb:~95`: documenting why they stay alive (removing would renumber every opcode alphabetically after them and break the fixed-Case dispatch).
   - Case 501 (SCENERYOWNER no-op-with-sentinel) and Case 530 (SETOWNER void no-op).
   - Both commented impls at `ScriptingCommands.bb:1046` and `:1071`.

Next contributor who hits any one of these has the full story without needing to grep the other four.

## Why not remove the contract entries

The BlitzForge command-set parser assigns opcodes **alphabetically by function name**. Removing SCENERYOWNER and SETOWNER would shift every BVM alphabetically after them down by 2, breaking the fixed-Case dispatch at lines 501+ for SCREENFLASH / SCRIPTLOG / SETACTORX / ... / WARP. That's a ~250-Case renumber-or-mapping audit — risky for a doc-only improvement. Audit comments + the sentinel fix is the surgical-safe choice.

## Test plan

- [x] `compile.bat -t` clean (Server + Client + GUE + Project Manager)
- [x] `test.bat` — all 26 tests pass
- [x] No content scripts in `data/` reference SetOwner/SceneryOwner (grep clean)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)