### PR TITLE
fix(loom-threads): plug LoomFocusEntry leak in Back / ClearStack

### DIFF
--- a/src/Modules/Loom/Browser.bb
+++ b/src/Modules/Loom/Browser.bb
@@ -75,7 +75,7 @@ End Function
 
 
 Function Browser_AddCategory(kind$, title$)
-    Local c.BrowserCategory = New BrowserCategory
+    Local c.BrowserCategory = New BrowserCategory()
     c\Kind$ = kind$
     c\Title$ = title$
 End Function

--- a/src/Modules/Loom/Threads.bb
+++ b/src/Modules/Loom/Threads.bb
@@ -110,7 +110,7 @@ Function Threads_Jump(kind$, refID)
 
     // Push current focus (if any) onto the back stack
     If Loom_FocusKind$ <> ""
-        Local prev.LoomFocusEntry = New LoomFocusEntry
+        Local prev.LoomFocusEntry = New LoomFocusEntry()
         prev\Kind$ = Loom_FocusKind$
         prev\RefID = Loom_FocusID
         ListAdd(Loom_BackStack, prev)
@@ -130,12 +130,18 @@ Function Threads_Back()
     Local n = ListSize(Loom_BackStack)
     If n = 0 Then Return False
 
-    // Pop the last entry
+    // Pop the last entry. The LoomFocusEntry instance lives on the heap;
+    // ListRemove only drops the list's reference to it, leaving the instance
+    // itself leaked. Without `EnableGC` at the top of this file, Blitz3D has
+    // no reference counting -- a long Loom session with N back/forward
+    // navigations leaks N LoomFocusEntry instances. Capture the fields we
+    // need, drop from list, then `Delete` the instance explicitly.
     Local prev.LoomFocusEntry = ListAt(Loom_BackStack, n - 1)
     If prev = Null Then Return False
     Local kind$ = prev\Kind$
     Local refID = prev\RefID
     ListRemove(Loom_BackStack, n - 1)
+    Delete prev
 
     Loom_FocusKind$ = kind$
     Loom_FocusID = refID
@@ -149,7 +155,15 @@ End Function
 // Threads_ClearStack
 // =============================================================================
 Function Threads_ClearStack()
-    If Loom_BackStack <> Null Then ListClear(Loom_BackStack)
+    If Loom_BackStack = Null Then Return
+    // Same leak rationale as Threads_Back: ListClear only drops the list's
+    // references; the LoomFocusEntry instances must be Deleted explicitly
+    // (no EnableGC at file top, no auto-collection).
+    Local entry.LoomFocusEntry
+    For entry = Each LoomFocusEntry
+        Delete entry
+    Next
+    ListClear(Loom_BackStack)
 End Function
 
 


### PR DESCRIPTION
## Summary

[`src/Modules/Loom/Threads.bb`](src/Modules/Loom/Threads.bb) has no `EnableGC` at the top (none of the Loom files do — new-file convention violation, but a file-level setting that needs its own audit before flipping). Without GC, the `New LoomFocusEntry()` in `Threads_Jump` is heap-allocated and never freed when removed from the back stack — `ListRemove` / `ListClear` drop the list's reference but the instance lives on.

## The leaks

- **`Threads_Back`** ([line ~129](src/Modules/Loom/Threads.bb#L129)) leaked one `LoomFocusEntry` per pop. For a long Loom session navigating through entities, every back press adds garbage.
- **`Threads_ClearStack`** ([line ~149](src/Modules/Loom/Threads.bb#L149)) leaked the entire stack contents on every Esc-back-to-browser (called from `Loom.bb`'s main loop when the user closes the composer).

## Fix

- `Threads_Back`: explicit `Delete prev` after `ListRemove`.
- `Threads_ClearStack`: walk `Each LoomFocusEntry` and `Delete` each before `ListClear` (sweep-all shape — the only `LoomFocusEntry` instances in the program are the back-stack entries).

Audit comments on both sites explain the EnableGC-absence rationale so a future reader doesn't wonder why the explicit `Delete` is needed.

## Bonus drive-by

`New BrowserCategory` → `New BrowserCategory()` in `Browser.bb`. BlitzForge requires parens on bare `New` (per the language skill: \"BlitzForge needs the parens — the implicit create method requires a call\"). Was tolerated only because Browser.bb is not Strict — which it should be, but flipping Strict requires fixing ~12 untyped Locals across the Loom files (deferred).

## Recon context

Discovered while attempting to add `Strict` + `EnableGC` to all 5 Loom files. **BlitzForge enforces `\"EnableGC may only be used in strict mode\"`** — the two cannot be flipped independently. Adding Strict alongside surfaced untyped Locals across the files that would need a broader sweep. That bigger refactor is captured for a future iteration; this PR is the focused leak fix.

## Test plan

- [x] `compile.bat -t` clean across all 5 engine targets
- [x] `git diff develop..HEAD --stat` shows only `Threads.bb` (+15) and `Browser.bb` (+1)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)