### PR TITLE
fix(iterators): close 4 unsafe For-Each + Delete sites via after-cursor walk

### DIFF
--- a/src/Modules/ClientCombat.bb
+++ b/src/Modules/ClientCombat.bb
@@ -199,7 +199,21 @@ End Function
 ; Updates all floating numbers
 Function UpdateFloatingNumbers()
 
-	For F.FloatingNumber = Each FloatingNumber
+	; After-cursor walk: the lifespan-expired branch calls FreeEntity +
+	; Delete F mid-iteration. The pre-fix `For F = Each FloatingNumber /
+	; Next` cursor advanced via the deleted instance's next pointer on
+	; the following step, so two FloatingNumbers expiring in the same
+	; tick (very common in group PvP -- each hit creates one and they
+	; all hit 50.0 lifespan together) would either skip the next entry
+	; or deref a freed Type instance. Silent client-side entity-handle
+	; leak + possible UB. See CLAUDE.md "Iterator-during-iteration
+	; hazards" for the three established fix shapes; this is the
+	; after-cursor walk template (Scripting.bb's PausedScript loop
+	; is the canonical example).
+	Local F.FloatingNumber = First FloatingNumber
+	Local FNext.FloatingNumber = Null
+	While F <> Null
+		FNext = After F
 		; Move
 		TranslateEntity F\EN, 0, 0.1 * Delta#, 0
 		PointEntity F\EN, Cam
@@ -210,6 +224,7 @@ Function UpdateFloatingNumbers()
 			FreeEntity F\EN
 			Delete F
 		EndIf
-	Next
+		F = FNext
+	Wend
 
 End Function

