### PR TITLE
fix(soft-fail): P_ActorGone for Me's RNID — last wire-driven crash site

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -124,7 +124,9 @@ If Result = False
 EndIf
 ```
 
-See the `Soft-fail` series of merged PRs (#128–#134 for the original cluster, #138–#144 for the follow-up rounds covering `CreateActorInstance(ActorList(...))`, `PreLoadSpawns`, missing-`Head`-joint, character-select preview, and stale `PlayerTarget` handles) — the audit comment block in each fix explains the threat model.
+See the `Soft-fail` series of merged PRs (#128–#134 for the original cluster, #138–#144 for the follow-up rounds covering `CreateActorInstance(ActorList(...))`, `PreLoadSpawns`, missing-`Head`-joint, character-select preview, and stale `PlayerTarget` handles, #306/#307/#308/#309 for the final sweep covering MainMenu mesh-load, names-filter file, ClientAreas zone-load mesh/emitter, and the `P_ActorGone` Me-self crash) — the audit comment block in each fix explains the threat model. As of #309 there are **no remaining wire-driven RuntimeError sites** in the client or server packet-handler paths; every recoverable failure soft-fails through `WriteLog + drop + continue`.
+
+**Me-only-RuntimeError exception.** A small set of failure paths preserve `RuntimeError(...)` even after the soft-fail sweep, *only* for the local-player case where there's no recoverable state: `ClientNet.bb:295` / `:306` / `:331` (Me's own actor mesh fails to load, or Me's mesh is missing a `Head` joint — there's no body to control). These are gated `If AI <> Me ... Else RuntimeError`, and the audit comment at `ClientNet.bb:284-290` records the intentional preservation. New code touching the actor-mesh load path on the client should follow the same shape — soft-fail for `AI <> Me`, hard-fail only when Me has no usable body.
 
 ### Bounds checks before array index
 

--- a/src/Modules/ClientNet.bb
+++ b/src/Modules/ClientNet.bb
@@ -1567,7 +1567,18 @@ Function UpdateNetwork()
 						; Free actor instance
 						SafeFreeActorInstance(A)
 					Else
-						RuntimeError("Serious error: player object was deleted")
+						; Soft-fail (was a RuntimeError that took down the
+						; client whenever the server sent P_ActorGone for
+						; Me's own RuntimeID). The server should never
+						; send this -- if Me genuinely needs to leave the
+						; current area, the canonical packet is a warp /
+						; disconnect. P_ActorGone for Me is an indicator
+						; of server-side inconsistency or a malicious
+						; server. Log and ignore: the next consistent
+						; state update will resync. (No cleanup work to
+						; do for Me anyway -- projectiles, shadows, etc.
+						; live elsewhere for the local player.)
+						WriteLog(MainLog, "P_ActorGone: server announced Me's own RuntimeID " + RuntimeID + " left the area; ignoring (server-side inconsistency)")
 					EndIf
 				EndIf
 


### PR DESCRIPTION
## Summary

Final wire-driven `RuntimeError` in the client packet-handler surface. The `Case P_ActorGone` handler at [ClientNet.bb:1570](src/Modules/ClientNet.bb#L1570) used to `RuntimeError("Serious error: player object was deleted")` when the server sent `P_ActorGone` with the local player Me's own `RuntimeID` — a server-side inconsistency or malicious-server vector that crashed every receiving client.

## Threat

The server should never legitimately send `P_ActorGone` for Me's RNID: if Me genuinely needs to leave the current area, the canonical packet is a warp or disconnect. Any other path produces this inconsistency (server bug, race, or malicious server).

## Fix

Log + ignore. No cleanup work to do for Me anyway — projectiles, shadows, and the actor entity itself live in different state for the local player than for remote actors. The next consistent state update will resync.

## Recon discovery — the soft-fail sweep is now complete for wire-driven crashes

While auditing, confirmed:

- [`P_NewActor`](src/Modules/ClientNet.bb#L1575) mesh-load (line 1582) — **already soft-failed** in an earlier PR (audit comment at 1583-1588 records the fix; was the original \"malicious or out-of-sync server\" crash vector).
- [Lines 295 / 306 / 331](src/Modules/ClientNet.bb#L295) — Me-only RuntimeErrors are **intentional**, gated `If AI <> Me ... Else RuntimeError`, with audit comment at [`ClientNet.bb:284-290`](src/Modules/ClientNet.bb#L284) explaining the preservation. There's no recoverable state when Me has no usable body.

## CLAUDE.md update

The \"Soft-fail on server-controlled data\" section now records:

> See the `Soft-fail` series of merged PRs (...#306/#307/#308/#309 for the final sweep covering MainMenu mesh-load, names-filter file, ClientAreas zone-load mesh/emitter, and the `P_ActorGone` Me-self crash) — the audit comment block in each fix explains the threat model. **As of #309 there are no remaining wire-driven RuntimeError sites in the client or server packet-handler paths**; every recoverable failure soft-fails through `WriteLog + drop + continue`.

Plus a documented exception for the Me-only-RuntimeError pattern at the actor-mesh load path, so future contributors know it's not a missed conversion.

## Test plan

- [x] `compile.bat -t` clean across all 5 engine targets
- [x] `test.bat` — 26 of 26 pass
- [x] All other ClientNet.bb `RuntimeError` sites verified intentional (boot-time, OnLostConnection paths, Me-only audited cases)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)