### PR TITLE
fix(soft-fail): ClientAreas* zone-load mesh/emitter RuntimeErrors

### DIFF
--- a/src/Modules/ClientAreas.bb
+++ b/src/Modules/ClientAreas.bb
@@ -520,11 +520,14 @@ Function LoadArea(Name$, CameraEN, DisplayItems = False, UpdateRottNet = False)
 				EndIf
 			; Mesh has been deleted or removed from the database!
 			Else
-				If DisplayItems = True
-					Delete(S)
-				Else
-					RuntimeError("Could not find model with ID " + S\MeshID)
-				EndIf
+				; Soft-fail (matching ClientAreas_FE.bb fix): log + drop.
+				; In GUE this previously took the Delete-only branch
+				; silently; in any caller that passes DisplayItems=False
+				; it RuntimeError'd. Unified to log + drop so neither
+				; admin nor live player gets a crash from missing world
+				; meshes.
+				WriteLog(MainLog, "LoadArea: scenery MeshID " + S\MeshID + " not found in model database; dropping scenery (zone: " + Name$ + ")")
+				Delete(S)
 			EndIf
 			.CancelScenery
 
@@ -666,9 +669,9 @@ Function LoadArea(Name$, CameraEN, DisplayItems = False, UpdateRottNet = False)
 				; Position/rotation
 				PositionEntity E\EN, X#, Y#, Z#
 				RotateEntity E\EN, Pitch#, Yaw#, Roll# 
-			; Failed to load config, remove the emitter and display an error message if running on client
+			; Failed to load config -- soft-fail matching the FE variant.
 			Else
-				If DisplayItems = False Then RuntimeError("Could not load emitter: " + E\ConfigName$)
+				WriteLog(MainLog, "LoadArea: emitter config '" + E\ConfigName$ + "' could not load; dropping emitter (zone: " + Name$ + ")")
 				HideEntity(E\EN)
 				FreeEntity(E\EN)
 				Delete(E)

--- a/src/Modules/ClientAreasTE.bb
+++ b/src/Modules/ClientAreasTE.bb
@@ -386,11 +386,13 @@ Function LoadArea(Name$, CameraEN, DisplayItems = False, UpdateRottNet = False)
 				EndIf
 			; Mesh has been deleted or removed from the database!
 			Else
-				If DisplayItems = True
-					Delete(S)
-				Else
-					RuntimeError("Could not find model with ID " + S\MeshID)
-				EndIf
+				; Soft-fail matching the FE / GUE variants -- log + drop.
+				; Terrain Editor previously took the silent-Delete
+				; branch in normal use; the RuntimeError fallback now
+				; logs instead so any caller passing DisplayItems=False
+				; doesn't crash mid-zone-load.
+				WriteLog(MainLog, "LoadArea: scenery MeshID " + S\MeshID + " not found in model database; dropping scenery (zone: " + Name$ + ")")
+				Delete(S)
 			EndIf
 			.CancelScenery
 
@@ -526,9 +528,12 @@ Function LoadArea(Name$, CameraEN, DisplayItems = False, UpdateRottNet = False)
 				; Position/rotation
 				PositionEntity E\EN, X#, Y#, Z#
 				RotateEntity E\EN, Pitch#, Yaw#, Roll#
