### PR TITLE
docs(modules): three more empty-doc overviews (Projectiles3D/Interface/MediaDialogs)

### DIFF
--- a/docs/modules/interface.md
+++ b/docs/modules/interface.md
@@ -1,1 +1,110 @@
 <!-- body { color:black background-color:white } a:link{ color:#0070FF } a:visited{ color:#0070FF } --> RealmCrafter: Community Edition Documentation
+
+**Interface.bb**
+
+The client-side 2D HUD substrate. Defines every per-window gadget handle (`W*`, `B*`, `L*`, `T*`, `S*`), the unified key-binding state (`Key_*` globals + `LoadControlBindings` / `SaveControlBindings` file I/O), the `InterfaceComponent` Type used by the persistent layout system (`LoadInterfaceSettings` / `SaveInterfaceSettings`), and the `ControlHit` / `ControlDown` / `ControlName$` cross-device input dispatch.
+
+This module is **declaration-heavy, logic-light**. Most of it is `Global W<Window>`, `Global B<Button>`, `Global L<Label>`, `Dim` arrays for inventory / spell-book / action-bar slots, etc. — the file is the central registry of UI gadget handles, not the place where UI behavior lives. Per-window event handling lives in [`MainMenu.bb`](mainmenu.md), [`ClientNet.bb`](clientnet.md), and other consumers.
+
+## Conceptual overview
+
+### Three small Types
+
+| Type | Purpose |
+|---|---|
+| `Dialog` | NPC-conversation modal. `Win`, 14 text lines (`TextLines[13]` / `TextText$[13]` + per-line R/G/B and `OptionNum[]`), an `ActorInstance` link, a `ScriptHandle`. Per-NPC dialog ID. |
+| `TextInput` | Single-line text-entry modal. `Win`, `TextBox`, `AcceptButton`, `ScriptHandle`. Used by `BVM_GETSTRING` and similar script prompts. |
+| `Bubble` | Floating chat-bubble entity that follows an actor for a short time. `EN`, `Width#` / `Height#`, `Timer`, `ActorInstance`. |
+| `InterfaceComponent` | Persistent layout descriptor (X/Y/W/H in fraction-of-screen, Alpha, Component handle, Texture, R/G/B). Backs `Chat`, `ChatEntry`, `BuffsArea`, `Radar`, `Compass`, the per-attribute bar array, and inventory buttons. Read/written via `ReadInterfaceComponent` / `WriteInterfaceComponent`. |
+| `EffectIcon` / `EffectIconSlot` | Buff-icon HUD entries (name, ID, texture). |
+
+`Dialog` and `TextInput` are addressed by Handle via `DialogScriptHandle(Han)` from script context, which returns the `ScriptHandle` field for downstream BVM dispatch.
+
+### The gadget-globals registry
+
+The bulk of this file is one large registry of `Global` handles, grouped by HUD region:
+
+| Group | Gadgets | Touched by |
+|---|---|---|
+| Action bar | `XPEN`, `BChat / BMap / BInventory / BSpells / BCharStats / BQuestLog / BParty / BHelp`, `BNextBar / BPrevBar`, `ActionBarSlots(35)`, `BActionBar(11)`, `ActionBarStart`, `ActionBarUpTex / DownTex` | UI input loop; `P_SetActionBar` packet handler |
+| Character interaction window | `WCharInteract`, `SCharInteractHealth`, `LCharInteractTalk`, `CharInteract.ActorInstance`, `LCharInteractFaction / Level / Reputation` | NPC right-click / examine flow |
+| Tooltip | `WTooltip` (created-on-the-fly), `WTooltipReturn`, `LTooltip` | hover detection in every window |
+| Party | `WParty`, `BPartyLeave`, `PartyName$(6)`, `LPartyName(6)` | `P_PartyUpdate` packet handler |
+| Menu (added 2014) | `WMenu`, `BMenu`, `BLogOut / BCharSelect / BExit / BOptions` | escape-key handler |
+| Help | `WHelp`, `BHelp`, `SHelpScroll`, `HelpText$(99)`, `LHelp(14)` | `/help` chat command |
+| Radar + map | `ShowRadar`, `WLargeMap`, `LargeMapVisible` (see [`Radar.bb`](radar.md) for the actual renderer) |
+| Inventory | `WInventory`, `LInventoryGold`, `BInventoryDrop / Eat`, `WAmount` + amount-prompt support, `MouseSlot*` drag-state, `BSlots(Slots_Inventory)`, `WItemWindow` | inventory-window event loop |
+| Trading | `WTrading`, `LTradingGold / Cost`, `BTradingOK / Cancel`, `TradeType`, `BCostUp / Down`, parallel mine/his slot arrays (32 each) | trade-window event loop; `P_InventoryUpdate "T"` |
+| Char stats | `WCharStats`, attribute-name/value label arrays | `P_StatUpdate` consumer |
+| Spells | `WSpells`, `BNextSpells / PrevSpells`, `LSpellsPage`, `WSpellRemove` + `WSpellError` modals, `BSpellImgs(9)` etc., `FirstSpell` cursor, `LastSpellRecharge` | `P_SpellUpdate` consumer |
+| Quest log | `WQuestLog`, `BCompleteQuests / Next / Prev`, `FirstQuest`, `LQuestLines(16)` | `P_StandardUpdate` quest-entry consumer |
+| Chat | `ChatHistory$(1999)` (permanent history), `ChatHistoryColour(1999)`, `ChatLines(0)` (resized on screen-resolution change), `MaxChatLine`, history mode toggle | `P_ChatMessage` consumer |
+
+`ChatHistory$` is a 2000-slot ring; `ChatLines` is dynamically `Dim`-resized to whatever fits the current resolution. A future high-DPI / wide-screen aware UI overhaul would touch this `Dim ChatLines(N)` call site.
+
+### Key bindings and the control-number space
+
+`Key_*` globals store integer control codes; `LoadControlBindings` / `SaveControlBindings` persist them via plain `ReadInt` / `WriteInt` (no SafeWrite — the file is small and a corrupt control-bindings file resets to defaults harmlessly on next launch).
+
+`ControlHit` / `ControlDown` / `ControlName$` partition the integer control space into three ranges:
+
+| Range | Device | Implementation |
+|---|---|---|
+| `1..499` | Keyboard | Direct `KeyHit(Ctrl)` / `KeyDown(Ctrl)` pass-through. Keys numbered by Blitz3D's standard scan-code table. |
+| `501..509` | Mouse | `MouseHit(1/2/3)` for buttons; `MXSpeed / MYSpeed / MZSpeed` axis tests for "Mouse Up/Down/Left/Right" and scroll-wheel up/down. |
+| `1001..1008` | Joystick buttons | `JoyHit(Ctrl - 1000)`. |
+| `1009..1016` | Joystick hat / axes | `JoyHat()` direction matching for "Hat Up/Down/Left/Right"; `JoyXDir() / JoyYDir()` for analog stick directions. |
+| else | Unknown | `ControlName$` returns `LanguageString$(LS_Unknown)`. |
+
+The hat-direction Cases use **edge detection** via static-`True` flags (`JoyHatUp = True` after the first hit, gating subsequent hits until the hat re-centers) — this is the **only** Hit-vs-Down distinction in the joystick path. Buttons get standard `JoyHit` edge behavior from Blitz; analog axes don't (they fire continuously while held).
+
+`ControlName$` is a switch-statement of every supported control number to a human-readable label. Used to populate the key-binding UI in the options menu.
+
+### Interface-component persistence
+
+`LoadInterfaceSettings` / `SaveInterfaceSettings` (re)build the global `Chat / ChatEntry / BuffsArea / Radar / Compass / InventoryWindow / etc.` `InterfaceComponent` handles by reading/writing fixed-shape records. Save uses **atomic `SafeWriteOpen$` / `SafeWriteCommit%`** (lines 340-368) so an interrupted save can't leave a truncated layout file.
+
+The component shape on disk is 8 fields per record:
+
+```
+WriteFloat X, Y, Width, Height, Alpha   ; 5 floats
+WriteByte  R, G, B                       ; 3 bytes
+```
+
+`Chat` carries an extra `Texture` field (read/written separately as a `Short`); all other components are pure layout.
+
+### `WordWrap(St$, MaxChars)`
+
+Linear scan backward from `MaxChars` for the last space character — gives the split index for the next line in a word-wrapped paragraph. Returns `MaxChars` (mid-word break) if no space found in the search window. Returns `0` if the string is shorter than the limit (caller's signal: "no wrap needed").
+
+This is a Blitz-friendly implementation of basic word-wrap — the `LTooltip` and dialog-multi-line rendering use it.
+
+## Conventions for new code touching this module
+
+- **A new UI window means a new `Global W<Name>` here**, paired with all `B<Name>` / `L<Name>` button/label handles, and ideally a `Dim` array if the window has repeating slots. Don't scatter window-state globals across consumer files.
+- **`InterfaceComponent`-backed elements need read/write entries in `Load/SaveInterfaceSettings`** — otherwise the user's layout customization isn't persisted. The on-disk record order is positional (no length-prefix / tag), so **never reorder** the read/write sequence — match `Read*` order to `Write*` order.
+- **`SaveInterfaceSettings` uses `SafeWriteOpen` / `SafeWriteCommit`.** If you add new persistent-layout state, follow the same atomic-write pattern (CLAUDE.md → "Atomic writes"). Direct `WriteFile` to the production path is forbidden.
+- **`ControlHit` vs `ControlDown` returns slightly different shapes for joystick hat directions** (edge-detected via static `True` flags vs immediate true while held). Don't assume they're symmetric — use `ControlHit` for menu-navigation single-press, `ControlDown` for held-movement input.
+- **Adding a new control number** requires entries in `ControlHit`, `ControlDown`, *and* `ControlName$`. Missing any one breaks UI rebinding or input dispatch.
+- **`ControlName$` returns `LanguageString$(LS_Unknown)` for unrecognised control numbers** — never hard-code "Unknown" or similar strings; route through the [`Language.bb`](language.md) registry.
+
+## Related modules
+
+- [`Language.bb`](language.md) — `LS_*` constants for UI labels; `LanguageString$(LS_Unknown)` is the fallback for `ControlName$`.
+- [`Logging.bb`](logging.md) — provides the `SafeWriteOpen$` / `SafeWriteCommit%` atomic-write helpers used by `SaveInterfaceSettings`.
+- [`MainMenu.bb`](mainmenu.md) — heaviest consumer; the in-game UI event loop dispatches on the gadget globals declared here.
+- [`Gooey.bb`](gooey.md) — provides the underlying Gooey UI primitives (`CreateWindow`, `CreateLabel`, `CreateListBox`, `CreateButton`, etc.). The `W*` / `B*` / `L*` handles here are Gooey-allocated.
+- [`F-UI.bb`](../../src/Modules/F-UI.bb) — the alternate Float-UI system used by [`MediaDialogs.bb`](mediadialogs.md). Coexists with Gooey for editor tools.
+- [`Radar.bb`](radar.md) — the `Radar.InterfaceComponent` declared here describes the **placement** of the radar HUD overlay; the actual renderer lives in `Radar.bb`.
+- [`Interface3D.bb`](interface3d.md) — the 3D-world HUD pieces (chat bubbles in world space, name labels above actor heads) that complement the 2D UI here.
+
+## See also
+
+- CLAUDE.md → "Atomic writes" — the canonical `SafeWriteOpen` / `SafeWriteCommit` pattern.
+- [`P_ChatMessage.md`](../protocol/packets/P_ChatMessage.md) — wire layer feeding `ChatHistory$()` / `ChatLines()`.
+- [`P_StatUpdate.md`](../protocol/packets/P_StatUpdate.md) — wire layer feeding the per-attribute display bars in `AttributeDisplays(39)`.
+- [`P_InventoryUpdate.md`](../protocol/packets/P_InventoryUpdate.md) — wire layer feeding `BSlots(Slots_Inventory)` and the trading parallel-slot arrays.
+
+* * *
+
+This module's source is mostly handle declarations with a handful of small functions. The 11 functions are: `DialogScriptHandle`, `LoadControlBindings`, `SaveControlBindings`, `WriteInterfaceComponent`, `ReadInterfaceComponent`, `LoadInterfaceSettings`, `SaveInterfaceSettings`, `WordWrap`, `ControlHit`, `ControlDown`, `ControlName$`. Read the source at [`src/Modules/Interface.bb`](../../src/Modules/Interface.bb) for full signatures.

--- a/docs/modules/interface.md
+++ b/docs/modules/interface.md
@@ -8,17 +8,18 @@ This module is **declaration-heavy, logic-light**. Most of it is `Global W<Windo
 
 ## Conceptual overview
 
-### Three small Types
+### Seven Types
 
 | Type | Purpose |
 |---|---|
 | `Dialog` | NPC-conversation modal. `Win`, 14 text lines (`TextLines[13]` / `TextText$[13]` + per-line R/G/B and `OptionNum[]`), an `ActorInstance` link, a `ScriptHandle`. Per-NPC dialog ID. |
 | `TextInput` | Single-line text-entry modal. `Win`, `TextBox`, `AcceptButton`, `ScriptHandle`. Used by `BVM_GETSTRING` and similar script prompts. |
 | `Bubble` | Floating chat-bubble entity that follows an actor for a short time. `EN`, `Width#` / `Height#`, `Timer`, `ActorInstance`. |
-| `InterfaceComponent` | Persistent layout descriptor (X/Y/W/H in fraction-of-screen, Alpha, Component handle, Texture, R/G/B). Backs `Chat`, `ChatEntry`, `BuffsArea`, `Radar`, `Compass`, the per-attribute bar array, and inventory buttons. Read/written via `ReadInterfaceComponent` / `WriteInterfaceComponent`. |
-| `EffectIcon` / `EffectIconSlot` | Buff-icon HUD entries (name, ID, texture). |
+| `CurrentChat` | Transient chat-line entry (`Dat$`, `cR`/`cG`/`cB`, `Timer`) — the "fades after N seconds" chat layer. Walked alongside `ChatHistory$` to render the volatile chat overlay. |
+| `EffectIcon` / `EffectIconSlot` | Buff-icon HUD entries — `EffectIcon` is the catalog entry (`Name$`, `ID`, `TextureID`); `EffectIconSlot` is the rendered slot pointing back at one (`EN`, `Effect.EffectIcon`). |
+| `InterfaceComponent` | Persistent layout descriptor (X/Y/W/H in fraction-of-screen, Alpha, Component handle, Texture, R/G/B). Backs `Chat`, `ChatEntry`, `BuffsArea`, `Radar`, `Compass`, the per-attribute bar array, inventory window/drop/eat/gold, and the inventory-slot button array. Read/written via `ReadInterfaceComponent` / `WriteInterfaceComponent`. |
 
-`Dialog` and `TextInput` are addressed by Handle via `DialogScriptHandle(Han)` from script context, which returns the `ScriptHandle` field for downstream BVM dispatch.
+`Dialog` is addressed by Handle via `DialogScriptHandle(Han)` at [`Interface.bb:196-201`](../../src/Modules/Interface.bb#L196), which returns the `Dialog\ScriptHandle` field for downstream BVM dispatch. **`TextInput` has no equivalent handle-walking helper in this file** — script-side TextInput lookups go through a different path. (Adding `TextInputScriptHandle(Han)` would close the asymmetry; not currently present.)
 
 ### The gadget-globals registry
 
@@ -56,13 +57,13 @@ The bulk of this file is one large registry of `Global` handles, grouped by HUD 
 | `1009..1016` | Joystick hat / axes | `JoyHat()` direction matching for "Hat Up/Down/Left/Right"; `JoyXDir() / JoyYDir()` for analog stick directions. |
 | else | Unknown | `ControlName$` returns `LanguageString$(LS_Unknown)`. |
 
-The hat-direction Cases use **edge detection** via static-`True` flags (`JoyHatUp = True` after the first hit, gating subsequent hits until the hat re-centers) — this is the **only** Hit-vs-Down distinction in the joystick path. Buttons get standard `JoyHit` edge behavior from Blitz; analog axes don't (they fire continuously while held).
+The hat-direction Cases **intend** edge detection — code like `If JoyHatUp = False Then JoyHatUp = True : Return True` reads as "first call returns true, subsequent calls suppressed until reset". But `JoyHatUp` / `JoyHatDown` / `JoyHatLeft` / `JoyHatRight` are **not declared anywhere** (no `Global`, no `Const`); under Blitz3D's non-Strict semantics they're function-local variables that re-initialize to 0 on every call. So the gating never actually fires — the `Return True` branch hits on every call where the hat is in the right position, identical to `ControlDown`'s behavior. This is a latent bug worth a follow-up (declare `Global JoyHatUp / Down / Left / Right` at file scope and reset on hat-centered, or just remove the dead gating). Analog axes (`JoyXDir() / JoyYDir()`) and buttons (`JoyHit`) use the standard Blitz idioms — only the hat branch has the latent edge-detect aspiration.
 
 `ControlName$` is a switch-statement of every supported control number to a human-readable label. Used to populate the key-binding UI in the options menu.
 
 ### Interface-component persistence
 
-`LoadInterfaceSettings` / `SaveInterfaceSettings` (re)build the global `Chat / ChatEntry / BuffsArea / Radar / Compass / InventoryWindow / etc.` `InterfaceComponent` handles by reading/writing fixed-shape records. Save uses **atomic `SafeWriteOpen$` / `SafeWriteCommit%`** (lines 340-368) so an interrupted save can't leave a truncated layout file.
+`LoadInterfaceSettings` / `SaveInterfaceSettings` (re)build the persistent layout. The full sequence (positional — read order must equal write order) is: `Chat` + its `Chat\Texture` (extra `ReadShort`/`WriteShort`), `ChatEntry`, `AttributeDisplays(0..39)`, `BuffsArea`, `Radar`, `Compass`, `InventoryWindow`, `InventoryDrop`, `InventoryEat`, `InventoryGold`, `InventoryButtons(0..Slots_Inventory)`. Save uses **atomic `SafeWriteOpen$` / `SafeWriteCommit%`** ([`Interface.bb:340-368`](../../src/Modules/Interface.bb#L340)) so an interrupted save can't leave a truncated layout file. `LoadInterfaceSettings` is a plain `ReadFile` ([`Interface.bb:298-337`](../../src/Modules/Interface.bb#L298)) — no atomicity needed on the read side.
 
 The component shape on disk is 8 fields per record:
 

--- a/docs/modules/mediadialogs.md
+++ b/docs/modules/mediadialogs.md
@@ -1,1 +1,108 @@
 <!-- body { color:black background-color:white } a:link{ color:#0070FF } a:visited{ color:#0070FF } --> RealmCrafter: Community Edition Documentation
+
+**MediaDialogs.bb**
+
+Editor-tool asset pickers. Four modal dialogs (Mesh / Texture / Sound / Music) that let the user browse a folder tree under `Data\` and pick a loaded media asset by name. Used by GUE, RC Architect, and other editor tools — not by the runtime game client.
+
+Each dialog caches an in-memory name table snapshotted from the media subsystem's `GetMeshName$ / GetTextureName$ / GetSoundName$ / GetMusicName$` registries (0..65534, mirroring [`Media.bb`](media.md)'s ID-space) and presents them as a two-pane Folder + File listbox using the **`F-UI`** alternate UI toolkit (not Gooey).
+
+## Conceptual overview
+
+### The four dialogs
+
+| Dialog | Window global | Filter constants |
+|---|---|---|
+| Mesh | `WMeshDialog` | `MeshDialog_All = 1`, `MeshDialog_Animated = 2`, `MeshDialog_Static = 3` |
+| Texture | `WTextureDialog` | (no filter — all textures) |
+| Sound | `WSoundDialog` | `SoundDialog_All = 1`, `SoundDialog_3D = 2`, `SoundDialog_Normal = 3` |
+| Music | `WMusicDialog` | (no filter — all music) |
+
+The Sound and Music dialogs additionally have a `BSoundDialogPlay` / `BMusicDialogPlay` button for in-dialog preview playback. The Mesh and Texture dialogs are pure pickers.
+
+### Name caches: four 65535-slot string arrays
+
+```basic
+Dim MeshNames$(65534)
+Dim TextureNames$(65534)
+Dim SoundNames$(65534)
+Dim MusicNames$(65534)
+```
+
+Populated once at `InitMediaDialogs()` time by iterating the entire ID space and calling `GetMeshName$(i) / GetTextureName$(i) / etc.` under the corresponding `LockMeshes() / LockTextures() / LockSounds() / LockMusic()` guards. **Snapshotted at init** — not refreshed as new assets are loaded. If a media asset is added to the registry after `InitMediaDialogs` runs, it won't appear in subsequent dialog invocations until the editor restarts.
+
+The 65535-slot size mirrors the runtime [`Media.bb`](media.md) registry capacity. Empty slots store `""`.
+
+### `F-UI` (Float-UI) — not Gooey
+
+The dialogs allocate gadgets via `FUI_Window`, `FUI_Button`, `FUI_ListBox` — the **F-UI** toolkit in [`F-UI.bb`](../../src/Modules/F-UI.bb), not the Gooey toolkit used by the runtime in-game HUD. F-UI is the editor-tool flavor with different sizing semantics and absolute-pixel positioning (vs Gooey's `ClientWidth / ClientHeight` scaling). The window is created off-screen (`-1000, -1000`) and re-positioned at show time by the `ChooseXDialog(...)` entry points.
+
+This means **MediaDialogs cannot be embedded in the runtime client** without re-implementing on Gooey, or pulling F-UI into the runtime include cascade. Today F-UI is only included by editor tool entry points.
+
+### The `ChooseXDialog(filter, InitialFolder$, XPos = -1, YPos = -1)` entry points
+
+Four parallel functions — `ChooseMeshDialog`, `ChooseTextureDialog`, `ChooseSoundDialog`, `ChooseMusicDialog` — implement the modal-event-loop pattern:
+
+1. Reposition the dialog window to `(XPos, YPos)` (or screen-center if `-1`).
+2. Populate the folder list via `FillXFolderList(LFolder, InitialFolder$)`.
+3. Populate the file list via `FillXList(LDialog, InitialFolder$, filter)`.
+4. Show the window and `Repeat ... Until` event loop with `FUI_HandleEvents()`:
+   - Folder list click → re-fill file list at new folder.
+   - File list click → enable OK button (or play preview for Sound/Music).
+   - OK / Cancel button → exit loop with selected name or empty string.
+5. Hide window; return selected `"<Folder>\<Filename>"` (or `""` on cancel).
+
+### `FolderChangeHandler$(Name$, InitialFolder$)`
+
+Helper that resolves the `..` parent-folder semantic in a folder-list click. Returns the new effective folder path. Used by all four dialogs.
+
+### `FillXList` / `FillXFolderList` family — eight similar functions
+
+The eight `Fill*` functions are direct parallels:
+
+- `FillMeshesList`, `FillMeshesFolderList`
+- `FillTexturesList`, `FillTexturesFolderList`
+- `FillSoundsList`, `FillSoundsFolderList`
+- `FillMusicList`, `FillMusicFolderList`
+
+Each `Fill<X>List(List, Folder$, [type])` walks the corresponding `<X>Names$(65534)` array, filters entries by:
+
+1. Folder prefix — `Left$(name$, Len(Folder$)) = Folder$`
+2. Slash-count — entries with more slashes than `Folder$` are sub-folders, not files in the current folder.
+3. (Sound/Mesh only) Type filter — `MeshType` / `SoundType` constant matches the asset's actual class.
+
+`FillXFolderList(List, Folder$)` is the same shape but emits **distinct sub-folder names** (one entry per unique sub-folder reached from `Folder$`), plus the `..` parent entry.
+
+The result is the standard two-pane folder browser: folders on top, files at bottom.
+
+## Conventions for new code touching this module
+
+- **`InitMediaDialogs` snapshots the name caches at init.** If you need post-init refresh (e.g. after loading a content pack at runtime), add a refresh function that re-iterates `0..65534` under the appropriate `Lock*` / `Unlock*` guard — don't re-call `InitMediaDialogs` (it re-allocates the dialog windows on top of the existing ones, leaking gadget handles).
+- **All four dialogs share the same gadget-naming pattern** — `W<Asset>Dialog`, `L<Asset>Folder`, `L<Asset>Dialog`, `B<Asset>DialogOK`, `B<Asset>DialogCancel`, optional `B<Asset>DialogPlay`. New asset-picker dialogs (e.g. shaders, fonts) should mirror this exactly so editor-tool consumers can dispatch generically.
+- **F-UI-only toolkit.** Don't mix Gooey and F-UI gadget calls within the same window — they have different event dispatch and re-flow semantics. The Mesh / Texture / Sound / Music dialogs are pure F-UI by convention.
+- **`GetXName$(i)` returning `""` is the empty-slot sentinel** — `FillXList` skips entries with `Len = 0` so empty slots are silently filtered. New asset Types should keep the empty-string-means-empty convention.
+- **Folder paths use backslash `\` separators** (Windows-native; matches Blitz3D's native file API). The slash-counting filter in `FillXList` assumes this.
+
+## Related modules
+
+- [`Media.bb`](media.md) — owns the `GetMeshName$ / GetTextureName$ / GetSoundName$ / GetMusicName$` registries and the underlying load functions. This module is a viewer / picker on top of it.
+- [`F-UI.bb`](../../src/Modules/F-UI.bb) — the alternate UI toolkit used here. Provides `FUI_Window / Button / ListBox / HandleEvents`. Editor-tool-side; not part of the runtime client.
+- [`Gooey.bb`](gooey.md) — the runtime UI toolkit (sibling of F-UI). Not used by this module.
+
+## See also
+
+- This module has no `LS_*` localization dependency — strings are hard-coded English ("Accept", "Cancel", "Choose Mesh", etc.). Editor tools typically aren't localized.
+- No `SafeWrite` / atomic-write integration — this module is read-only against the media registries.
+
+* * *
+
+The legacy function-by-function reference for this module has not been generated. The conceptual overview above is the primary reference; consult the source at [`src/Modules/MediaDialogs.bb`](../../src/Modules/MediaDialogs.bb) for full signatures.
+
+### Functions
+
+- **`InitMediaDialogs()`** — snapshot all four name registries into the 65535-slot caches; allocate the four F-UI windows + their gadgets off-screen.
+- **`ChooseMeshDialog(MeshType, InitialFolder$, XPos, YPos)`** — modal mesh picker. Returns the selected `"<Folder>\<Filename>"` or `""` on cancel.
+- **`ChooseTextureDialog(InitialFolder$, XPos, YPos)`** — same, for textures.
+- **`ChooseSoundDialog(SoundType, InitialFolder$, XPos, YPos)`** — same, for sounds. Has in-dialog preview-play.
+- **`ChooseMusicDialog(InitialFolder$, XPos, YPos)`** — same, for music. Has in-dialog preview-play.
+- **`FolderChangeHandler$(Name$, InitialFolder$)`** — resolve `..` parent-folder navigation.
+- **`FillMeshesList(List, Folder$, MeshType)` / `FillMeshesFolderList(List, Folder$)`** — populate file and folder list-boxes for meshes in `Folder$`. The eight parallel `Fill*` functions follow the same shape per asset type.

--- a/docs/modules/mediadialogs.md
+++ b/docs/modules/mediadialogs.md
@@ -53,7 +53,7 @@ Four parallel functions — `ChooseMeshDialog`, `ChooseTextureDialog`, `ChooseSo
 
 ### `FolderChangeHandler$(Name$, InitialFolder$)`
 
-Helper that resolves the `..` parent-folder semantic in a folder-list click. Returns the new effective folder path. Used by all four dialogs.
+Helper that resolves the `(Previous folder)` parent-folder semantic in a folder-list click. If `Name$ = "(Previous folder)"`, returns `InitialFolder$` with its final path component stripped; otherwise returns `InitialFolder$ + "\" + Name$`. Used by all four dialogs.
 
 ### `FillXList` / `FillXFolderList` family — eight similar functions
 
@@ -64,13 +64,9 @@ The eight `Fill*` functions are direct parallels:
 - `FillSoundsList`, `FillSoundsFolderList`
 - `FillMusicList`, `FillMusicFolderList`
 
-Each `Fill<X>List(List, Folder$, [type])` walks the corresponding `<X>Names$(65534)` array, filters entries by:
+Each `Fill<X>List(List, Folder$, [type])` walks the corresponding `<X>Names$(65534)` array. For each entry, the algorithm scans **backward from end-of-name** to the last `\` or `/`, splits the name into `Name$` (basename) and `Path$` (parent directory), then accepts the entry if and only if `Upper$(Right$(Path$, Len(Folder$))) = Upper$(Folder$)` — a **case-insensitive suffix match on the parent directory**. A file at `Meshes\Goblins\warlord.b3d` has parent `Meshes\Goblins`; opening dialog at `Folder$ = "Goblins"` accepts it because `Right$("Meshes\Goblins", Len("Goblins"))` is `"Goblins"`. The empty `Folder$ = ""` case takes the special branch: accept iff `Name$` has no slash (top-level only). The (Sound / Mesh)-only type filter (`MeshType` / `SoundType`) is an additional gate on the same loop.
 
-1. Folder prefix — `Left$(name$, Len(Folder$)) = Folder$`
-2. Slash-count — entries with more slashes than `Folder$` are sub-folders, not files in the current folder.
-3. (Sound/Mesh only) Type filter — `MeshType` / `SoundType` constant matches the asset's actual class.
-
-`FillXFolderList(List, Folder$)` is the same shape but emits **distinct sub-folder names** (one entry per unique sub-folder reached from `Folder$`), plus the `..` parent entry.
+`FillXFolderList(List, Folder$)` is the same shape but emits **distinct sub-folder names**: walks all names, computes each name's path relative to `Folder$`, splits at the first `\` or `/`, and inserts each unique first-component as a folder entry. If `Folder$ <> ""` it prepends a `(Previous folder)` row that `FolderChangeHandler$` (see below) maps to the parent path.
 
 The result is the standard two-pane folder browser: folders on top, files at bottom.
 
@@ -80,7 +76,7 @@ The result is the standard two-pane folder browser: folders on top, files at bot
 - **All four dialogs share the same gadget-naming pattern** — `W<Asset>Dialog`, `L<Asset>Folder`, `L<Asset>Dialog`, `B<Asset>DialogOK`, `B<Asset>DialogCancel`, optional `B<Asset>DialogPlay`. New asset-picker dialogs (e.g. shaders, fonts) should mirror this exactly so editor-tool consumers can dispatch generically.
 - **F-UI-only toolkit.** Don't mix Gooey and F-UI gadget calls within the same window — they have different event dispatch and re-flow semantics. The Mesh / Texture / Sound / Music dialogs are pure F-UI by convention.
 - **`GetXName$(i)` returning `""` is the empty-slot sentinel** — `FillXList` skips entries with `Len = 0` so empty slots are silently filtered. New asset Types should keep the empty-string-means-empty convention.
-- **Folder paths use backslash `\` separators** (Windows-native; matches Blitz3D's native file API). The slash-counting filter in `FillXList` assumes this.
+- **Folder paths tolerate both `\` and `/` separators** — the path-split scan accepts either ([`MediaDialogs.bb:418`](../../src/Modules/MediaDialogs.bb#L418), `:461-462`). Asset paths in the wild are typically Windows-native backslash, but mixed-separator names are handled correctly.
 
 ## Related modules
 
@@ -105,4 +101,4 @@ The legacy function-by-function reference for this module has not been generated
 - **`ChooseSoundDialog(SoundType, InitialFolder$, XPos, YPos)`** — same, for sounds. Has in-dialog preview-play.
 - **`ChooseMusicDialog(InitialFolder$, XPos, YPos)`** — same, for music. Has in-dialog preview-play.
 - **`FolderChangeHandler$(Name$, InitialFolder$)`** — resolve `..` parent-folder navigation.
-- **`FillMeshesList(List, Folder$, MeshType)` / `FillMeshesFolderList(List, Folder$)`** — populate file and folder list-boxes for meshes in `Folder$`. The eight parallel `Fill*` functions follow the same shape per asset type.
+- **`FillMeshesList(List, Folder$, MeshType)` / `FillMeshesFolderList(List, Folder$)`** — populate file and folder list-boxes for meshes in `Folder$`. The eight parallel `Fill*` functions follow the same shape, with one detail: `FillMeshesList` and `FillSoundsList` take a third `MeshType` / `SoundType` argument; `FillTexturesList` and `FillMusicList` are two-argument (no filter).

--- a/docs/modules/projectiles3d.md
+++ b/docs/modules/projectiles3d.md
@@ -2,9 +2,11 @@
 
 **Projectiles3D.bb**
 
-Client-side projectile rendering. The whole module is three functions plus one Type — total source is ~107 lines. Owns the `ProjectileInstance` Type, the per-tick `UpdateProjectiles` mover that walks every live projectile and frees them on impact, and the `CreateProjectile` / `FreeProjectileInstance` lifecycle pair.
+Client-side projectile rendering. The whole module is three functions plus one Type — total source is ~107 lines. Owns the `ProjectileInstance` Type (a live in-flight projectile), the per-tick `UpdateProjectiles` mover that walks every live projectile and frees them on impact, and the `CreateProjectile(Source, Target, MeshID, Homing, Speed, ...)` / `FreeProjectileInstance` lifecycle pair.
 
-The server side of projectile gameplay (damage application, hit registration, target validation) lives in [`Projectiles.bb`](projectiles.md). This module is *only* the visual representation on the client.
+Sibling module [`Projectiles.bb`](projectiles.md) owns the `Projectile` Type (the static **template** — name, mesh ID, damage, hit chance, emitter names, included on both server and client) and the `LoadProjectiles` / `SaveProjectiles` / `FindProjectile` file-I/O over `ProjectileList(5000)`. Damage application, hit registration, and target validation actually live in combat code in [`Spells.bb`](spells.md) / [`GameServer.bb`](gameserver.md), not in `Projectiles.bb`. This module (`Projectiles3D.bb`) is *only* the visual representation on the client.
+
+> **Function-name collision:** both [`Projectiles.bb:14`](../../src/Modules/Projectiles.bb#L14) (`Function CreateProjectile.Projectile()` — allocates a template slot in `ProjectileList`) **and** [`Projectiles3D.bb:11`](../../src/Modules/Projectiles3D.bb#L11) (`Function CreateProjectile(Source.ActorInstance, Target.ActorInstance, MeshID, Homing, Speed#, ...)` — allocates a live `ProjectileInstance`) declare a function named `CreateProjectile`. BlitzForge resolves them by the typed-return marker on the template form vs. the untyped instance form, so both compile. When this doc says "`CreateProjectile`" unqualified, it means **this module's** instance-side function. Cross-referencing the source by name will hit two definitions — the template one is the unrelated template-allocation helper.
 
 ## Conceptual overview
 
@@ -61,12 +63,12 @@ Both emitters are optional — empty `Emitter1$` / `Emitter2$` strings skip the 
 
 ### Globals it reads
 
-The module doesn't define globals itself but reads three from elsewhere:
+The module doesn't define globals itself but reads four from elsewhere:
 
 - **`Cam`** — the world camera handle (defined in [`Environment3D.bb`](environment3d.md)). Passed to `RP_LoadEmitterConfig` as the billboard camera.
-- **`GPP`** — the global position pivot, reused by `UpdateProjectiles` to position the target coordinate so `EntityDistance` can be called.
+- **`GPP`** — the global position pivot allocated in [`ClientLoaders.bb:197`](../../src/Modules/ClientLoaders.bb#L197). Reused by `UpdateProjectiles` to position the target coordinate so `EntityDistance` can be called against `P\EN`. Each tick the homing branch overrides `P\TargetX/Y/Z` from the live target before positioning `GPP`.
 - **`Delta#`** — the frame delta, used to scale `MoveEntity(P\EN, 0, 0, P\Speed# * Delta#)` for framerate-independent movement.
-- **`LoadedMeshScales#(MeshID)`** — per-template scale factor, sourced from the mesh registry.
+- **`LoadedMeshScales#(MeshID)`** — per-template scale factor, declared `Dim LoadedMeshScales#(65534)` in [`Media.bb:3`](../../src/Modules/Media.bb#L3). Indexed by `Actor\MeshID` (or here, by the projectile's `MeshID` argument).
 
 ## Conventions for new code touching this module
 
@@ -77,11 +79,13 @@ The module doesn't define globals itself but reads three from elsewhere:
 
 ## Related modules
 
-- [`Projectiles.bb`](projectiles.md) — server-side projectile logic (damage, target validation, hit packets). The client `CreateProjectile` is driven by packets emitted from here.
+- [`Projectiles.bb`](projectiles.md) — **template** registry (`Projectile` Type — name, mesh ID, damage, emitter names, hit chance), shared between server and client. Damage application is not here; see `Spells.bb` / `GameServer.bb`.
 - [`RottParticles.bb`](rottparticles.md) — supplies `RP_LoadEmitterConfig` / `RP_CreateEmitter` / `RP_KillEmitter`. The emitter substrate.
 - [`Environment3D.bb`](environment3d.md) — owns `Cam` (the world camera) and the entity-management primitives.
-- [`Spells.bb`](spells.md) — caller (server-side spell-cast packets trigger client-side `CreateProjectile`).
-- [`Actors3D.bb`](actors3d.md) — owns `ActorInstance\CollisionEN`, the source/target collision entity that the projectile homes on.
+- [`Spells.bb`](spells.md) — combat path that issues the projectile-spawn packets the client then materializes via `CreateProjectile` here.
+- [`Actors.bb`](actors.md) — declares `Field CollisionEN` on `ActorInstance` ([`Actors.bb:153`](../../src/Modules/Actors.bb#L153)). `Actors3D.bb` is what allocates and frees it.
+- [`ClientLoaders.bb`](clientloaders.md) — owns the `GPP` global pivot used here.
+- [`Media.bb`](media.md) — owns the `LoadedMeshScales#(65534)` `Dim` array consulted by `CreateProjectile`.
 
 ## See also
 

--- a/docs/modules/projectiles3d.md
+++ b/docs/modules/projectiles3d.md
@@ -1,1 +1,92 @@
 <!-- body { color:black background-color:white } a:link{ color:#0070FF } a:visited{ color:#0070FF } --> RealmCrafter: Community Edition Documentation
+
+**Projectiles3D.bb**
+
+Client-side projectile rendering. The whole module is three functions plus one Type — total source is ~107 lines. Owns the `ProjectileInstance` Type, the per-tick `UpdateProjectiles` mover that walks every live projectile and frees them on impact, and the `CreateProjectile` / `FreeProjectileInstance` lifecycle pair.
+
+The server side of projectile gameplay (damage application, hit registration, target validation) lives in [`Projectiles.bb`](projectiles.md). This module is *only* the visual representation on the client.
+
+## Conceptual overview
+
+### `ProjectileInstance` Type
+
+```basic
+Type ProjectileInstance
+    Field Target.ActorInstance       ; homing target (Null = fire-and-forget at TargetX/Y/Z)
+    Field TargetX#, TargetY#, TargetZ#  ; resolved coordinate target when Target is Null
+    Field EN, EmitterEN1, EmitterEN2 ; main mesh entity + two RottParticles emitters
+    Field TexID1, TexID2             ; texture IDs used by the emitters (for unload bookkeeping)
+    Field Speed#
+End Type
+```
+
+The Type is allocated by `CreateProjectile` and `Delete`d by `FreeProjectileInstance`. There is no `Dim` array of projectiles — the global `For Each ProjectileInstance` walk in `UpdateProjectiles` is the only enumeration path.
+
+### Homing vs. fire-and-forget
+
+The `Homing` argument to `CreateProjectile` switches between two modes:
+
+- **`Homing = True`**: `P\Target` is set to the target `ActorInstance`. Each `UpdateProjectiles` tick re-reads the target's current `CollisionEN` position. Tracks moving targets.
+- **`Homing = False`**: `P\TargetX/Y/Z` are sampled **once** from the target's `CollisionEN` at creation, and `P\Target` stays `Null`. The projectile flies to those frozen coordinates regardless of target movement.
+
+The destroy check is `EntityDistance#(P\EN, GPP) < 2.0` (where `GPP` is the global position pivot positioned at the current target each tick) — a 2-unit-radius proximity. Either mode lands within that radius; homing just re-aims toward a moving target.
+
+### Per-tick walk: after-cursor pattern
+
+```basic
+Function UpdateProjectiles()
+    Local P.ProjectileInstance = First ProjectileInstance
+    Local PNext.ProjectileInstance = Null
+    While P <> Null
+        PNext = After P             ; capture next BEFORE the Delete branch
+        ; ... move, retarget, then maybe FreeProjectileInstance(P) ...
+        P = PNext
+    Wend
+End Function
+```
+
+The audit-comment block at [`Projectiles3D.bb:62-66`](../../src/Modules/Projectiles3D.bb#L62) records why this shape is mandatory: `FreeProjectileInstance(P)` calls `Delete(P)`, and a naive `For Each ... Next` cursor would then dereference the freed object's next pointer on the following iteration step. The capture-`After`-before-`Delete` shape is one of the three established iterator-during-iteration fixes (CLAUDE.md → "Iterator-during-iteration hazards"). The trigger case is two projectiles landing in the same frame.
+
+### Mesh + emitter binding
+
+`CreateProjectile` allocates resources in three stages:
+
+1. **Main mesh** (`P\EN`): looked up via `GetMesh(MeshID)` if `MeshID > -1 And MeshID < 65535`; scaled with `LoadedMeshScales#(MeshID)`. If the lookup fails (template missing or out-of-range ID), falls back to `CreatePivot()` so the projectile is still a positionable transform — emitters and the EntityDistance check still work on an invisible pivot.
+2. **Emitter 1** (`P\EmitterEN1`): created via `RP_LoadEmitterConfig("Data\Emitter Configs\<name>.rpc", Tex, Cam)` + `RP_CreateEmitter(Config)`, parented to `P\EN`. The texture ID is remembered in `P\TexID1` for later `UnloadTexture`.
+3. **Emitter 2** (`P\EmitterEN2`): same shape as emitter 1.
+
+Both emitters are optional — empty `Emitter1$` / `Emitter2$` strings skip the allocation. The texture lookup goes through `GetTexture(TexID)`; a failed lookup also skips the emitter (no fallback).
+
+`FreeProjectileInstance` undoes all three in reverse: `UnloadTexture` for each `TexID*` that's `> -1`, `RP_KillEmitter` for each emitter that's `<> 0` (re-parented to root before kill so the emitter doesn't get yanked with the parent mesh), `FreeEntity(P\EN)`, `Delete(P)`.
+
+### Globals it reads
+
+The module doesn't define globals itself but reads three from elsewhere:
+
+- **`Cam`** — the world camera handle (defined in [`Environment3D.bb`](environment3d.md)). Passed to `RP_LoadEmitterConfig` as the billboard camera.
+- **`GPP`** — the global position pivot, reused by `UpdateProjectiles` to position the target coordinate so `EntityDistance` can be called.
+- **`Delta#`** — the frame delta, used to scale `MoveEntity(P\EN, 0, 0, P\Speed# * Delta#)` for framerate-independent movement.
+- **`LoadedMeshScales#(MeshID)`** — per-template scale factor, sourced from the mesh registry.
+
+## Conventions for new code touching this module
+
+- **All per-frame walks over `ProjectileInstance` must use the after-cursor pattern** (`First` + `After` + `PNext` capture). Free-current-during-walk is the most common operation; the `For Each` iterator can't survive it. The single existing site at `UpdateProjectiles` is the canonical example.
+- **Texture and emitter handles are owned by the projectile.** Never share a `TexID` across projectiles without a refcount — `FreeProjectileInstance` will `UnloadTexture` the first projectile's texture and the second projectile will render with a stale handle.
+- **`P\EN = 0` is impossible** — if the mesh lookup fails, `CreatePivot()` always succeeds (returns a non-zero handle). No null-deref guard needed downstream.
+- **Stale `P\Target` from a freed actor** — `UpdateProjectiles` reads `P\Target\CollisionEN` without a `Null` check. If `FreeActorInstance` runs while a projectile is in flight toward that actor, the next tick dereferences a freed handle. There is no current cleanup hook; a follow-up could either iterate live projectiles in `FreeActorInstance` and clear `Target`, or guard the deref with `Object.ActorInstance(Handle(P\Target)) <> Null` per CLAUDE.md → "Handle-lookup Null discipline".
+
+## Related modules
+
+- [`Projectiles.bb`](projectiles.md) — server-side projectile logic (damage, target validation, hit packets). The client `CreateProjectile` is driven by packets emitted from here.
+- [`RottParticles.bb`](rottparticles.md) — supplies `RP_LoadEmitterConfig` / `RP_CreateEmitter` / `RP_KillEmitter`. The emitter substrate.
+- [`Environment3D.bb`](environment3d.md) — owns `Cam` (the world camera) and the entity-management primitives.
+- [`Spells.bb`](spells.md) — caller (server-side spell-cast packets trigger client-side `CreateProjectile`).
+- [`Actors3D.bb`](actors3d.md) — owns `ActorInstance\CollisionEN`, the source/target collision entity that the projectile homes on.
+
+## See also
+
+- CLAUDE.md → "Iterator-during-iteration hazards" — the after-cursor walk pattern. `UpdateProjectiles` is one of the canonical examples cited there.
+
+* * *
+
+The full source at [`src/Modules/Projectiles3D.bb`](../../src/Modules/Projectiles3D.bb) is short enough that a function-by-function reference adds little. The three public functions are `CreateProjectile`, `UpdateProjectiles`, and `FreeProjectileInstance`.


### PR DESCRIPTION
## Summary

Replaces three more stubs at `docs/modules/{projectiles3d,interface,mediadialogs}.md` with full conceptual overviews. Continuing the empty-docs sweep — bundled because each source is small-to-medium and the modules are independent.

## What each doc covers

**projectiles3d.md** — client-side projectile renderer (107 lines). `ProjectileInstance` Type, homing-vs-fire-and-forget switch, per-tick after-cursor walk pattern in `UpdateProjectiles` (canonical example of CLAUDE.md iterator-during-iteration hazard — two projectiles landing in same frame is the reproducer), mesh+emitter lifecycle. Surfaces a potential follow-up: stale `P\Target` race when `FreeActorInstance` runs while a projectile is in flight at the freed actor.

**interface.md** — 2D HUD substrate (601 lines). Small Types, gadget-globals registry table by HUD region (chat, action bar, inventory, trading, spells, quest log, etc.), three-range control-number space (keyboard 1-499 / mouse 501-509 / joystick 1001-1016) with `ControlHit` / `ControlDown` / `ControlName\$` dispatch, SafeWrite-atomic `InterfaceComponent` persistence with positional-record file format.

**mediadialogs.md** — editor-tool asset pickers (700 lines). Four parallel Mesh/Texture/Sound/Music modals, F-UI toolkit (vs Gooey), four 65535-slot name caches snapshotted at `InitMediaDialogs` time, `ChooseXDialog` modal event-loop, eight parallel `Fill*List` / `Fill*FolderList` filter functions.

## Fact-check before commit

All cross-references verified by source inspection:
- `UpdateProjectiles` after-cursor walk at Projectiles3D.bb:62-66 (audit comment) + 69-88 (impl).
- `ControlHit` device ranges at Interface.bb:382-429; `ControlName\$` ranges at 470-598.
- `SaveInterfaceSettings` SafeWrite at Interface.bb:340-368.
- `MediaDialogs.bb` uses FUI_* (not Gooey) at 42-69; four 65535-slot caches Dim'd at 16-19; all four `Lock*/Unlock*` guarded in `InitMediaDialogs`.

## Test plan

- [x] `compile.bat -t` clean
- [ ] CI green
- [ ] Hostile-reviewer audit