--- a/src/Modules/F-UI.bb
+++ b/src/Modules/F-UI.bb
@@ -1693,10 +1693,17 @@ Function FUI_CustomOpenDialog( title$ = "", initdir$ = "", filter$ = "", BackHac
 	DlgDir$ = initdir$
 	DlgFile$ = ""
 	Repeat
-		
+
 		FUI_Update
 
-		For e.Event = Each Event
+		; After-cursor walk: the body unconditionally Delete's e. Same
+		; multi-event-tick hazard as the MessageBox event-pump above
+		; (CLAUDE.md "Iterator-during-iteration hazards"). PR #330
+		; reviewer caught this sibling that the initial pass missed.
+		Local e.Event = First Event
+		Local eNext.Event = Null
+		While e <> Null
+			eNext = After e
 			Select e\EventID
 				;Window Events
 				Case win
@@ -1812,19 +1819,20 @@ Function FUI_CustomOpenDialog( title$ = "", initdir$ = "", filter$ = "", BackHac
 						EndIf
 					EndIf
 			End Select
-			
+
 			;Remove event from queue
 			Delete e
-		Next
+			e = eNext
+		Wend
 
 		RenderWorld
 		Flip
 
 ;		FUI_SetCursor app\Win32Mouse
-		
+
 	Until DlgClose = True
 	DlgClose = False
-	
+
 ;	FUI_SetCursor IDCArrow
 	
 	FUI_DeleteGadget win
@@ -1890,10 +1898,17 @@ Function FUI_CustomSaveDialog( title$ = "", initdir$ = "", filter$ = "", index =
 	DlgDir$ = initdir$
 	DlgFile$ = ""
 	Repeat
-		
+
 		FUI_Update
-		
-		For e.Event = Each Event
+
+		; After-cursor walk: same multi-event-tick hazard as the
+		; MessageBox / FUI_CustomOpenDialog event-pumps above. PR #330
+		; reviewer caught this third sibling that the initial pass
+		; missed. See CLAUDE.md "Iterator-during-iteration hazards".
+		Local e.Event = First Event
+		Local eNext.Event = Null
+		While e <> Null
+			eNext = After e
 			Select e\EventID
 				;Window Events
 				Case win
@@ -1945,7 +1960,7 @@ Function FUI_CustomSaveDialog( title$ = "", initdir$ = "", filter$ = "", index =
 						FILTER_CURRENT_INDEX = Int( e\EventData ) - 1
 						FUI_GetFiles lst, DlgDir$
 					EndIf
-					
+
 				Case ok
 					app\currentFile = DlgDir$ + DlgFile$
 					DlgResult = True
@@ -1954,16 +1969,17 @@ Function FUI_CustomSaveDialog( title$ = "", initdir$ = "", filter$ = "", index =
 					DlgResult = False
 					DlgClose = True
 			End Select
-			
+
 			;Remove event from queue
 			Delete e
-		Next
-		
+			e = eNext
+		Wend
+
 		RenderWorld
 		Flip
-		
+
 ;		FUI_SetCursor app\Win32Mouse
-		
+
 	Until DlgClose = True
 	DlgClose = False
 	

--- a/src/Modules/F-UI.bb
+++ b/src/Modules/F-UI.bb
@@ -1550,8 +1550,19 @@ Function FUI_CustomMessageBox( msg$, title$="", style=0 )
 	Repeat
 
 		FUI_Update
-		
-		For e.Event = Each Event
+
+		; After-cursor walk: the body unconditionally Delete's e after
+		; the Select Case. Pre-fix `For e = Each Event / ... / Next`
+		; advanced the cursor via the deleted instance's next pointer,
+		; so a multi-event tick (window-resize + button-click delivered
+		; in the same frame) lost the second event -- modal hangs on
+		; missed input. Sibling Architect_Gui_Shell_Fui.bb's event loop
+		; already uses this after-cursor shape (PR #76 / #247). See
+		; CLAUDE.md "Iterator-during-iteration hazards".
+		Local e.Event = First Event
+		Local eNext.Event = Null
+		While e <> Null
+			eNext = After e
 			Select e\EventID
 				;Window Events
 				Case win
@@ -1608,10 +1619,11 @@ Function FUI_CustomMessageBox( msg$, title$="", style=0 )
 					EndIf
 					DlgClose = True
 			End Select
-			
+
 			;Remove event from queue
 			Delete e
-		Next
+			e = eNext
+		Wend
 		
 		RenderWorld
 		Flip
@@ -24022,14 +24034,25 @@ Function FUI_FreeEntity( mesh.BBEntity )
 End Function
 
 Function FUI_FreeAllEntities( ID=2 )
-	
-	For m.Mesh = Each Mesh
+
+	; After-cursor walk: selective Delete with no Exit -- multiple
+	; meshes match the filter (ID=0 matches all; ID=2 default matches
+	; every F-UI-owned mesh) and the deleted instance's next pointer
+	; was the iterator's hop target. The sibling FUI_FreeEntity at
+	; ~line 24013 is safe because it has `Exit` after the Delete; this
+	; bulk-free path was the only multi-match variant left unfixed.
+	; See CLAUDE.md "Iterator-during-iteration hazards".
+	Local m.Mesh = First Mesh
+	Local mNext.Mesh = Null
+	While m <> Null
+		mNext = After m
 		If m\ID = ID Or ID = 0
 			FreeEntity m\Mesh
 			Delete m
 		EndIf
-	Next
-	
+		m = mNext
+	Wend
+
 End Function
 
 Function FUI_WireFrame.BBEntity( mesh.BBEntity, Value=True )

--- a/src/Modules/MySQL.bb
+++ b/src/Modules/MySQL.bb
@@ -64,14 +64,27 @@ Global BBThreadCount = 0
 
 ; Update all BB Threads
 Function My_UpdateThreads()
-	
-	; Loop through the threads	
-	For T.BBThread = Each BBThread
+
+	; After-cursor walk: the complete-thread branch calls Delete T
+	; mid-iteration. Pre-fix the `For T = Each BBThread / Next` cursor
+	; advanced through the deleted instance's next pointer, so multiple
+	; threads completing in the same tick would skip / deref freed Type
+	; instances.
+	;
+	; This function is currently DORMANT -- its only callsite at
+	; Server.bb:533 is commented out (the MySQL-async path is disabled).
+	; The fix lands as doctrinal hygiene so the bug doesn't re-arm if
+	; someone uncomments the call. Matches the post-PR-#74 Track-E
+	; rewrite intent. See CLAUDE.md "Iterator-during-iteration hazards".
+	Local T.BBThread = First BBThread
+	Local TNext.BBThread = Null
+	While T <> Null
+		TNext = After T
 		If BBThreadComplete(T\Hand) Then
-			
+
 			; Update all the new info!
 			A.ActorInstance = Object.ActorInstance(T\Actor)
-			
+
 			A\My_ID					= BBGetInt(T\Cont,0)
 			A\Attribute_ID			= BBGetInt(T\Cont,1)
 			A\Inventory\My_ID 		= BBGetInt(T\Cont,2)
@@ -81,34 +94,35 @@ Function My_UpdateThreads()
 			A\Script_ID				= BBGetInt(T\Cont,6)
 			A\Memorised_ID			= BBGetInt(T\Cont,7)
 			A\Resistance_ID			= BBGetInt(T\Cont,8)
-			
+
 			; If its a PC
 			If T\isslave = False Then
-			
+
 				; Get their data
 				Q.Questlog = Object.QuestLog(T\Quest)
 				C.ActionBarData = Object.ActionBarData(T\Action)
-				
+
 				Q\My_ID = BBGetInt(T\Cont,8)
 				C\My_ID = BBGetInt(T\Cont,9)
-				
+
 				; Update the client (slaves are stored when they leave,
 				; 	all Human characters will be at this point)
 				RCE_Send(Host, T\MsgID, P_CreateCharacter, "Y", True)
-				
+
 			End If
-			
+
 			; Write to the log
 			WriteLog(MainLog,"SQL Thread Ended: "+T\Hand , True, True)
-			
+
 			; Free Thread Instance information
 			BBFreeThread(T\Hand)
 			Delete T
 			; Test code to correctly report current threads
 			BBThreadCount = BBThreadCount - 1
 		End If
-	Next
-	
+		T = TNext
+	Wend
+
 End Function
 			
 			

--- a/src/Tests/Modules/IteratorAfterCursorTest.bb
+++ b/src/Tests/Modules/IteratorAfterCursorTest.bb
@@ -1,0 +1,134 @@
+Strict
+
+; Tests pinning the "After-cursor walk" pattern from CLAUDE.md
+; "Iterator-during-iteration hazards (Blitz3D `For Each` + `Delete`)".
+;
+; The four production sites this PR's sibling commit closes:
+;   1. ClientCombat.bb::UpdateFloatingNumbers
+;   2. F-UI.bb::MessageBox event-pump
+;   3. F-UI.bb::FUI_FreeAllEntities
+;   4. MySQL.bb::My_UpdateThreads (dormant)
+;
+; The test pins the *pattern* against a Mock Type pool, asserting that
+; the after-cursor walk visits every non-deleted element exactly once
+; when the body Delete's some elements.
+
+Type MockItem
+	Field ID%
+End Type
+
+; Drain the MockItem pool. For-Each + Delete-current is safe in
+; BlitzForge per the verified basic.cpp ref-counting walk (see
+; feedback_blitzforge_enablegc_requires_strict memory).
+Function ResetPool()
+	Local entry.MockItem
+	For entry = Each MockItem
+		Delete entry
+	Next
+End Function
+
+; ====================================================================
+; The after-cursor walk template from CLAUDE.md. Returns survived
+; count via direct iteration -- avoids a second For-Each (which
+; BlitzCC's runtime walker stack-overflows on in this test
+; environment).
+; ====================================================================
+Function SweepAfterCursor%(divisor%)
+	Local m.MockItem = First MockItem
+	Local mNext.MockItem = Null
+	Local survived% = 0
+	While m <> Null
+		mNext = After m
+		; Guard the Mod with a nested If -- BlitzForge `And` is NOT
+		; short-circuit (per feedback_blitzforge_and_non_short_circuit
+		; memory), so `divisor > 0 And (m\ID Mod divisor) = 0` would
+		; evaluate `Mod 0` and crash when divisor = 0.
+		Local shouldDelete% = False
+		If divisor > 0
+			If (m\ID Mod divisor) = 0 Then shouldDelete = True
+		EndIf
+		If shouldDelete
+			Delete m
+		Else
+			survived = survived + 1
+		EndIf
+		m = mNext
+	Wend
+	Return survived
+End Function
+
+; ====================================================================
+; Basic correctness: after-cursor walk visits every item once.
+; Asserts are on the SweepAfterCursor return value alone (an independent
+; counter); we don't re-walk the pool with a second For-Each because
+; BlitzCC's runtime walker is fragile in this multi-test environment.
+; ====================================================================
+
+Test testAfterCursorWalkVisitsAllItems()
+	ResetPool()
+	Local a.MockItem = New MockItem() : a\ID = 0
+	Local b.MockItem = New MockItem() : b\ID = 1
+	Local c.MockItem = New MockItem() : c\ID = 2
+	Local d.MockItem = New MockItem() : d\ID = 3
+	Local e.MockItem = New MockItem() : e\ID = 4
+	; divisor=0 = no deletes; all 5 items survive the sweep.
+	Assert(SweepAfterCursor%(0) = 5)
+End Test
+
+Test testAfterCursorWalkDeletesEveryItem()
+	ResetPool()
+	Local a.MockItem = New MockItem() : a\ID = 0
+	Local b.MockItem = New MockItem() : b\ID = 1
+	Local c.MockItem = New MockItem() : c\ID = 2
+	; divisor=1 = every ID divisible by 1 = all 3 deleted.
+	Assert(SweepAfterCursor%(1) = 0)
+End Test
+
+Test testAfterCursorWalkDeletesAlternateItems()
+	ResetPool()
+	Local a.MockItem = New MockItem() : a\ID = 0
+	Local b.MockItem = New MockItem() : b\ID = 1
+	Local c.MockItem = New MockItem() : c\ID = 2
+	Local d.MockItem = New MockItem() : d\ID = 3
+	Local e.MockItem = New MockItem() : e\ID = 4
+	Local f.MockItem = New MockItem() : f\ID = 5
+	; divisor=2 = IDs 0/2/4 deleted; IDs 1/3/5 survive.
+	Assert(SweepAfterCursor%(2) = 3)
+End Test
+
+; ====================================================================
+; Empty pool boundary -- the after-cursor's `m = First MockItem`
+; correctly returns Null, the While condition is False, the function
+; returns 0.
+; ====================================================================
+
+Test testAfterCursorWalkOnEmptyPool()
+	ResetPool()
+	Assert(SweepAfterCursor%(1) = 0)
+End Test
+
+; ====================================================================
+; Single-item boundary -- After-cursor correctly captures Null as
+; the next pointer and terminates after one iteration.
+; ====================================================================
+
+Test testAfterCursorWalkOnSingleItemKept()
+	ResetPool()
+	Local a.MockItem = New MockItem() : a\ID = 0
+	Assert(SweepAfterCursor%(0) = 1)
+End Test
+
+Test testAfterCursorWalkOnSingleItemDeleted()
+	ResetPool()
+	Local a.MockItem = New MockItem() : a\ID = 0
+	Assert(SweepAfterCursor%(1) = 0)
+End Test
+
+; ====================================================================
+; Trailing teardown -- drains the pool before process exit (per
+; feedback_chain_test_pool_leak memory).
+; ====================================================================
+
+Test zzz_TeardownPoolSweep()
+	ResetPool()
+End Test


### PR DESCRIPTION
## Summary

Closes the iterator-during-iteration hazard at 4 sites that escaped prior sweeps (PRs #74/#76/#246/#247/#254). Each had the unsafe `For X = Each Y / ... / Delete X / Next` shape with no `Exit` and no `After`-cursor capture; multi-delete-in-same-tick scenarios skip the next entry or dereference freed memory.

## Sites closed (with established CLAUDE.md "after-cursor walk" template)

1. **`ClientCombat.bb::UpdateFloatingNumbers`** — per-frame client-side combat overlay. Floating damage/heal numbers; lifespan-expired branch frees the entity + Deletes F. Triggers on multi-hit ticks (group PvP, AOE spells); silent client-side entity-handle leak.
2. **`F-UI.bb::MessageBox` event-pump (~line 1554)** — modal-dialog event loop. Multi-event ticks (window resize + button click delivered together) lose the second event and hang the modal. F-UI is `Include`d by Server, GUE, Gubbin Tool.
3. **`F-UI.bb::FUI_FreeAllEntities` (~line 24024)** — bulk-free helper, selective Delete with no Exit. ID=0 default matches every F-UI-owned mesh; multi-match walks through freed instances.
4. **`MySQL.bb::My_UpdateThreads` (line 66)** — DORMANT (commented out caller at `Server.bb:533`). Fix lands as doctrinal hygiene so the bug doesn't re-arm if the MySQL-async path is uncommented.

Each site carries an audit comment explaining the pre-fix bug + the fix shape + cross-reference to CLAUDE.md.

## Regression test

`src/Tests/Modules/IteratorAfterCursorTest.bb` (new, Strict, 7 test blocks). Pins the after-cursor walk pattern against a `MockItem` pool: keeps-all-N, deletes-all-N, deletes-alternates, empty-pool boundary, single-item-kept, single-item-deleted, trailing teardown.

Hit the BlitzForge non-short-circuit `And` trap during test authoring (`divisor > 0 And (m\ID Mod divisor) = 0` evaluates `Mod 0` even when divisor=0; runtime stack overflow). Restructured the test's predicate with a nested If; documented in the test header. Production sites don't use this Mod pattern.

## Acceptance

- [x] 4 production sites use the after-cursor walk shape (`First X` + `After X` + `While X <> Null`)
- [x] Each site has an audit comment referencing CLAUDE.md "Iterator-during-iteration hazards"
- [x] `IteratorAfterCursorTest.bb` passes (7/7)
- [x] Full `compile.bat` clean (Tools rebuild)
- [x] `test.bat`: 32 passed (was 31), 0 failed
- [ ] CI green

## Scope

In: the 4 sites + 1 new test. Out: Delete-in-loop sites that already use `Exit` after Delete (verified safe at Logging.bb:162, ClientNet.bb:505 / :1314, RCTrees.bb:481, ShadowsSimple.bb:493, ScriptingCommands.bb:1467). Out: editor-only `_gui_shell_fui.bb` Event loops. Out: `inc_csg.bb` (CSG editor scope). Out: `ShadowsMultiple.bb::FreeShadows` (one-shot teardown).