### PR TITLE
fix(soft-fail): CreateActorInstance(Null) no longer crashes; guard change-race preview

### DIFF
--- a/src/Modules/Actors.bb
+++ b/src/Modules/Actors.bb
@@ -580,7 +580,23 @@ End Function
 ; Creates a new instance of an actor
 Function CreateActorInstance.ActorInstance(Actor.Actor)
 
-	If Actor = Null Then RuntimeError("Could not create actor instance - actor does not exist!")
+	; Soft-fail on Null Actor template. Previously RuntimeError'd, which
+	; crashed the server (any thread) or client (UI preview thread)
+	; if any caller forgot the upstream ActorList(ActorID) <> Null
+	; guard. The production-server callers all guard upstream (PR
+	; #138-#144 sweep): Actors.bb (PreLoadSpawns + ActorInstanceFromString)
+	; ServerNet.bb (P_CreateCharacter), MySQL.bb (LoadCharacter). The
+	; client-side preview callers in MainMenu.bb mostly guard too,
+	; except the change-race path -- a combo-box pick of a race that
+	; was deleted from the project would crash. Defense-in-depth: log
+	; the unexpected Null and Return Null. Callers that already check
+	; the return value handle this naturally; callers that don't will
+	; deref Null on the next line which is at least a localized crash
+	; (not a server-wide RuntimeError) the runtime traps cleanly.
+	If Actor = Null
+		WriteLog(MainLog, "CreateActorInstance: called with Null Actor template; returning Null instead of RuntimeError-ing the whole process")
+		Return Null
+	EndIf
 
 	A.ActorInstance = New ActorInstance
 	A\Attributes = New Attributes

--- a/src/Modules/MainMenu.bb
+++ b/src/Modules/MainMenu.bb
@@ -2505,12 +2505,42 @@ Function CreateChar()
 			PointsToSpend = AttributeAssignment
 			For i = 0 To 39 : PointSpends(i) = 0 : Next
 			ChosenRace$ = Upper$(GY_ComboBoxItem$(CRace))
+			Chosen.Actor = Null  ; reset before the search so a no-match leaves Null
 			For A.Actor = Each Actor
 				If Upper$(A\Race$) = ChosenRace$ Then Chosen.Actor = A : Exit
 			Next
-			Preview.ActorInstance = CreateActorInstance(Chosen)
-			Result = LoadActorInstance3D(Preview, 1.0, False, False)
-			If Result = False Then RuntimeError("Could not load actor mesh for " + Chosen\Race$ + "!")
+			; If the combo-box race no longer exists in the client's
+			; Actors table (project updated, race deleted, or update-
+			; channel skew), Chosen stays Null. CreateActorInstance
+			; (Null) used to RuntimeError-crash the client; now soft-
+			; fails to Null. Skip the preview swap and leave the
+			; previous Preview in place rather than render an empty
+			; character-creation screen.
+			If Chosen = Null
+				WriteLog(MainLog, "CharCreation race-change: combo-box race '" + ChosenRace$ + "' not in client Actors table; keeping previous preview")
+			Else
+				Preview.ActorInstance = CreateActorInstance(Chosen)
+				If Preview = Null
+					WriteLog(MainLog, "CharCreation race-change: CreateActorInstance returned Null for race '" + Chosen\Race$ + "'; keeping previous preview")
+				Else
+					Result = LoadActorInstance3D(Preview, 1.0, False, False)
+					If Result = False
+						; Mesh-load failure: log + free + bail rather
+						; than RuntimeError-crash the client. Mirrors
+						; the same recovery pattern as the initial
+						; character-pick at line 2292.
+						WriteLog(MainLog, "CharCreation race-change: mesh load failed for race '" + Chosen\Race$ + "'; freeing preview")
+						SafeFreeActorInstance(Preview)
+						Preview = Null
+					EndIf
+				EndIf
+			EndIf
+			; The follow-on code (PositionEntity Preview\CollisionEN,
+			; SetUpPreview(Preview\Actor), ...) requires Preview to be
+			; non-Null. Skip when the preview wasn't created.
+			If Preview = Null
+				Goto SkipPreviewSetup
+			EndIf
 			;PlayAnimation(Preview, 1, 0.003, Anim_Idle)
 			PositionEntity Preview\CollisionEN, 30, -(35.0 + EntityY#(Preview\EN, True)), 100
 			;If Preview\ShadowEN <> 0 Then HideEntity(Preview\ShadowEN) [###]
@@ -2521,6 +2551,7 @@ Function CreateChar()
 			GY_LockGadget(BNextHair, Not ActorHasHair(Preview\Actor, Preview\Gender + 1)) : GY_LockGadget(BPrevHair, Not ActorHasHair(Preview\Actor, Preview\Gender + 1))
 			GY_LockGadget(BNextBeard, Not ActorHasBeard(Preview\Actor)) : GY_LockGadget(BPrevBeard, Not ActorHasBeard(Preview\Actor))
 			GY_LockGadget(BNextGender, Preview\Actor\Genders) : GY_LockGadget(BPrevGender, Preview\Actor\Genders)
+			.SkipPreviewSetup
 		EndIf
 
 		; Next/Previous class


### PR DESCRIPTION
## Summary

Iteration #39 RuntimeError audit of server-and-client modules surfaced 3 sites; the `CreateActorInstance` one at [Actors.bb:583](src/Modules/Actors.bb#L583) was the most dangerous because every caller routed through it without a localized Null check. **Real bug** found in the audit: MainMenu.bb's change-character-race path is unguarded — pick a combo-box race that doesn't exist in the client's `Actors` table (project updated, race deleted between sessions, update-channel skew) → `Chosen` stays Null → `CreateActorInstance(Null)` crashes the client.

## Defense-in-depth

Converted `Actors.bb:583` from `If Actor = Null Then RuntimeError(...)` to soft-fail (Return Null + WriteLog). The production-server callers all already guard upstream with `If ActorList(ActorID) = Null Then ... bail` (PR #138–#144 sweep): `PreLoadSpawns`, `ActorInstanceFromString`, `P_CreateCharacter`, `LoadCharacter`. Switching the bottom-line gate to soft-fail means a future caller that forgets the upstream check gets a localized Null crash on the next deref instead of a process-wide `RuntimeError` that disconnects everyone.

## The real bug

[MainMenu.bb:2511](src/Modules/MainMenu.bb#L2511) — change-character-race:

```basic
For A.Actor = Each Actor
    If Upper$(A\Race$) = ChosenRace$ Then Chosen.Actor = A : Exit
Next
Preview.ActorInstance = CreateActorInstance(Chosen)   ' crash on no-match
Result = LoadActorInstance3D(Preview, 1.0, False, False)
If Result = False Then RuntimeError(...)              ' also crashes
```

## Fix

- Explicit `Chosen.Actor = Null` reset before the search (so a no-match leaves Null even when a previous iteration left a stale value)
- `If Chosen = Null` → log + keep previous preview (don't render an empty character-creation screen)
- `Else`: CreateActorInstance + check return for Null (defense-in-depth via the soft-fail above)
- Mesh-load failure no longer `RuntimeError`s — mirrors the established pattern at [MainMenu.bb:2292](src/Modules/MainMenu.bb#L2292) (free + log + bail)
- `SkipPreviewSetup` label gates the follow-on `PositionEntity` / `SetUpPreview(Preview\Actor)` calls when `Preview` wasn't created

## Out of scope (follow-up candidates)

The audit also found 2 more `RuntimeError` sites that should soft-fail:
- `ServerNet.bb:2745` and `GameServer.bb:1405` — `If F = 0 Then RuntimeError(\"Could not open Names Filter.txt!\")` (boot-time; server should boot without filtering and log a warning)

Both are boot-only (not per-tick), so the urgency is lower; deferred to a separate iteration.

## Test plan

- [x] `compile.bat -t` clean across all 5 engine targets (Server + Client + GUE + Project Manager + Loom)
- [x] `test.bat` — 26 of 26 pass
- [x] Production-server callers all already guard `ActorList(ActorID) = Null` upstream (verified)
- [ ] CI green
- [ ] In-game smoke (out of scope for CI): create a character-creation screen, change the race combo box, confirm no crash + previous preview persists for invalid picks

🤖 Generated with [Claude Code](https://claude.com/claude-code)