### PR TITLE
Loom: reference-field editing (phase 2) — right-click chip → palette as picker

### DIFF
--- a/docs/loom/roadmap.md
+++ b/docs/loom/roadmap.md
@@ -17,17 +17,12 @@ Shipped, next, and deferred. Read this when picking what to build next.
 - **Editing phase 1 (broaden)** — int / float / bool field types; ~40 editable fields across every entity kind (Actor / Item / Spell / Zone / Faction / AnimSet); Save dispatch for every kind (`SaveActors`, `SaveItems`, `SaveFactions`, `SaveAnimSets`, `ServerSaveArea`); `SetFactionName` helper added to `Actors.bb` to work around the Strict-mode global-array-write trap. ([#336](https://github.com/RydeTec/rcce2/pull/336))
 - **Entity creation (+ New)** — `EntityFactory.bb` wraps the GUE constructors (`CreateActor`, `CreateItem`, `CreateSpell`, `ServerCreateArea`, `CreateAnimSet`, faction-slot-first-empty); "+ New X" button on the browser filter bar dispatches per active category, focuses the new entity for immediate editing, marks the kind dirty. Zone names auto-deduplicate via `EntityFactory_UniqueZoneName` so a new zone doesn't overwrite an existing `.dat`. ([#337](https://github.com/RydeTec/rcce2/pull/337))
 - **Entity deletion + Discard + Validation Ribbon** — Delete button on the composer (two-click arm/confirm); Discard button (revert kind from disk, also arm/confirm); Validation Conscience Ribbon at the top of every Loom surface showing per-kind dirty badges (click to save), broken-reference count (Actor->Faction, Actor->AnimSet, Zone->Portal->Zone), and total entity counts. New `Ribbon.bb` module; new `DeleteX Template` helpers in `Actors.bb`/`Items.bb`/`Spells.bb`/`Animations.bb` (non-Strict, to work around the Dim-write trap). ([#338](https://github.com/RydeTec/rcce2/pull/338))
-- **World Atlas** — design's #3 signature surface. Zones tab gains a Card / Atlas toggle. Atlas renders zones as nodes with portals as edges using a Fruchterman-Reingold force-directed layout derived from the portal-link graph topology. Click a node → focus that zone; layout rebuilds on zone add / delete; circular seeding avoids the all-same-position singularity.
+- **World Atlas** — design's #3 signature surface. Zones tab gains a Card / Atlas toggle. Atlas renders zones as nodes with portals as edges using a Fruchterman-Reingold force-directed layout derived from the portal-link graph topology. Click a node → focus that zone; layout rebuilds on zone add / delete; circular seeding avoids the all-same-position singularity. ([#339](https://github.com/RydeTec/rcce2/pull/339))
+- **Reference-field editing (phase 2)** — right-click any thread chip → palette opens as a picker filtered to that chip's kind; choosing writes the new refID into the underlying field (Actor→DefaultFaction, Actor→MAnimationSet, Actor→FAnimationSet, Zone→portal target by name). Works on broken-ref chips too (so dangling references can be repaired in place). Picker mode with empty query lists every candidate of the kind (no need to type to discover the roster).
 
 ## Next up (in rough order of leverage)
 
-### 1. Editing — phase 2: reference-field editing
-
-Once free-form fields edit, reference-typed fields (faction, anim set, zone target) need pickers. The chip becomes click-to-jump-OR-shift-click-to-edit (or some affordance — UX decision). Reuses the palette as the picker.
-
-Estimated scope: 200-300 LOC. Builds on the shipped palette as picker.
-
-### 2. Session timeline scrubber
+### 1. Session timeline scrubber
 
 Visible history of the session's edits (entity X changed field Y from A to B at time T). Click an entry → revert. Drag the handle → preview a past state. Needs an undo log layered on top of the existing in-memory dirty tracking.
 

--- a/src/Loom.bb
+++ b/src/Loom.bb
@@ -145,6 +145,14 @@ Type Loom
         self\composer = New Composer(self\threads)
         self\palette = New Palette(self\threads)
 
+        // Cross-link Palette <-> Composer for ref-field picker mode. The
+        // Composer's chipRow opens the palette as a picker on right-click;
+        // the Palette's commit path writes via Composer::writeField. The
+        // cycle is fine because both refs are set after both instances
+        // exist (no constructor-time call).
+        Composer::setPalette(self\composer, self\palette)
+        Palette::setComposer(self\palette, self\composer)
+
         // Ribbon holds Threads (for future broken-ref-finder jumps) +
         // Composer (so a dirty-badge click can dispatch to the same
         // commitSaveForKind path the composer's Save button uses).

--- a/src/Modules/Loom/Composer.bb
+++ b/src/Modules/Loom/Composer.bb
@@ -88,6 +88,11 @@ Type Composer
     Field discardArmKind$
     Field discardArmAt%
 
+    // Palette reference -- set by setPalette from Loom.bb at construction.
+    // Used by chipRow to dispatch picker-mode opens on right-click of a
+    // thread chip.
+    Field palette.Palette
+
 
     Method create.Composer(threads.Threads)
         self\threads = threads
@@ -101,7 +106,17 @@ Type Composer
         self\deleteArmAt = 0
         self\discardArmKind = ""
         self\discardArmAt = 0
+        self\palette = Null
         Return self
+    End Method
+
+
+    // -------------------------------------------------------------------------
+    // setPalette -- injection point from Loom.bb so chipRow can dispatch
+    // picker-mode opens. Called once at construction.
+    // -------------------------------------------------------------------------
+    Method setPalette(palette.Palette)
+        self\palette = palette
     End Method
 
 
@@ -154,6 +169,11 @@ Type Composer
         Local mx% = MouseX()
         Local my% = MouseY()
         Local clicked% = MouseHit(1)
+        // Right-click captured once per frame; thread chips read it via
+        // chipRow -> renderChip to dispatch picker-mode opens. Capture
+        // here (not in chipRow) so MouseHit(2)'s consume-once semantics
+        // don't make only the first chip see the press.
+        Local rightClicked% = MouseHit(2)
 
         Local x% = sw - CMP_W
         Local y% = CMP_TOP
@@ -202,17 +222,17 @@ Type Composer
         self\chipHit = False
 
         If kind = "actor"
-            Composer::renderActor(self, x, bodyY, w, bodyH, mx, my, clicked)
+            Composer::renderActor(self, x, bodyY, w, bodyH, mx, my, clicked, rightClicked)
         Else If kind = "item"
             Composer::renderItem(self, x, bodyY, w, bodyH, mx, my, clicked)
         Else If kind = "spell"
             Composer::renderSpell(self, x, bodyY, w, bodyH, mx, my, clicked)
         Else If kind = "zone"
-            Composer::renderZone(self, x, bodyY, w, bodyH, mx, my, clicked)
+            Composer::renderZone(self, x, bodyY, w, bodyH, mx, my, clicked, rightClicked)
         Else If kind = "faction"
-            Composer::renderFaction(self, x, bodyY, w, bodyH, mx, my, clicked)
+            Composer::renderFaction(self, x, bodyY, w, bodyH, mx, my, clicked, rightClicked)
         Else If kind = "animset"
-            Composer::renderAnimSet(self, x, bodyY, w, bodyH, mx, my, clicked)
+            Composer::renderAnimSet(self, x, bodyY, w, bodyH, mx, my, clicked, rightClicked)
         EndIf
 
         // Footer: back-stack hint (or edit-mode hint when editing). Two
@@ -525,6 +545,12 @@ Type Composer
             If fieldId = "trade_mode"     Then A\TradeMode       = Composer::parseIntClamped(self, value, A\TradeMode,       0, 2) : Return
             If fieldId = "playable"       Then A\Playable    = (value = "1") : Return
             If fieldId = "rideable"       Then A\Rideable    = (value = "1") : Return
+            // Reference fields edited via the palette picker. The picker
+            // writes the chosen entity's refID as a string; clamp to the
+            // valid slot range for the kind.
+            If fieldId = "default_faction" Then A\DefaultFaction = Composer::parseIntClamped(self, value, A\DefaultFaction, 0, 99)   : Return
+            If fieldId = "manim_set"       Then A\MAnimationSet  = Composer::parseIntClamped(self, value, A\MAnimationSet,  0, 999)  : Return
+            If fieldId = "fanim_set"       Then A\FAnimationSet  = Composer::parseIntClamped(self, value, A\FAnimationSet,  0, 999)  : Return
         EndIf
 
         // ---- ZONE -----------------------------------------------------------
@@ -538,6 +564,14 @@ Type Composer
             If fieldId = "weather_link"   Then Ar\WeatherLink$ = value   : Return
             If fieldId = "outdoors"       Then Ar\Outdoors = (value = "1") : Return
             If fieldId = "pvp"            Then Ar\PvP      = (value = "1") : Return
+            // Portal-target reference fields: editFieldId = "portal_<i>".
+            // The picker passes the chosen zone's Name as the value (the
+            // portal stores by name, not handle).
+            If Left$(fieldId, 7) = "portal_"
+                Local portIdx% = Int(Mid$(fieldId, 8))
+                If portIdx >= 0 And portIdx <= 99 Then Ar\PortalLinkArea$[portIdx] = value
+                Return
+            EndIf
         EndIf
 
         // ---- FACTION --------------------------------------------------------
@@ -959,13 +993,22 @@ Type Composer
 
     // label : thread chip row. Returns the next Y. ORs into self\chipHit
     // when the chip is clicked so renderAndUpdate can surface it.
-    Method chipRow%(panelX%, panelW%, rowY%, label$, kind$, refID%, mx%, my%, clicked%)
+    //
+    // editFieldId$: when non-empty + right-click consumed, open the palette
+    // as a picker targeting (self\threads\focusKind, self\threads\focusID,
+    // editFieldId). When empty (back-reference chips, e.g. faction members
+    // or animset users), right-click is ignored -- there's no field on the
+    // current focus to write the chosen entity into.
+    Method chipRow%(panelX%, panelW%, rowY%, label$, kind$, refID%, mx%, my%, clicked%, rightClicked%, editFieldId$)
         LoomText(panelX + CMP_PAD, rowY + 4, label, LOOM_BRASS_500_R, LOOM_BRASS_500_G, LOOM_BRASS_500_B)
 
         Local chipX% = panelX + CMP_PAD + 120
         Local chipW% = panelW - CMP_PAD * 2 - 120
-        Local hit% = Threads::renderChip(self\threads, chipX, rowY, chipW, CMP_CHIP_H, kind, refID, mx, my, clicked)
-        If hit Then self\chipHit = True
+        Local code% = Threads::renderChip(self\threads, chipX, rowY, chipW, CMP_CHIP_H, kind, refID, mx, my, clicked, rightClicked)
+        If code = 1 Then self\chipHit = True
+        If code = 2 And editFieldId <> "" And self\palette <> Null
+            Palette::openAsPicker(self\palette, kind, self\threads\focusKind, self\threads\focusID, editFieldId)
+        EndIf
 
         Return rowY + CMP_CHIP_H + 4
     End Method
@@ -995,7 +1038,7 @@ Type Composer
     // returns void; chipHit is latched onto self for renderAndUpdate to see.
     // -------------------------------------------------------------------------
 
-    Method renderActor(panelX%, bodyY%, panelW%, bodyH%, mx%, my%, clicked%)
+    Method renderActor(panelX%, bodyY%, panelW%, bodyH%, mx%, my%, clicked%, rightClicked%)
         Local refID% = self\threads\focusID
         If refID < 0 Or refID > 65535 Then Return
         Local A.Actor = ActorList(refID)
@@ -1019,9 +1062,12 @@ Type Composer
 
         y = Composer::sectionHeader(self, panelX, panelW, y, "Threads")
 
-        y = Composer::chipRow(self, panelX, panelW, y, "Faction",    "faction", A\DefaultFaction, mx, my, clicked)
-        y = Composer::chipRow(self, panelX, panelW, y, "M anim set", "animset", A\MAnimationSet,  mx, my, clicked)
-        y = Composer::chipRow(self, panelX, panelW, y, "F anim set", "animset", A\FAnimationSet,  mx, my, clicked)
+        // Editable ref chips: right-click opens the palette as a picker
+        // filtered to the chip's kind; selection writes the new refID
+        // into the named field via Composer::writeField.
+        y = Composer::chipRow(self, panelX, panelW, y, "Faction",    "faction", A\DefaultFaction, mx, my, clicked, rightClicked, "default_faction")
+        y = Composer::chipRow(self, panelX, panelW, y, "M anim set", "animset", A\MAnimationSet,  mx, my, clicked, rightClicked, "manim_set")
+        y = Composer::chipRow(self, panelX, panelW, y, "F anim set", "animset", A\FAnimationSet,  mx, my, clicked, rightClicked, "fanim_set")
     End Method
 
 
@@ -1092,7 +1138,7 @@ Type Composer
     End Method
 
 
-    Method renderZone(panelX%, bodyY%, panelW%, bodyH%, mx%, my%, clicked%)
+    Method renderZone(panelX%, bodyY%, panelW%, bodyH%, mx%, my%, clicked%, rightClicked%)
         Local Ar.Area = Object.Area(self\threads\focusID)
         If Ar = Null Then Return
         Local h% = Handle(Ar)
@@ -1142,7 +1188,12 @@ Type Composer
                 If Ar\PortalName$[p] <> "" And y < bodyY + bodyH - CMP_CHIP_H - 24
                     Local targetHandle% = Composer::findZoneByName(self, Ar\PortalLinkArea$[p])
                     If targetHandle <> 0
-                        y = Composer::chipRow(self, panelX, panelW, y, Ar\PortalName$[p], "zone", targetHandle, mx, my, clicked)
+                        // Portal-target chips: editable via right-click. fieldId
+                        // encodes the portal index ("portal_<i>") so writeField
+                        // can route to the right slot. Picker writes the
+                        // target zone's NAME (not handle) because the wire
+                        // format stores by string.
+                        y = Composer::chipRow(self, panelX, panelW, y, Ar\PortalName$[p], "zone", targetHandle, mx, my, clicked, rightClicked, "portal_" + Str(p))
                     Else
                         // Unknown target -- render a brass label that names it in danger-red.
                         LoomText(panelX + CMP_PAD, y + 4, Ar\PortalName$[p], LOOM_BRASS_500_R, LOOM_BRASS_500_G, LOOM_BRASS_500_B)
@@ -1157,7 +1208,7 @@ Type Composer
     End Method
 
 
-    Method renderFaction(panelX%, bodyY%, panelW%, bodyH%, mx%, my%, clicked%)
+    Method renderFaction(panelX%, bodyY%, panelW%, bodyH%, mx%, my%, clicked%, rightClicked%)
         Local idx% = self\threads\focusID
         If idx < 0 Or idx > 99 Then Return
 
@@ -1172,7 +1223,9 @@ Type Composer
         Local memberCount% = 0
         For Ac.Actor = Each Actor
             If Ac\DefaultFaction = idx And y < bodyY + bodyH - CMP_CHIP_H - 24
-                y = Composer::chipRow(self, panelX, panelW, y, "", "actor", Ac\ID, mx, my, clicked)
+                // Members are a back-reference; no field on the focused
+                // faction to edit via this chip, so editFieldId = "".
+                y = Composer::chipRow(self, panelX, panelW, y, "", "actor", Ac\ID, mx, my, clicked, rightClicked, "")
                 memberCount = memberCount + 1
             EndIf
         Next
@@ -1183,7 +1236,7 @@ Type Composer
     End Method
 
 
-    Method renderAnimSet(panelX%, bodyY%, panelW%, bodyH%, mx%, my%, clicked%)
+    Method renderAnimSet(panelX%, bodyY%, panelW%, bodyH%, mx%, my%, clicked%, rightClicked%)
         Local targetID% = self\threads\focusID
 
         // AnimSet is iterated, not indexed -- walk to find.
@@ -1208,7 +1261,9 @@ Type Composer
         Local userCount% = 0
         For Ac.Actor = Each Actor
             If (Ac\MAnimationSet = targetID Or Ac\FAnimationSet = targetID) And y < bodyY + bodyH - CMP_CHIP_H - 24
-                y = Composer::chipRow(self, panelX, panelW, y, "", "actor", Ac\ID, mx, my, clicked)
+                // Back-reference (actors using this anim set); no field
+                // on the focused animset to edit via this chip.
+                y = Composer::chipRow(self, panelX, panelW, y, "", "actor", Ac\ID, mx, my, clicked, rightClicked, "")
                 userCount = userCount + 1
             EndIf
         Next

--- a/src/Modules/Loom/Palette.bb
+++ b/src/Modules/Loom/Palette.bb
@@ -76,34 +76,97 @@ End Type
 // =============================================================================
 Type Palette
     Field threads.Threads
+    Field composer.Composer       // set via setComposer, used in picker mode
+                                  // to dispatch writeField on selection
 
     Field open%
     Field query$
     Field highlightIdx%
     Field resultCount%      // total candidates with score > 0
 
+    // Picker mode -- when True, the palette is acting as a reference-field
+    // picker rather than a navigator. Only results matching pickerKind are
+    // shown (filtered in rebuildResults); on selection, we WRITE the
+    // chosen entity's refID into Composer::writeField at the target
+    // coordinates instead of calling Threads::jump.
+    //
+    // pickerTargetValueStrFn is implicit: for typed-ID refs (faction,
+    // animset) we write Str(refID). For zone-portal-by-name we write the
+    // entity's name string. The kind discriminator handles this in
+    // commitPicker below.
+    Field pickerMode%
+    Field pickerKind$              // kind to filter results by
+    Field pickerTargetKind$        // entity kind that owns the field
+    Field pickerTargetRefID%       // entity ID
+    Field pickerTargetFieldId$     // field name within the entity
+
 
     Method create.Palette(threads.Threads)
         self\threads = threads
+        self\composer = Null
         self\open = False
         self\query = ""
         self\highlightIdx = 0
         self\resultCount = 0
+        self\pickerMode = False
+        self\pickerKind = ""
+        self\pickerTargetKind = ""
+        self\pickerTargetRefID = 0
+        self\pickerTargetFieldId = ""
         Return self
     End Method
 
 
     // -------------------------------------------------------------------------
-    // openModal -- show the palette, clear any prior query. Called when the
+    // setComposer -- injection point from Loom.bb so the picker mode can
+    // dispatch writeField. Called once at construction.
+    // -------------------------------------------------------------------------
+    Method setComposer(composer.Composer)
+        self\composer = composer
+    End Method
+
+
+    // -------------------------------------------------------------------------
+    // openModal -- show the palette in navigator mode. Called when the
     // outer Loom frame detects Ctrl+K.
     // -------------------------------------------------------------------------
     Method openModal()
         self\open = True
         self\query = ""
         self\highlightIdx = 0
+        self\pickerMode = False
+        self\pickerKind = ""
+        self\pickerTargetKind = ""
+        self\pickerTargetRefID = 0
+        self\pickerTargetFieldId = ""
         Palette::clearResults(self)
         FlushKeys
-        WriteLog(LoomLog, "Palette: open")
+        WriteLog(LoomLog, "Palette: open (navigator)")
+    End Method
+
+
+    // -------------------------------------------------------------------------
+    // openAsPicker -- show the palette in picker mode. Only entities of
+    // `pickerKind` will be candidates; on selection, the chosen entity's
+    // refID is written into (targetKind, targetRefID, targetFieldId) via
+    // Composer::writeField + markDirtyForKind.
+    //
+    // Called by Composer::chipRow on a right-click of a thread chip. The
+    // pickerKind matches the chip's kind so the user can only pick a
+    // valid replacement (no cross-kind shenanigans).
+    // -------------------------------------------------------------------------
+    Method openAsPicker(pickerKind$, targetKind$, targetRefID%, targetFieldId$)
+        self\open = True
+        self\query = ""
+        self\highlightIdx = 0
+        self\pickerMode = True
+        self\pickerKind = pickerKind
+        self\pickerTargetKind = targetKind
+        self\pickerTargetRefID = targetRefID
+        self\pickerTargetFieldId = targetFieldId
+        Palette::clearResults(self)
+        FlushKeys
+        WriteLog(LoomLog, "Palette: open (picker " + pickerKind + " -> " + targetKind + "#" + Str(targetRefID) + "." + targetFieldId + ")")
     End Method
 
 
@@ -114,6 +177,11 @@ Type Palette
         self\open = False
         self\query = ""
         self\highlightIdx = 0
+        self\pickerMode = False
+        self\pickerKind = ""
+        self\pickerTargetKind = ""
+        self\pickerTargetRefID = 0
+        self\pickerTargetFieldId = ""
         Palette::clearResults(self)
         WriteLog(LoomLog, "Palette: close")
     End Method
@@ -246,7 +314,11 @@ Type Palette
 
         If self\resultCount = 0
             If Len(self\query) = 0
-                LoomText(rx, startY, "Type to search actors, items, spells, zones, factions, animation sets.", LOOM_STONE_300_R, LOOM_STONE_300_G, LOOM_STONE_300_B)
+                If self\pickerMode = True
+                    LoomText(rx, startY, "Picking a " + self\pickerKind + ". Type to filter.", LOOM_STONE_300_R, LOOM_STONE_300_G, LOOM_STONE_300_B)
+                Else
+                    LoomText(rx, startY, "Type to search actors, items, spells, zones, factions, animation sets.", LOOM_STONE_300_R, LOOM_STONE_300_G, LOOM_STONE_300_B)
+                EndIf
             Else
                 LoomText(rx, startY, "No matches.", LOOM_STONE_300_R, LOOM_STONE_300_G, LOOM_STONE_300_B)
             EndIf
@@ -366,65 +438,100 @@ Type Palette
         Palette::clearResults(self)
 
         Local q$ = Lower$(Trim$(self\query))
-        If q = "" Then Return
 
-        // Actors -- "Race [Class]" composite name
-        For Ac.Actor = Each Actor
-            Local aName$ = Ac\Race$ + " [" + Ac\Class$ + "]"
-            Local aScore% = Palette::scoreName(self, q, aName)
-            If aScore > 0
-                Palette::addResult(self, "actor", Ac\ID, aName, "actor", aScore)
-            EndIf
-        Next
+        // Navigator mode: empty query = no results (avoids dumping the
+        // whole project unprompted). Picker mode: empty query = show
+        // every candidate of the picker kind unranked (score 1) so the
+        // user can scan a small fixed roster without typing -- common
+        // case for "what factions exist?".
+        Local showAllBaseline% = False
+        If self\pickerMode = True And q = "" Then showAllBaseline = True
+        If self\pickerMode = False And q = "" Then Return
 
-        // Items
-        For It.Item = Each Item
-            Local iScore% = Palette::scoreName(self, q, It\Name$)
-            If iScore > 0
-                Palette::addResult(self, "item", It\ID, It\Name$, "item", iScore)
-            EndIf
-        Next
+        // Helper-less per-kind gates: in picker mode, skip kinds that
+        // don't match pickerKind. In navigator mode, all kinds emit.
+        Local emitActor% = (self\pickerMode = False Or self\pickerKind = "actor")
+        Local emitItem% = (self\pickerMode = False Or self\pickerKind = "item")
+        Local emitSpell% = (self\pickerMode = False Or self\pickerKind = "spell")
+        Local emitZone% = (self\pickerMode = False Or self\pickerKind = "zone")
+        Local emitFaction% = (self\pickerMode = False Or self\pickerKind = "faction")
+        Local emitAnimSet% = (self\pickerMode = False Or self\pickerKind = "animset")
 
-        // Spells
-        For Sp.Spell = Each Spell
-            Local sScore% = Palette::scoreName(self, q, Sp\Name$)
-            If sScore > 0
-                Palette::addResult(self, "spell", Sp\ID, Sp\Name$, "spell", sScore)
-            EndIf
-        Next
-
-        // Zones
-        For Ar.Area = Each Area
-            Local zScore% = Palette::scoreName(self, q, Ar\Name$)
-            If zScore > 0
-                Palette::addResult(self, "zone", Handle(Ar), Ar\Name$, "zone", zScore)
-            EndIf
-        Next
-
-        // Factions
-        Local fi% = 0
-        For fi = 0 To 99
-            If FactionNames$(fi) <> ""
-                Local fScore% = Palette::scoreName(self, q, FactionNames$(fi))
-                If fScore > 0
-                    Palette::addResult(self, "faction", fi, FactionNames$(fi), "faction", fScore)
+        If emitActor = True
+            For Ac.Actor = Each Actor
+                Local aName$ = Ac\Race$ + " [" + Ac\Class$ + "]"
+                Local aScore% = Palette::scoreOrBaseline(self, q, aName, showAllBaseline)
+                If aScore > 0
+                    Palette::addResult(self, "actor", Ac\ID, aName, "actor", aScore)
                 EndIf
-            EndIf
-        Next
+            Next
+        EndIf
 
-        // Anim sets
-        For As.AnimSet = Each AnimSet
-            Local mScore% = Palette::scoreName(self, q, As\Name$)
-            If mScore > 0
-                Palette::addResult(self, "animset", As\ID, As\Name$, "anim set", mScore)
-            EndIf
-        Next
+        If emitItem = True
+            For It.Item = Each Item
+                Local iScore% = Palette::scoreOrBaseline(self, q, It\Name$, showAllBaseline)
+                If iScore > 0
+                    Palette::addResult(self, "item", It\ID, It\Name$, "item", iScore)
+                EndIf
+            Next
+        EndIf
+
+        If emitSpell = True
+            For Sp.Spell = Each Spell
+                Local sScore% = Palette::scoreOrBaseline(self, q, Sp\Name$, showAllBaseline)
+                If sScore > 0
+                    Palette::addResult(self, "spell", Sp\ID, Sp\Name$, "spell", sScore)
+                EndIf
+            Next
+        EndIf
+
+        If emitZone = True
+            For Ar.Area = Each Area
+                Local zScore% = Palette::scoreOrBaseline(self, q, Ar\Name$, showAllBaseline)
+                If zScore > 0
+                    Palette::addResult(self, "zone", Handle(Ar), Ar\Name$, "zone", zScore)
+                EndIf
+            Next
+        EndIf
+
+        If emitFaction = True
+            Local fi% = 0
+            For fi = 0 To 99
+                If FactionNames$(fi) <> ""
+                    Local fScore% = Palette::scoreOrBaseline(self, q, FactionNames$(fi), showAllBaseline)
+                    If fScore > 0
+                        Palette::addResult(self, "faction", fi, FactionNames$(fi), "faction", fScore)
+                    EndIf
+                EndIf
+            Next
+        EndIf
+
+        If emitAnimSet = True
+            For As.AnimSet = Each AnimSet
+                Local mScore% = Palette::scoreOrBaseline(self, q, As\Name$, showAllBaseline)
+                If mScore > 0
+                    Palette::addResult(self, "animset", As\ID, As\Name$, "anim set", mScore)
+                EndIf
+            Next
+        EndIf
 
         // Clamp highlight to the (possibly smaller) result count.
         Local cap% = self\resultCount
         If cap > PAL_MAX_RESULTS Then cap = PAL_MAX_RESULTS
         If self\highlightIdx >= cap Then self\highlightIdx = cap - 1
         If self\highlightIdx < 0 Then self\highlightIdx = 0
+    End Method
+
+
+    // -------------------------------------------------------------------------
+    // scoreOrBaseline -- scoreName with a fallback: when showAllBaseline is
+    // True (picker-mode empty-query), every name gets a score of 1 so it
+    // shows up in the unranked list. Used to populate the picker with the
+    // full roster when the user hasn't typed anything yet.
+    // -------------------------------------------------------------------------
+    Method scoreOrBaseline%(q$, name$, showAllBaseline%)
+        If showAllBaseline = True Then Return 1
+        Return Palette::scoreName(self, q, name)
     End Method
 
 
@@ -504,13 +611,50 @@ Type Palette
 
     // -------------------------------------------------------------------------
     // jumpToResult -- shared dispatch for click + Enter. Closes the modal
-    // before jumping so the focus change isn't shadowed by the dim overlay
-    // on the same frame.
+    // first so the focus change isn't shadowed by the dim overlay on the
+    // same frame.
+    //
+    // In navigator mode: Threads::jump pushes prev focus to the back stack
+    // and sets the new focus.
+    // In picker mode: Composer::writeField writes the chosen entity's
+    // refID into the target field; mark dirty so Save appears. The
+    // current focus is preserved (the user is still on the entity whose
+    // field they were picking for).
     // -------------------------------------------------------------------------
     Method jumpToResult(r.PaletteResult)
         Local k$ = r\Kind
         Local id% = r\RefID
         Local nm$ = r\DisplayName
+
+        If self\pickerMode = True
+            // Capture picker target before closeModal clears it.
+            Local tKind$ = self\pickerTargetKind
+            Local tID% = self\pickerTargetRefID
+            Local tField$ = self\pickerTargetFieldId
+
+            Palette::closeModal(self)
+
+            If self\composer = Null
+                WriteLog(LoomLog, "Palette: picker selected but Composer not wired -- noop")
+                Return
+            EndIf
+
+            // Encode the chosen value for the target field. For zone
+            // portals (string-by-name) we'd write the entity name; all
+            // other ref fields take the integer ID as string.
+            Local val$
+            If k = "zone"
+                val = nm        // for any future zone-by-name field
+            Else
+                val = Str(id)
+            EndIf
+
+            Composer::writeField(self\composer, tKind, tID, tField, val)
+            Composer::markDirtyForKind(self\composer, tKind)
+            WriteLog(LoomLog, "Palette: picked " + k + "#" + Str(id) + " (" + nm + ") -> " + tKind + "#" + Str(tID) + "." + tField)
+            Return
+        EndIf
+
         Palette::closeModal(self)
         Threads::jump(self\threads, k, id)
         WriteLog(LoomLog, "Palette: jumped to " + k + "#" + Str(id) + " (" + nm + ")")

--- a/src/Modules/Loom/Threads.bb
+++ b/src/Modules/Loom/Threads.bb
@@ -196,15 +196,22 @@ Type Threads
 
 
     // -------------------------------------------------------------------------
-    // renderChip -- draw a clickable chip, hit-test the mouse, call jump on
-    // click. Returns True if the chip consumed a click this frame.
+    // renderChip -- draw a clickable chip, hit-test mouse, dispatch on click.
     //
-    // The chip handles the navigation internally so callers can be dumb -- they
-    // just lay out the rect and pass mouse state. The Composer reads the
-    // boolean return only to OR-fold into its own "any chip clicked this
-    // frame?" flag for the back-stack hint.
+    // Return codes:
+    //   0  no interaction this frame
+    //   1  left click consumed -- chip already called Threads::jump
+    //   2  right click consumed -- caller should open a picker for (kind, refID)
+    //
+    // The chip handles the navigation internally so callers can be dumb --
+    // they just lay out the rect and pass mouse state. Right-click never
+    // jumps; it's a signal to the Composer's chipRow to open the palette
+    // in picker mode targeting the field this chip represents.
+    //
+    // Broken refs accept right-click (so the user can pick a replacement
+    // for a dangling chip) but not left-click (no entity to jump to).
     // -------------------------------------------------------------------------
-    Method renderChip%(x%, y%, w%, h%, kind$, refID%, mx%, my%, clicked%)
+    Method renderChip%(x%, y%, w%, h%, kind$, refID%, mx%, my%, clicked%, rightClicked%)
         Local hovered% = (mx >= x And mx < x + w And my >= y And my < y + h)
 
         Local cName$ = Threads::lookupName(self, kind, refID)
@@ -239,17 +246,28 @@ Type Threads
             LoomText(x + CHIP_PAD_X + CHIP_ICON_W, y + 5, cName, LOOM_PARCHMENT_100_R, LOOM_PARCHMENT_100_G, LOOM_PARCHMENT_100_B)
         EndIf
 
-        // Right-side arrow indicating "jump"
-        If broken = False
+        // Right-side affordance -- on hover, show pencil hint for the
+        // right-click-to-edit affordance; otherwise the > arrow for the
+        // left-click-jump affordance.
+        If hovered = True
+            LoomText(x + w - 32, y + 5, "RMB:edit", LOOM_BRASS_500_R, LOOM_BRASS_500_G, LOOM_BRASS_500_B)
+        Else If broken = False
             LoomText(x + w - 16, y + 5, ">", LOOM_BRASS_500_R, LOOM_BRASS_500_G, LOOM_BRASS_500_B)
         EndIf
 
-        // Click consumed?
+        // Left click jumps (only when not broken).
         If hovered And clicked And broken = False
             Threads::jump(self, kind, refID)
-            Return True
+            Return 1
         EndIf
-        Return False
+
+        // Right click signals picker request (works on broken refs too,
+        // so a dangling chip can be fixed in place).
+        If hovered And rightClicked
+            Return 2
+        EndIf
+
+        Return 0
     End Method
 
 


### PR DESCRIPTION
## Summary

Closes the **editing phase 2** gap. Reference-typed fields (Actor→Faction, Actor→MAnimationSet, Actor→FAnimationSet, Zone→portal-target) become editable by **right-clicking the existing thread chip**. The palette opens in picker mode filtered to the chip's kind; on selection, the chosen entity's refID is written into the target field via the established \`Composer::writeField + markDirtyForKind\` path.

## Three new pieces

### 1. Palette gains picker mode

New fields: \`pickerMode%\`, \`pickerKind\$\`, \`pickerTargetKind\$\`, \`pickerTargetRefID%\`, \`pickerTargetFieldId\$\`. New \`openAsPicker\` method seeds them. \`rebuildResults\` filters by \`pickerKind\` when in picker mode; **with an empty query in picker mode, every candidate of the kind shows up unranked** (so a fresh picker isn't blank — common case for \"what factions exist?\").

\`jumpToResult\` branches: picker mode dispatches \`Composer::writeField + markDirtyForKind\` on the chosen entity's refID; navigator mode unchanged. For zone-by-name fields (portal targets), the picker writes the entity's **name string**; for typed-ID fields (faction, animset), it writes \`Str(refID)\`.

### 2. \`Threads::renderChip\` return shape: bool → tri-code

| Code | Meaning |
|---|---|
| 0 | no interaction |
| 1 | left-click jumped (existing) |
| 2 | right-click consumed (caller opens picker) |

Broken refs accept right-click (no left-click target to jump to) so a **dangling chip can be repaired in place**. Hover shows the \"RMB:edit\" hint where the \`>\` arrow used to live.

### 3. Composer plumbing

- New \`palette\` field + \`setPalette\` injection from \`Loom.bb\`.
- \`chipRow\` signature gains \`rightClicked% + editFieldId\$\`. On code=2 with non-empty fieldId + non-null palette, calls \`openAsPicker\` targeting \`(focusKind, focusID, fieldId)\`.
- Back-reference chips (faction members, animset users) pass \`fieldId=\"\"\` so right-click is ignored — there's no field on the current focus to write into.
- \`MouseHit(2)\` captured **once** at \`renderAndUpdate\` and propagated through the render path (consume-once semantics would otherwise give only the first chip the press).
- \`writeField\` gains:
  - \`actor.default_faction\` → \`A\DefaultFaction = clamp(0, 99)\`
  - \`actor.manim_set\` → \`A\MAnimationSet = clamp(0, 999)\`
  - \`actor.fanim_set\` → \`A\FAnimationSet = clamp(0, 999)\`
  - \`zone.portal_<i>\` → \`Ar\PortalLinkArea\$[i] = name\`

\`Loom.bb\` cross-links the cycle: \`Composer::setPalette\` and \`Palette::setComposer\`. Both refs are set after both instances exist so there's no constructor-time call into the other side.

## Test plan

- [x] \`compile.bat\` — all five engine targets + every tool clean
- [x] \`test.bat\` — 32/32 pass
- [ ] Focus an Actor, right-click its Faction chip → palette opens filtered to Factions, every faction shown
- [ ] Pick a faction → DefaultFaction updates, dirty asterisk appears, Save persists
- [ ] Same for M / F anim set chips on Actor
- [ ] Focus a Zone with a broken-target portal → right-click the danger-red chip → repair via picker