### PR TITLE
docs(loom): catch up architecture / README / roadmap after 10 iterations of beta work + 2 new ADRs

### DIFF
--- a/docs/loom/README.md
+++ b/docs/loom/README.md
@@ -27,22 +27,29 @@ The full original design brief — written for an outside design agent — is pr
 5. **Session timeline scrubber** — visible history of the current session's edits, with a draggable handle to rewind.
 6. **Walk-in playtest** — spawn into the zone you're editing as a live player without restarting the server.
 
-The shipped alpha implements **one of these (threads)** and a simpler version of one more (the atlas, as the browser's category grid). The other four are deferred — see [roadmap.md](roadmap.md).
+The shipped beta implements **five of these directly** (threads, conscience ribbon, world atlas, command palette, session timeline scrubber) and a sixth (walk-in playtest) remains the only deferred signature surface.
 
-## What Loom is today (alpha)
+## What Loom is today (beta)
 
-Read-only entity browser with thread navigation. Specifically:
+A full-featured GUE replacement with thread navigation, search, and a custom-drawn aesthetic. Specifically:
 
-- Boots into a **browser** that lists every actor / item / spell / zone / faction / animation set as clickable cards.
-- Picking a card opens a **composer** panel on the right showing the entity's full property set.
-- Reference fields render as **thread chips**: click an actor's faction → composer switches to that faction with its member roster → click a member → that actor. Esc walks back through the trail.
-- Reads through the same data loaders GUE uses (`LoadActors`, `LoadItems`, `LoadSpells`, `ServerLoadArea`, …) so anything GUE can edit, Loom can see.
+- **Browser** with seven categories (actors / items / spells / zones / factions / anim sets / tools) — each card is clickable; arrow keys + Enter for keyboard nav; live filter input above the grid.
+- **Composer** panel for the focused entity — ~40 editable fields across every kind; Save / Discard / Delete buttons (arm-confirm on the destructive ones); per-field range clamps so typos can't poison data.
+- **Thread chips** for every reference between entities — left-click jumps + pushes back stack (Esc walks back); right-click opens the **palette as a picker** filtered to that chip's kind so you can swap the referent without leaving the composer. Broken refs render danger-red.
+- **Conscience Ribbon** at the top — per-kind dirty badges (click to Save), broken-reference count (click → modal that enumerates each dangling ref with click-to-jump), total entity counts.
+- **Command palette** (Ctrl+K) — type-to-search find-anywhere across every entity in the project with prefix > substring ranking.
+- **Session timeline** (Ctrl+H) — every edit / create / delete recorded with click-to-revert on edits.
+- **Recents** (Ctrl+R) — per-project persisted list of recently-focused entities; survives across sessions.
+- **World Atlas** — Zones tab has a Card / Atlas toggle; Atlas renders the portal-link graph as a force-directed spatial view.
+- **Tools tab** — launchers for GUE's seven standalone editors (RC Architect, Terrain / Caves / Rock / Tree, Gubbin, Spell Wizard). Missing-binary detection paints unbuilt tools in danger-red.
+- **+ New** button on every entity tab — create a fresh actor / item / spell / zone / faction / anim set, auto-focused for editing.
+- Reads through the same data loaders GUE uses and writes through the same `SaveX` functions, so the two editors cannot drift on the file format.
 
-What it deliberately can't do:
+What it deliberately still can't do:
 
-- **Edit anything.** Every field is read-only. Editing needs save / dirty tracking that's its own design surface — see [decisions/002-read-only-alpha.md](decisions/002-read-only-alpha.md).
 - **Render zones in 3D.** The 3D mesh loader is locked into GUE's UI substrate — see [decisions/004-deferred-3d-viewport.md](decisions/004-deferred-3d-viewport.md).
-- **Search across everything (Ctrl+K).** Not yet wired. The command palette is on the roadmap.
+- **Walk-in playtest.** Requires server-side feature work (out-of-band player spawn API) — see roadmap "Deferred."
+- **Multi-cursor / collaboration.** Out of scope indefinitely.
 
 ## How to read this directory
 

--- a/docs/loom/architecture.md
+++ b/docs/loom/architecture.md
@@ -11,52 +11,131 @@ src/
 └── Modules/
     ├── (existing GUE data modules — Items.bb, Actors.bb, etc.)
     │                                read-only consumed; not modified
+    │                                except for narrow setter helpers
+    │                                (SetFactionName, DeleteXTemplate)
     └── Loom/
         ├── Theme.bb                 color palette + 2D drawing primitives
         ├── Threads.bb               focus state + back stack + chip primitive
-        ├── Browser.bb               category bar + filter input + card grid
-        ├── Composer.bb              right-side property panel per kind
-        └── Palette.bb               Ctrl+K find-anywhere modal
+        ├── Browser.bb               brand strip + tab bar + filter input +
+        │                            card grid + Tools card grid
+        ├── Composer.bb              right-side property panel per kind;
+        │                            edit / save / delete / discard actions
+        ├── Palette.bb               Ctrl+K find-anywhere; also picker
+        │                            mode for ref-field editing
+        ├── Ribbon.bb                top "Validation Conscience" strip:
+        │                            dirty badges + broken-ref count + totals
+        ├── BrokenRefs.bb            modal listing every dangling reference
+        │                            (clicked from the Ribbon's red count)
+        ├── Atlas.bb                 zone spatial view (FR force-directed
+        │                            graph from portal links)
+        ├── Timeline.bb              Ctrl+H session edit history with
+        │                            click-to-revert
+        ├── Recents.bb               Ctrl+R per-project persisted recently-
+        │                            focused entities (Data/Loom/recents.txt)
+        ├── Tools.bb                 launcher catalog for GUE's standalone
+        │                            editors (Architect / Terrain / etc.)
+        └── EntityFactory.bb         create / delete dispatch wrapping
+                                     GUE's Create* + (new) DeleteXTemplate
 ```
 
 ### One-line module summaries
 
-- **`Loom.bb`** — Bootstrap globals + data-loader sequence (mirrors `GUE.bb`'s order) + defines `Type Loom` and constructs an instance. The main loop is `While Loom::renderFrame(app) Wend` — `renderFrame` returns False when Esc exits from an empty state.
-- **`Theme.bb`** — Color tokens as `LOOM_STONE_900_R/G/B`-style constants (the design's full palette). Drawing primitives wrap Blitz's `Color/Rect/Line/Text` so callers paint through `LoomFill / LoomGradientV / LoomHRule / LoomText / LoomTextCentered`. Stateless helpers; kept as free functions per the rule of thumb in the BlitzForge skill (no state → free functions are fine).
-- **`Threads.bb`** — The centerpiece module. `Type Threads` owns `focusKind$`, `focusID%`, and a `backStack.BBList` of `LoomFocusEntry`. Methods: `create.Threads`, `focus(kind, refID)` (direct set), `jump(kind, refID)` (set + push back stack), `back%()` (pop), `clearStack()`, `lookupName$(kind, refID)`, `renderChip%(...)` (the clickable rounded-rect every reference field uses).
-- **`Browser.bb`** — The boot surface. `Type Browser` holds a reference to the shared `Threads` instance + the current `category$`. Six categories (`Actors / Items / Spells / Zones / Factions / Animation Sets`); each has its own per-kind grid method (`drawActorGrid`, `drawItemGrid`, etc.) dispatched from `drawCardGrid`. Click a card → `Threads::focus(self\threads, kind, refID)`.
-- **`Composer.bb`** — Right-side panel that appears when something's focused. `Type Composer` holds a reference to the same `Threads` instance. Per-kind body renderer methods (`renderActor`, `renderItem`, …) lay out rows of `label : value` and rows of `label : [thread chip]`. Reads from the data modules' globals (`ActorList`, `ItemList`, `FactionNames$`, `Each AnimSet`, `Each Area`). `width%()` returns 0 when nothing is focused so the Browser knows whether to reserve right-edge space.
+- **`Loom.bb`** — Bootstrap globals + data-loader sequence (mirrors `GUE.bb`'s order) + defines `Type Loom` and constructs every sub-instance. Main loop is `While Loom::renderFrame(app) Wend`; returns False from `renderFrame` when Esc exits an empty state. Owns the **modal stacking + Esc priority chain** (see below) and the global keybinding dispatch (Ctrl+K / Ctrl+H / Ctrl+R).
+- **`Theme.bb`** — Color tokens as `LOOM_STONE_900_R/G/B`-style constants (the design's full palette). Drawing primitives wrap Blitz's `Color/Rect/Line/Text` so callers paint through `LoomFill / LoomGradientV / LoomHRule / LoomText / LoomTextCentered`. Also exports `LOOM_TOP_RIBBON_H` so every surface shares the same y-offset for the Conscience Ribbon.
+- **`Threads.bb`** — The centerpiece module. `Type Threads` owns `focusKind$`, `focusID%`, and a `backStack.BBList` of `LoomFocusEntry`. Methods: `focus`, `jump` (push back stack), `back`, `clearStack`, `lookupName$`, `renderChip%` (returns a tri-code: 0=no-op / 1=left-jumped / 2=right-picker-request). Every focus / jump call emits to `Recents_Record` so navigation lands in the recents list.
+- **`Browser.bb`** — The boot surface. Seven categories (`Actors / Items / Spells / Zones / Factions / Animation Sets / Tools`); per-kind grid methods dispatched from `drawCardGrid`. Filter input live-filters; arrow keys move a brass-ringed selection cursor; Enter focuses. Tools category swaps in `drawToolsGrid` which dispatches `Tools_Launch` on click. Zones tab has a `Card | Atlas` toggle that swaps the grid for the `Atlas` surface.
+- **`Composer.bb`** — Right-side panel when something's focused. Per-kind body renderers (`renderActor`, `renderItem`, …) with editable rows: `editableRow` (string), `editableIntRow`, `editableFloatRow`, `toggleRow` (click-to-flip pill), `chipRow` (thread chip with right-click → picker). Top-right action cluster: Save / Discard / Delete buttons (arm-confirm on Discard + Delete). `commitEdit` records to Timeline before writing.
+- **`Palette.bb`** — Ctrl+K modal find-anywhere across every kind with prefix > substring scoring and arrow-key navigation. Also serves as **picker mode** for ref-field editing — when opened via `openAsPicker(kind, targetKind, targetID, targetFieldId)`, results are filtered by kind and selection writes via `Composer::writeField` instead of `Threads::jump`.
+- **`Ribbon.bb`** — Top "Validation Conscience" strip (28px). Per-kind dirty badges (brass when dirty, click to Save), broken-ref count chip (clickable when > 0 → opens BrokenRefs modal), total entity counts. Recomputed once per frame via `Ribbon::recomputeCache`.
+- **`BrokenRefs.bb`** — Modal that enumerates every dangling reference with diagnosis text and click-to-jump-to-source. Re-scans on every open (no staleness). Capped at 250 entries.
+- **`Atlas.bb`** — Spatial zone-graph view. Fruchterman-Reingold force-directed layout derived from portal-link topology (no persisted world position). Layout rebuilds on zone add / delete; cached between frames.
+- **`Timeline.bb`** — Ctrl+H session edit history; ring-buffered at 200 entries. Records every edit / toggle / create / delete; revert button on edits + toggles dispatches `Composer::writeField`. Module-level facade (`Timeline_Record{Edit,Toggle,Create,Delete}`) lets callers record without an instance ref.
+- **`Recents.bb`** — Ctrl+R per-project persisted recently-focused entities (`Data/Loom/recents.txt`). Stable keys per kind (refID for typed entities, name for zones) survive Handle regeneration across sessions. Move-to-front insertion; cap 30.
+- **`Tools.bb`** — Free-function catalog of GUE's seven standalone editors. `Tools_Init` registers at boot; `Tools_Launch` `ExecFile`s the .exe with the project's `Data/` folder as CWD. Missing-binary detection (`FileType <> 1`) so the Browser can render the card as broken.
+- **`EntityFactory.bb`** — Free-function module wrapping the GUE constructors (`CreateActor`, `CreateItem`, `CreateSpell`, `ServerCreateArea`, `CreateAnimSet`) plus the new non-Strict `DeleteXTemplate` helpers (added to `Actors.bb` / `Items.bb` / `Spells.bb` / `Animations.bb` to work around the Strict-mode Dim-array-write trap). Records every create / delete to Timeline.
 
 ### Why Types with Methods (not prefixed free functions)
 
-Loom's UI modules each own state — `Browser` owns the current category, `Composer` owns layout latches, `Threads` owns focus + back stack. The project's canonical OO convention (`Project Manager.bb`, `Framework/RCCEApp.bb`, `Framework/Project/Project.bb`) is **`Type` with `Method`s called via `TypeName::method(self, args)`** for stateful modules; Loom follows that pattern. See [`.claude/skills/blitzforge-language/SKILL.md`](../../.claude/skills/blitzforge-language/SKILL.md) "Module architecture" section for the rule + canonical examples.
+Loom's stateful UI modules own state — Browser owns the category and cursor, Composer owns edit / delete-arm state, Threads owns focus + back stack, Atlas owns the cached force-layout. The project's canonical OO convention is **`Type` with `Method`s called via `TypeName::method(self, args)`** for stateful modules; Loom follows that pattern. See [`.claude/skills/blitzforge-language/SKILL.md`](../../.claude/skills/blitzforge-language/SKILL.md) "Module architecture" section for the rule + canonical examples.
 
-The top-level `Type Loom` holds the three sub-instances:
+Stateless modules (`Theme`, `Tools`, `EntityFactory`) stay as free functions per the same skill's rule of thumb (no state → free functions are fine).
+
+The top-level `Type Loom` owns every sub-instance:
 
 ```basic
 Type Loom
+    Field windowWidth%, windowHeight%
+    Field projectName$
     Field threads.Threads
     Field browser.Browser
     Field composer.Composer
-    Field projectName$
-    Field windowWidth%, windowHeight%
+    Field palette.Palette
+    Field ribbon.Ribbon
+    Field atlas.Atlas
+    Field timeline.Timeline
+    Field brokenRefs.BrokenRefs
+    Field recents.Recents
 
     Method create.Loom(w%, h%, name$)
         self\threads = New Threads()
-        self\browser = New Browser(self\threads)     // shares Threads
-        self\composer = New Composer(self\threads)   // shares Threads
-        ...
-    End Method
-
-    Method renderFrame%()
-        Browser::renderAndUpdate(self\browser, self\windowWidth, self\windowHeight, self\projectName)
-        Composer::renderAndUpdate(self\composer, self\windowWidth, self\windowHeight)
-        ...
+        self\browser = New Browser(self\threads)
+        self\composer = New Composer(self\threads)
+        self\palette = New Palette(self\threads)
+        // ... cross-link Composer <-> Palette (picker mode)
+        // ... construct Ribbon, Atlas, Timeline, BrokenRefs, Recents
+        // ... set module-level facade pointers (LoomTimeline, LoomRecents)
     End Method
 End Type
 ```
 
-The Browser and Composer both receive the same Threads reference at construction, so card clicks (Browser → `Threads::focus`) and chip clicks (Composer → `Threads::jump` via `Threads::renderChip`) write to the same back stack without globals.
+Every UI module that needs the focus state holds a Threads reference passed at construction — no globals for shared focus state.
+
+## The render loop + modal stacking
+
+The frame paints back-to-front: Browser → Composer → Ribbon → (Timeline | BrokenRefs | Recents | Palette modals). Each modal consumes its own keys when open and returns True from `renderAndUpdate` so the outer Esc handler skips. Browser keyboard input is gated by `browserInput%` — disabled when any modal is open or the Composer is editing a field.
+
+**Esc priority chain** (highest-priority handler wins each frame):
+
+```
+modal-eats > clear browser filter > pop Threads back stack > close composer > exit Loom
+```
+
+**Modifier-shortcut chain** (only when no modal is open):
+
+```
+Ctrl+K  -> Palette (navigator mode)
+Ctrl+H  -> Timeline
+Ctrl+R  -> Recents
+```
+
+**Mouse priorities**:
+
+```
+Composer right-click on chip  -> Palette (picker mode)
+Composer right-click elsewhere -> no-op (consumed by chipRow guard)
+Mouse left-click               -> normal hit-test
+```
+
+A `MouseHit(2)` is captured ONCE at `Composer::renderAndUpdate` and propagated through the per-kind renderers → chipRow → renderChip — consuming the press at the first chipRow would make only the first chip see the press.
+
+## Recorder facade pattern
+
+Three modules (`Timeline`, `Recents`) record events from many call sites (Composer / EntityFactory / Palette commit / Threads::focus). Threading an instance reference through every caller is noise; instead each module exposes a **module-level facade** of free functions backed by a `Global Loom<Module>.Type` pointer that `Loom.bb` sets at construction:
+
+```basic
+// In Timeline.bb
+Global LoomTimeline.Timeline = Null
+Function Timeline_RecordEdit(kind$, refID%, fieldId$, oldValue$, newValue$, label$)
+    If LoomTimeline = Null Then Return
+    Timeline::record(LoomTimeline, TLE_EDIT, ...)
+End Function
+
+// In Loom.bb create.Loom
+self\timeline = New Timeline()
+LoomTimeline = self\timeline
+```
+
+The facade is defensive about Null (early-boot calls before wiring don't crash). Callers (Composer, EntityFactory, Palette, Threads) call the facade and never know there's a singleton behind it. The same shape is used by `LoomRecents` / `Recents_Record`.
 
 ## Data flow
 
@@ -64,36 +143,39 @@ The Browser and Composer both receive the same Threads reference at construction
                        ┌──────────────────────────┐
                        │  Data .dat files on disk │
                        │  (under <project>/Data/) │
-                       └─────────────┬────────────┘
-                                     │  LoadActors, LoadItems,
-                                     │  LoadSpells, ServerLoadArea,
-                                     │  LoadFactions, LoadAnimSets, ...
-                                     ▼
-              ┌──────────────────────────────────────────┐
-              │  In-memory type instances + arrays:      │
-              │  ActorList(N), ItemList(N), SpellsList,  │
-              │  FactionNames$(99), Each Area / AnimSet  │
-              └─────────────┬────────────────────┬───────┘
-                            │                    │
-                read by:    │                    │  written by GUE
-                            │                    │  (Loom is read-only)
-                            ▼                    │
-                  ┌────────────────────┐         │
-                  │  Loom UI modules   │         │
-                  │  (Browser/Composer)│         │
-                  └─────────┬──────────┘         │
-                            │                    │
-                            ▼                    ▼
-                       paint to screen      Save*.dat
-                       via Theme.bb
-                       primitives
+                       └─────┬────────────────┬───┘
+                             │                ▲
+              LoadActors,    │                │  SaveActors,
+              LoadItems,     │                │  SaveItems,
+              ...            ▼                │  ServerSaveArea,
+        ┌──────────────────────────────────────┴──┐
+        │  In-memory type instances + arrays:      │
+        │  ActorList(N), ItemList(N), SpellsList,  │
+        │  FactionNames$(99), Each Area / AnimSet  │
+        └─────────┬────────────────────┬───────────┘
+                  │ read by            │ written by GUE
+                  │                    │ AND by Loom
+                  ▼                    │ (Composer / EntityFactory)
+        ┌────────────────────┐         │
+        │  Loom UI modules   │─────────┘
+        │  (Browser/Composer │
+        │   /Palette/Ribbon/ │
+        │   Atlas/Timeline/  │
+        │   BrokenRefs/      │
+        │   Recents)         │
+        └─────────┬──────────┘
+                  │
+                  ▼
+            paint to screen via Theme.bb primitives
 ```
 
-**Key invariant:** Loom reads through the exact same `LoadX` functions GUE uses, so the two editors cannot drift in how they parse the file format. The cost is dragging in GUE's data modules wholesale; the benefit is correctness by construction.
+**Key invariant:** Loom reads through the exact same `LoadX` functions GUE uses, so the two editors cannot drift in how they parse the file format. Writes go through the same `SaveX` functions for the bulk-serialized kinds (Spells / Items / Actors / Factions / AnimSets); zones use the per-file `ServerSaveArea(Area)` since each zone is its own `.dat`.
+
+The few mutating helpers Loom needed that don't exist in GUE — `SetFactionName`, `DeleteActorTemplate`, `DeleteItemTemplate`, `DeleteSpellTemplate`, `DeleteAnimSetTemplate` — were added to the respective data modules as **non-Strict** functions. They live in non-Strict modules so they can write to `Dim`'d global arrays (the Strict-mode trap; see Gotchas below).
 
 ## Shared state (the vocabulary)
 
-Lives as fields on the `Threads` instance, which is the source of truth shared between Browser and Composer (both hold a reference set at construction time — no globals):
+Lives as fields on the `Threads` instance, which is the source of truth shared between every UI module that needs to know what's focused (no globals for focus state):
 
 | Field | Type | Meaning |
 |---|---|---|
@@ -103,76 +185,53 @@ Lives as fields on the `Threads` instance, which is the source of truth shared b
 
 **`refID` payload per kind** — every Loom module uses these conventions; never deviate:
 
-| Kind | `refID` payload |
-|---|---|
-| `actor` | `Actor\ID` (array index into `ActorList`) |
-| `item` | `Item\ID` (array index into `ItemList`) |
-| `spell` | `Spell\ID` (array index into `SpellsList`) |
-| `zone` | `Handle(Area)` (round-trips via `Object.Area(handle)`) |
-| `faction` | `FactionNames$` array index 0..99 |
-| `animset` | `AnimSet\ID` |
+| Kind | `refID` payload | Stable across sessions? |
+|---|---|---|
+| `actor` | `Actor\ID` (array index into `ActorList`) | yes |
+| `item` | `Item\ID` (array index into `ItemList`) | yes |
+| `spell` | `Spell\ID` (array index into `SpellsList`) | yes |
+| `zone` | `Handle(Area)` (round-trips via `Object.Area(handle)`) | **no** — regenerates per load |
+| `faction` | `FactionNames$` array index 0..99 | yes |
+| `animset` | `AnimSet\ID` | yes |
 
-## The render loop
+The zone-handle instability is why `Recents` persists zones by `Ar\Name$` instead of refID — see [Recents.bb](../../src/Modules/Loom/Recents.bb) "STABLE KEYS" comment.
 
-`Loom.bb` main loop, simplified — `Loom::renderFrame` returns False when Loom should exit:
+## Edit / save / dirty-flag plumbing
 
-```basic
-Local app.Loom = New Loom(boot_width, boot_height, projectName)
-While Loom::renderFrame(app) = True
-Wend
-```
+The per-kind `*Saved` globals (`ItemsSaved`, `ActorsSaved`, `SpellsSaved`, `FactionsSaved`, `ZoneSaved`, `AnimsSaved`) are **shared with GUE** — `Loom.bb` redeclares the same set at lines 58-69 so writes from Loom's Composer / EntityFactory flip the same flags GUE inspects. `False` = unsaved changes pending; `True` = on-disk == in-memory.
 
-Inside `renderFrame`:
+The edit lifecycle:
 
-```basic
-Method renderFrame%()
-    Cls
-    Browser::renderAndUpdate(self\browser, self\windowWidth, self\windowHeight, self\projectName)
-    Composer::renderAndUpdate(self\composer, self\windowWidth, self\windowHeight)  // no-op when focus = ""
+1. **`Composer::beginEdit(kind, refID, fieldId, currentValue)`** — opens a text-entry session for one field. Captures `editOldValue` for the Timeline.
+2. **Keystrokes pump into `editBuffer$`** via `Composer::pumpKeyboard`. Backspace + ASCII drain.
+3. **`Composer::commitEdit`** — `writeField` dispatches per-kind; `markDirtyForKind` flips the `*Saved` global; `Timeline_RecordEdit` records if value changed.
+4. **`Composer::commitSaveForKind(kind)`** — calls the GUE serializer (`SaveSpells` / `SaveItems` / `SaveActors` / `SaveFactions` / `SaveAnimSets`) or per-zone `ServerSaveArea(Area)`. Resets `*Saved` to `True`.
+5. **Discard** — frees every in-memory instance via the new `DeleteXTemplate` helpers, re-runs the `LoadX` function. Zones use `ServerUnloadArea` + `ServerLoadArea(name)`.
 
-    If KeyHit(1)   // Esc
-        If Threads::back(self\threads) = False
-            If self\threads\focusKind <> ""
-                Threads::focus(self\threads, "", 0)        // close composer
-                Threads::clearStack(self\threads)
-            Else
-                Return False                                // exit Loom
-            EndIf
-        EndIf
-    EndIf
-
-    Flip
-    Return True
-End Method
-```
-
-The two render calls are **idempotent and stateless from the caller's POV** — every frame re-reads the data, re-runs hit-tests, re-paints. There's no "switch to a different mode" dispatch; the composer's visibility is purely a function of `self\threads\focusKind`.
-
-`Composer::width(composer)` returns 0 when nothing is focused (else `CMP_W`); the Browser reads this so a future PR can shrink the grid by that many pixels on the right when the composer is visible. Today the composer just overlays.
+Numeric edits go through `Composer::parseIntClamped` / `parseFloatClamped` with per-field `[lo, hi]` ranges so a typo can't poison a field. Garbage strings parse to 0 via `Int()` / `Float()` and get clamped to `lo`.
 
 ## Why custom-draw + not F-UI
 
-See [decisions/001-custom-draw-not-fui.md](decisions/001-custom-draw-not-fui.md) for the full rationale. Short version: F-UI is built for utilitarian Windows-style gadgets and cannot render the gradient-heavy, ornament-heavy aesthetic the Loom design called for, and a previous round of trying to retrofit Loom concepts on top of F-UI hit several quirks (window `M_HIDE` no-ops, listbox/combobox `M_GETSELECTED` handle inversion, `Tab M_SETINDEX` nested-iterator pathology) that made the retrofit a losing game. Loom paints everything itself through `Theme.bb` primitives directly on top of Blitz3D.
+See [decisions/001-custom-draw-not-fui.md](decisions/001-custom-draw-not-fui.md) for the full rationale. Short version: F-UI is built for utilitarian Windows-style gadgets and cannot render the gradient-heavy, ornament-heavy aesthetic the Loom design called for. We chose custom-draw and have not regretted it — the modal stack, the chip primitive, the ribbon, the atlas, and the timeline all paint through the same `Theme.bb` primitives and share visual language without any of F-UI's per-widget retrofit cost.
 
-**Caveat for the future:** F-UI is still pulled in for things F-UI is genuinely good at — file dialogs, native text input boxes — if/when Loom needs them. Today Loom needs neither (it's read-only). When editing lands, expect F-UI to be Included for the text-input widgets only.
+**F-UI is still not Included by Loom even though editing landed.** The composer's text-input uses a hand-rolled GetKey-drain pump (see `Composer::pumpKeyboard`) which costs maybe 30 LOC and gives full control over the cursor blink, color, and edit-arm state.
 
 ## Why no `ClientAreas.bb` Include
 
 `ClientAreas.bb`'s `LoadArea` is the canonical 3D zone-mesh loader. It's transitively coupled to GUE's UI substrate: `GY_Cam` (Gooey's 3D camera), `GY_CreateProgressBar`, `ResolutionType`, `RandomImages`, `GetMusicName$`, `GetTexture`, `GetFilename$` (which is defined inside `GUE.bb` itself, not in a shared module). Pulling it in would lock Loom to GUE's UI substrate — exactly what Loom is supposed to decouple.
 
-Concrete consequence: **Loom cannot render the 3D zone mesh.** Zone composer shows zone metadata as text + portal-target chips. See [decisions/004-deferred-3d-viewport.md](decisions/004-deferred-3d-viewport.md) for the path to fixing this in beta (extract `GetFilename$` to a shared helper; either rewrite `LoadArea`'s data path with the GUI side ripped out, or build a Loom-side mesh loader).
+Concrete consequence: **Loom cannot render the 3D zone mesh.** Zone composer shows zone metadata as text + portal-target chips; the Atlas surface gives a 2D spatial view from the portal graph topology. See [decisions/004-deferred-3d-viewport.md](decisions/004-deferred-3d-viewport.md) for the path to fixing this (extract `GetFilename$` to a shared helper; either rewrite `LoadArea`'s data path with the GUI side ripped out, or build a Loom-side mesh loader).
 
 ## Data-model gotchas
 
 The thread model assumes reference fields are typed pointers, but rcce2 often stores them as plain strings:
 
-- **Actor → faction**: typed (index into `FactionNames$`). Thread works.
-- **Actor → anim set**: typed (`AnimSet\ID`). Thread works.
-- **Zone → portal target**: stored as `PortalLinkArea$[i]` *string*. Composer resolves the string to a zone `Handle` via `Composer_FindZoneByName`; works for valid names, renders as broken-ref-red for unknown.
+- **Actor → faction**: typed (index into `FactionNames$`). Thread works; editable via right-click → picker.
+- **Actor → anim set**: typed (`AnimSet\ID`). Thread works; editable via right-click → picker.
+- **Zone → portal target**: stored as `PortalLinkArea$[i]` *string*. Composer resolves the string to a zone `Handle` via `Composer::findZoneByName`; works for valid names, renders as broken-ref-red for unknown. Editable via right-click → picker (the picker writes the NAME, not the handle, since the wire format stores by name).
 - **Faction → members**: not stored. Computed: walk `Each Actor` looking for `Ac\DefaultFaction = idx`. Cheap.
 - **AnimSet → users**: same pattern — walk actors looking for M or F binding.
-- **Item → script**: stored as `Item\Script$` string. No entity to jump to (scripts live as `.rsl` files on disk; not Loom's data model). Rendered as text.
-- **Spell → script / emitter**: same. Strings. No thread.
+- **Item / Spell → script**: stored as `Item\Script$` / `Sp\Script$` string. No entity to jump to (scripts live as `.rsl` files on disk; not Loom's data model). Rendered as text; editable as a plain string field.
 - **Spell → casters**: cannot be derived from the data model — casts come from scripts. No back-reference possible without grepping scripts.
 
 When adding a new thread chip site, check: is the reference field a typed ID, or a string? Strings either resolve through a lookup (like zone names) or render as text (no thread).
@@ -181,19 +240,27 @@ When adding a new thread chip site, check: is the reference field a typed ID, or
 
 - All Loom-specific modules under `src/Modules/Loom/`
 - All exported symbols prefixed by their module: `Browser_*`, `Composer_*`, `Threads_*`, `LoomTheme_*`, `Loom_*` for cross-module state
+- Module-level facade functions follow `<Module>_<Verb>` (no double-colon): `Timeline_RecordEdit`, `Recents_Record`, `Tools_Launch`, `EntityFactory_Create`
 - Color constants: `LOOM_STONE_900_R / _G / _B` (channel-separated so `LoomFill(x, y, w, h, ...)` calls don't need to unpack a single int)
-- Layout constants module-prefixed: `BR_TOP_RIBBON`, `CMP_PAD`, `CHIP_PAD_X`
-- New `.bb` files don't need to be Strict — non-Strict matches the existing module convention and avoids spurious cross-file declaration friction
+- Layout constants module-prefixed: `BR_TOP_RIBBON`, `CMP_PAD`, `CHIP_PAD_X`, `PAL_MODAL_W`, `TIMELINE_ROW_H`
+- New `.bb` files default to Strict. The exceptions — `Recents.bb` — note their reason in the file header (typically `WriteFile`/`WriteLine` BBStream typing that doesn't thread through `SafeWriteCommit%`'s int signature)
 
-## Known BlitzForge gotchas hit during the alpha
+## Known BlitzForge gotchas hit during the alpha + beta
 
 Documented here so the next agent doesn't re-discover them:
 
 - **`..` line continuation is not supported.** Long function calls have to fit on one line. (`Mismatched brackets` is the parser error.)
-- **`First` and `Last` are reserved.** Don't use them as variable names — `Expecting identifier near: first Got: first`. We use `firstFound`, `prev`, `endIdx`.
+- **`First` and `Last` are reserved.** Don't use them as variable names. We use `firstFound`, `prev`, `endIdx`.
 - **`data` is reserved** (the `Data/Read/Restore` family). Don't use as a variable name.
+- **`step` is reserved** (For-loop syntax). Atlas had to rename `step` → `arc`.
+- **`pi` is reserved** (math constant). Ribbon had to rename `pi` → `portalIdx`.
+- **`default` is reserved**. Composer's `parseIntClamped` had to rename its default param to `fallback`.
 - **Single-line `For ... : If ... Then ... : Next` doesn't compose.** The `If ... Then ...` on the same line swallows the rest of the line up to the implicit `EndIf`, so the `: Next` becomes part of the IF body and the For has no Next. Always multi-line the body.
-- **`New TypeName()` parens are required** in BlitzForge even with no args; bare `New TypeName` errors. (Holdover from the BlitzForge skill — if you forget, the parser complains.)
-- **Type instances leak without `EnableGC`.** None of the Loom files use `EnableGC` (matches the project's canonical OO files — `Project Manager.bb` doesn't either). `BBList`'s `ListClear` and `ListRemove` only drop the list's references; the underlying instances stay on the heap. `Threads.bb` explicitly `Delete`s `LoomFocusEntry` instances in `back()` and `clearStack()` to avoid leaking N entries per N back/forward navigations.
-- **`Strict` + reassigning a Method-scope `Local` from inside nested `If`/`For` blocks doesn't compile.** Error: `<varname> assignment should start with local, global or const modifier`. Reassigning at the same nesting level as the `Local` declaration is fine; reassigning from a deeper nested block (or from a sibling `Else If` branch after using it in an earlier branch) errors. Workaround: write to a **Field on the Type** instead (`self\latch = True` works at any depth). Loom hit this in `Browser::drawCardGrid`'s six-branch `If/Else If` chain and ended up refactoring to per-kind grid methods (`drawActorGrid`, `drawItemGrid`, …) — which turned out to be cleaner OO design anyway.
-- **Tab gadget `M_SETINDEX` has a nested-iterator bug in F-UI.** Calling `FUI_SendMessage(TabMain, M_SETINDEX, 9)` doesn't reliably switch the visible tab when called from outside F-UI's own click path. The previous retrofit round documented this; Loom sidesteps it entirely by not using F-UI's Tab gadget.
+- **`New TypeName()` parens are required** in BlitzForge even with no args; bare `New TypeName` errors.
+- **Type instances leak without `EnableGC`.** None of the Loom files use `EnableGC` (matches the project's canonical OO files). Every Type that holds heap state (`LoomFocusEntry`, `PaletteResult`, `TimelineEntry`, `BrokenRef`, `RecentEntry`, `AtlasNode`, `AtlasEdge`) has an explicit `Delete` in its clear / trim method.
+- **`Strict` + reassigning a Method-scope `Local` from inside nested `If`/`For` blocks doesn't compile.** Error: `<varname> assignment should start with local, global or const modifier`. Reassigning at the same nesting level as the `Local` declaration is fine; reassigning from a deeper nested block (or from a sibling `Else If` branch after using it in an earlier branch) errors. **Workaround**: write to a **Field on the Type** instead (`self\latch = True` works at any depth). Loom hit this in `Browser::drawCardGrid`'s six-branch chain (refactored to per-kind grid methods), `Ribbon::recomputeCache` (moved counters to `self\cached*` Fields), `Timeline::drawOneEntry`'s action-glyph dispatch (extracted to `Timeline::actionGlyph`), and `Composer::parseFloatClamped`'s digit-counter loop (skipped the validator entirely).
+- **`Strict` + writing to a `Dim`'d global array from inside a Method errors** the same way. `FactionNames$(idx) = value` from Loom's Strict Composer can't compile. Workaround: a non-Strict setter function (`SetFactionName`, `DeleteActorTemplate`, etc.) in the non-Strict data module. Routing through the setter is the established pattern.
+- **`Strict` + `WriteFile` returns `BBStream`** which doesn't auto-convert to the int file handle that legacy IO helpers like `SafeWriteCommit%` take. `Recents.bb` drops Strict at the module level for this reason; an alternative would be `Local F.BBStream = WriteFile(...)` but the typing doesn't thread through `SafeWriteCommit`.
+- **Tab gadget `M_SETINDEX` has a nested-iterator bug in F-UI.** Calling `FUI_SendMessage(TabMain, M_SETINDEX, 9)` doesn't reliably switch the visible tab when called from outside F-UI's own click path. Loom sidesteps it entirely by not using F-UI's Tab gadget — the browser's category tab bar is hand-drawn.
+- **`MouseHit(2)` consume-once.** Calling `MouseHit(2)` inside a per-chip iteration would only give the first chip the right-click. Capture once at `Composer::renderAndUpdate` and propagate `rightClicked%` through the render path.
+- **`KeyHit(N)` consume-once** has the same shape. Global keybindings (Ctrl+K / Ctrl+H / Ctrl+R) are captured at `Loom::renderFrame` BEFORE any modal's `pumpKeyboard` runs, so the modal-open keystroke doesn't dribble into the modal's own query.

--- a/docs/loom/decisions/005-recorder-facade-pattern.md
+++ b/docs/loom/decisions/005-recorder-facade-pattern.md
@@ -1,0 +1,81 @@
+# ADR 005: Module-level recorder facade for cross-cutting events
+
+## Context
+
+As Loom grew from the read-only alpha into the beta, multiple modules acquired the need to **record events that span the application**:
+
+- **Timeline.bb** records every in-memory mutation (edit / toggle / create / delete) so Ctrl+H can show the session history with click-to-revert.
+- **Recents.bb** records every entity focus so Ctrl+R can show recently-touched entities across sessions.
+
+The callers are everywhere. Edits flow from `Composer::commitEdit` (text), `Composer::toggleRow` (bool), and `Palette::jumpToResult` (picker mode). Creates flow from `EntityFactory_Create*`. Deletes flow from `EntityFactory_Delete*`. Focuses flow from `Threads::focus` and `Threads::jump` — which are themselves called by Browser card clicks, chip clicks, palette navigator-mode commits, BrokenRefs jumps, Atlas node clicks, and Recents modal clicks.
+
+The naïve approach would be to thread a `timeline.Timeline` reference (and `recents.Recents` reference) through every call site that might need to record. That's a lot of plumbing — at the limit, every Method that mutates state would need both refs added to its signature, and the constructor chain in `Loom.bb` would need to set them at every level. Worse, some callers (`Threads::focus`) live in modules that are **Included before** the recorder module, so the recorder Type wouldn't even be in scope at the call site.
+
+## Decision
+
+Each recorder module exposes a **module-level facade** of free functions backed by a `Global Loom<Module>.Type` pointer that `Loom.bb` sets at construction:
+
+```basic
+// In Timeline.bb
+Global LoomTimeline.Timeline = Null
+
+Function Timeline_RecordEdit(kind$, refID%, fieldId$, oldValue$, newValue$, label$)
+    If LoomTimeline = Null Then Return
+    Timeline::record(LoomTimeline, TLE_EDIT, kind, refID, fieldId, oldValue, newValue, label)
+End Function
+
+// In Loom.bb create.Loom
+self\timeline = New Timeline()
+LoomTimeline = self\timeline    // facade is live from here on
+```
+
+Callers invoke the free function and never see the singleton:
+
+```basic
+// In Composer::commitEdit
+Timeline_RecordEdit(k, id, fid, oldVal, val, Threads::lookupName(self\threads, k, id))
+
+// In EntityFactory_CreateActor
+Timeline_RecordCreate("actor", A\ID, A\Race$ + " [" + A\Class$ + "]")
+
+// In Threads::focus (Included BEFORE Recents.bb!)
+Recents_Record(kind$, refID, Threads::lookupName(self, kind$, refID))
+```
+
+Same shape applies to Recents (`LoomRecents.Recents` + `Recents_Record`).
+
+## Consequences
+
+### Positive
+
+- **Caller signatures stay clean.** No new reference parameters threading through `commitEdit` / `Create*` / `Delete*` / `focus` / `jump`.
+- **Forward references work.** Threads.bb is Included before Recents.bb in Loom.bb's chain, but `Recents_Record` is resolved at whole-program link time so the call compiles fine. The Type isn't needed at the call site — only the free function name is.
+- **Defensive against early-boot calls.** Every facade function null-checks the singleton (`If LoomTimeline = Null Then Return`). The first few focus calls before `Loom.bb` wires the pointer are silent no-ops — no crash, no special-case at the call site.
+- **Extension is local.** Adding a new recorder doesn't require touching any caller's signature; the new module declares its facade + singleton, and callers gradually adopt by adding a one-liner.
+
+### Negative
+
+- **One global per recorder.** Loom isn't a multi-instance app, but in principle this shape couples the recorder modules to "there is exactly one Loom in this process." Acceptable trade-off; we don't run multiple Looms.
+- **Initialization-order discipline.** Facade callers may run before `Loom.bb` sets the pointer. We rely on the null-check inside each facade function to handle the early-boot window. A more pedantic alternative would be to defer the call site invocation until after wiring, but that complicates every caller for a window measured in microseconds.
+- **Hides ownership.** Reading a caller in isolation — `Timeline_RecordEdit(...)` — doesn't reveal where the singleton came from. The facade is a documented convention; readers have to know to look in `Loom.bb` for the wiring + the recorder module's header for the singleton.
+
+## Alternatives considered
+
+- **Pass the Timeline/Recents ref through every call site.** Rejected for the plumbing cost (every Composer Method, every EntityFactory function, every Threads Method gains two new parameters).
+- **Put recorders on the Threads Type.** Conflates focus-state with edit-history; Threads has no business owning a 200-entry ring buffer. Rejected for cohesion.
+- **Subscribe / publish via a generic event bus.** Overkill for two consumers. The facade is the smallest shape that does the job.
+
+## When to add a new recorder
+
+Use this pattern when:
+- The recorder needs to observe events from 3+ unrelated call sites.
+- The recorder's lifecycle matches the app's lifecycle (single instance, lives for the whole session).
+- The caller would otherwise need a new constructor parameter / setter just to dispatch one event.
+
+Don't use this pattern for module-private state — that's what Type Fields are for. The facade is specifically for app-singleton modules with many callers.
+
+## Related
+
+- ADR 006 — modal stacking + Esc priority chain (the other cross-cutting concern that emerged alongside this one).
+- `Modules/Loom/Timeline.bb` — `LoomTimeline` + `Timeline_Record*`.
+- `Modules/Loom/Recents.bb` — `LoomRecents` + `Recents_Record`.

--- a/docs/loom/decisions/006-modal-stacking-and-esc-priority.md
+++ b/docs/loom/decisions/006-modal-stacking-and-esc-priority.md
@@ -1,0 +1,100 @@
+# ADR 006: Modal stacking + Esc priority chain
+
+## Context
+
+The beta accumulated four full-screen modal overlays: Palette (Ctrl+K), Timeline (Ctrl+H), Recents (Ctrl+R), BrokenRefs (click the ribbon's count chip). Each dims the world behind itself and consumes keyboard input — text into a query, arrow keys to scroll, Esc to close. They share enough shape that a single "are we in a modal?" gate isn't sufficient — the rules for who-handles-what need to be explicit.
+
+Esc is the single most-asked-for key. It needs to do one of seven things depending on UI state, and the answer "the highest-priority thing that applies" requires a documented chain.
+
+## Decision
+
+### Modal render + input ownership
+
+Every modal exposes:
+- `Module::isOpen%(self)` — read accessor used to gate other surfaces.
+- `Module::openModal(self)` — sets `open = True`, `FlushKeys` to drop the open-keystroke buffer, scrolls to top.
+- `Module::closeModal(self)` — sets `open = False`, clears transient state.
+- `Module::renderAndUpdate%(self, sw, sh)` — paints + pumps input + returns `True` if the modal consumed input this frame.
+
+`Loom::renderFrame` paints back-to-front: Browser → Composer → Ribbon → (modals). The modal `renderAndUpdate` calls return `modalAte%`; the outer Esc handler runs **only when no modal ate input that frame**.
+
+### Browser input gate
+
+The Browser's filter pump + nav pump are gated by `browserInput%`:
+
+```basic
+Local browserInput% = True
+If Timeline::isOpen(self\timeline) = True Then browserInput = False
+If Palette::isOpen(self\palette) = True Then browserInput = False
+If BrokenRefs::isOpen(self\brokenRefs) = True Then browserInput = False
+If Recents::isOpen(self\recents) = True Then browserInput = False
+If Composer::isEditing(self\composer) = True Then browserInput = False
+```
+
+Browser still **paints** when a modal is open (its surface is what gets dimmed behind the modal), but its keyboard handlers don't fire. The Composer's edit pump shares the same gate logic — when the Composer is in field-edit mode, keystrokes go to the edit buffer, not the browser's filter or nav.
+
+### Esc priority chain
+
+In `Loom::renderFrame`, Esc is checked in this order. The first match wins; subsequent handlers don't see the key:
+
+```
+modal-ate (Timeline / Palette / Recents / BrokenRefs)
+  >  clear browser filter
+  >  pop Threads back stack
+  >  close composer back to browser
+  >  exit Loom
+```
+
+The fall-through is intentional. A user with a non-empty filter who hits Esc expects the filter to clear before any other action. With an empty filter but a non-empty back stack, Esc walks back. With both clear and the composer focused, Esc closes the composer. With nothing focused, Esc exits.
+
+### Modifier-shortcut chain
+
+Global shortcuts (Ctrl+K / Ctrl+H / Ctrl+R) are checked **before any modal's `renderAndUpdate`** so the open-keystroke doesn't dribble into the modal's own query buffer:
+
+```basic
+If Palette::isOpen(self\palette) = False And ...all-other-modals-closed...
+    If (KeyDown(29) Or KeyDown(157)) And KeyHit(37)
+        Palette::openModal(self\palette)
+    Else If (KeyDown(29) Or KeyDown(157)) And KeyHit(35)
+        Timeline::openModal(self\timeline)
+    Else If (KeyDown(29) Or KeyDown(157)) And KeyHit(19)
+        Recents::openModal(self\recents)
+    EndIf
+EndIf
+```
+
+`openModal`'s `FlushKeys` drops the K / H / R from the queue so the modal's `pumpKeyboard` doesn't see them. Without that, the user would open Recents and see "r" pre-typed into the scroll cursor's keyboard buffer.
+
+Only one shortcut chain fires per frame (Else-If), so simultaneous Ctrl+K + Ctrl+H is impossible.
+
+### Mutually-exclusive modal opens
+
+Each `openModal` doesn't explicitly close the others (the surrounding gate already prevents two modals from being open at once). If a code path ever needs to switch modals atomically, the pattern is `A::closeModal(self\a); B::openModal(self\b)` — the close runs first so the gate check at the next frame sees a clean state.
+
+## Consequences
+
+### Positive
+
+- **Predictable Esc.** Users can rely on Esc doing the most-local thing first. No surprise jumps.
+- **No modal-vs-keystroke race.** The `FlushKeys` + isOpen-gate combination guarantees that opening a modal never feeds the opening keystroke into the modal's own input.
+- **Modal authors don't need to coordinate.** Each modal owns its own keyboard pump + return-True semantics; the outer frame handles the precedence.
+- **Browser stays responsive.** Even with a modal open, the browser's surface is visible behind the dim overlay — useful for context.
+
+### Negative
+
+- **Three levels of gating** (modal-renders + browser-input check + Esc-priority chain) means a new modal has touch points in three places. Adding a fifth modal requires updates to:
+  - The `isOpen = False And ...` chain in the keybinding section
+  - The `If <New>::isOpen() = True Then browserInput = False` line
+  - The `<new>Ate%` capture and the `modalAte%` OR-fold
+- **No modal-modal stacking.** If two modals were ever opened simultaneously (currently impossible by construction), Esc would only close the highest-priority one per frame. Acceptable since we don't have nested modals.
+
+## When to use a different shape
+
+- A **non-blocking overlay** (e.g. a transient tooltip) shouldn't be a modal — render it from the surface that owns it, don't add it to the modal stack.
+- A **modeless tool window** (e.g. a docked properties panel) is closer to the Composer / Atlas pattern — paint inline, no overlay, no Esc-eat.
+- The modal stack is for "the entire window is now in a different mode." If your surface doesn't need to dim the world behind it, it's not a modal.
+
+## Related
+
+- ADR 005 — module-level recorder facade (the other cross-cutting pattern).
+- `src/Loom.bb` `Loom::renderFrame` — the canonical implementation.

--- a/docs/loom/roadmap.md
+++ b/docs/loom/roadmap.md
@@ -2,7 +2,7 @@
 
 Shipped, next, and deferred. Read this when picking what to build next.
 
-## Shipped (alpha)
+## Shipped (alpha + beta)
 
 - **Skeleton** — `bin/Loom.exe` builds, Project Manager launches it, themed window opens, exits cleanly. ([#292](https://github.com/RydeTec/rcce2/pull/292), merged)
 - **Theme primitives** — Loom design palette + 2D drawing helpers. Everything Loom paints goes through this layer.
@@ -25,7 +25,37 @@ Shipped, next, and deferred. Read this when picking what to build next.
 - **Tools tab** — new browser category exposing GUE's seven standalone editor launchers (RC Architect, Terrain / Caves / Rock / Tree Editor, Gubbin Tool, Spell Wizard). Each card shows the tool name, description, and a Launch >> hint; click `ExecFile`s the .exe with the project's `Data/` folder as CWD. Missing-binary detection paints the card with a danger-red border + "binary not built" label so the user gets immediate feedback when the partial-build trap bites. ([#343](https://github.com/RydeTec/rcce2/pull/343))
 - **Recents list (Ctrl+R)** — persisted per-project list of recently-focused entities. `Modules/Loom/Recents.bb` writes to `Data/Loom/recents.txt` (via `SafeWriteOpen/Commit`); load on boot, save on shutdown. `Threads::focus` + `Threads::jump` emit through a `Recents_Record` facade. Stable keys per kind (refID for typed entities, Name for zones since Handles regenerate) so the list survives across sessions. Ctrl+R opens a modal newest-first; stale entries (referenced entity deleted between sessions) render in danger-red and skip on click.
 
-All six original "next up" roadmap items are now shipped. The remaining work is in the **Deferred** section below.
+All six original "next up" roadmap items are shipped, plus eight scope-expanded surfaces (palette, search-within-category, entity creation, deletion, discard, conscience ribbon, broken-ref finder, keyboard nav, atlas, ref-field editing, timeline scrubber, recents, tools tab). Loom is now in **beta** — every primary GUE workflow has a Loom equivalent.
+
+Beta vs alpha distinction: alpha was read-only browsing; beta covers full editing parity with GUE. Out-of-scope items (3D viewport, walk-in playtest, multi-cursor) remain in the deferred list below.
+
+## Next up
+
+The next-tier roadmap items, in rough order of leverage:
+
+### 1. Performance: cache the data scans
+
+Ribbon::recomputeCache, BrokenRefs::rebuild, Atlas::countZones, and Palette::rebuildResults all walk the same global type pools per-frame or per-modal-open. At 50-100 entities none of this matters; at 5000+ actors / items the per-frame ribbon scan starts to bite. Add a shared dirty-bit cache that invalidates on Composer::commitEdit / EntityFactory create/delete, so Ribbon and friends only recompute when the underlying data changed.
+
+Estimated scope: 200-300 LOC across Composer + Ribbon + a new `Cache.bb`.
+
+### 2. Bulk edit / multi-select
+
+Select multiple cards via Shift+Click on the grid; opening the composer shows a unified property panel where edits apply to every selected entity. Useful for "bump every weapon's damage by 10%." Today the composer is single-focus only.
+
+Estimated scope: 400-600 LOC. Touches Browser (selection set), Composer (multi-focus rendering), writeField (broadcast).
+
+### 3. Asset preview (textures + meshes)
+
+Item / Actor reference textures and meshes by integer ID. The composer shows the ID but not the asset itself. A small preview panel in the composer (or a hover-thumbnail on the chip) would surface the asset directly. Needs the texture / mesh loaders Loom currently avoids — likely a Loom-side decoder rather than pulling in GUE's media stack.
+
+Estimated scope: 500-800 LOC. Significant new surface.
+
+### 4. Aesthetic immersion toggle (Tool / Balanced / In-world)
+
+The design's slider for chrome-density: utilitarian "Tool" mode at one end, fully-immersive "In-world" parchment-scroll aesthetic at the other. Current Loom chrome is "Balanced." Add a toggle in the Conscience Ribbon's right-side that re-themes the surfaces. Mostly a Theme.bb palette swap + a few layout tweaks per mode.
+
+Estimated scope: 200-300 LOC.
 
 ## Deferred (with reasons — read before reopening)
 
@@ -37,23 +67,11 @@ All six original "next up" roadmap items are now shipped. The remaining work is 
 
 See [decisions/004-deferred-3d-viewport.md](decisions/004-deferred-3d-viewport.md) for full context.
 
-### Validation conscience ribbon
-
-**Reason:** The design called for a top status ribbon with broken-reference counts, balance hints, and unsaved-entity badges. Loom already detects broken references inline (thread chips render in red when they don't resolve). A separate ribbon adds value when there are *many* findings and you need a roll-up — that's mostly a #3-editing concern (unsaved counts) plus a real validator framework (balance hints).
-
-**Path to unblocking:** ships after #3 (editing), since pre-edit there are no unsaved entities to count.
-
 ### Walk-in playtest
 
 **Reason:** The design called for "spawn into the zone as a player without restarting the server." This requires a live server bridge — Loom would have to either (a) speak the wire protocol to a running `Server.exe` to inject a player, or (b) embed a server in-process. (b) is huge. (a) needs the wire protocol stable and a way for the server to accept "spawn this account at this position" out of band, which it doesn't today.
 
 **Path to unblocking:** server-side feature work, not Loom work. Out of scope until a Server.exe admin/test API exists.
-
-### Aesthetic immersion toggle (Tool / Balanced / In-world)
-
-**Reason:** The design had a slider for chrome-density: utilitarian "Tool" mode at one end, fully-immersive "In-world" parchment-scroll aesthetic at the other. Cute, but not load-bearing for the alpha. The current Loom chrome is "Balanced" by default and there's no demand yet for variants.
-
-**Path to unblocking:** ship when there's a real user request. Don't pre-build.
 
 ### Multi-cursor / collaboration
 


### PR DESCRIPTION
## Summary

Ten iterations of beta work (palette, ribbon, atlas, timeline, recents, broken-ref finder, keynav, tools tab, edit broaden, ref-field editing) landed without doc maintenance. This catches everything up.

## architecture.md

- **Module map** expanded from 4 to 11 modules (added Palette, Ribbon, Atlas, Timeline, BrokenRefs, Tools, Recents, EntityFactory).
- One-line summaries for every new module.
- **New \"The render loop + modal stacking\" section** documenting back-to-front paint order, the four-modal stack, the Esc priority chain, global keybinding precedence, the right-click \`MouseHit(2)\` capture-once propagation.
- **New \"Recorder facade pattern\" section** explaining the Timeline / Recents pointer + free-function dispatch shape with code.
- Data flow diagram updated — Loom is no longer read-only; writes go through the same `Save*` functions GUE uses, plus new `DeleteXTemplate` / `SetFactionName` non-Strict helpers.
- **New \"Edit / save / dirty-flag plumbing\" section** covering the begin/pump/commit/save/discard lifecycle + the numeric clamp model.
- \"Why custom-draw + not F-UI\" caveat updated — editing landed without needing F-UI.
- Refid-payload table gains a \"stable across sessions?\" column (zone Handle = no, everything else = yes) which Recents.bb relies on.
- **\"Known gotchas\" expanded** with reserved-word casualties from beta (`step`, `pi`, `default`), the Dim-array-write trap workaround, the `BBStream` typing issue, `MouseHit` / `KeyHit` consume-once.

## README.md

- \"What Loom is today\" rewritten from \"read-only alpha\" to \"beta with full editing parity.\" Lists nine concrete shipped surfaces.
- \"What it can't do\" pared down to the actual remaining gaps (3D viewport, walk-in playtest, multi-cursor).

## roadmap.md

- \"Shipped\" header updated alpha → alpha + beta.
- **New \"Next up\" tier** for post-beta work (perf caching, bulk edit, asset preview, immersion toggle).
- \"Deferred\" trimmed — validation conscience ribbon promoted to shipped; aesthetic immersion promoted to Next up.

## New ADRs

- **[005-recorder-facade-pattern](docs/loom/decisions/005-recorder-facade-pattern.md)** — Timeline / Recents module-level pointer + free-function dispatch shape, why it beats threading instance refs through every caller, and when NOT to use it.
- **[006-modal-stacking-and-esc-priority](docs/loom/decisions/006-modal-stacking-and-esc-priority.md)** — four-modal stack + Esc-priority chain + global keybinding precedence + the three gating points a new modal needs to touch.

## Test plan

- [x] \`compile.bat -t\` — engine targets clean
- [x] \`test.bat\` — 32/32 pass
- Touched only `.md` files; CI re-runs are belt-and-braces.