### PR TITLE
Loom: World Atlas — spatial zone view with portal-graph force-directed layout

### DIFF
--- a/docs/loom/roadmap.md
+++ b/docs/loom/roadmap.md
@@ -16,7 +16,8 @@ Shipped, next, and deferred. Read this when picking what to build next.
 - **Search-within-category** — live filter input above the card grid; case-insensitive substring match against the current category's name field. Esc clears the filter (priority above the back-stack pop). ([#335](https://github.com/RydeTec/rcce2/pull/335))
 - **Editing phase 1 (broaden)** — int / float / bool field types; ~40 editable fields across every entity kind (Actor / Item / Spell / Zone / Faction / AnimSet); Save dispatch for every kind (`SaveActors`, `SaveItems`, `SaveFactions`, `SaveAnimSets`, `ServerSaveArea`); `SetFactionName` helper added to `Actors.bb` to work around the Strict-mode global-array-write trap. ([#336](https://github.com/RydeTec/rcce2/pull/336))
 - **Entity creation (+ New)** — `EntityFactory.bb` wraps the GUE constructors (`CreateActor`, `CreateItem`, `CreateSpell`, `ServerCreateArea`, `CreateAnimSet`, faction-slot-first-empty); "+ New X" button on the browser filter bar dispatches per active category, focuses the new entity for immediate editing, marks the kind dirty. Zone names auto-deduplicate via `EntityFactory_UniqueZoneName` so a new zone doesn't overwrite an existing `.dat`. ([#337](https://github.com/RydeTec/rcce2/pull/337))
-- **Entity deletion + Discard + Validation Ribbon** — Delete button on the composer (two-click arm/confirm); Discard button (revert kind from disk, also arm/confirm); Validation Conscience Ribbon at the top of every Loom surface showing per-kind dirty badges (click to save), broken-reference count (Actor->Faction, Actor->AnimSet, Zone->Portal->Zone), and total entity counts. New `Ribbon.bb` module; new `DeleteX Template` helpers in `Actors.bb`/`Items.bb`/`Spells.bb`/`Animations.bb` (non-Strict, to work around the Dim-write trap).
+- **Entity deletion + Discard + Validation Ribbon** — Delete button on the composer (two-click arm/confirm); Discard button (revert kind from disk, also arm/confirm); Validation Conscience Ribbon at the top of every Loom surface showing per-kind dirty badges (click to save), broken-reference count (Actor->Faction, Actor->AnimSet, Zone->Portal->Zone), and total entity counts. New `Ribbon.bb` module; new `DeleteX Template` helpers in `Actors.bb`/`Items.bb`/`Spells.bb`/`Animations.bb` (non-Strict, to work around the Dim-write trap). ([#338](https://github.com/RydeTec/rcce2/pull/338))
+- **World Atlas** — design's #3 signature surface. Zones tab gains a Card / Atlas toggle. Atlas renders zones as nodes with portals as edges using a Fruchterman-Reingold force-directed layout derived from the portal-link graph topology. Click a node → focus that zone; layout rebuilds on zone add / delete; circular seeding avoids the all-same-position singularity.
 
 ## Next up (in rough order of leverage)
 
@@ -26,15 +27,7 @@ Once free-form fields edit, reference-typed fields (faction, anim set, zone targ
 
 Estimated scope: 200-300 LOC. Builds on the shipped palette as picker.
 
-### 2. World atlas (spatial zone view)
-
-Today the Zones tab in the browser is a card grid. The design called for a spatial atlas: zones laid out by position with portals drawn as lines between them. Worth shipping once there are enough zones in a project for the spatial layout to communicate something the grid doesn't (probably >10 zones).
-
-Open question: zones in rcce2 don't have a stored "world position" — they're just floating in a flat list. The spatial layout would have to be either (a) derived from portal-link graph topology, or (b) a manual layout Loom remembers per-project.
-
-Estimated scope: 400-500 LOC including layout heuristic. Skip if no project pressure for it.
-
-### 3. Session timeline scrubber
+### 2. Session timeline scrubber
 
 Visible history of the session's edits (entity X changed field Y from A to B at time T). Click an entry → revert. Drag the handle → preview a past state. Needs an undo log layered on top of the existing in-memory dirty tracking.
 

--- a/src/Loom.bb
+++ b/src/Loom.bb
@@ -110,6 +110,7 @@ Include "Modules\Loom\Browser.bb"
 Include "Modules\Loom\Composer.bb"
 Include "Modules\Loom\Palette.bb"
 Include "Modules\Loom\Ribbon.bb"
+Include "Modules\Loom\Atlas.bb"
 Include "Modules\Loom\EntityFactory.bb"
 
 
@@ -126,6 +127,7 @@ Type Loom
     Field composer.Composer
     Field palette.Palette
     Field ribbon.Ribbon
+    Field atlas.Atlas
 
 
     Method create.Loom(windowWidth%, windowHeight%, projectName$)
@@ -147,6 +149,13 @@ Type Loom
         // Composer (so a dirty-badge click can dispatch to the same
         // commitSaveForKind path the composer's Save button uses).
         self\ribbon = New Ribbon(self\threads, self\composer)
+
+        // Atlas holds a Threads reference for node-click focus dispatch.
+        // The Browser activates / deactivates Atlas via Browser::setAtlas
+        // and routes the viewport rect through to Atlas::renderAndUpdate
+        // when the user toggles to atlas mode on the Zones tab.
+        self\atlas = New Atlas(self\threads)
+        Browser::setAtlas(self\browser, self\atlas)
 
         Return self
     End Method

--- a/src/Modules/Loom/Atlas.bb
+++ b/src/Modules/Loom/Atlas.bb
@@ -1,0 +1,419 @@
+Strict
+
+// =============================================================================
+// Loom/Atlas.bb -- spatial world atlas (zones as nodes, portals as edges)
+// =============================================================================
+//
+// The design's #3 signature surface (README.md): "World atlas - spatial
+// overview of every zone, with portals drawn as lines between them."
+//
+// rcce2 doesn't store world positions for zones (they're a flat list), so
+// the atlas layout is DERIVED from the portal-link graph topology via a
+// force-directed layout (Fruchterman-Reingold-style spring model).
+// Position is recomputed on entry / when nodes are added or removed (cheap
+// at our scale -- a few hundred zones tops); cached between frames so
+// re-rendering at 60fps doesn't re-solve the graph every frame.
+//
+// Layout algorithm (simplified FR):
+//   For each iteration (up to ATLAS_ITERATIONS, with cooling):
+//     - REPULSION: every pair of nodes pushes apart with force k*k/d
+//     - ATTRACTION: every edge pulls its endpoints together with d*d/k
+//     - Apply accumulated force, clamped to current temperature
+//     - Decay temperature
+//   Center + normalize to fit viewport.
+//
+// Activation: Browser exposes a "Card | Atlas" toggle on the Zones tab
+// only. When Atlas mode is on, the browser skips its zone card grid and
+// asks Atlas::renderAndUpdate to paint the viewport instead.
+//
+// Architecture: Type with Methods (Atlas owns layout state). Holds a
+// Threads reference so node clicks dispatch focus changes consistently
+// with the rest of Loom.
+
+
+// Layout constants
+Const ATLAS_ITERATIONS    = 240
+Const ATLAS_NODE_R        = 22
+Const ATLAS_NODE_PAD      = 6
+Const ATLAS_INITIAL_TEMP# = 80.0
+Const ATLAS_MIN_TEMP#     = 0.5
+Const ATLAS_TEMP_DECAY#   = 0.97
+Const ATLAS_VIEWPORT_PAD  = 60
+
+
+// -----------------------------------------------------------------------------
+// AtlasNode -- one zone node. Position + per-iteration force accumulator.
+// Allocated by rebuildLayout, freed by clearNodes. Manual lifecycle (no
+// EnableGC in Loom modules).
+// -----------------------------------------------------------------------------
+Type AtlasNode
+    Field ZoneHandle%   // Handle(Area)
+    Field Label$        // cached A\Name$ for display
+    Field X#, Y#        // current world-space position
+    Field DX#, DY#      // accumulated displacement this iteration
+End Type
+
+
+// -----------------------------------------------------------------------------
+// AtlasEdge -- one directed portal link. Allocated alongside nodes; freed
+// alongside nodes.
+// -----------------------------------------------------------------------------
+Type AtlasEdge
+    Field FromHandle%
+    Field ToHandle%
+End Type
+
+
+// =============================================================================
+// Atlas -- spatial zone-graph view.
+// =============================================================================
+Type Atlas
+    Field threads.Threads
+
+    // Layout state. nodeCount lets us know when zones were added/removed
+    // and force a rebuild. minX/maxX/minY/maxY are the layout bounding box
+    // computed by recenterLayout; render scales these to the viewport rect.
+    Field nodeCount%
+    Field minX#, minY#, maxX#, maxY#
+    Field temperature#
+
+    // Per-iteration accumulators -- kept as Fields rather than Method
+    // Locals because BlitzForge Strict rejects re-assigning a Method
+    // Local from inside nested For/If blocks.
+    Field iterTemp#
+
+
+    Method create.Atlas(threads.Threads)
+        self\threads = threads
+        self\nodeCount = 0
+        self\minX# = 0.0 : self\minY# = 0.0 : self\maxX# = 1.0 : self\maxY# = 1.0
+        self\temperature# = ATLAS_INITIAL_TEMP#
+        Return self
+    End Method
+
+
+    // -------------------------------------------------------------------------
+    // renderAndUpdate -- per-frame paint + hit-test for the atlas viewport.
+    // viewportX/Y/W/H is the rect Browser hands us (i.e. the area BELOW the
+    // ribbon/brand/tab/filter strips and ABOVE the bottom footer).
+    //
+    // If the node pool is empty (first paint, or zones were added/removed
+    // and we haven't rebuilt yet), rebuild the layout before drawing.
+    // Returns True if a node was clicked this frame (so Browser knows a
+    // focus change happened).
+    // -------------------------------------------------------------------------
+    Method renderAndUpdate%(viewportX%, viewportY%, viewportW%, viewportH%)
+        // Detect zone-count change -- a delete or create would invalidate
+        // the cached node pool. Cheap O(zones) walk per frame; the layout
+        // rebuild itself is the expensive part and only fires on change.
+        Local zonesNow% = Atlas::countZones(self)
+        If zonesNow <> self\nodeCount
+            Atlas::rebuildLayout(self)
+        EndIf
+
+        // Background -- darker tint than the browser to read as a distinct
+        // surface, with a brass border around the viewport rect.
+        LoomFill(viewportX, viewportY, viewportW, viewportH, LOOM_STONE_900_R, LOOM_STONE_900_G, LOOM_STONE_900_B)
+        LoomBorder(viewportX, viewportY, viewportW, viewportH, LOOM_BRASS_700_R, LOOM_BRASS_700_G, LOOM_BRASS_700_B)
+
+        If self\nodeCount = 0
+            LoomTextCentered(viewportX + viewportW / 2, viewportY + viewportH / 2, "No zones yet -- click + New Zone to add one.", LOOM_STONE_300_R, LOOM_STONE_300_G, LOOM_STONE_300_B)
+            Return False
+        EndIf
+
+        // Title strip
+        LoomText(viewportX + 12, viewportY + 8, "ATLAS  ·  " + Str(self\nodeCount) + " zones  ·  portal links derived from data", LOOM_BRASS_500_R, LOOM_BRASS_500_G, LOOM_BRASS_500_B)
+
+        Local mx% = MouseX()
+        Local my% = MouseY()
+        Local clicked% = MouseHit(1)
+
+        // Draw edges first so node disks paint on top of them.
+        Atlas::drawEdges(self, viewportX, viewportY + 28, viewportW, viewportH - 28)
+
+        // Draw nodes + hit-test.
+        Local hit% = Atlas::drawNodes(self, viewportX, viewportY + 28, viewportW, viewportH - 28, mx, my, clicked)
+        Return hit
+    End Method
+
+
+    // -------------------------------------------------------------------------
+    // rebuildLayout -- drop old pool, allocate one AtlasNode per zone, run
+    // ATLAS_ITERATIONS force-directed steps, recenter. Cheap at our scale.
+    // -------------------------------------------------------------------------
+    Method rebuildLayout()
+        Atlas::clearNodes(self)
+        Atlas::clearEdges(self)
+        self\nodeCount = 0
+
+        // Seed nodes -- circular layout to start (avoids the all-same-
+        // position singularity that gives FR a zero-vector problem).
+        Local zones% = Atlas::countZones(self)
+        If zones = 0 Then Return
+
+        Local theta# = 0.0
+        Local arc# = 0.0
+        If zones > 0 Then arc# = 6.28318 / Float(zones)
+        Local r# = 200.0
+        For Ar.Area = Each Area
+            Local n.AtlasNode = New AtlasNode()
+            n\ZoneHandle = Handle(Ar)
+            n\Label = Ar\Name$
+            n\X# = Cos#(theta * 57.2958) * r
+            n\Y# = Sin#(theta * 57.2958) * r
+            n\DX# = 0.0
+            n\DY# = 0.0
+            theta = theta + arc
+            self\nodeCount = self\nodeCount + 1
+        Next
+
+        // Seed edges -- one per portal whose target name resolves to a
+        // zone. Strings the user typed get a soft fail (no edge) rather
+        // than a broken edge.
+        For Ar.Area = Each Area
+            Local p% = 0
+            For p = 0 To 99
+                If Ar\PortalLinkArea$[p] <> ""
+                    Local toHandle% = Atlas::findZoneHandleByName(self, Ar\PortalLinkArea$[p])
+                    If toHandle <> 0
+                        Local e.AtlasEdge = New AtlasEdge()
+                        e\FromHandle = Handle(Ar)
+                        e\ToHandle = toHandle
+                    EndIf
+                EndIf
+            Next
+        Next
+
+        // Run the force-directed iterations.
+        self\temperature# = ATLAS_INITIAL_TEMP#
+        Local iter% = 0
+        For iter = 0 To ATLAS_ITERATIONS - 1
+            Atlas::layoutStep(self)
+            self\temperature# = self\temperature# * ATLAS_TEMP_DECAY#
+            If self\temperature# < ATLAS_MIN_TEMP# Then self\temperature# = ATLAS_MIN_TEMP#
+        Next
+
+        Atlas::recenterLayout(self)
+    End Method
+
+
+    // -------------------------------------------------------------------------
+    // layoutStep -- one Fruchterman-Reingold iteration. Repulsion between
+    // every pair, attraction along every edge, displacement clamped to
+    // current temperature, applied.
+    // -------------------------------------------------------------------------
+    Method layoutStep()
+        // k = ideal edge length. Bigger k spreads the graph more.
+        Local k# = 90.0
+        Local k2# = k * k
+
+        // Reset accumulated displacement
+        Local n.AtlasNode
+        For n = Each AtlasNode
+            n\DX# = 0.0
+            n\DY# = 0.0
+        Next
+
+        // Repulsion -- every pair pushes apart. O(N^2) -- fine for ~hundreds.
+        Local n1.AtlasNode
+        Local n2.AtlasNode
+        For n1 = Each AtlasNode
+            For n2 = Each AtlasNode
+                If Handle(n1) <> Handle(n2)
+                    Local dx# = n1\X# - n2\X#
+                    Local dy# = n1\Y# - n2\Y#
+                    Local dist# = Sqr#(dx * dx + dy * dy)
+                    If dist# < 0.01 Then dist# = 0.01
+                    Local force# = k2 / dist#
+                    n1\DX# = n1\DX# + (dx / dist#) * force#
+                    n1\DY# = n1\DY# + (dy / dist#) * force#
+                EndIf
+            Next
+        Next
+
+        // Attraction -- pull edge endpoints together
+        Local e.AtlasEdge
+        For e = Each AtlasEdge
+            Local na.AtlasNode = Atlas::findNodeByHandle(self, e\FromHandle)
+            Local nb.AtlasNode = Atlas::findNodeByHandle(self, e\ToHandle)
+            If na <> Null And nb <> Null
+                Local dxE# = na\X# - nb\X#
+                Local dyE# = na\Y# - nb\Y#
+                Local distE# = Sqr#(dxE * dxE + dyE * dyE)
+                If distE# < 0.01 Then distE# = 0.01
+                Local forceE# = (distE * distE) / k
+                na\DX# = na\DX# - (dxE / distE) * forceE
+                na\DY# = na\DY# - (dyE / distE) * forceE
+                nb\DX# = nb\DX# + (dxE / distE) * forceE
+                nb\DY# = nb\DY# + (dyE / distE) * forceE
+            EndIf
+        Next
+
+        // Apply displacement, clamped by temperature
+        Local napp.AtlasNode
+        For napp = Each AtlasNode
+            Local d# = Sqr#(napp\DX# * napp\DX# + napp\DY# * napp\DY#)
+            If d# < 0.01 Then d# = 0.01
+            Local scale# = self\temperature#
+            If d# < scale# Then scale# = d#
+            napp\X# = napp\X# + (napp\DX# / d#) * scale#
+            napp\Y# = napp\Y# + (napp\DY# / d#) * scale#
+        Next
+    End Method
+
+
+    // -------------------------------------------------------------------------
+    // recenterLayout -- compute the bounding box of all nodes so render can
+    // normalize them to the viewport rect. Stored on self.
+    // -------------------------------------------------------------------------
+    Method recenterLayout()
+        self\minX# = 999999.0 : self\minY# = 999999.0
+        self\maxX# = -999999.0 : self\maxY# = -999999.0
+        Local n.AtlasNode
+        For n = Each AtlasNode
+            If n\X# < self\minX# Then self\minX# = n\X#
+            If n\Y# < self\minY# Then self\minY# = n\Y#
+            If n\X# > self\maxX# Then self\maxX# = n\X#
+            If n\Y# > self\maxY# Then self\maxY# = n\Y#
+        Next
+        // Avoid divide-by-zero in render's scale calc.
+        If self\maxX# - self\minX# < 1.0 Then self\maxX# = self\minX# + 1.0
+        If self\maxY# - self\minY# < 1.0 Then self\maxY# = self\minY# + 1.0
+    End Method
+
+
+    // -------------------------------------------------------------------------
+    // worldToScreenX / worldToScreenY -- map a node's world-space position
+    // into the viewport rect, keeping aspect ratio.
+    // -------------------------------------------------------------------------
+    Method worldToScreenX%(vx%, vw%, wx#)
+        Local span# = self\maxX# - self\minX#
+        Local norm# = (wx# - self\minX#) / span#
+        Return vx + ATLAS_VIEWPORT_PAD + Int(norm# * Float(vw - ATLAS_VIEWPORT_PAD * 2))
+    End Method
+
+
+    Method worldToScreenY%(vy%, vh%, wy#)
+        Local span# = self\maxY# - self\minY#
+        Local norm# = (wy# - self\minY#) / span#
+        Return vy + ATLAS_VIEWPORT_PAD + Int(norm# * Float(vh - ATLAS_VIEWPORT_PAD * 2))
+    End Method
+
+
+    // -------------------------------------------------------------------------
+    // drawEdges -- paint a brass line between each connected pair.
+    // -------------------------------------------------------------------------
+    Method drawEdges(vx%, vy%, vw%, vh%)
+        Color LOOM_BRASS_700_R, LOOM_BRASS_700_G, LOOM_BRASS_700_B
+        Local e.AtlasEdge
+        For e = Each AtlasEdge
+            Local na.AtlasNode = Atlas::findNodeByHandle(self, e\FromHandle)
+            Local nb.AtlasNode = Atlas::findNodeByHandle(self, e\ToHandle)
+            If na <> Null And nb <> Null
+                Local x1% = Atlas::worldToScreenX(self, vx, vw, na\X#)
+                Local y1% = Atlas::worldToScreenY(self, vy, vh, na\Y#)
+                Local x2% = Atlas::worldToScreenX(self, vx, vw, nb\X#)
+                Local y2% = Atlas::worldToScreenY(self, vy, vh, nb\Y#)
+                Line x1, y1, x2, y2
+            EndIf
+        Next
+    End Method
+
+
+    // -------------------------------------------------------------------------
+    // drawNodes -- paint each node as a stone disk with a brass ring, label
+    // below; hit-test for clicks. Returns True if click landed on a node.
+    //
+    // Hover highlights with arcane border; the currently focused zone (if
+    // any) gets a brass-filled disk so the user can see "I am here."
+    // -------------------------------------------------------------------------
+    Method drawNodes%(vx%, vy%, vw%, vh%, mx%, my%, clicked%)
+        Local hit% = False
+        Local n.AtlasNode
+        For n = Each AtlasNode
+            Local sx% = Atlas::worldToScreenX(self, vx, vw, n\X#)
+            Local sy% = Atlas::worldToScreenY(self, vy, vh, n\Y#)
+
+            Local dx% = mx - sx
+            Local dy% = my - sy
+            Local dist2% = dx * dx + dy * dy
+            Local hovered% = (dist2 < ATLAS_NODE_R * ATLAS_NODE_R)
+            Local focused% = (self\threads\focusKind = "zone" And self\threads\focusID = n\ZoneHandle)
+
+            // Node disk -- approximate circle via successive filled rects.
+            // Blitz3D doesn't have a one-shot filled-circle primitive, so
+            // for the small radius we use we draw a centered square and
+            // round it visually with a 1px ring. Cheap and reads as a node.
+            If focused = True
+                LoomFill(sx - ATLAS_NODE_R, sy - ATLAS_NODE_R, ATLAS_NODE_R * 2, ATLAS_NODE_R * 2, LOOM_BRASS_500_R, LOOM_BRASS_500_G, LOOM_BRASS_500_B)
+            Else If hovered = True
+                LoomFill(sx - ATLAS_NODE_R, sy - ATLAS_NODE_R, ATLAS_NODE_R * 2, ATLAS_NODE_R * 2, LOOM_ARCANE_700_R, LOOM_ARCANE_700_G, LOOM_ARCANE_700_B)
+            Else
+                LoomFill(sx - ATLAS_NODE_R, sy - ATLAS_NODE_R, ATLAS_NODE_R * 2, ATLAS_NODE_R * 2, LOOM_STONE_700_R, LOOM_STONE_700_G, LOOM_STONE_700_B)
+            EndIf
+
+            // Outer brass ring
+            LoomBorder(sx - ATLAS_NODE_R, sy - ATLAS_NODE_R, ATLAS_NODE_R * 2, ATLAS_NODE_R * 2, LOOM_BRASS_500_R, LOOM_BRASS_500_G, LOOM_BRASS_500_B)
+
+            // Label below
+            Local labelTxt$ = n\Label
+            If Len(labelTxt) > 16 Then labelTxt = Left$(labelTxt, 14) + ".."
+            LoomTextCentered(sx, sy + ATLAS_NODE_R + 4, labelTxt, LOOM_PARCHMENT_100_R, LOOM_PARCHMENT_100_G, LOOM_PARCHMENT_100_B)
+
+            If hovered = True And clicked = True
+                Threads::focus(self\threads, "zone", n\ZoneHandle)
+                hit = True
+                WriteLog(LoomLog, "Atlas: focused zone handle " + Str(n\ZoneHandle))
+            EndIf
+        Next
+        Return hit
+    End Method
+
+
+    // -------------------------------------------------------------------------
+    // Helpers
+    // -------------------------------------------------------------------------
+
+    Method countZones%()
+        Local c% = 0
+        For Ar.Area = Each Area
+            c = c + 1
+        Next
+        Return c
+    End Method
+
+
+    Method findZoneHandleByName%(name$)
+        If name = "" Then Return 0
+        Local upr$ = Upper$(name)
+        For Ar.Area = Each Area
+            If Upper$(Ar\Name$) = upr Then Return Handle(Ar)
+        Next
+        Return 0
+    End Method
+
+
+    Method findNodeByHandle.AtlasNode(h%)
+        Local n.AtlasNode
+        For n = Each AtlasNode
+            If n\ZoneHandle = h Then Return n
+        Next
+        Return Null
+    End Method
+
+
+    Method clearNodes()
+        Local n.AtlasNode
+        For n = Each AtlasNode
+            Delete n
+        Next
+    End Method
+
+
+    Method clearEdges()
+        Local e.AtlasEdge
+        For e = Each AtlasEdge
+            Delete e
+        Next
+    End Method
+End Type

--- a/src/Modules/Loom/Browser.bb
+++ b/src/Modules/Loom/Browser.bb
@@ -79,12 +79,22 @@ Type Browser
     // typing into the browser feels immediate without a click-into-input.
     Field filterQuery$
 
+    // Atlas state -- the Zones tab can swap from card grid to a spatial
+    // portal-graph view. Atlas instance is set by Loom.bb at construction
+    // via Browser::setAtlas; atlasMode tracks whether the user has toggled
+    // it on (persists across tab switches so a return to Zones honors the
+    // last setting). Defaults to card-mode.
+    Field atlas.Atlas
+    Field atlasMode%
+
 
     Method create.Browser(threads.Threads)
         self\threads = threads
         self\category = "actor"     // richest content; most useful starting point
         self\cardClickLatch = False
         self\filterQuery = ""
+        self\atlas = Null
+        self\atlasMode = False
 
         // Build the ordered category list. Iterated via `Each BrowserCategory`
         // in insertion order (Blitz3D's global type pool is FIFO) -- also the
@@ -104,6 +114,15 @@ Type Browser
         Local c.BrowserCategory = New BrowserCategory()
         c\Kind = kind$
         c\Title = title$
+    End Method
+
+
+    // -------------------------------------------------------------------------
+    // setAtlas -- injection point for the Loom top-level type to share the
+    // Atlas instance with the Browser. Called once at construction.
+    // -------------------------------------------------------------------------
+    Method setAtlas(atlas.Atlas)
+        self\atlas = atlas
     End Method
 
 
@@ -239,8 +258,49 @@ Type Browser
             // (the Composer takes over from here).
         EndIf
 
-        // Hint between the button and the input
-        LoomText(nbX + nbW + 16, y + 8, "TYPE TO FILTER  ·  CTRL+K SEARCH ALL", LOOM_BRASS_500_R, LOOM_BRASS_500_G, LOOM_BRASS_500_B)
+        // Card / Atlas view toggle -- only present on the Zones tab. Lives
+        // immediately right of the "+ New" button so the action cluster
+        // stays packed together.
+        Local hintX% = nbX + nbW + 16
+        If self\category = "zone" And self\atlas <> Null
+            Local tbX% = nbX + nbW + 10
+            Local tbY% = y + 4
+            Local tbW% = 130
+            Local tbH% = 22
+            Local tbHover% = (mx >= tbX And mx < tbX + tbW And my >= tbY And my < tbY + tbH)
+
+            If tbHover = True
+                LoomFill(tbX, tbY, tbW, tbH, LOOM_ARCANE_700_R, LOOM_ARCANE_700_G, LOOM_ARCANE_700_B)
+                LoomBorder(tbX, tbY, tbW, tbH, LOOM_ARCANE_500_R, LOOM_ARCANE_500_G, LOOM_ARCANE_500_B)
+            Else
+                LoomFill(tbX, tbY, tbW, tbH, LOOM_STONE_800_R, LOOM_STONE_800_G, LOOM_STONE_800_B)
+                LoomBorder(tbX, tbY, tbW, tbH, LOOM_BRASS_500_R, LOOM_BRASS_500_G, LOOM_BRASS_500_B)
+            EndIf
+
+            // Active half gets a brass fill underline; inactive half stays
+            // neutral. Click anywhere on the button flips.
+            Local halfW% = tbW / 2
+            If self\atlasMode = False
+                LoomFill(tbX, tbY + tbH - 3, halfW, 3, LOOM_BRASS_500_R, LOOM_BRASS_500_G, LOOM_BRASS_500_B)
+            Else
+                LoomFill(tbX + halfW, tbY + tbH - 3, halfW, 3, LOOM_BRASS_500_R, LOOM_BRASS_500_G, LOOM_BRASS_500_B)
+            EndIf
+            LoomText(tbX + 10, tbY + 4, "Card", LOOM_PARCHMENT_100_R, LOOM_PARCHMENT_100_G, LOOM_PARCHMENT_100_B)
+            LoomText(tbX + halfW + 10, tbY + 4, "Atlas", LOOM_PARCHMENT_100_R, LOOM_PARCHMENT_100_G, LOOM_PARCHMENT_100_B)
+
+            If tbHover And clicked
+                If mx < tbX + halfW
+                    self\atlasMode = False
+                Else
+                    self\atlasMode = True
+                EndIf
+                WriteLog(LoomLog, "Browser: zone view -> " + Browser::viewModeLabel(self))
+            EndIf
+            hintX = tbX + tbW + 16
+        EndIf
+
+        // Hint between the button cluster and the input
+        LoomText(hintX, y + 8, "TYPE TO FILTER  ·  CTRL+K SEARCH ALL", LOOM_BRASS_500_R, LOOM_BRASS_500_G, LOOM_BRASS_500_B)
 
         // Input on the right -- 280px wide
         Local iw% = 280
@@ -289,6 +349,16 @@ Type Browser
         If kind = "faction" Then Return "Faction"
         If kind = "animset" Then Return "Anim Set"
         Return kind
+    End Method
+
+
+    // -------------------------------------------------------------------------
+    // viewModeLabel -- short human label for the current zone view mode.
+    // Used in WriteLog calls and could surface in the footer hint later.
+    // -------------------------------------------------------------------------
+    Method viewModeLabel$()
+        If self\atlasMode = True Then Return "atlas"
+        Return "card"
     End Method
 
 
@@ -363,8 +433,20 @@ Type Browser
 
         self\cardClickLatch = False
 
-        Local count% = 0
         Local cat$ = self\category
+
+        // Zone tab + atlasMode = swap the card grid for the spatial atlas.
+        // Atlas owns its own paint + hit-test inside the viewport rect.
+        // (Filter applies to the card view only -- the atlas always shows
+        //  every zone since spatial context is what it's for.)
+        If cat = "zone" And self\atlasMode = True And self\atlas <> Null
+            Local viewportH% = sh - gridY - BR_BOT_RIBBON - BR_SECTION_PAD
+            Local hit% = Atlas::renderAndUpdate(self\atlas, gridX, gridY, gridW, viewportH)
+            If hit = True Then self\cardClickLatch = True
+            Return self\cardClickLatch
+        EndIf
+
+        Local count% = 0
 
         If cat = "actor"
             count = Browser::drawActorGrid(self, sw, sh, mx, my, clicked, gridX, gridY, cols)


### PR DESCRIPTION
## Summary

Ships the design's **#3 signature surface** (see [docs/loom/README.md](docs/loom/README.md)). Zones tab gains a **Card / Atlas** toggle on the filter bar; flipping to Atlas swaps the card grid for a spatial portal-graph visualization.

## Why a derived layout

rcce2 doesn't store world positions for zones — they're a flat list. Atlas derives a layout from the **portal-link graph topology** rather than introducing a new persisted \"world position\" field. Keeps the on-disk data format intact; lets the spatial picture emerge from the connections the designer has already authored.

## Algorithm

Fruchterman-Reingold force-directed layout in [src/Modules/Loom/Atlas.bb](src/Modules/Loom/Atlas.bb):
- One \`AtlasNode\` per zone (cached in the global type pool)
- One \`AtlasEdge\` per portal whose target name resolves
- For \`ATLAS_ITERATIONS = 240\` steps:
  - Every pair of nodes **repels** with force \`k² / d\`
  - Every edge **attracts** its endpoints together with \`d² / k\`
  - Displacement clamped to current temperature
  - Temperature decays by \`ATLAS_TEMP_DECAY = 0.97\`
- Recenter into the viewport rect, keeping aspect

**Circular seeding** (cos/sin around a 200px radius) avoids the all-same-position singularity that gives FR a zero-vector pathology.

## Invalidation

Layout rebuilds on every zone count change — cheap \`O(zones)\` check per frame, the expensive iteration loop only fires when zones are added/deleted (typical projects are stable so this is rare). Manual \`Delete\` on \`AtlasNode\` / \`AtlasEdge\` instances (no \`EnableGC\` in Loom modules) per the established Threads / Palette pattern.

## Integration

- Browser gains \`atlas\` / \`atlasMode\` fields, a Card/Atlas toggle button (only visible on the Zones tab), and a \`setAtlas\` injection point.
- \`Loom.bb\` top-level Type constructs the Atlas instance and wires it to the Browser via \`Browser::setAtlas\`.
- \`Browser::drawCardGrid\` early-returns to \`Atlas::renderAndUpdate\` when \`category=zone\` AND \`atlasMode=True\`, handing through the viewport rect.
- Atlas paints into the same viewport pixels the card grid would use; node click dispatches \`Threads::focus(\"zone\", handle)\` so the composer takes over identically to a card-click focus.

## Test plan

- [x] \`compile.bat\` — all five engine targets + every tool clean
- [x] \`test.bat\` — 32/32 pass
- [ ] Boot Loom, switch to Zones tab → see \"Card | Atlas\" toggle
- [ ] Click Atlas → cards replaced by graph; nodes connected by portal edges
- [ ] Click a node → composer focuses that zone
- [ ] Add a portal between two zones, save, re-toggle Atlas → graph updates
- [ ] Delete a zone → atlas rebuilds (node count change triggers it)