### PR TITLE
fix(test): chain-test pool sweep Phase 2 — trailing teardown Test

### DIFF
--- a/src/Tests/Modules/OnlinePlayerChainTest.bb
+++ b/src/Tests/Modules/OnlinePlayerChainTest.bb
@@ -301,9 +301,20 @@ End Test
 ; (~10-15% post-PR#313 rate; close+reopen retry was the workaround).
 ;
 ; This Test runs LAST because BlitzForge's test runner walks `Test`
-; declarations in source order. Its body sweeps everything
-; testRemoveAllOneByOne left behind, bringing the live count to zero
-; before BlitzCC's exit-time pool walker fires.
+; declarations in source order (verified by reading
+; compiler/BlitzForge/src/parser.cpp `case TEST`). Its body sweeps
+; everything testRemoveAllOneByOne left behind, bringing the
+; MockActor count to zero before BlitzCC's exit-time pool walker
+; fires.
+;
+; **Residual flake rate: ~5-7%** (50-run reviewer sample on PR
+; #322). Draining the MockActor pool is a contributor but not the
+; sole driver of the exit-time stack-overflow -- the remaining
+; failures occur with `Active objects: 0` after this sweep. Full
+; elimination requires the BlitzCC runtime pool-walker recursion
+; fix (compiler submodule work, out of scope here). The documented
+; `gh pr close N && reopen` retry remains the workaround for the
+; residual.
 ;
 ; Belt-and-suspenders against future additions: any new Test inserted
 ; between testRemoveAllOneByOne and this teardown still gets swept

--- a/src/Tests/Modules/OnlinePlayerChainTest.bb
+++ b/src/Tests/Modules/OnlinePlayerChainTest.bb
@@ -285,3 +285,41 @@ Test testRemoveAllOneByOne()
 	Assert(MockHead = Null)
 	Assert(ChainLen%() = 0)
 End Test
+
+; ====================================================================
+; Trailing pool sweep -- Phase 2 of the CI flake fix.
+; ====================================================================
+;
+; PR #313 added ResetChain() at the START of every Test. That capped
+; the live MockActor count per-test but left the LAST test's
+; instances pinned in the type pool through process exit --
+; testRemoveAllOneByOne above allocates 3 MockActors and the per-test
+; ResetChain pattern cannot sweep the suite's tail. BlitzCC's
+; process-exit pool walk is recursive in some shapes; 3 trailing
+; instances are enough to trip `Error: Stack overflow! [FAIL]
+; OnlinePlayerChainTest.bb` non-deterministically under CI scheduling
+; (~10-15% post-PR#313 rate; close+reopen retry was the workaround).
+;
+; This Test runs LAST because BlitzForge's test runner walks `Test`
+; declarations in source order. Its body sweeps everything
+; testRemoveAllOneByOne left behind, bringing the live count to zero
+; before BlitzCC's exit-time pool walker fires.
+;
+; Belt-and-suspenders against future additions: any new Test inserted
+; between testRemoveAllOneByOne and this teardown still gets swept
+; because its own start-of-test ResetChain catches its predecessor's
+; leftovers, and this teardown remains the file's last source
+; position.
+Test zzz_TeardownPoolSweep()
+	ResetChain()
+	; Verify the sweep actually drained the pool. If a future change
+	; ever leaves entries behind here, the assert fires and points at
+	; the new leak rather than letting it accumulate into a stack
+	; overflow at process exit.
+	Local entry.MockActor
+	Local count% = 0
+	For entry = Each MockActor
+		count = count + 1
+	Next
+	Assert(count = 0)
+End Test

--- a/src/Tests/Modules/SlaveChainTest.bb
+++ b/src/Tests/Modules/SlaveChainTest.bb
@@ -354,3 +354,23 @@ Test testNumberOfSlavesMatchesChainLengthAfterChurn()
 	MockSlaveUnlink(D) : Assert(L\NumberOfSlaves = ChainLen%(L))
 	Assert(L\NumberOfSlaves = 0)
 End Test
+
+; ====================================================================
+; Trailing pool sweep -- Phase 2 of the CI flake fix. Mirrors
+; OnlinePlayerChainTest's same-named teardown. See PR #313's
+; ResetPool sweep + the Phase 2 fix PR for rationale.
+; ====================================================================
+;
+; The last test above allocates 5 MockActors (L + A/B/C/D) and the
+; per-test ResetPool pattern cannot sweep the suite's tail. Without
+; this teardown those 5 instances persist into process exit where
+; BlitzCC's pool-walker can stack-overflow.
+Test zzz_TeardownPoolSweep()
+	ResetPool()
+	Local entry.MockActor
+	Local count% = 0
+	For entry = Each MockActor
+		count = count + 1
+	Next
+	Assert(count = 0)
+End Test

--- a/src/Tests/Modules/SlaveChainTest.bb
+++ b/src/Tests/Modules/SlaveChainTest.bb
@@ -365,6 +365,12 @@ End Test
 ; per-test ResetPool pattern cannot sweep the suite's tail. Without
 ; this teardown those 5 instances persist into process exit where
 ; BlitzCC's pool-walker can stack-overflow.
+;
+; **Residual flake rate ~5-7%** even with this teardown -- not all
+; of the exit-time overflow is driven by the MockActor pool. Full
+; elimination requires the BlitzCC runtime pool-walker recursion
+; fix (out of scope). See the matching note in
+; OnlinePlayerChainTest.bb's zzz_TeardownPoolSweep.
 Test zzz_TeardownPoolSweep()
 	ResetPool()
 	Local entry.MockActor


### PR DESCRIPTION
## Summary

**Reduces** the residual `OnlinePlayerChainTest.bb` / `SlaveChainTest.bb` CI flake from ~10-15% (post-PR #313) to ~5-7% empirically (per reviewer's 50-run sample, 3 stack-overflow failures still occurred with `Active objects: 0` after the teardown). Does **not** fully eliminate it — the residual driver is not a non-empty MockActor pool, so full closure requires the BlitzCC runtime pool-walker fix (out of scope per CLAUDE.md "Known intermittent flake" note).

The documented `gh pr close N && reopen` retry workaround remains, but should be needed much less often.

## Root cause (what this PR addresses)

PR #313 added `ResetChain()` / `ResetPool()` at the START of every Test. That capped live MockActor count per-test, but the LAST test's instances persist through process exit:
- `OnlinePlayerChainTest.bb::testRemoveAllOneByOne` allocates 3 MockActors.
- `SlaveChainTest.bb::testNumberOfSlavesMatchesChainLengthAfterChurn` allocates 5.

BlitzCC's process-exit pool walker is recursive in some shapes; 3-5 trailing instances are a contributor (not the sole driver) to `Error: Stack overflow!` failures under CI's stack limits.

## What this PR does NOT close

Reviewer's 50-run local sample showed ~5-7% residual stack-overflow at process exit **even with the MockActor pool empty** after the teardown. The remaining contributor is likely string-pool or BBObj used-list depth at exit, not the MockActor count alone. Full elimination requires the BlitzCC runtime pool-walker recursion fix, which is out of scope (compiler submodule work).

## Fix

Add a trailing `Test zzz_TeardownPoolSweep()` to each file. Tests run in source order (verified by reviewer via `compiler/BlitzForge/src/parser.cpp:483-499` — `case TEST` appends to the parse-position stmts sequence), so a last-position Test is always last. Body sweeps the pool via the existing `ResetChain` / `ResetPool` helper and asserts the live count is zero — a regression catcher for any future leak that bypasses the existing per-test sweep.

The `zzz_` name prefix is decorative; end-of-file position is what makes it run last.

## Acceptance

- [x] Both files end with `Test zzz_TeardownPoolSweep()`
- [x] `compile.bat -t` clean
- [x] Full `test.bat`: 27 passed, 0 failed
- [~] 10x local `OnlinePlayerChainTest` passes — passes 10-in-a-row most windows (54% likelihood at 94% per-run rate) but is NOT deterministic. Reviewer's 50-run sample: 47 pass, 3 fail (~94%). Acceptance criterion partially met — significant reduction, not elimination.
- [ ] CI green (in progress)

## Scope

In: the two chain-test files. Out of scope:
- BlitzCC runtime pool-walker recursion fix (compiler submodule — the actual closure path for the residual 5-7%)
- `ItemsTest.bb`'s separate documented flake (different allocation shape)
- `EnableGC` adoption (chain types with self-pointers overflow under GC tracing per `feedback_blitzforge_test_handle_object_gc` memory)