### PR TITLE
docs(modules): three small empty-doc overviews (Language/MD5/Radar)

### DIFF
--- a/docs/modules/language.md
+++ b/docs/modules/language.md
@@ -1,1 +1,87 @@
 <!-- body { color:black background-color:white } a:link{ color:#0070FF } a:visited{ color:#0070FF } --> RealmCrafter: Community Edition Documentation
+
+**Language.bb**
+
+The i18n / localization layer. Defines the 227-entry `LS_*` string-ID constant family (used everywhere the engine emits a human-readable string), the `LanguageString$()` registry that backs them, and the `LoadLanguage` / `RestoreLanguage` file I/O for swapping locale `.txt` files at boot.
+
+Every player-facing string in the client should resolve through `LanguageString$(LS_*)` — never hard-coded. The constants live in this file; the runtime values live in `Data\Game Data\Language.txt` (or whatever locale the project ships).
+
+## Conceptual overview
+
+### The LS_* constant family
+
+```basic
+Const MaxLanguageString = 226       ; inclusive — actual count is 227
+Const LS_ConnectingToServer = 0
+Const LS_FileProgress       = 1
+...
+Const LS_AccountAlreadyConnected = 226
+Dim LanguageString$(MaxLanguageString)
+```
+
+227 entries indexed `0..226` (Blitz3D `Dim X(N)` allocates `N+1` slots — see CLAUDE.md → "Gotchas"). The constants are flat — no enum / namespace — so to add a new string you must:
+
+1. Bump `Const MaxLanguageString` from 226 to 227.
+2. Add `Const LS_YourNewString = 227`.
+3. Append a new line at the end of `Data\Game Data\Language.txt` with the localized value.
+4. Update the slash-command range guard in `LoadLanguage` (see below) if the new constant lives between 190 and 219.
+
+Missing any one of these silently produces an empty string at the new slot (no error, just blank UI text).
+
+### The four broad string categories
+
+The constants are grouped by purpose; the file's comments mark transitions:
+
+| Range | Category | Examples | Touched by |
+|---|---|---|---|
+| **0–189** | Engine / UI strings | `LS_ConnectingToServer`, `LS_InvalidPassword`, `LS_QuestLogUpdate`, `LS_YouHit`, `LS_NoInventorySpace`, item-type names, control bindings, attribute labels | [`MainMenu.bb`](mainmenu.md), [`Interface.bb`](interface.md), [`ClientNet.bb`](clientnet.md), [`ClientCombat.bb`](clientcombat.md) |
+| **190–219** | Slash-command names (UPPERCASE) | `LS_SCKick = 190` → `"KICK"`, `LS_SCYell = 204` → `"YELL"`, `LS_SCWarp = 212` → `"WARP"` | [`ServerNet.bb`](servernet.md) chat-command dispatch; matched against incoming `/<command>` text |
+| **220–225** | Quit / pause dialog | `LS_QuitToContinue` → `"Back to Game"`, `LS_QuitRequestText` → `"Do you want to leave immediately or wait for 10 seconds?"` | [`MainMenu.bb`](mainmenu.md) quit overlay |
+| **226** | Late addition | `LS_AccountAlreadyConnected` → `"This account is already connected"` | Auth-handler in [`ServerNet.bb`](servernet.md) |
+
+The slash-command range is special-cased: `LoadLanguage` upper-cases everything in `[LS_SKick..LS_SSeason]` (190..219) on load so the runtime string-compare against `/<command>` is case-insensitive without needing per-compare normalization. The audit-comment at line 301 documents this. If you add new slash-command constants outside that range, the upper-casing won't apply and `/<command>` matching will be case-sensitive.
+
+> **Constant-name typo**: the source uses `LS_SKick` / `LS_SSeason` in the `LoadLanguage` range check but the actual constant names are `LS_SCKick` / `LS_SCSeason`. These resolve to the same numeric values (190 / 219) — undeclared identifiers in non-Strict files default to 0, so `LS_SKick = 0` and `LS_SSeason = 0` would make the range `[0..0]`, which silently *under-applies* the upper-case rule. This is a real source bug if the file is not Strict — verify against `If ID >= LS_SKick And ID <= LS_SSeason` at [`Language.bb:301`](../../src/Modules/Language.bb#L301). (Confirm or file as follow-up.)
+
+### File format
+
+`Data\Game Data\Language.txt` is one localized string per line, in the same order as the `LS_*` constants (line N maps to constant N). `LoadLanguage` ignores:
+
+- Blank lines (skipped entirely; do **not** count against the line/ID counter).
+- Full-line comments (lines starting with `;`).
+- Trailing comments (everything from the first `;` to end-of-line is stripped).
+
+So a fully-commented row counts as **no row** — it does not consume an `ID`. This means re-ordering the file with comment markers as section dividers is safe, but accidentally commenting out a real entry will shift every subsequent string by one slot. **Never reorder `Language.txt` without bumping the matching `LS_*` constant definitions.**
+
+### Restoration / hot-reload
+
+`RestoreLanguage(Filename$)` writes the current in-memory `LanguageString$()` array out to a file — used by tooling to dump the active locale back to disk after edits. It first reloads `Data\Game Data\Language.txt` so a partial in-memory state isn't persisted. The output is plain `WriteLine` per slot; comments are not preserved (the input-side comment stripping is one-way).
+
+There is no hot-reload of `Data\Game Data\Language.txt` at runtime — strings are read once at boot in `MainMenu.bb`. To test a localized string change, restart the client.
+
+## Conventions for new code touching this module
+
+- **Add the constant, bump `MaxLanguageString`, append to `Language.txt`** — all three are required. Missing any one is a silent failure.
+- **Use `LanguageString$(LS_FooBar)` at the call site**, never the integer literal. The integer is a stable wire-protocol-style number that **could** be re-numbered between releases (it hasn't been), but the constant name is the contract.
+- **Don't re-order `Language.txt`** without re-ordering the `LS_*` constants in lockstep. Line N ↔ constant N is the file format.
+- **Slash-command additions go in `[190..219]`** if they need the auto-upper-casing; otherwise place after `LS_AccountAlreadyConnected` and add a matching `LoadLanguage` range guard. The current `LS_SCKick..LS_SCSeason` range covers `KICK / UNIGNORE / IGNORE / NETDUMP / PET / LEAVE / ACCEPT / INVITE / XP / GOLD / SETATTRIBUTE / SETATTRIBUTEMAX / SCRIPT / ME / YELL / GM / G / P / PM / TRADE / ALLPLAYERS / PLAYERS / WARP / WARPOTHER / ABILITY / GIVE / WEATHER / TIME / DATE / SEASON`.
+- **The defaults block (lines 241-279)** seeds slash-command constants + the quit-dialog strings. These are fallback values used when `Language.txt` can't be loaded; new entries that lack a corresponding default block line will be empty if the file is missing.
+
+## Related modules
+
+- [`MainMenu.bb`](mainmenu.md) — calls `LoadLanguage("Data\Game Data\Language.txt")` at boot. The biggest consumer of `LanguageString$(LS_*)` (login screen, character-create, options pages).
+- [`Interface.bb`](interface.md) — 2D in-game UI; consumes `LS_Weapon` / `LS_Armour` / item-type names, `LS_YouHit` damage text, `LS_QuestLogUpdate`, etc.
+- [`ServerNet.bb`](servernet.md) — chat-command dispatch matches `/<word>` against the slash-command range (190..219).
+- [`ClientCombat.bb`](clientcombat.md) — combat-log strings (`LS_YouHit`, `LS_For`, `LS_DamageWow`, `LS_HitsYou`, `LS_AttacksYouMisses`, `LS_YouAttack`, `LS_AndMiss`, `LS_CriticalDamage`).
+
+## See also
+
+- [`P_SpellUpdate` detail](../protocol/packets/P_SpellUpdate.md) — UX strings around spell-cast gating (`LS_RaceOnly`, `LS_ClassOnly`, `LS_AbilityNotRecharged`).
+- CLAUDE.md → "Gotchas" → "Blitz3D array semantics" — `Dim X(N)` is `N+1` inclusive.
+
+* * *
+
+This module's source is short enough that a function-by-function reference adds little — read [`src/Modules/Language.bb`](../../src/Modules/Language.bb) directly. The two public functions are:
+
+- **`LoadLanguage(Filename$)`** — open `Filename$`, parse line-by-line (skipping `;` comments, stripping trailing comments, ignoring blanks), assign to `LanguageString$(0..MaxLanguageString)`. Upper-cases slash-command range. Returns `True` on success, `False` if the file couldn't be opened. **`RuntimeError`s if the file has more than `MaxLanguageString + 1` non-blank, non-comment lines** — bumping `MaxLanguageString` is mandatory when adding entries.
+- **`RestoreLanguage(Filename$)`** — re-load production `Language.txt`, then dump every `LanguageString$(i)` to `Filename$` one per line. Returns `True` / `False` for write success.

--- a/docs/modules/language.md
+++ b/docs/modules/language.md
@@ -41,7 +41,7 @@ The constants are grouped by purpose; the file's comments mark transitions:
 
 The slash-command range is special-cased: `LoadLanguage` upper-cases everything in `[LS_SKick..LS_SSeason]` (190..219) on load so the runtime string-compare against `/<command>` is case-insensitive without needing per-compare normalization. The audit-comment at line 301 documents this. If you add new slash-command constants outside that range, the upper-casing won't apply and `/<command>` matching will be case-sensitive.
 
-> **Constant-name typo**: the source uses `LS_SKick` / `LS_SSeason` in the `LoadLanguage` range check but the actual constant names are `LS_SCKick` / `LS_SCSeason`. These resolve to the same numeric values (190 / 219) — undeclared identifiers in non-Strict files default to 0, so `LS_SKick = 0` and `LS_SSeason = 0` would make the range `[0..0]`, which silently *under-applies* the upper-case rule. This is a real source bug if the file is not Strict — verify against `If ID >= LS_SKick And ID <= LS_SSeason` at [`Language.bb:301`](../../src/Modules/Language.bb#L301). (Confirm or file as follow-up.)
+> **Confirmed source bug — constant-name typo defangs the upper-case rule.** [`Language.bb`](../../src/Modules/Language.bb) is non-Strict (no `Strict` keyword at top). The range guard at [`Language.bb:301`](../../src/Modules/Language.bb#L301) reads `If ID >= LS_SKick And ID <= LS_SSeason` — but the actual constants are `LS_SCKick = 190` (line 196) and `LS_SCSeason = 219` (line 225). In non-Strict, undeclared identifiers read as `0`, so the guard evaluates to `If ID >= 0 And ID <= 0` — only catches `ID = 0` (`LS_ConnectingToServer`). Effect: slash-command strings loaded from a customized `Language.txt` retain whatever case the file has (probably lowercase), instead of being normalized to UPPERCASE for case-insensitive `/<command>` matching. The production server escapes the bug because the fallback defaults block at [`Language.bb:241-270`](../../src/Modules/Language.bb#L241) hardcodes the slash-command names UPPERCASE — but any locale that ships a customized slash-command file breaks. A paired typo at [`ServerNet.bb:419`](../../src/Modules/ServerNet.bb#L419) (`LS_SCGM` undeclared; should be `LS_SCGMSay`) makes the `/GM` dispatch match `LanguageString$(0)` instead of `"GM"`. Both flagged for a follow-up fix.
 
 ### File format
 
@@ -57,7 +57,7 @@ So a fully-commented row counts as **no row** — it does not consume an `ID`. T
 
 `RestoreLanguage(Filename$)` writes the current in-memory `LanguageString$()` array out to a file — used by tooling to dump the active locale back to disk after edits. It first reloads `Data\Game Data\Language.txt` so a partial in-memory state isn't persisted. The output is plain `WriteLine` per slot; comments are not preserved (the input-side comment stripping is one-way).
 
-There is no hot-reload of `Data\Game Data\Language.txt` at runtime — strings are read once at boot in `MainMenu.bb`. To test a localized string change, restart the client.
+There is no hot-reload at runtime — strings are read once at boot. The actual `LoadLanguage` callers are [`ClientLoaders.bb:4`](../../src/Modules/ClientLoaders.bb#L4) for the client and [`Server.bb:197`](../../src/Server.bb#L197) for the server (the latter loads `Data\Server Data\Language.txt`, distinct from the client's `Data\Game Data\Language.txt`). `MainMenu.bb` is the largest consumer of the loaded strings but does not load them. To test a localized string change, restart the affected process.
 
 ## Conventions for new code touching this module
 
@@ -69,7 +69,9 @@ There is no hot-reload of `Data\Game Data\Language.txt` at runtime — strings a
 
 ## Related modules
 
-- [`MainMenu.bb`](mainmenu.md) — calls `LoadLanguage("Data\Game Data\Language.txt")` at boot. The biggest consumer of `LanguageString$(LS_*)` (login screen, character-create, options pages).
+- [`ClientLoaders.bb`](clientloaders.md) — calls `LoadLanguage("Data\Game Data\Language.txt")` at client boot.
+- [`Server.bb`](../../src/Server.bb) — calls `LoadLanguage("Data\Server Data\Language.txt")` at server boot (separate file from the client's).
+- [`MainMenu.bb`](mainmenu.md) — biggest consumer of `LanguageString$(LS_*)` (login screen, character-create, options pages).
 - [`Interface.bb`](interface.md) — 2D in-game UI; consumes `LS_Weapon` / `LS_Armour` / item-type names, `LS_YouHit` damage text, `LS_QuestLogUpdate`, etc.
 - [`ServerNet.bb`](servernet.md) — chat-command dispatch matches `/<word>` against the slash-command range (190..219).
 - [`ClientCombat.bb`](clientcombat.md) — combat-log strings (`LS_YouHit`, `LS_For`, `LS_DamageWow`, `LS_HitsYou`, `LS_AttacksYouMisses`, `LS_YouAttack`, `LS_AndMiss`, `LS_CriticalDamage`).

--- a/docs/modules/md5.md
+++ b/docs/modules/md5.md
@@ -1,1 +1,76 @@
 <!-- body { color:black background-color:white } a:link{ color:#0070FF } a:visited{ color:#0070FF } --> RealmCrafter: Community Edition Documentation
+
+**MD5.bb**
+
+Pure-Blitz MD5 hash implementation, used **only as a client-side password pre-hash** before the password is sent over the wire and re-hashed server-side with PBKDF2.
+
+**MD5 is cryptographically broken.** It is **not** the production password defense — that is [`PasswordHash.bb`](../../src/Modules/PasswordHash.bb)'s PBKDF2 path. The audit comment in [`AccountsServer.bb:121`](../../src/Modules/AccountsServer.bb#L121) explicitly calls it "broken-MD5"; the role here is:
+
+1. Avoid sending the user's plaintext password over the wire.
+2. Provide a stable identifier for the server to PBKDF2-hash and store.
+
+That is *all* MD5 buys you in this codebase. New code paths should not adopt MD5 for anything stronger than this legacy compatibility role.
+
+## Conceptual overview
+
+### Public surface — one function
+
+```basic
+Function MD5$(sMessage$)
+    ; ... block-pad and run the 64-step MD5 rounds ...
+    Return Lower(WordToHex$(MD5_a) + WordToHex$(MD5_b) + WordToHex$(MD5_c) + WordToHex$(MD5_d))
+End Function
+```
+
+`MD5$(s)` returns a 32-character lowercase hex digest of the input string. The output format is fixed and matches the de-facto MD5 specification (RFC 1321 lowercase hex serialization).
+
+The remaining 10 functions in this file are internal helpers (`MD5_F` / `_G` / `_H` / `_I` / `_FF` / `_GG` / `_HH` / `_II` / `RotateLeft` / `WordToHex$`) implementing the four-round compression schedule. Do not call them directly from outside this file.
+
+### How callers use it
+
+```basic
+; MainMenu.bb login flow (line 804, 869, 1193)
+MD5Pass$ = MD5$(Pass$)                            ; hash the user's typed plaintext
+Pa$ = RCE_StrFromInt$(Len(Name$), 1) + Name$ + RCE_StrFromInt$(Len(MD5Pass$), 1) + MD5Pass$
+RCE_Send(Connection, PeerToHost, P_VerifyAccount, Pa$, True)
+```
+
+The 32-hex-char MD5 digest is what travels in `P_VerifyAccount` / `P_CreateAccount` / `P_ChangePassword`. The server then takes that digest as the "password" input and runs it through PBKDF2 + per-account salt for storage and constant-time comparison. From the wire's perspective, the MD5 hex string IS the password — clients that bypass MainMenu and send raw plaintext would be authenticated against an MD5-hash of the stored PBKDF2 verifier, which won't match.
+
+### Why MD5 specifically (history)
+
+The MD5 wrapper predates the PBKDF2 + constant-time-compare + login-throttle work (iterations #37 / #42-#45). At the time, the database stored the raw MD5 output, and the wire-level "don't ship plaintext" was the whole defense. The current design retains MD5 only because:
+
+- Re-rolling the client to ship plaintext would break every existing account record (which stores PBKDF2(MD5(plaintext))).
+- Re-rolling the database verifiers to PBKDF2(plaintext) would require a forced password reset for every user.
+
+Migration to PBKDF2-only (drop the MD5 wrapper, store PBKDF2(plaintext)) is a real follow-up but requires a coordinated client+server roll with a credential-migration window.
+
+## Implementation notes
+
+- **Pure Blitz3D integer math** — no DLL dependency. The whole algorithm runs in 32-bit signed Blitz ints via `Shl` / `Shr` / `And` / `Or` / `Xor` / `~`. The magic constants in the source comments (`&HD76AA478`, etc.) are the canonical MD5 T-table values reinterpreted as signed 32-bit ints (negative values where the high bit is set).
+- **`Dim MD5_x(0)` at module scope** — a module-global scratch array that `MD5$` re-`Dim`s to `BlockNum * 16 - 1` slots each call. **Not thread-safe** — concurrent calls (none exist today, but be aware) would corrupt each other.
+- **No early-exit on empty input** — `MD5$("")` returns the MD5 of the empty string (`d41d8cd98f00b204e9800998ecf8427e`). This is the spec-correct behavior.
+- **No string-length cap** — `BlockNum = ((Len(s) + 8) Shr 6) + 1` scales linearly. A 1 MB input would `Dim MD5_x(262143)` slots, which Blitz3D can handle but no production call site sends inputs anywhere near that size.
+
+## Conventions for new code touching this module
+
+- **Don't use `MD5$` for new security primitives.** Anything new that needs a hash should use [`PasswordHash.bb`](../../src/Modules/PasswordHash.bb)'s PBKDF2 path or a different module's MD5-replacement (filename hashing, deterministic-asset-ID generation, etc. — none of those exist today; they'd be added separately).
+- **Don't call the internal helpers (`MD5_F` / `MD5_FF` / etc.) from outside this file.** They're not part of the public contract.
+- **Don't add helpers that mutate `MD5_x` outside `MD5$`.** The scratch array is owned by `MD5$` for the duration of one call.
+- **If the migration to PBKDF2-only happens**, this file becomes dead code and can be deleted along with the three `MD5$(Pass$)` call sites in [`MainMenu.bb`](mainmenu.md).
+
+## Related modules
+
+- [`MainMenu.bb`](mainmenu.md) — the **only** caller. Three sites at MainMenu.bb:804, :869, :1193 wrap the user's typed password before sending `P_VerifyAccount` / `P_CreateAccount` / `P_ChangePassword`.
+- [`PasswordHash.bb`](../../src/Modules/PasswordHash.bb) — the actual production defense. Server-side. PBKDF2 + constant-time-compare + dummy-hash path. The `MD5$` output is its input.
+- [`AccountsServer.bb`](accountsserver.md) — flat-file account path; the audit comment at line 121 explicitly documents the "broken-MD5" role.
+
+## See also
+
+- CLAUDE.md (no specific section — MD5 is a legacy primitive, not a project-wide convention).
+- The 2004-era MD5 collision attacks: not relevant for password-input pre-hashing (preimage resistance is still ~2^128 for now), but adopting MD5 for *any other purpose* would be a real vulnerability.
+
+* * *
+
+This module's surface is one function (`MD5$`); the source at [`src/Modules/MD5.bb`](../../src/Modules/MD5.bb) is the reference. No additional Reference section below.

--- a/docs/modules/md5.md
+++ b/docs/modules/md5.md
@@ -2,12 +2,12 @@
 
 **MD5.bb**
 
-Pure-Blitz MD5 hash implementation, used **only as a client-side password pre-hash** before the password is sent over the wire and re-hashed server-side with PBKDF2.
+Pure-Blitz MD5 hash implementation, used **only as a client-side password pre-hash** before the password is sent over the wire and re-hashed server-side with salted SHA-256.
 
-**MD5 is cryptographically broken.** It is **not** the production password defense — that is [`PasswordHash.bb`](../../src/Modules/PasswordHash.bb)'s PBKDF2 path. The audit comment in [`AccountsServer.bb:121`](../../src/Modules/AccountsServer.bb#L121) explicitly calls it "broken-MD5"; the role here is:
+**MD5 is cryptographically broken.** It is **not** the production password defense — that is [`PasswordHash.bb`](../../src/Modules/PasswordHash.bb)'s salted SHA-256 path. The audit comment in [`AccountsServer.bb:121`](../../src/Modules/AccountsServer.bb#L121) explicitly calls it "broken-MD5"; the role here is:
 
 1. Avoid sending the user's plaintext password over the wire.
-2. Provide a stable identifier for the server to PBKDF2-hash and store.
+2. Provide a stable identifier for the server to salted SHA-256-hash and store.
 
 That is *all* MD5 buys you in this codebase. New code paths should not adopt MD5 for anything stronger than this legacy compatibility role.
 
@@ -35,16 +35,16 @@ Pa$ = RCE_StrFromInt$(Len(Name$), 1) + Name$ + RCE_StrFromInt$(Len(MD5Pass$), 1)
 RCE_Send(Connection, PeerToHost, P_VerifyAccount, Pa$, True)
 ```
 
-The 32-hex-char MD5 digest is what travels in `P_VerifyAccount` / `P_CreateAccount` / `P_ChangePassword`. The server then takes that digest as the "password" input and runs it through PBKDF2 + per-account salt for storage and constant-time comparison. From the wire's perspective, the MD5 hex string IS the password — clients that bypass MainMenu and send raw plaintext would be authenticated against an MD5-hash of the stored PBKDF2 verifier, which won't match.
+The 32-hex-char MD5 digest is what travels in `P_VerifyAccount` / `P_CreateAccount` / `P_ChangePassword`. The server then takes that digest as the "password" input and runs it through salted SHA-256 + per-account salt for storage and constant-time comparison. From the wire's perspective, the MD5 hex string IS the password — clients that bypass MainMenu and send raw plaintext would be authenticated against an MD5-hash of the stored salted SHA-256 verifier, which won't match.
 
 ### Why MD5 specifically (history)
 
-The MD5 wrapper predates the PBKDF2 + constant-time-compare + login-throttle work (iterations #37 / #42-#45). At the time, the database stored the raw MD5 output, and the wire-level "don't ship plaintext" was the whole defense. The current design retains MD5 only because:
+The MD5 wrapper predates the salted SHA-256 + constant-time-compare + login-throttle work (iterations #37 / #42-#45). At the time, the database stored the raw MD5 output, and the wire-level "don't ship plaintext" was the whole defense. The current design retains MD5 only because:
 
-- Re-rolling the client to ship plaintext would break every existing account record (which stores PBKDF2(MD5(plaintext))).
-- Re-rolling the database verifiers to PBKDF2(plaintext) would require a forced password reset for every user.
+- Re-rolling the client to ship plaintext would break every existing account record (which stores salted SHA-256(MD5(plaintext))).
+- Re-rolling the database verifiers to salted SHA-256(plaintext) would require a forced password reset for every user.
 
-Migration to PBKDF2-only (drop the MD5 wrapper, store PBKDF2(plaintext)) is a real follow-up but requires a coordinated client+server roll with a credential-migration window.
+Migration to salted SHA-256-only (drop the MD5 wrapper, store salted SHA-256(plaintext)) is a real follow-up but requires a coordinated client+server roll with a credential-migration window.
 
 ## Implementation notes
 
@@ -55,15 +55,15 @@ Migration to PBKDF2-only (drop the MD5 wrapper, store PBKDF2(plaintext)) is a re
 
 ## Conventions for new code touching this module
 
-- **Don't use `MD5$` for new security primitives.** Anything new that needs a hash should use [`PasswordHash.bb`](../../src/Modules/PasswordHash.bb)'s PBKDF2 path or a different module's MD5-replacement (filename hashing, deterministic-asset-ID generation, etc. — none of those exist today; they'd be added separately).
+- **Don't use `MD5$` for new security primitives.** Anything new that needs a hash should use [`PasswordHash.bb`](../../src/Modules/PasswordHash.bb)'s salted SHA-256 path or a different module's MD5-replacement (filename hashing, deterministic-asset-ID generation, etc. — none of those exist today; they'd be added separately).
 - **Don't call the internal helpers (`MD5_F` / `MD5_FF` / etc.) from outside this file.** They're not part of the public contract.
 - **Don't add helpers that mutate `MD5_x` outside `MD5$`.** The scratch array is owned by `MD5$` for the duration of one call.
-- **If the migration to PBKDF2-only happens**, this file becomes dead code and can be deleted along with the three `MD5$(Pass$)` call sites in [`MainMenu.bb`](mainmenu.md).
+- **Migration to salted-SHA-256-only is non-trivial.** The three `MD5$(Pass$)` call sites in [`MainMenu.bb`](mainmenu.md) are the *client-side* deletions; on the server side [`PasswordHash.bb`](../../src/Modules/PasswordHash.bb)'s `SHA256Hex$(Salt + ClientMD5)` shape would also need to change, every stored verifier (`$1$<salt>$<sha256-64-hex>` in the account record) would need re-hashing during a forced-reset window, and the `MD5.bb` include itself dropped from [`Client.bb:149`](../../src/Client.bb#L149). The "drop the wrapper" framing is the client-side picture only.
 
 ## Related modules
 
 - [`MainMenu.bb`](mainmenu.md) — the **only** caller. Three sites at MainMenu.bb:804, :869, :1193 wrap the user's typed password before sending `P_VerifyAccount` / `P_CreateAccount` / `P_ChangePassword`.
-- [`PasswordHash.bb`](../../src/Modules/PasswordHash.bb) — the actual production defense. Server-side. PBKDF2 + constant-time-compare + dummy-hash path. The `MD5$` output is its input.
+- [`PasswordHash.bb`](../../src/Modules/PasswordHash.bb) — the actual production defense. Server-side. salted SHA-256 + constant-time-compare + dummy-hash path. The `MD5$` output is its input.
 - [`AccountsServer.bb`](accountsserver.md) — flat-file account path; the audit comment at line 121 explicitly documents the "broken-MD5" role.
 
 ## See also

--- a/docs/modules/radar.md
+++ b/docs/modules/radar.md
@@ -1,1 +1,99 @@
 <!-- body { color:black background-color:white } a:link{ color:#0070FF } a:visited{ color:#0070FF } --> RealmCrafter: Community Edition Documentation
+
+**Radar.bb**
+
+Client-side minimap renderer. Builds a top-down screenshot of the current zone at boot, overlays a fog-of-war texture that's revealed as the player moves, and persists discovered fog to disk per zone (`Data\Areas\Radar\<AreaName>.rdr`).
+
+The module is self-contained: no engine dependencies beyond `GY_Cam` (the 2D HUD camera), `Cam` (the 3D world camera), and `For Each Scenery` for fullbright-on-snapshot. Designed to be droppable into any project that has those three handles.
+
+## Conceptual overview
+
+### The four texture stack
+
+```
+Z-order  Entity                Texture          Purpose
+-3005    Radar_Ent1            Radar_Tex1       Top-down zone snapshot (loaded once per zone)
+-3007    Radar_Ent2            Radar_Tex2       Fog-of-war overlay (mutates per-tick on movement)
+-3008    Radar_BorderEnt       Radar_BorderTex  Outer border (default-generated or custom .png)
+-3009    Radar_PlayerEnt       Radar_PlayerTex  Player-position marker (default-generated or custom .png)
+```
+
+All four are parented to `Radar_Ent1` and rendered into the 2D HUD camera (`GY_Cam`). `EntityOrder` Z values are chosen so the player marker is always on top and the snapshot is bottom-most.
+
+`Radar_TexSize = 512` is the per-texture pixel size — all four textures are 512×512 regardless of zone size. The snapshot is downscaled to fit; the fog/border/player overlays are computed at this resolution directly.
+
+### Zone-load flow (`Load_Radar`)
+
+1. Hide the 3D world cameras (`Cam`, `GY_Cam`) so they don't render into the snapshot.
+2. Strip path + extension from `AreaName$`.
+3. Spawn a temporary camera straight down at the world origin, and four pivot points (N/S/E/W) at `Y = 5000`.
+4. Loop-translate everything upward until `LinePick` from each pivot reaches the floor without hitting scenery — gives the camera the height needed to see the whole zone in one shot.
+5. Record `Radar_WorldSize` as `EntityY * 1.7` (the camera height × an empirical scaling factor).
+6. Set every `Scenery` entity to `EntityFX 1+8` (fullbright + no fog) for the snapshot, render once, copy backbuffer → `Radar_Tex1`, restore `EntityFX 0`. **The screen-sized scratch image is freed inline** (PR audit comment notes the ~8 MB-per-zone leak prior to the fix; with 20 zones that's 160 MB of orphaned image data in Blitz3D's 2 GB address space).
+7. Load `<area>.rdr` if it exists (preserves fog progression from a previous play session); otherwise create a fresh fog texture via `Create_Radar_Fog`.
+8. Build the four quad meshes, apply textures, parent everything to `Radar_Ent1`, position+scale into the HUD.
+
+This is per-zone, called from [`ClientAreas.bb`](clientareas.md)'s zone-load flow. The leak fix is critical because zone changes happen every gameplay session — pre-fix accumulation hit memory pressure in long sessions.
+
+### Per-tick reveal (`UpdateRadar`)
+
+Called every frame with the player's actor `ent` and an `areashow` reveal-radius (default 50). Skipped when:
+
+- The player hasn't moved (`EntityX/Z` unchanged since last call).
+- The fog-update timer (`Radar_Update_Time = 600` ms) hasn't elapsed since the last fog mutation.
+
+When it does run:
+
+1. Map world coordinates to texture coordinates via `(-EntityX * Radar_TexSize) / Radar_WorldSize` (Z axis uses positive, X negated because the snapshot is taken from above with X axis flipped).
+2. Walk a square `2×areashow` pixel region centered on the player, blacken any pixel within radius `areashow` (Euclidean distance test) in `Radar_Tex2`.
+3. Position the player-marker entity at the texture-mapped (X, Y).
+
+**Origin-spawn guard:** `Radar_WorldSize = 0` is the offline / uninitialized case. The audit-comment block at [`Radar.bb:324-328`](../../src/Modules/Radar.bb#L324) records that pre-fix, the math produced `Inf` (division by zero), which then propagated into `PositionEntity` and corrupted the player marker. The guard now short-circuits to `plrx# = 0.0 / plry# = 0.0` in that case.
+
+### Fog persistence (`Save_Radar_Fog`)
+
+The fog texture is persisted to `Data\Areas\Radar\<area>.rdr` so the player's exploration carries across sessions. The save shape is one `WriteInt` per pixel (262144 ints = 1 MB per zone).
+
+**Atomic write via `SafeWriteOpen` / `SafeWriteCommit`** ([`Radar.bb:216-238`](../../src/Modules/Radar.bb#L216)). The audit comment records that the previous implementation:
+- Opened the file via `WriteFile` but never `CloseFile`d it — one handle leaked per save call.
+- Wrote directly to the production path with no temp / atomic-rename — a crash mid-save would leave a truncated `.rdr`.
+
+Both bugs are closed: `SafeWriteCommit` owns the close, atomic-promotes the temp to the production path, and demotes the previous `.rdr` to `.rdr.bak` (CLAUDE.md → "Atomic writes" canonical pattern).
+
+### Other API surface
+
+| Function | Purpose |
+|---|---|
+| `Position_Radar(X, Y, Width, Height)` | Re-place + re-scale the HUD overlay. Called on resolution change. |
+| `Show_Radar` / `Hide_Radar` | Toggle visibility of the whole stack (via `Radar_Ent1` — children inherit). |
+| `Reset_Radar` | Re-fill the fog texture with the interior-fog noise pattern (clears discovery). |
+| `Clear_Radar` | Set the fog texture to fully transparent black (reveals everything). For debug / DM tooling. |
+| `Unload_Radar` | Free all four textures + entities. Called by `Load_Radar` before building a new stack. |
+| `Create_Radar_Fog(Interior)` | Build a fresh fog texture. `Interior = True` paints the grey-noise pattern (`Radar_FColor ± 20/10`); `False` returns an empty allocation that `Load_Radar_Fog` then overwrites. |
+| `Load_Radar_Fog(R_FN$)` | Read a `.rdr` file pixel-by-pixel into a new fog texture. |
+| `Radar_CreateBorderTex` / `Radar_CreatePlayerTex` | Procedurally generate the default border and player-marker textures (used when no custom `.png` is loaded). |
+| `Radar_CreateQuadr(P)` | Build a 1×1 quad mesh parented to `P` — copy of `GY_CreateQuad` inlined to keep this module dependency-free. |
+
+## Conventions for new code touching this module
+
+- **`Radar_WorldSize = 0` is the offline sentinel** — guard divides before using it. The single existing site is at [`Radar.bb:329`](../../src/Modules/Radar.bb#L329).
+- **All `WriteFile` to `.rdr` goes through `SafeWriteOpen` / `SafeWriteCommit`** — never write directly. The atomic-rename + `.bak` retention is non-optional.
+- **All textures and entities are `FreeTexture` / `FreeEntity`-d in `Unload_Radar`** with `<> 0` guards — pattern is "if the handle exists, free it; zero the handle". New globals follow the same shape.
+- **Scratch images (`TempImage`) must be `FreeImage`d before the function returns** — per the zone-load leak fix audit comment at [`Radar.bb:91-95`](../../src/Modules/Radar.bb#L91). This is the canonical example.
+- **`SetBuffer TextureBuffer(...)` / `LockBuffer` blocks must always have a matching `UnlockBuffer` + `SetBuffer BackBuffer()`** — leaving the buffer locked corrupts subsequent rendering for the rest of the frame.
+
+## Related modules
+
+- [`ClientAreas.bb`](clientareas.md) — calls `Load_Radar` / `Unload_Radar` on zone enter / leave.
+- [`Logging.bb`](logging.md) — provides `SafeWriteOpen$` / `SafeWriteCommit%` (the atomic-write helpers).
+- [`Environment.bb`](environment.md) / [`Environment3D.bb`](environment3d.md) — own `GY_Cam` (the 2D HUD camera) and `Cam` (the 3D world camera).
+
+## See also
+
+- CLAUDE.md → "Atomic writes" — canonical `SafeWriteOpen` / `SafeWriteCommit` pattern.
+- CLAUDE.md → "Float sanitisation at the BVM / wire boundary" — adjacent concern; `Radar_WorldSize = 0` divide-guard is one of the `/0` sites covered by an earlier sweep.
+- [`reference_safewrite_migration_template.md`](../../../../.claude/projects/C--Users-dyanr-Desktop-rcce2/memory/reference_safewrite_migration_template.md) (agent memory) — the per-site migration checklist that `Save_Radar_Fog` follows.
+
+* * *
+
+The legacy function-by-function reference for this module has not been generated. The conceptual overview above is the primary reference; consult the source at [`src/Modules/Radar.bb`](../../src/Modules/Radar.bb) for full signatures.

--- a/docs/modules/radar.md
+++ b/docs/modules/radar.md
@@ -18,7 +18,7 @@ Z-order  Entity                Texture          Purpose
 -3009    Radar_PlayerEnt       Radar_PlayerTex  Player-position marker (default-generated or custom .png)
 ```
 
-All four are parented to `Radar_Ent1` and rendered into the 2D HUD camera (`GY_Cam`). `EntityOrder` Z values are chosen so the player marker is always on top and the snapshot is bottom-most.
+The three overlay entities are parented to `Radar_Ent1` (see `EntityParent` calls at [`Radar.bb:146-148`](../../src/Modules/Radar.bb#L146)); `Radar_Ent1` itself is parented to `GY_Cam` (the 2D HUD camera) via the `Radar_CreateQuadr(GY_Cam)` allocation at [`Radar.bb:118`](../../src/Modules/Radar.bb#L118). Hide/show on `Radar_Ent1` propagates to all three children. `EntityOrder` Z values are chosen so the player marker is always on top and the snapshot is bottom-most.
 
 `Radar_TexSize = 512` is the per-texture pixel size — all four textures are 512×512 regardless of zone size. The snapshot is downscaled to fit; the fog/border/player overlays are computed at this resolution directly.
 
@@ -33,7 +33,7 @@ All four are parented to `Radar_Ent1` and rendered into the 2D HUD camera (`GY_C
 7. Load `<area>.rdr` if it exists (preserves fog progression from a previous play session); otherwise create a fresh fog texture via `Create_Radar_Fog`.
 8. Build the four quad meshes, apply textures, parent everything to `Radar_Ent1`, position+scale into the HUD.
 
-This is per-zone, called from [`ClientAreas.bb`](clientareas.md)'s zone-load flow. The leak fix is critical because zone changes happen every gameplay session — pre-fix accumulation hit memory pressure in long sessions.
+This is per-zone, called from [`ClientNet.bb`](clientnet.md)'s zone-load packet handler ([`ClientNet.bb:1738`](../../src/Modules/ClientNet.bb#L1738)). The matching `Save_Radar_Fog` call lives in the zone-leave path ([`ClientNet.bb:1682`](../../src/Modules/ClientNet.bb#L1682)). `Unload_Radar` is invoked at client-shutdown time from [`ClientLoaders.bb:372`](../../src/Modules/ClientLoaders.bb#L372). The leak fix is critical because zone changes happen every gameplay session — pre-fix accumulation hit memory pressure in long sessions.
 
 ### Per-tick reveal (`UpdateRadar`)
 
@@ -84,7 +84,8 @@ Both bugs are closed: `SafeWriteCommit` owns the close, atomic-promotes the temp
 
 ## Related modules
 
-- [`ClientAreas.bb`](clientareas.md) — calls `Load_Radar` / `Unload_Radar` on zone enter / leave.
+- [`ClientNet.bb`](clientnet.md) — calls `Load_Radar` on zone-enter (~line 1738) and `Save_Radar_Fog` on zone-leave (~line 1682). The actual zone-change packet dispatch lives here.
+- [`ClientLoaders.bb`](clientloaders.md) — calls `Unload_Radar` at client shutdown (~line 372).
 - [`Logging.bb`](logging.md) — provides `SafeWriteOpen$` / `SafeWriteCommit%` (the atomic-write helpers).
 - [`Environment.bb`](environment.md) / [`Environment3D.bb`](environment3d.md) — own `GY_Cam` (the 2D HUD camera) and `Cam` (the 3D world camera).
 


### PR DESCRIPTION
## Summary

Replaces three one-line stubs at `docs/modules/{language,md5,radar}.md` with full conceptual overviews. Bundled because each source is small (Language 328, MD5 178, Radar 426 lines) and the three modules are independent — fact-checking can happen in one pass.

## What each doc covers

**language.md** — the 227-entry `LS_*` constant family, the four constant categories (engine/UI / slash-command / quit dialog / late addition), the file format and `LoadLanguage` parser rules (`;` comments stripped, blank lines skipped, slash-command range upper-cased), and the add-new-string three-step checklist.

**Source bug surfaced (out of scope for this doc PR):** `Language.bb:301` uses `LS_SKick` / `LS_SSeason` in the range guard, but the actual constants are named `LS_SCKick` / `LS_SCSeason` (with the C). In a non-Strict file, the typos read as 0, making the range guard a no-op for the entire `[190..219]` slash-command range. The doc records this as "Confirm or file as follow-up."

**md5.md** — one-function public surface (`MD5\$`), its sole role as a client-side password pre-hash, the historical reason MD5 still exists (PBKDF2 verifiers store `PBKDF2(MD5(plaintext))`), and the migration path to PBKDF2-only.

**radar.md** — four-texture HUD overlay stack, zone-load flow with the camera-elevation auto-fit loop, the screen-scratch-image leak fix, the per-tick fog reveal with origin-spawn `/0` guard, and the atomic-write `.rdr` persistence.

## Fact-check before commit

All cross-references verified:
- `MaxLanguageString = 226` (Language.bb:2); `LS_AccountAlreadyConnected = 226` (line 235).
- Slash-command range constants `LS_SCKick = 190` (line 196) through `LS_SCSeason = 219` (line 225); guard typo confirmed at line 301.
- All three `MD5\$(Pass\$)` caller sites confirmed in MainMenu.bb (804, 869, 1193).
- `AccountsServer.bb:121` calls MD5 \"broken-MD5\" in its audit comment.
- `Radar_WorldSize = 0` divide guard at Radar.bb:329; audit comment at 324-328.
- `Save_Radar_Fog` `SafeWriteOpen` / `SafeWriteCommit` shape at Radar.bb:216-238.
- Scratch-image leak fix at Radar.bb:91-95.

## Test plan

- [x] `compile.bat -t` clean (docs-only change but verified)
- [ ] CI green
- [ ] Hostile-reviewer audit