-			; Failed to load config, remove the emitter and display an error message if running on client
+			; Failed to load config -- soft-fail matching the FE / GUE
+			; variants. Note this variant lacks the HideEntity call
+			; the others have (TE doesn't hide before free); preserving
+			; the existing TE-specific cleanup shape.
 			Else
-				If DisplayItems = False Then RuntimeError("Could not load emitter: " + E\ConfigName$)
+				WriteLog(MainLog, "LoadArea: emitter config '" + E\ConfigName$ + "' could not load; dropping emitter (zone: " + Name$ + ")")
 				FreeEntity(E\EN)
 				Delete(E)
 			EndIf
@@ -726,7 +731,12 @@ Function LoadAreaTE(Name$)
 				RotateEntity dm\ent,dm\pitch,dm\yaw,dm\roll
 				EntityFX dm\ent,2
 			Else
-				RuntimeError("Could not find model with ID " + dm\id)
+				; Soft-fail (Terrain-Editor-specific scenery load path):
+				; log + skip placement. Refusing to load the entire
+				; zone for one missing mesh used to require restarting
+				; the editor; logging instead lets the author notice
+				; and fix the bad reference.
+				WriteLog(MainLog, "LoadAreaTE: scenery dm\id " + dm\id + " could not load mesh; skipping placement")
 			EndIf
 		Else
 			loadworkpath$ = dm\rcTe$

--- a/src/Modules/ClientAreas_FE.bb
+++ b/src/Modules/ClientAreas_FE.bb
@@ -678,11 +678,14 @@ Function LoadArea(Name$, CameraEN, DisplayItems = False, UpdateRottNet = False)
 				EndIf
 			; Mesh has been deleted or removed from the database!
 			Else
-				If DisplayItems = True
-					Delete(S)
-				Else
-					RuntimeError("Could not find model with ID " + S\MeshID)
-				EndIf
+				; Soft-fail: log and drop the scenery. Pre-fix, the
+				; live-game path (DisplayItems=False) RuntimeError-
+				; crashed every player entering a zone with a missing
+				; MeshID -- bad world data could grief the entire
+				; server. The editor path (True) already silently
+				; Delete'd; now both branches log + drop uniformly.
+				WriteLog(MainLog, "LoadArea: scenery MeshID " + S\MeshID + " not found in model database; dropping scenery (zone: " + Name$ + ")")
+				Delete(S)
 			EndIf
 			.CancelScenery
 
@@ -844,9 +847,13 @@ Function LoadArea(Name$, CameraEN, DisplayItems = False, UpdateRottNet = False)
 				; Position/rotation
 				PositionEntity E\EN, X#, Y#, Z#
 				RotateEntity E\EN, Pitch#, Yaw#, Roll# 
-			; Failed to load config, remove the emitter and display an error message if running on client
+			; Failed to load config, remove the emitter and (pre-fix)
+			; RuntimeError on the live-game path. Now soft-fail: log
+			; and continue zone load. Same threat-model as the scenery
+			; site above -- a bad emitter ConfigName$ in world data
+			; should not crash the whole client.
 			Else
-				If DisplayItems = False Then RuntimeError("Could not load emitter: " + E\ConfigName$)
+				WriteLog(MainLog, "LoadArea: emitter config '" + E\ConfigName$ + "' could not load; dropping emitter (zone: " + Name$ + ")")
 				HideEntity(E\EN)
 				FreeEntity(E\EN)
 				Delete(E)


### PR DESCRIPTION
## Summary

Closes the iteration #40 follow-up captured from [PR #307](https://github.com/RydeTec/rcce2/pull/307)'s reviewer. Seven `RuntimeError` sites across the three `ClientAreas*` variants (main client, GUE editor, Terrain Editor) used to crash the recipient on missing scenery meshes or broken emitter configs during zone load.

## Threat

[`ClientAreas_FE.bb`](src/Modules/ClientAreas_FE.bb) is included by [`Client.bb`](src/Client.bb), the live game client. [`ClientNet.bb:1702`](src/Modules/ClientNet.bb#L1702) calls `LoadArea(..., False, True)` — `DisplayItems=False` — so any zone with a missing MeshID or broken emitter ConfigName$ **crashed every player who tried to enter it**. The same shape was duplicated in the editor variants, blocking authors from loading a zone that had been partially broken between sessions.

## Fix

Unified both branches to log + drop (no behavior change for the editor's silent-drop path; live-client crash → graceful degradation):

| Site (pre-fix line) | File | Type | Fix |
|---|---|---|---|
| ~526 | ClientAreas.bb | Scenery | log + Delete (was: log silently OR crash) |
| ~671 | ClientAreas.bb | Emitter | log + free + Delete |
| ~684 | ClientAreas_FE.bb | Scenery | same |
| ~849 | ClientAreas_FE.bb | Emitter | same |
| ~392 | ClientAreasTE.bb | Scenery | same |
| ~531 | ClientAreasTE.bb | Emitter | same (preserves TE-specific cleanup shape — no HideEntity) |
| ~729 | ClientAreasTE.bb | TE-specific dm\id scenery | log + skip Position/Scale/Rotate (preserves dm record so author can fix the bad ref without restarting the editor) |

For the live client this turns a **server-griefable client crash** into an audit-loggable graceful degradation. For the editors it turns a fatal RuntimeError into a recoverable warning.

## Test plan

- [x] Full `compile.bat` clean across all 5 engine targets + all 7 Tools binaries (Terrain Editor pulls in ClientAreasTE)
- [x] `test.bat` — 26 of 26 pass
- [ ] CI green
- [ ] In-game smoke (out of scope for CI): zone with deliberately broken MeshID, confirm no crash + zone loads with the broken scenery dropped

## Remaining

For the next iteration: [ClientNet.bb:295](src/Modules/ClientNet.bb#L295) / [:331](src/Modules/ClientNet.bb#L331) — wire-driven actor mesh load on `P_PlayerJoined` / `P_NewActor`. Bad mesh in any joining player's actor template can still crash the recipient. Same threat class; separate file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)