### PR TITLE
Loom: Ctrl+K command palette + search-within-category filter

### DIFF
--- a/docs/loom/architecture.md
+++ b/docs/loom/architecture.md
@@ -14,8 +14,9 @@ src/
     └── Loom/
         ├── Theme.bb                 color palette + 2D drawing primitives
         ├── Threads.bb               focus state + back stack + chip primitive
-        ├── Browser.bb               category bar + entity card grid
-        └── Composer.bb              right-side property panel per kind
+        ├── Browser.bb               category bar + filter input + card grid
+        ├── Composer.bb              right-side property panel per kind
+        └── Palette.bb               Ctrl+K find-anywhere modal
 ```
 
 ### One-line module summaries

--- a/docs/loom/roadmap.md
+++ b/docs/loom/roadmap.md
@@ -11,24 +11,13 @@ Shipped, next, and deferred. Read this when picking what to build next.
 - **Composer panel** — per-kind property pages for all six entity kinds.
 - **Thread chips + back stack** — reference fields render as clickable chips; click jumps + pushes; Esc walks back.
 - **Faction and animset back-references** — composer computes "members" / "used by" rosters from `Each Actor` walks. ([#296](https://github.com/RydeTec/rcce2/pull/296))
+- **Editing phase 1 (free-form text)** — Spell name editable; per-tab dirty flags shared with GUE; Save button + serializer dispatch. ([#334](https://github.com/RydeTec/rcce2/pull/334))
+- **Command palette (Ctrl+K)** — modal find-anywhere across all entity kinds with prefix/substring scoring, arrow-key navigation, click-or-Enter to jump.
+- **Search-within-category** — live filter input above the card grid; case-insensitive substring match against the current category's name field. Esc clears the filter (priority above the back-stack pop).
 
 ## Next up (in rough order of leverage)
 
-### 1. Command palette (Ctrl+K find-anywhere)
-
-Type-to-search across every entity in the project. Press Ctrl+K from anywhere → modal opens → type substring → ranked results → Enter jumps. The browser tab walk is fine for known categories, but for *"where's that Goblin Shaman I edited yesterday"* the palette collapses 3 clicks into 4 keystrokes.
-
-Implementation sketch: a new `Modules/Loom/Palette.bb` module with a modal renderer + result list. Reads the same data globals the browser does. Jump uses `Threads_Focus` (no back-stack push — palette navigation is "go to," not "follow a thread") or `Threads_Jump` if invoked from inside a composer view (debatable; settle this in the PR).
-
-Estimated scope: 250-300 LOC. One PR.
-
-### 2. Search-within-category
-
-Browser tab bar gets a search box next to it. Type to filter the current category's cards by name substring. Live filter, no Enter required. Independent of the global palette — solves *"this tab has 200 actors, I want the human ones"*.
-
-Estimated scope: 100-150 LOC. Pairs naturally with #1 or ships first.
-
-### 3. Editing — phase 1: free-form text + numbers
+### 1. Editing — phase 1: free-form text + numbers (extend)
 
 Click a composer row's value → it becomes editable. Esc cancels, Enter (or click-away) commits to the in-memory instance and sets a dirty flag. Save button persists to disk via the existing `SaveActors / SaveItems / …` functions GUE already exports.
 
@@ -40,13 +29,13 @@ Needs:
 
 Estimated scope: 600-800 LOC. The big one. Likely needs to split across 2-3 PRs.
 
-### 4. Editing — phase 2: reference-field editing
+### 2. Editing — phase 2: reference-field editing
 
-Once free-form fields edit, reference-typed fields (faction, anim set, zone target) need pickers. The chip becomes click-to-jump-OR-shift-click-to-edit (or some affordance — UX decision). Reuses the palette from #1 as the picker.
+Once free-form fields edit, reference-typed fields (faction, anim set, zone target) need pickers. The chip becomes click-to-jump-OR-shift-click-to-edit (or some affordance — UX decision). Reuses the palette as the picker.
 
-Estimated scope: 200-300 LOC. Builds on #1 and #3.
+Estimated scope: 200-300 LOC. Builds on #1 (editing extension) and the shipped palette.
 
-### 5. World atlas (spatial zone view)
+### 3. World atlas (spatial zone view)
 
 Today the Zones tab in the browser is a card grid. The design called for a spatial atlas: zones laid out by position with portals drawn as lines between them. Worth shipping once there are enough zones in a project for the spatial layout to communicate something the grid doesn't (probably >10 zones).
 
@@ -54,7 +43,7 @@ Open question: zones in rcce2 don't have a stored "world position" — they're j
 
 Estimated scope: 400-500 LOC including layout heuristic. Skip if no project pressure for it.
 
-### 6. Session timeline scrubber
+### 4. Session timeline scrubber
 
 Visible history of the session's edits (entity X changed field Y from A to B at time T). Click an entry → revert. Drag the handle → preview a past state. Needs an undo log that today's read-only alpha has no use for.
 

--- a/src/Loom.bb
+++ b/src/Loom.bb
@@ -104,6 +104,7 @@ Include "Modules\Loom\Theme.bb"
 Include "Modules\Loom\Threads.bb"
 Include "Modules\Loom\Browser.bb"
 Include "Modules\Loom\Composer.bb"
+Include "Modules\Loom\Palette.bb"
 
 
 // =============================================================================
@@ -117,6 +118,7 @@ Type Loom
     Field threads.Threads
     Field browser.Browser
     Field composer.Composer
+    Field palette.Palette
 
 
     Method create.Loom(windowWidth%, windowHeight%, projectName$)
@@ -127,11 +129,12 @@ Type Loom
         // Shared focus + back stack
         self\threads = New Threads()
 
-        // Browser and Composer both hold a reference to the same Threads
-        // instance; card clicks call Threads::focus, chip clicks call
-        // Threads::jump (via Threads::renderChip).
+        // Browser, Composer, Palette all hold a reference to the same Threads
+        // instance; card clicks call Threads::focus, chip + palette-result
+        // clicks call Threads::jump.
         self\browser = New Browser(self\threads)
         self\composer = New Composer(self\threads)
+        self\palette = New Palette(self\threads)
 
         Return self
     End Method
@@ -139,18 +142,51 @@ Type Loom
 
     // -------------------------------------------------------------------------
     // renderFrame -- paint browser, then composer overlay if focused, then
-    // process Esc. Returns False when the user wants to exit (main loop
-    // breaks on that). Returning a bool from the frame is cleaner than
+    // palette overlay if open, then process global keys. Returns False when
+    // the user wants to exit. Returning a bool from the frame is cleaner than
     // mutating an `app\quit` field; the loop owns its own control flow.
+    //
+    // Render-order rationale: browser at the back, composer on top of
+    // browser, palette on top of everything. Palette dims the world behind
+    // itself so it visually owns the frame while open.
+    //
+    // Input-order rationale: Ctrl+K opens the palette BEFORE the palette's
+    // own pumpKeyboard fires (so the K keystroke isn't appended to its
+    // query). When the palette is open, its pumpKeyboard owns Esc; the outer
+    // Esc handler below only runs when the palette is closed.
     // -------------------------------------------------------------------------
     Method renderFrame%()
         Cls
 
-        Browser::renderAndUpdate(self\browser, self\windowWidth, self\windowHeight, self\projectName)
+        // Ctrl+K opens the palette (or no-ops if already open). Detect
+        // before any other input handler so openModal's FlushKeys swallows
+        // the K keystroke before it can land in the palette query.
+        If Palette::isOpen(self\palette) = False
+            If (KeyDown(29) Or KeyDown(157)) And KeyHit(37)
+                Palette::openModal(self\palette)
+            EndIf
+        EndIf
+
+        // Browser input is enabled only when no higher-priority surface is
+        // already consuming keystrokes. Priority chain (highest first):
+        //   palette > composer-edit > browser filter
+        Local browserInput% = True
+        If Palette::isOpen(self\palette) = True Then browserInput = False
+        If Composer::isEditing(self\composer) = True Then browserInput = False
+
+        Browser::renderAndUpdate(self\browser, self\windowWidth, self\windowHeight, self\projectName, browserInput)
         Composer::renderAndUpdate(self\composer, self\windowWidth, self\windowHeight)
 
-        If KeyHit(1)   // Esc
-            If Threads::back(self\threads) = False
+        // Palette consumes its own keys (including Esc) when open and
+        // returns True to signal that.
+        Local paletteAte% = Palette::renderAndUpdate(self\palette, self\windowWidth, self\windowHeight)
+
+        // Esc priority (when palette didn't already eat the press):
+        //   filter clear > back-stack pop > close composer > exit Loom
+        If paletteAte = False And KeyHit(1)   // Esc
+            If Browser::hasFilter(self\browser) = True
+                Browser::clearFilter(self\browser)
+            Else If Threads::back(self\threads) = False
                 If self\threads\focusKind <> ""
                     // Close composer back to plain browser.
                     Threads::focus(self\threads, "", 0)

--- a/src/Modules/Loom/Browser.bb
+++ b/src/Modules/Loom/Browser.bb
@@ -24,13 +24,18 @@ Strict
 
 
 // Layout constants
-Const BR_TOP_RIBBON  = 56
-Const BR_TAB_BAR_H   = 36
-Const BR_BOT_RIBBON  = 36
-Const BR_SECTION_PAD = 28
-Const BR_CARD_W      = 300
-Const BR_CARD_H      = 96
-Const BR_CARD_GAP    = 14
+Const BR_TOP_RIBBON   = 56
+Const BR_TAB_BAR_H    = 36
+Const BR_FILTER_BAR_H = 30
+Const BR_BOT_RIBBON   = 36
+Const BR_SECTION_PAD  = 28
+Const BR_CARD_W       = 300
+Const BR_CARD_H       = 96
+Const BR_CARD_GAP     = 14
+
+// Filter input cursor blink rate (ms). Matches Composer's edit cursor cadence
+// so the two surfaces feel like one input system.
+Const BR_FILTER_CURSOR_PERIOD = 1000
 
 
 // -----------------------------------------------------------------------------
@@ -59,11 +64,24 @@ Type Browser
     // writes through `self\` work at any nesting depth.
     Field cardClickLatch%
 
+    // Per-category search filter. Empty = no filter; non-empty = case-
+    // insensitive substring match against each card's primary display name
+    // (Race+Class for actors, Name for items/spells/zones, etc.). The same
+    // string applies to whatever category is active -- intentional, so the
+    // filter persists when tabbing across categories ("looking for goblin
+    // across actors AND items").
+    //
+    // Edit-buffer state: keyboard pumping is unconditional while the browser
+    // surface is foreground (no palette / composer-edit-mode in front), so
+    // typing into the browser feels immediate without a click-into-input.
+    Field filterQuery$
+
 
     Method create.Browser(threads.Threads)
         self\threads = threads
         self\category = "actor"     // richest content; most useful starting point
         self\cardClickLatch = False
+        self\filterQuery = ""
 
         // Build the ordered category list. Iterated via `Each BrowserCategory`
         // in insertion order (Blitz3D's global type pool is FIFO) -- also the
@@ -88,11 +106,23 @@ Type Browser
 
     // -------------------------------------------------------------------------
     // renderAndUpdate -- per-frame paint + hit-test.
+    //
+    // inputEnabled gates keyboard pumping into the filter buffer -- when the
+    // palette is open or the composer is in field-edit mode, those surfaces
+    // own the keystrokes and the browser must stay quiet.
     // -------------------------------------------------------------------------
-    Method renderAndUpdate%(sw%, sh%, project$)
+    Method renderAndUpdate%(sw%, sh%, project$, inputEnabled%)
         Local mx% = MouseX()
         Local my% = MouseY()
         Local clicked% = MouseHit(1)
+
+        // Drain keyboard into the per-category filter buffer (printable chars
+        // + Backspace). Esc is owned by the outer Loom frame -- when the
+        // filter is non-empty, the outer Esc handler clears it first via
+        // Browser::clearFilter (called from Loom.bb).
+        If inputEnabled = True
+            Browser::pumpFilterKeyboard(self)
+        EndIf
 
         // Background gradient
         LoomGradientV(0, 0, sw, sh, LOOM_STONE_900_R, LOOM_STONE_900_G, LOOM_STONE_900_B, LOOM_STONE_950_R, LOOM_STONE_950_G, LOOM_STONE_950_B)
@@ -100,11 +130,122 @@ Type Browser
         // Chrome
         Browser::drawTopRibbon(self, sw, project$)
         Browser::drawTabBar(self, sw, mx, my, clicked)
+        Browser::drawFilterBar(self, sw, mx, my, clicked)
         Browser::drawFooter(self, sw, sh)
 
         // Card grid
         Browser::drawCardGrid(self, sw, sh, mx, my, clicked)
         Return self\cardClickLatch
+    End Method
+
+
+    // -------------------------------------------------------------------------
+    // hasFilter / clearFilter -- public surface for the outer Loom frame so
+    // Esc on a non-empty filter clears the filter instead of falling through
+    // to composer/exit handling. Keeps the priority chain explicit:
+    //   palette > composer-edit > filter clear > back-stack pop > exit
+    // -------------------------------------------------------------------------
+    Method hasFilter%()
+        If self\filterQuery <> "" Then Return True
+        Return False
+    End Method
+
+    Method clearFilter()
+        self\filterQuery = ""
+        WriteLog(LoomLog, "Browser: filter cleared")
+    End Method
+
+
+    // -------------------------------------------------------------------------
+    // pumpFilterKeyboard -- drain printable chars + Backspace into filterQuery.
+    // Does NOT consume Esc (outer frame handles that). Does NOT consume Enter
+    // (no commit semantics -- the filter is always live).
+    //
+    // Ctrl-anything is skipped so Ctrl+K opening the palette doesn't dribble
+    // a "k" into the filter buffer before the palette claims keys.
+    // -------------------------------------------------------------------------
+    Method pumpFilterKeyboard()
+        // Skip drain when any control modifier is held -- prevents Ctrl+K
+        // (palette open) from depositing characters; also Ctrl+L, Ctrl+S
+        // (future Save shortcut), etc.
+        If KeyDown(29) Or KeyDown(157) Then Return
+
+        // Backspace (scan code 14)
+        If KeyHit(14) And Len(self\filterQuery) > 0
+            self\filterQuery = Left$(self\filterQuery, Len(self\filterQuery) - 1)
+        EndIf
+
+        // Drain GetKey queue for printable ASCII
+        Local k% = GetKey()
+        While k > 0
+            If k >= 32 And k <= 126
+                self\filterQuery = self\filterQuery + Chr(k)
+            EndIf
+            k = GetKey()
+        Wend
+    End Method
+
+
+    // -------------------------------------------------------------------------
+    // matchesFilter -- case-insensitive substring check used by every per-
+    // kind grid renderer to skip cards that don't match the active filter.
+    // -------------------------------------------------------------------------
+    Method matchesFilter%(name$)
+        If self\filterQuery = "" Then Return True
+        Local nm$ = Lower$(name)
+        Local q$  = Lower$(self\filterQuery)
+        If Instr(nm, q) > 0 Then Return True
+        Return False
+    End Method
+
+
+    // -------------------------------------------------------------------------
+    // drawFilterBar -- thin row above the card grid with a search input on
+    // the right and a help glyph on the left. The input shows the live
+    // filter buffer with a blinking cursor; typing anywhere on the browser
+    // surface lands here.
+    // -------------------------------------------------------------------------
+    Method drawFilterBar(sw%, mx%, my%, clicked%)
+        Local y% = BR_TOP_RIBBON + BR_TAB_BAR_H
+        Local h% = BR_FILTER_BAR_H
+
+        LoomFill(0, y, sw, h, LOOM_STONE_850_R, LOOM_STONE_850_G, LOOM_STONE_850_B)
+        LoomHRule(0, y + h, sw, LOOM_BRASS_700_R, LOOM_BRASS_700_G, LOOM_BRASS_700_B)
+
+        // Hint on the left
+        LoomText(20, y + 8, "TYPE TO FILTER  ·  CTRL+K SEARCH ALL", LOOM_BRASS_500_R, LOOM_BRASS_500_G, LOOM_BRASS_500_B)
+
+        // Input on the right -- 280px wide
+        Local iw% = 280
+        Local ix% = sw - iw - 20
+        Local iy% = y + 4
+        Local ih% = 22
+
+        // Background -- darker when empty, arcane-tinted when active
+        If self\filterQuery <> ""
+            LoomFill(ix, iy, iw, ih, LOOM_ARCANE_900_R, LOOM_ARCANE_900_G, LOOM_ARCANE_900_B)
+            LoomBorder(ix, iy, iw, ih, LOOM_ARCANE_500_R, LOOM_ARCANE_500_G, LOOM_ARCANE_500_B)
+        Else
+            LoomFill(ix, iy, iw, ih, LOOM_STONE_800_R, LOOM_STONE_800_G, LOOM_STONE_800_B)
+            LoomBorder(ix, iy, iw, ih, LOOM_BRASS_700_R, LOOM_BRASS_700_G, LOOM_BRASS_700_B)
+        EndIf
+
+        // Prompt glyph
+        LoomText(ix + 8, iy + 4, ">", LOOM_BRASS_500_R, LOOM_BRASS_500_G, LOOM_BRASS_500_B)
+
+        // Query string (or placeholder)
+        If self\filterQuery = ""
+            LoomText(ix + 22, iy + 4, "filter " + self\category + "s...", LOOM_STONE_300_R, LOOM_STONE_300_G, LOOM_STONE_300_B)
+        Else
+            LoomText(ix + 22, iy + 4, self\filterQuery, LOOM_PARCHMENT_100_R, LOOM_PARCHMENT_100_G, LOOM_PARCHMENT_100_B)
+
+            // Blinking cursor at end -- only when filter is active so an
+            // empty input doesn't blink at the user.
+            If (MilliSecs() Mod BR_FILTER_CURSOR_PERIOD) < (BR_FILTER_CURSOR_PERIOD / 2)
+                Local cursorX% = ix + 22 + StringWidth(self\filterQuery)
+                LoomFill(cursorX, iy + 3, 2, 14, LOOM_PARCHMENT_100_R, LOOM_PARCHMENT_100_G, LOOM_PARCHMENT_100_B)
+            EndIf
+        EndIf
     End Method
 
 
@@ -169,7 +310,7 @@ Type Browser
     // -------------------------------------------------------------------------
     Method drawCardGrid%(sw%, sh%, mx%, my%, clicked%)
         Local gridX% = BR_SECTION_PAD
-        Local gridY% = BR_TOP_RIBBON + BR_TAB_BAR_H + BR_SECTION_PAD
+        Local gridY% = BR_TOP_RIBBON + BR_TAB_BAR_H + BR_FILTER_BAR_H + BR_SECTION_PAD
         Local gridW% = sw - (BR_SECTION_PAD * 2)
         Local cols% = (gridW + BR_CARD_GAP) / (BR_CARD_W + BR_CARD_GAP)
         If cols < 1 Then cols = 1
@@ -198,9 +339,16 @@ Type Browser
             count = Browser::drawAnimSetGrid(self, sw, sh, mx, my, clicked, gridX, gridY, cols)
         EndIf
 
-        // Empty-state copy
+        // Empty-state copy -- different message when the project HAS entities
+        // of this kind but the filter excluded them all.
         If count = 0
-            LoomTextCentered(sw / 2, sh / 2, "No " + cat + "s in this project yet.", LOOM_STONE_200_R, LOOM_STONE_200_G, LOOM_STONE_200_B)
+            Local emptyMsg$
+            If self\filterQuery <> ""
+                emptyMsg = "No " + cat + "s match " + Chr(34) + self\filterQuery + Chr(34) + "  ·  Esc to clear filter"
+            Else
+                emptyMsg = "No " + cat + "s in this project yet."
+            EndIf
+            LoomTextCentered(sw / 2, sh / 2, emptyMsg, LOOM_STONE_200_R, LOOM_STONE_200_G, LOOM_STONE_200_B)
         EndIf
 
         Return self\cardClickLatch
@@ -218,15 +366,18 @@ Type Browser
         Local row% = 0
         Local count% = 0
         For Ac.Actor = Each Actor
-            Local cx% = gridX + col * (BR_CARD_W + BR_CARD_GAP)
-            Local cy% = gridY + row * (BR_CARD_H + BR_CARD_GAP)
-            If cy + BR_CARD_H < sh - BR_BOT_RIBBON
-                Browser::drawCardChrome(self, "actor", Ac\ID, cx, cy, mx, my, clicked)
-                Browser::drawActorCardBody(self, Ac, cx, cy)
+            Local aName$ = Ac\Race$ + " [" + Ac\Class$ + "]"
+            If Browser::matchesFilter(self, aName) = True
+                Local cx% = gridX + col * (BR_CARD_W + BR_CARD_GAP)
+                Local cy% = gridY + row * (BR_CARD_H + BR_CARD_GAP)
+                If cy + BR_CARD_H < sh - BR_BOT_RIBBON
+                    Browser::drawCardChrome(self, "actor", Ac\ID, cx, cy, mx, my, clicked)
+                    Browser::drawActorCardBody(self, Ac, cx, cy)
+                EndIf
+                count = count + 1
+                col = col + 1
+                If col >= cols Then col = 0 : row = row + 1
             EndIf
-            count = count + 1
-            col = col + 1
-            If col >= cols Then col = 0 : row = row + 1
         Next
         Return count
     End Method
@@ -237,15 +388,17 @@ Type Browser
         Local row% = 0
         Local count% = 0
         For It.Item = Each Item
-            Local cx% = gridX + col * (BR_CARD_W + BR_CARD_GAP)
-            Local cy% = gridY + row * (BR_CARD_H + BR_CARD_GAP)
-            If cy + BR_CARD_H < sh - BR_BOT_RIBBON
-                Browser::drawCardChrome(self, "item", It\ID, cx, cy, mx, my, clicked)
-                Browser::drawItemCardBody(self, It, cx, cy)
+            If Browser::matchesFilter(self, It\Name$) = True
+                Local cx% = gridX + col * (BR_CARD_W + BR_CARD_GAP)
+                Local cy% = gridY + row * (BR_CARD_H + BR_CARD_GAP)
+                If cy + BR_CARD_H < sh - BR_BOT_RIBBON
+                    Browser::drawCardChrome(self, "item", It\ID, cx, cy, mx, my, clicked)
+                    Browser::drawItemCardBody(self, It, cx, cy)
+                EndIf
+                count = count + 1
+                col = col + 1
+                If col >= cols Then col = 0 : row = row + 1
             EndIf
-            count = count + 1
-            col = col + 1
-            If col >= cols Then col = 0 : row = row + 1
         Next
         Return count
     End Method
@@ -256,15 +409,17 @@ Type Browser
         Local row% = 0
         Local count% = 0
         For Sp.Spell = Each Spell
-            Local cx% = gridX + col * (BR_CARD_W + BR_CARD_GAP)
-            Local cy% = gridY + row * (BR_CARD_H + BR_CARD_GAP)
-            If cy + BR_CARD_H < sh - BR_BOT_RIBBON
-                Browser::drawCardChrome(self, "spell", Sp\ID, cx, cy, mx, my, clicked)
-                Browser::drawSpellCardBody(self, Sp, cx, cy)
+            If Browser::matchesFilter(self, Sp\Name$) = True
+                Local cx% = gridX + col * (BR_CARD_W + BR_CARD_GAP)
+                Local cy% = gridY + row * (BR_CARD_H + BR_CARD_GAP)
+                If cy + BR_CARD_H < sh - BR_BOT_RIBBON
+                    Browser::drawCardChrome(self, "spell", Sp\ID, cx, cy, mx, my, clicked)
+                    Browser::drawSpellCardBody(self, Sp, cx, cy)
+                EndIf
+                count = count + 1
+                col = col + 1
+                If col >= cols Then col = 0 : row = row + 1
             EndIf
-            count = count + 1
-            col = col + 1
-            If col >= cols Then col = 0 : row = row + 1
         Next
         Return count
     End Method
@@ -275,15 +430,17 @@ Type Browser
         Local row% = 0
         Local count% = 0
         For Ar.Area = Each Area
-            Local cx% = gridX + col * (BR_CARD_W + BR_CARD_GAP)
-            Local cy% = gridY + row * (BR_CARD_H + BR_CARD_GAP)
-            If cy + BR_CARD_H < sh - BR_BOT_RIBBON
-                Browser::drawCardChrome(self, "zone", Handle(Ar), cx, cy, mx, my, clicked)
-                Browser::drawZoneCardBody(self, Ar, cx, cy)
+            If Browser::matchesFilter(self, Ar\Name$) = True
+                Local cx% = gridX + col * (BR_CARD_W + BR_CARD_GAP)
+                Local cy% = gridY + row * (BR_CARD_H + BR_CARD_GAP)
+                If cy + BR_CARD_H < sh - BR_BOT_RIBBON
+                    Browser::drawCardChrome(self, "zone", Handle(Ar), cx, cy, mx, my, clicked)
+                    Browser::drawZoneCardBody(self, Ar, cx, cy)
+                EndIf
+                count = count + 1
+                col = col + 1
+                If col >= cols Then col = 0 : row = row + 1
             EndIf
-            count = count + 1
-            col = col + 1
-            If col >= cols Then col = 0 : row = row + 1
         Next
         Return count
     End Method
@@ -296,15 +453,17 @@ Type Browser
         Local i% = 0
         For i = 0 To 99
             If FactionNames$(i) <> ""
-                Local cx% = gridX + col * (BR_CARD_W + BR_CARD_GAP)
-                Local cy% = gridY + row * (BR_CARD_H + BR_CARD_GAP)
-                If cy + BR_CARD_H < sh - BR_BOT_RIBBON
-                    Browser::drawCardChrome(self, "faction", i, cx, cy, mx, my, clicked)
-                    Browser::drawFactionCardBody(self, i, cx, cy)
+                If Browser::matchesFilter(self, FactionNames$(i)) = True
+                    Local cx% = gridX + col * (BR_CARD_W + BR_CARD_GAP)
+                    Local cy% = gridY + row * (BR_CARD_H + BR_CARD_GAP)
+                    If cy + BR_CARD_H < sh - BR_BOT_RIBBON
+                        Browser::drawCardChrome(self, "faction", i, cx, cy, mx, my, clicked)
+                        Browser::drawFactionCardBody(self, i, cx, cy)
+                    EndIf
+                    count = count + 1
+                    col = col + 1
+                    If col >= cols Then col = 0 : row = row + 1
                 EndIf
-                count = count + 1
-                col = col + 1
-                If col >= cols Then col = 0 : row = row + 1
             EndIf
         Next
         Return count
@@ -316,15 +475,17 @@ Type Browser
         Local row% = 0
         Local count% = 0
         For As.AnimSet = Each AnimSet
-            Local cx% = gridX + col * (BR_CARD_W + BR_CARD_GAP)
-            Local cy% = gridY + row * (BR_CARD_H + BR_CARD_GAP)
-            If cy + BR_CARD_H < sh - BR_BOT_RIBBON
-                Browser::drawCardChrome(self, "animset", As\ID, cx, cy, mx, my, clicked)
-                Browser::drawAnimSetCardBody(self, As, cx, cy)
+            If Browser::matchesFilter(self, As\Name$) = True
+                Local cx% = gridX + col * (BR_CARD_W + BR_CARD_GAP)
+                Local cy% = gridY + row * (BR_CARD_H + BR_CARD_GAP)
+                If cy + BR_CARD_H < sh - BR_BOT_RIBBON
+                    Browser::drawCardChrome(self, "animset", As\ID, cx, cy, mx, my, clicked)
+                    Browser::drawAnimSetCardBody(self, As, cx, cy)
+                EndIf
+                count = count + 1
+                col = col + 1
+                If col >= cols Then col = 0 : row = row + 1
             EndIf
-            count = count + 1
-            col = col + 1
-            If col >= cols Then col = 0 : row = row + 1
         Next
         Return count
     End Method

--- a/src/Modules/Loom/Composer.bb
+++ b/src/Modules/Loom/Composer.bb
@@ -84,6 +84,17 @@ Type Composer
 
 
     // -------------------------------------------------------------------------
+    // isEditing -- read accessor for the outer Loom frame so it knows the
+    // composer is currently consuming keystrokes (and the Browser's filter
+    // input must stay quiet).
+    // -------------------------------------------------------------------------
+    Method isEditing%()
+        If self\editKind <> "" Then Return True
+        Return False
+    End Method
+
+
+    // -------------------------------------------------------------------------
     // renderAndUpdate -- per-frame paint + chip hit-test. No-op when nothing
     // is focused. Returns True if any chip was clicked this frame.
     // -------------------------------------------------------------------------

--- a/src/Modules/Loom/Palette.bb
+++ b/src/Modules/Loom/Palette.bb
@@ -1,0 +1,534 @@
+Strict
+
+// =============================================================================
+// Loom/Palette.bb -- Ctrl+K command palette (find-anywhere)
+// =============================================================================
+//
+// A modal search overlay invoked by Ctrl+K from anywhere. Type to filter every
+// entity in the project by name substring; Enter (or click) jumps focus to
+// the highlighted result. Esc closes without changing focus.
+//
+// Jumps use Threads::jump so the result becomes the focused entity AND the
+// previous focus (if any) is pushed onto the back stack -- consistent with
+// chip-click semantics. This is debatable per the roadmap (the alternative
+// is Threads::focus to make palette nav "go to," not "follow a thread"); we
+// land on `jump` because the palette is functionally a giant chip rack and
+// users will want Esc to walk back to where they were before they searched.
+//
+// Architecture: Type with Methods, called as `Palette::method(self, args)`.
+// Holds a reference to the shared Threads instance (set at construction) so
+// result clicks dispatch focus changes without globals.
+//
+// State machine:
+//   open=False                      -- hidden, Ctrl+K opens
+//   open=True, query=""             -- modal visible, hint shown
+//   open=True, query=<chars>        -- live-filtered results
+//   open=True, Enter                -- jump to highlighted result, close
+//   open=True, Esc                  -- close, no jump
+//
+// Result ranking: substring match with prefix bonus. Names that START with the
+// query rank above names that merely CONTAIN it. Ties broken by name length
+// (shorter first, since shorter names are more likely the canonical entity).
+// Exact match beats both.
+//
+// Why selection-sort over a sorted insert: the BlitzForge Strict-mode Dim
+// gotcha (writes to a Dim'd local array inside a Method error) ruled out
+// the obvious "sort a temp array" path. Repeated-max with a `picked` flag
+// on each PaletteResult is allocation-free and O(K*N) for K results from
+// N candidates -- trivial at our scale (a few hundred entities, K=12).
+
+
+// Layout constants
+Const PAL_MODAL_W       = 640
+Const PAL_MODAL_H       = 480
+Const PAL_PAD           = 16
+Const PAL_INPUT_H       = 36
+Const PAL_RESULT_H      = 28
+Const PAL_MAX_RESULTS   = 12
+Const PAL_HINT_H        = 24
+Const PAL_CURSOR_PERIOD = 1000
+
+// Scoring constants (higher = better)
+Const PAL_SCORE_PREFIX = 1000
+Const PAL_SCORE_SUBSTR = 100
+Const PAL_SCORE_EXACT  = 5000
+
+
+// -----------------------------------------------------------------------------
+// PaletteResult -- one search hit. Allocated per-frame inside rebuildResults
+// and freed at the top of each rebuild via clearResults. Holds the entity
+// kind+refID for dispatch plus the display name, sub-label, and score (for
+// ranking). The `picked` flag is used by drawResults' repeated-max walk to
+// mark which entries have already been emitted in render order.
+// -----------------------------------------------------------------------------
+Type PaletteResult
+    Field Kind$
+    Field RefID%
+    Field DisplayName$
+    Field SubLabel$
+    Field Score%
+    Field Picked%
+End Type
+
+
+// =============================================================================
+// Palette -- type-to-search modal overlay.
+// =============================================================================
+Type Palette
+    Field threads.Threads
+
+    Field open%
+    Field query$
+    Field highlightIdx%
+    Field resultCount%      // total candidates with score > 0
+
+
+    Method create.Palette(threads.Threads)
+        self\threads = threads
+        self\open = False
+        self\query = ""
+        self\highlightIdx = 0
+        self\resultCount = 0
+        Return self
+    End Method
+
+
+    // -------------------------------------------------------------------------
+    // openModal -- show the palette, clear any prior query. Called when the
+    // outer Loom frame detects Ctrl+K.
+    // -------------------------------------------------------------------------
+    Method openModal()
+        self\open = True
+        self\query = ""
+        self\highlightIdx = 0
+        Palette::clearResults(self)
+        FlushKeys
+        WriteLog(LoomLog, "Palette: open")
+    End Method
+
+
+    // -------------------------------------------------------------------------
+    // closeModal -- hide and drop results. No focus change.
+    // -------------------------------------------------------------------------
+    Method closeModal()
+        self\open = False
+        self\query = ""
+        self\highlightIdx = 0
+        Palette::clearResults(self)
+        WriteLog(LoomLog, "Palette: close")
+    End Method
+
+
+    // -------------------------------------------------------------------------
+    // isOpen -- read accessor used by the outer Loom frame to decide whether
+    // to skip its own input handlers (so the palette gets the keystrokes
+    // first).
+    // -------------------------------------------------------------------------
+    Method isOpen%()
+        Return self\open
+    End Method
+
+
+    // -------------------------------------------------------------------------
+    // clearResults -- drop every PaletteResult instance. Manual Delete (no
+    // EnableGC in Loom modules) so results don't leak across frames.
+    // -------------------------------------------------------------------------
+    Method clearResults()
+        Local r.PaletteResult
+        For r = Each PaletteResult
+            Delete r
+        Next
+        self\resultCount = 0
+    End Method
+
+
+    // -------------------------------------------------------------------------
+    // renderAndUpdate -- per-frame paint + input. Returns True if the palette
+    // consumed input this frame (so the outer Loom frame knows to skip its
+    // own Esc handler, etc.).
+    //
+    // The palette renders ABOVE the browser/composer (called last in the
+    // frame after they've drawn) so it overlays everything.
+    // -------------------------------------------------------------------------
+    Method renderAndUpdate%(sw%, sh%)
+        If self\open = False Then Return False
+
+        // Drain keyboard into the query before re-running search.
+        Palette::pumpKeyboard(self)
+
+        // Closed by pumpKeyboard? bail.
+        If self\open = False Then Return True
+
+        // Re-rank on every frame -- query may have changed and entity counts
+        // are small enough that scanning is cheap.
+        Palette::rebuildResults(self)
+
+        // Dim the world behind the modal (full-screen wash).
+        LoomFill(0, 0, sw, sh, LOOM_STONE_950_R, LOOM_STONE_950_G, LOOM_STONE_950_B)
+
+        // Centered modal
+        Local mx_screen% = MouseX()
+        Local my_screen% = MouseY()
+        Local clicked%   = MouseHit(1)
+
+        Local modalX% = (sw - PAL_MODAL_W) / 2
+        Local modalY% = (sh - PAL_MODAL_H) / 3      // upper third, closer to eye line
+
+        Palette::drawModalChrome(self, modalX, modalY)
+        Palette::drawInput(self, modalX, modalY)
+        Palette::drawResults(self, modalX, modalY, mx_screen, my_screen, clicked)
+        Palette::drawHint(self, modalX, modalY)
+
+        // Click-outside-modal closes.
+        If clicked = True
+            If mx_screen < modalX Or mx_screen >= modalX + PAL_MODAL_W Or my_screen < modalY Or my_screen >= modalY + PAL_MODAL_H
+                Palette::closeModal(self)
+            EndIf
+        EndIf
+
+        Return True
+    End Method
+
+
+    // -------------------------------------------------------------------------
+    // drawModalChrome -- the modal backdrop, border, and brass top-rule.
+    // -------------------------------------------------------------------------
+    Method drawModalChrome(modalX%, modalY%)
+        LoomFill(modalX, modalY, PAL_MODAL_W, PAL_MODAL_H, LOOM_STONE_850_R, LOOM_STONE_850_G, LOOM_STONE_850_B)
+        LoomBorder(modalX, modalY, PAL_MODAL_W, PAL_MODAL_H, LOOM_BRASS_500_R, LOOM_BRASS_500_G, LOOM_BRASS_500_B)
+        LoomBorder(modalX + 1, modalY + 1, PAL_MODAL_W - 2, PAL_MODAL_H - 2, LOOM_BRASS_700_R, LOOM_BRASS_700_G, LOOM_BRASS_700_B)
+
+        // Top brass strip + LOOM tag
+        LoomFill(modalX, modalY, PAL_MODAL_W, 3, LOOM_BRASS_500_R, LOOM_BRASS_500_G, LOOM_BRASS_500_B)
+        LoomText(modalX + PAL_PAD, modalY + 8, "FIND  ANYTHING", LOOM_BRASS_500_R, LOOM_BRASS_500_G, LOOM_BRASS_500_B)
+    End Method
+
+
+    // -------------------------------------------------------------------------
+    // drawInput -- the query input rect with blinking cursor at the end.
+    // -------------------------------------------------------------------------
+    Method drawInput(modalX%, modalY%)
+        Local ix% = modalX + PAL_PAD
+        Local iy% = modalY + 32
+        Local iw% = PAL_MODAL_W - PAL_PAD * 2
+        Local ih% = PAL_INPUT_H
+
+        LoomFill(ix, iy, iw, ih, LOOM_STONE_700_R, LOOM_STONE_700_G, LOOM_STONE_700_B)
+        LoomBorder(ix, iy, iw, ih, LOOM_ARCANE_500_R, LOOM_ARCANE_500_G, LOOM_ARCANE_500_B)
+
+        // Prompt glyph
+        LoomText(ix + 10, iy + 11, ">", LOOM_BRASS_500_R, LOOM_BRASS_500_G, LOOM_BRASS_500_B)
+
+        // Query string
+        LoomText(ix + 28, iy + 11, self\query, LOOM_PARCHMENT_100_R, LOOM_PARCHMENT_100_G, LOOM_PARCHMENT_100_B)
+
+        // Blinking cursor at end of query
+        If (MilliSecs() Mod PAL_CURSOR_PERIOD) < (PAL_CURSOR_PERIOD / 2)
+            Local cursorX% = ix + 28 + StringWidth(self\query)
+            LoomFill(cursorX, iy + 10, 2, 16, LOOM_PARCHMENT_100_R, LOOM_PARCHMENT_100_G, LOOM_PARCHMENT_100_B)
+        EndIf
+    End Method
+
+
+    // -------------------------------------------------------------------------
+    // drawResults -- ranked result list. Uses repeated-max-selection over the
+    // PaletteResult pool: on each render slot, find the highest-Score result
+    // whose Picked=False, mark it Picked=True, paint it. K=PAL_MAX_RESULTS
+    // sweeps over N candidates. After the loop, every Picked=True result is
+    // released by the next clearResults call.
+    //
+    // Highlight follows arrow keys and mouse hover; click or Enter jumps.
+    // -------------------------------------------------------------------------
+    Method drawResults(modalX%, modalY%, mx%, my%, clicked%)
+        Local startY% = modalY + 32 + PAL_INPUT_H + PAL_PAD
+        Local rx%     = modalX + PAL_PAD
+        Local rw%     = PAL_MODAL_W - PAL_PAD * 2
+
+        If self\resultCount = 0
+            If Len(self\query) = 0
+                LoomText(rx, startY, "Type to search actors, items, spells, zones, factions, animation sets.", LOOM_STONE_300_R, LOOM_STONE_300_G, LOOM_STONE_300_B)
+            Else
+                LoomText(rx, startY, "No matches.", LOOM_STONE_300_R, LOOM_STONE_300_G, LOOM_STONE_300_B)
+            EndIf
+            Return
+        EndIf
+
+        // Render up to PAL_MAX_RESULTS slots via repeated-max.
+        Local slotsToShow% = self\resultCount
+        If slotsToShow > PAL_MAX_RESULTS Then slotsToShow = PAL_MAX_RESULTS
+
+        Local slot% = 0
+        For slot = 0 To slotsToShow - 1
+            Local best.PaletteResult = Null
+            Local bestScore% = -1
+            Local cand.PaletteResult
+            For cand = Each PaletteResult
+                If cand\Picked = False And cand\Score > bestScore
+                    best = cand
+                    bestScore = cand\Score
+                EndIf
+            Next
+            If best = Null Then Exit
+            best\Picked = True
+
+            Local ry% = startY + slot * PAL_RESULT_H
+            Local hovered% = (mx >= rx And mx < rx + rw And my >= ry And my < ry + PAL_RESULT_H)
+            If hovered = True Then self\highlightIdx = slot
+
+            Local highlighted% = (slot = self\highlightIdx)
+            If highlighted = True
+                LoomFill(rx, ry, rw, PAL_RESULT_H, LOOM_ARCANE_900_R, LOOM_ARCANE_900_G, LOOM_ARCANE_900_B)
+                LoomBorder(rx, ry, rw, PAL_RESULT_H, LOOM_ARCANE_500_R, LOOM_ARCANE_500_G, LOOM_ARCANE_500_B)
+            EndIf
+
+            // Kind glyph (one-letter)
+            Local glyph$ = Palette::kindGlyph(self, best\Kind)
+            LoomText(rx + 10, ry + 6, glyph, LOOM_BRASS_500_R, LOOM_BRASS_500_G, LOOM_BRASS_500_B)
+
+            // Name
+            LoomText(rx + 36, ry + 6, best\DisplayName, LOOM_PARCHMENT_100_R, LOOM_PARCHMENT_100_G, LOOM_PARCHMENT_100_B)
+
+            // Sub-label (kind name) right-aligned
+            If best\SubLabel <> ""
+                LoomText(rx + rw - StringWidth(best\SubLabel) - 12, ry + 6, best\SubLabel, LOOM_STONE_300_R, LOOM_STONE_300_G, LOOM_STONE_300_B)
+            EndIf
+
+            If hovered And clicked
+                Palette::jumpToResult(self, best)
+                Return
+            EndIf
+        Next
+    End Method
+
+
+    // -------------------------------------------------------------------------
+    // drawHint -- footer text reminding the user of keybindings.
+    // -------------------------------------------------------------------------
+    Method drawHint(modalX%, modalY%)
+        Local hy% = modalY + PAL_MODAL_H - PAL_HINT_H - 4
+        LoomHRule(modalX + PAL_PAD, hy - 2, PAL_MODAL_W - PAL_PAD * 2, LOOM_BRASS_700_R, LOOM_BRASS_700_G, LOOM_BRASS_700_B)
+        LoomText(modalX + PAL_PAD, hy + 4, "Enter to jump  ·  arrow keys to move  ·  Esc to close", LOOM_STONE_300_R, LOOM_STONE_300_G, LOOM_STONE_300_B)
+    End Method
+
+
+    // -------------------------------------------------------------------------
+    // pumpKeyboard -- drain key input into query, handle Enter / Esc / arrows /
+    // Backspace. Called only when self\open = True.
+    // -------------------------------------------------------------------------
+    Method pumpKeyboard()
+        // Esc -- close (consumed; outer Esc handler won't fire same frame).
+        If KeyHit(1)
+            Palette::closeModal(self)
+            Return
+        EndIf
+
+        // Enter -- jump to current highlight.
+        If KeyHit(28)
+            Palette::jumpHighlighted(self)
+            Return
+        EndIf
+
+        // Backspace
+        If KeyHit(14) And Len(self\query) > 0
+            self\query = Left$(self\query, Len(self\query) - 1)
+            self\highlightIdx = 0
+        EndIf
+
+        // Up arrow (200) / Down arrow (208)
+        If KeyHit(200) And self\highlightIdx > 0
+            self\highlightIdx = self\highlightIdx - 1
+        EndIf
+        If KeyHit(208)
+            self\highlightIdx = self\highlightIdx + 1
+        EndIf
+
+        // Drain printable chars
+        Local k% = GetKey()
+        While k > 0
+            If k >= 32 And k <= 126
+                self\query = self\query + Chr(k)
+                self\highlightIdx = 0
+            EndIf
+            k = GetKey()
+        Wend
+    End Method
+
+
+    // -------------------------------------------------------------------------
+    // rebuildResults -- scan every entity, score against the query, keep
+    // every candidate with score > 0 as a fresh PaletteResult. Empty query
+    // -> empty results (no point listing the entire project unprompted).
+    //
+    // Result ordering is established at render time via repeated-max in
+    // drawResults; this function just emits unordered candidates.
+    // -------------------------------------------------------------------------
+    Method rebuildResults()
+        Palette::clearResults(self)
+
+        Local q$ = Lower$(Trim$(self\query))
+        If q = "" Then Return
+
+        // Actors -- "Race [Class]" composite name
+        For Ac.Actor = Each Actor
+            Local aName$ = Ac\Race$ + " [" + Ac\Class$ + "]"
+            Local aScore% = Palette::scoreName(self, q, aName)
+            If aScore > 0
+                Palette::addResult(self, "actor", Ac\ID, aName, "actor", aScore)
+            EndIf
+        Next
+
+        // Items
+        For It.Item = Each Item
+            Local iScore% = Palette::scoreName(self, q, It\Name$)
+            If iScore > 0
+                Palette::addResult(self, "item", It\ID, It\Name$, "item", iScore)
+            EndIf
+        Next
+
+        // Spells
+        For Sp.Spell = Each Spell
+            Local sScore% = Palette::scoreName(self, q, Sp\Name$)
+            If sScore > 0
+                Palette::addResult(self, "spell", Sp\ID, Sp\Name$, "spell", sScore)
+            EndIf
+        Next
+
+        // Zones
+        For Ar.Area = Each Area
+            Local zScore% = Palette::scoreName(self, q, Ar\Name$)
+            If zScore > 0
+                Palette::addResult(self, "zone", Handle(Ar), Ar\Name$, "zone", zScore)
+            EndIf
+        Next
+
+        // Factions
+        Local fi% = 0
+        For fi = 0 To 99
+            If FactionNames$(fi) <> ""
+                Local fScore% = Palette::scoreName(self, q, FactionNames$(fi))
+                If fScore > 0
+                    Palette::addResult(self, "faction", fi, FactionNames$(fi), "faction", fScore)
+                EndIf
+            EndIf
+        Next
+
+        // Anim sets
+        For As.AnimSet = Each AnimSet
+            Local mScore% = Palette::scoreName(self, q, As\Name$)
+            If mScore > 0
+                Palette::addResult(self, "animset", As\ID, As\Name$, "anim set", mScore)
+            EndIf
+        Next
+
+        // Clamp highlight to the (possibly smaller) result count.
+        Local cap% = self\resultCount
+        If cap > PAL_MAX_RESULTS Then cap = PAL_MAX_RESULTS
+        If self\highlightIdx >= cap Then self\highlightIdx = cap - 1
+        If self\highlightIdx < 0 Then self\highlightIdx = 0
+    End Method
+
+
+    // -------------------------------------------------------------------------
+    // scoreName -- substring score with prefix + exact bonuses. q must be
+    // already lower-cased and trimmed by the caller; this function lowers
+    // name. Returns 0 for no match.
+    // -------------------------------------------------------------------------
+    Method scoreName%(q$, name$)
+        If name = "" Then Return 0
+        Local lname$ = Lower$(name)
+
+        If lname = q Then Return PAL_SCORE_EXACT
+        If Left$(lname, Len(q)) = q Then Return PAL_SCORE_PREFIX + (200 - Len(name))
+
+        // Substring -- Instr returns 1-based index, 0 = not found
+        Local pos% = Instr(lname, q)
+        If pos > 0 Then Return PAL_SCORE_SUBSTR + (100 - pos)
+        Return 0
+    End Method
+
+
+    // -------------------------------------------------------------------------
+    // addResult -- allocate + populate one PaletteResult and bump the count.
+    // Ranking is deferred to render-time repeated-max selection.
+    // -------------------------------------------------------------------------
+    Method addResult(kind$, refID%, displayName$, subLabel$, score%)
+        Local r.PaletteResult = New PaletteResult()
+        r\Kind = kind
+        r\RefID = refID
+        r\DisplayName = displayName
+        r\SubLabel = subLabel
+        r\Score = score
+        r\Picked = False
+        self\resultCount = self\resultCount + 1
+    End Method
+
+
+    // -------------------------------------------------------------------------
+    // jumpHighlighted -- Enter handler: find the highlightIdx'th best result
+    // by repeated-max selection over the pool, then jump.
+    //
+    // We can't index PaletteResult by an int -- it's a global pool, not a
+    // BBList here -- so we re-do the same repeated-max walk drawResults uses,
+    // counting until we hit highlightIdx, then act on that one.
+    // -------------------------------------------------------------------------
+    Method jumpHighlighted()
+        If self\resultCount = 0 Then Return
+
+        // Reset Picked across the pool so the count is honest.
+        Local rr.PaletteResult
+        For rr = Each PaletteResult
+            rr\Picked = False
+        Next
+
+        Local slot% = 0
+        While slot <= self\highlightIdx
+            Local best.PaletteResult = Null
+            Local bestScore% = -1
+            Local cand.PaletteResult
+            For cand = Each PaletteResult
+                If cand\Picked = False And cand\Score > bestScore
+                    best = cand
+                    bestScore = cand\Score
+                EndIf
+            Next
+            If best = Null Then Return
+            If slot = self\highlightIdx
+                Palette::jumpToResult(self, best)
+                Return
+            EndIf
+            best\Picked = True
+            slot = slot + 1
+        Wend
+    End Method
+
+
+    // -------------------------------------------------------------------------
+    // jumpToResult -- shared dispatch for click + Enter. Closes the modal
+    // before jumping so the focus change isn't shadowed by the dim overlay
+    // on the same frame.
+    // -------------------------------------------------------------------------
+    Method jumpToResult(r.PaletteResult)
+        Local k$ = r\Kind
+        Local id% = r\RefID
+        Local nm$ = r\DisplayName
+        Palette::closeModal(self)
+        Threads::jump(self\threads, k, id)
+        WriteLog(LoomLog, "Palette: jumped to " + k + "#" + Str(id) + " (" + nm + ")")
+    End Method
+
+
+    // -------------------------------------------------------------------------
+    // kindGlyph -- mirror of Threads::kindGlyph; copied locally so Palette
+    // doesn't depend on Threads having a public method just for this one
+    // glyph (keeps the chip primitive's contract narrower).
+    // -------------------------------------------------------------------------
+    Method kindGlyph$(kind$)
+        If kind = "actor"   Then Return "A"
+        If kind = "item"    Then Return "I"
+        If kind = "spell"   Then Return "S"
+        If kind = "zone"    Then Return "Z"
+        If kind = "faction" Then Return "F"
+        If kind = "animset" Then Return "M"
+        Return "?"
+    End Method
+End Type


### PR DESCRIPTION
## Summary

Ships items #1 and #2 from the [Loom roadmap](docs/loom/roadmap.md) together — they share the search primitive and naturally pair.

**Command palette (Ctrl+K)** — `Modules/Loom/Palette.bb` (new). Centered modal, type-to-search across every entity in the project (actors, items, spells, zones, factions, anim sets). Scoring: exact > prefix (shorter name wins ties) > substring (earlier position wins ties). Arrow keys move highlight, Enter/click jumps via \`Threads::jump\` so the prior focus pushes onto the back stack — Esc walks back to where the user was before searching.

**Search-within-category** — new 30px filter bar above the card grid with a live input. Case-insensitive substring match against each card's primary display name. Filter persists across category tabs (intentional: looking for *goblin* across actors AND items is a real flow). Empty-state copy differs between \"no matches\" and \"category is genuinely empty.\"

**Input priority chain** (Loom.bb): \`palette > composer-edit > browser filter\`. Esc cascade: \`palette-eats > clear filter > pop back stack > close composer > exit\`. \`Browser::renderAndUpdate\` now takes \`inputEnabled%\` so the top-level frame can gate keyboard pumping based on which surface owns the foreground. Composer gets \`isEditing%\` accessor for the same gating reason.

## Implementation notes

- **Selection-sort over the candidate pool** for palette result ranking (per-result \`Picked\` flag) — sidesteps the BlitzForge Strict-mode Dim-inside-Method write gotcha that ruled out the obvious \"sort a temp array\" path.
- **Manual \`Delete\` on PaletteResult** instances in \`clearResults\` (no \`EnableGC\` in Loom modules) per the [Threads.bb back-stack pattern](src/Modules/Loom/Threads.bb).
- **Ctrl-anything skipped in \`pumpFilterKeyboard\`** so Ctrl+K opening the palette doesn't deposit a \"k\" into the filter buffer before the palette claims keys.

## Test plan

- [x] \`compile.bat\` — all five engine targets + every tool built clean
- [x] \`test.bat\` — 32/32 pass
- [ ] Boot Loom, press Ctrl+K, type a partial name → see ranked results across kinds
- [ ] Arrow keys move highlight; Enter jumps to focused entity in composer
- [ ] Click outside modal closes it without jumping
- [ ] Type into browser surface → cards live-filter; Esc clears the filter (and only after the filter is empty does Esc walk the back stack)