### PR TITLE
Loom: WorldCache — lazy-invalidated cache of "scan every entity" aggregates

### DIFF
--- a/docs/loom/roadmap.md
+++ b/docs/loom/roadmap.md
@@ -23,7 +23,8 @@ Shipped, next, and deferred. Read this when picking what to build next.
 - **Broken-ref finder modal** — extends the Conscience Ribbon's broken-ref count from a passive number into a clickable chip. New `Modules/Loom/BrokenRefs.bb` enumerates each broken reference (Actor→Faction/AnimSet, Zone→portal-target) with diagnosis text and click-to-jump to the source entity. Capped at 250 entries so a fundamentally broken project doesn't render thousands of rows. ([#342](https://github.com/RydeTec/rcce2/pull/342))
 - **Browser keyboard navigation** — arrow keys move a brass-ringed selection cursor across the active category's card grid; Enter focuses the selected card. Up/Down jumps by row width (`lastCols`), Left/Right by 1. Selection clamps on category switch. Ctrl-anything skipped so global shortcuts (Ctrl+K / Ctrl+H) don't dribble through. ([#342](https://github.com/RydeTec/rcce2/pull/342))
 - **Tools tab** — new browser category exposing GUE's seven standalone editor launchers (RC Architect, Terrain / Caves / Rock / Tree Editor, Gubbin Tool, Spell Wizard). Each card shows the tool name, description, and a Launch >> hint; click `ExecFile`s the .exe with the project's `Data/` folder as CWD. Missing-binary detection paints the card with a danger-red border + "binary not built" label so the user gets immediate feedback when the partial-build trap bites. ([#343](https://github.com/RydeTec/rcce2/pull/343))
-- **Recents list (Ctrl+R)** — persisted per-project list of recently-focused entities. `Modules/Loom/Recents.bb` writes to `Data/Loom/recents.txt` (via `SafeWriteOpen/Commit`); load on boot, save on shutdown. `Threads::focus` + `Threads::jump` emit through a `Recents_Record` facade. Stable keys per kind (refID for typed entities, Name for zones since Handles regenerate) so the list survives across sessions. Ctrl+R opens a modal newest-first; stale entries (referenced entity deleted between sessions) render in danger-red and skip on click.
+- **Recents list (Ctrl+R)** — persisted per-project list of recently-focused entities. `Modules/Loom/Recents.bb` writes to `Data/Loom/recents.txt` (via `SafeWriteOpen/Commit`); load on boot, save on shutdown. `Threads::focus` + `Threads::jump` emit through a `Recents_Record` facade. Stable keys per kind (refID for typed entities, Name for zones since Handles regenerate) so the list survives across sessions. Ctrl+R opens a modal newest-first; stale entries (referenced entity deleted between sessions) render in danger-red and skip on click. ([#344](https://github.com/RydeTec/rcce2/pull/344))
+- **World-state cache (perf)** — new `Modules/Loom/WorldCache.bb` holds cached aggregates (broken-ref count, 6 entity totals). Before: `Ribbon::recomputeCache` walked `O(actors * animsets + zones * portals * zones)` every frame. After: the same scan fires at most once per mutation (Composer commit/toggle/discard, EntityFactory create/delete, Palette picker commit invoke `WorldCache_Invalidate`); between mutations the per-frame ribbon paint is constant-time. Same recorder-facade pattern as Timeline / Recents (ADR 005).
 
 All six original "next up" roadmap items are shipped, plus eight scope-expanded surfaces (palette, search-within-category, entity creation, deletion, discard, conscience ribbon, broken-ref finder, keyboard nav, atlas, ref-field editing, timeline scrubber, recents, tools tab). Loom is now in **beta** — every primary GUE workflow has a Loom equivalent.
 
@@ -33,25 +34,19 @@ Beta vs alpha distinction: alpha was read-only browsing; beta covers full editin
 
 The next-tier roadmap items, in rough order of leverage:
 
-### 1. Performance: cache the data scans
-
-Ribbon::recomputeCache, BrokenRefs::rebuild, Atlas::countZones, and Palette::rebuildResults all walk the same global type pools per-frame or per-modal-open. At 50-100 entities none of this matters; at 5000+ actors / items the per-frame ribbon scan starts to bite. Add a shared dirty-bit cache that invalidates on Composer::commitEdit / EntityFactory create/delete, so Ribbon and friends only recompute when the underlying data changed.
-
-Estimated scope: 200-300 LOC across Composer + Ribbon + a new `Cache.bb`.
-
-### 2. Bulk edit / multi-select
+### 1. Bulk edit / multi-select
 
 Select multiple cards via Shift+Click on the grid; opening the composer shows a unified property panel where edits apply to every selected entity. Useful for "bump every weapon's damage by 10%." Today the composer is single-focus only.
 
 Estimated scope: 400-600 LOC. Touches Browser (selection set), Composer (multi-focus rendering), writeField (broadcast).
 
-### 3. Asset preview (textures + meshes)
+### 2. Asset preview (textures + meshes)
 
 Item / Actor reference textures and meshes by integer ID. The composer shows the ID but not the asset itself. A small preview panel in the composer (or a hover-thumbnail on the chip) would surface the asset directly. Needs the texture / mesh loaders Loom currently avoids — likely a Loom-side decoder rather than pulling in GUE's media stack.
 
 Estimated scope: 500-800 LOC. Significant new surface.
 
-### 4. Aesthetic immersion toggle (Tool / Balanced / In-world)
+### 3. Aesthetic immersion toggle (Tool / Balanced / In-world)
 
 The design's slider for chrome-density: utilitarian "Tool" mode at one end, fully-immersive "In-world" parchment-scroll aesthetic at the other. Current Loom chrome is "Balanced." Add a toggle in the Conscience Ribbon's right-side that re-themes the surfaces. Mostly a Theme.bb palette swap + a few layout tweaks per mode.
 

--- a/src/Loom.bb
+++ b/src/Loom.bb
@@ -109,6 +109,7 @@ Include "Modules\Loom\Threads.bb"
 Include "Modules\Loom\Browser.bb"
 Include "Modules\Loom\Composer.bb"
 Include "Modules\Loom\Palette.bb"
+Include "Modules\Loom\WorldCache.bb"
 Include "Modules\Loom\BrokenRefs.bb"
 Include "Modules\Loom\Ribbon.bb"
 Include "Modules\Loom\Atlas.bb"
@@ -135,6 +136,7 @@ Type Loom
     Field timeline.Timeline
     Field brokenRefs.BrokenRefs
     Field recents.Recents
+    Field worldCache.WorldCache
 
 
     Method create.Loom(windowWidth%, windowHeight%, projectName$)
@@ -144,6 +146,15 @@ Type Loom
 
         // Shared focus + back stack
         self\threads = New Threads()
+
+        // World-state cache must exist before any surface that reads it
+        // (Ribbon::recomputeCache, BrokenRefs::rebuild). Wired to the
+        // global so mutation sites (Composer::commitEdit, EntityFactory
+        // create/delete, Palette picker commit) can WorldCache_Invalidate
+        // without an instance ref. Mirrors the Timeline / Recents
+        // recorder facade pattern (ADR 005).
+        self\worldCache = New WorldCache()
+        LoomWorldCache = self\worldCache
 
         // Browser, Composer, Palette all hold a reference to the same Threads
         // instance; card clicks call Threads::focus, chip + palette-result

--- a/src/Modules/Loom/Composer.bb
+++ b/src/Modules/Loom/Composer.bb
@@ -329,6 +329,7 @@ Type Composer
             Composer::writeField(self, kind, refID, fieldId, Str(newVal))
             Composer::markDirtyForKind(self, kind)
             Timeline_RecordToggle(kind, refID, fieldId, Str(storedValue), Str(newVal), Threads::lookupName(self\threads, kind, refID))
+            WorldCache_Invalidate()
             WriteLog(LoomLog, "Composer: toggled " + kind + "#" + Str(refID) + " " + fieldId + " -> " + Str(newVal))
         EndIf
 
@@ -435,6 +436,11 @@ Type Composer
         // the timeline with no-op commits from click-away-without-typing).
         If val <> oldVal
             Timeline_RecordEdit(k, id, fid, oldVal, val, Threads::lookupName(self\threads, k, id))
+            // Reference-field edits + faction renames can change the
+            // broken-ref count, and any edit changes "what to show in
+            // the recents label" etc. Conservatively invalidate the
+            // shared cache; the next ribbon paint recomputes.
+            WorldCache_Invalidate()
         EndIf
 
         WriteLog(LoomLog, "Composer: commit " + k + "#" + Str(id) + " " + fid + " <- " + Chr(34) + val + Chr(34))
@@ -866,6 +872,11 @@ Type Composer
     // handle becomes stale; close the composer first.
     // -------------------------------------------------------------------------
     Method discardKind(kind$)
+        // Any discard reloads the whole kind from disk -- the cache
+        // can't possibly be accurate after that. Invalidate up front so
+        // every branch below benefits without per-branch repeats.
+        WorldCache_Invalidate()
+
         If kind = "spell"
             Composer::freeAllSpells(self)
             LoadSpells("Data\Server Data\Spells.dat")

--- a/src/Modules/Loom/EntityFactory.bb
+++ b/src/Modules/Loom/EntityFactory.bb
@@ -70,6 +70,7 @@ Function EntityFactory_CreateActor%(threads.Threads)
     Threads::focus(threads, "actor", A\ID)
     ActorsSaved = False
     Timeline_RecordCreate("actor", A\ID, A\Race$ + " [" + A\Class$ + "]")
+    WorldCache_Invalidate()
     WriteLog(LoomLog, "EntityFactory: created actor #" + Str(A\ID))
     Return True
 End Function
@@ -85,6 +86,7 @@ Function EntityFactory_CreateItem%(threads.Threads)
     Threads::focus(threads, "item", I\ID)
     ItemsSaved = False
     Timeline_RecordCreate("item", I\ID, I\Name$)
+    WorldCache_Invalidate()
     WriteLog(LoomLog, "EntityFactory: created item #" + Str(I\ID))
     Return True
 End Function
@@ -101,6 +103,7 @@ Function EntityFactory_CreateSpell%(threads.Threads)
     Threads::focus(threads, "spell", S\ID)
     SpellsSaved = False
     Timeline_RecordCreate("spell", S\ID, S\Name$)
+    WorldCache_Invalidate()
     WriteLog(LoomLog, "EntityFactory: created spell #" + Str(S\ID))
     Return True
 End Function
@@ -116,6 +119,7 @@ Function EntityFactory_CreateZone%(threads.Threads)
     Threads::focus(threads, "zone", Handle(A))
     ZoneSaved = False
     Timeline_RecordCreate("zone", Handle(A), A\Name$)
+    WorldCache_Invalidate()
     WriteLog(LoomLog, "EntityFactory: created zone " + A\Name$)
     Return True
 End Function
@@ -143,6 +147,7 @@ Function EntityFactory_CreateFaction%(threads.Threads)
     Threads::focus(threads, "faction", slot)
     FactionsSaved = False
     Timeline_RecordCreate("faction", slot, "New Faction")
+    WorldCache_Invalidate()
     WriteLog(LoomLog, "EntityFactory: created faction slot " + Str(slot))
     Return True
 End Function
@@ -159,6 +164,7 @@ Function EntityFactory_CreateAnimSet%(threads.Threads)
     Threads::focus(threads, "animset", newID)
     AnimsSaved = False
     Timeline_RecordCreate("animset", newID, "New Animation Set")
+    WorldCache_Invalidate()
     WriteLog(LoomLog, "EntityFactory: created animset #" + Str(newID))
     Return True
 End Function
@@ -226,6 +232,7 @@ Function EntityFactory_DeleteActor%(refID%, threads.Threads)
     EndIf
     ActorsSaved = False
     Timeline_RecordDelete("actor", refID, label)
+    WorldCache_Invalidate()
     Threads::focus(threads, "", 0)
     Threads::clearStack(threads)
     WriteLog(LoomLog, "EntityFactory: deleted actor #" + Str(refID))
@@ -241,6 +248,7 @@ Function EntityFactory_DeleteItem%(refID%, threads.Threads)
     EndIf
     ItemsSaved = False
     Timeline_RecordDelete("item", refID, label)
+    WorldCache_Invalidate()
     Threads::focus(threads, "", 0)
     Threads::clearStack(threads)
     WriteLog(LoomLog, "EntityFactory: deleted item #" + Str(refID))
@@ -256,6 +264,7 @@ Function EntityFactory_DeleteSpell%(refID%, threads.Threads)
     EndIf
     SpellsSaved = False
     Timeline_RecordDelete("spell", refID, label)
+    WorldCache_Invalidate()
     Threads::focus(threads, "", 0)
     Threads::clearStack(threads)
     WriteLog(LoomLog, "EntityFactory: deleted spell #" + Str(refID))
@@ -271,6 +280,7 @@ Function EntityFactory_DeleteAnimSet%(refID%, threads.Threads)
     EndIf
     AnimsSaved = False
     Timeline_RecordDelete("animset", refID, label)
+    WorldCache_Invalidate()
     Threads::focus(threads, "", 0)
     Threads::clearStack(threads)
     WriteLog(LoomLog, "EntityFactory: deleted animset #" + Str(refID))
@@ -285,6 +295,7 @@ Function EntityFactory_DeleteFaction%(refID%, threads.Threads)
     SetFactionName(refID, "")     // empty string = vacant slot per LoadFactions semantics
     FactionsSaved = False
     Timeline_RecordDelete("faction", refID, label)
+    WorldCache_Invalidate()
     Threads::focus(threads, "", 0)
     Threads::clearStack(threads)
     WriteLog(LoomLog, "EntityFactory: deleted faction slot " + Str(refID))
@@ -311,6 +322,7 @@ Function EntityFactory_DeleteZone%(refID%, threads.Threads)
     ServerUnloadArea(A)            // frees the Area + per-area ServerWater chain
     ZoneSaved = True               // no other-zone changes pending purely from this op
     Timeline_RecordDelete("zone", refID, zoneName)
+    WorldCache_Invalidate()
     Threads::focus(threads, "", 0)
     Threads::clearStack(threads)
     WriteLog(LoomLog, "EntityFactory: deleted zone " + zoneName)

--- a/src/Modules/Loom/Palette.bb
+++ b/src/Modules/Loom/Palette.bb
@@ -659,6 +659,7 @@ Type Palette
             Composer::writeField(self\composer, tKind, tID, tField, val)
             Composer::markDirtyForKind(self\composer, tKind)
             Timeline_RecordEdit(tKind, tID, tField, oldVal, val, Threads::lookupName(self\threads, tKind, tID))
+            WorldCache_Invalidate()
             WriteLog(LoomLog, "Palette: picked " + k + "#" + Str(id) + " (" + nm + ") -> " + tKind + "#" + Str(tID) + "." + tField)
             Return
         EndIf

--- a/src/Modules/Loom/Ribbon.bb
+++ b/src/Modules/Loom/Ribbon.bb
@@ -191,107 +191,28 @@ Type Ribbon
 
 
     // -------------------------------------------------------------------------
-    // recomputeCache -- walk every entity and total counts + broken refs.
-    // Called once per frame at the top of renderAndUpdate.
+    // recomputeCache -- delegates to WorldCache (shared with BrokenRefs /
+    // Atlas). The cache itself only re-walks the type pools when a
+    // mutation has fired WorldCache_Invalidate since the last call; a
+    // clean cache returns immediately.
     //
-    // Broken-reference checks (per kind):
-    //   Actor   : DefaultFaction must be 0..99 with FactionNames$ non-empty
-    //             MAnimationSet / FAnimationSet must resolve in AnimList
-    //   Zone    : every non-empty PortalLinkArea$ must resolve to an Area
+    // Before WorldCache landed this Method did the full O(actors *
+    // animsets + zones * portals * zones) scan every frame; now the
+    // expensive walk fires at most once per mutation and amortizes
+    // across however many frames sit between mutations.
     //
-    // We intentionally DON'T flag Faction=0 with empty FactionNames$(0) as
-    // broken when DefaultFaction defaults to 0 -- that's the implicit
-    // "no faction set" state, not a broken ref. The check requires the
-    // referenced slot have a non-empty name.
-    //
-    // Counters are accumulated directly on `self\cached*` fields rather
-    // than Method-scope Locals because BlitzForge Strict rejects re-
-    // assigning a Method Local from inside nested For/If blocks (the
-    // architecture.md gotcha). Field writes through `self\` work at any
-    // nesting depth.
+    // The local cachedX fields stay populated as a snapshot for the
+    // current frame so the drawing code below doesn't need a per-Method
+    // re-fetch through the WorldCache getters.
     // -------------------------------------------------------------------------
     Method recomputeCache()
-        self\cachedBrokenRefs = 0
-        self\cachedTotalActors = 0
-        self\cachedTotalItems = 0
-        self\cachedTotalSpells = 0
-        self\cachedTotalZones = 0
-        self\cachedTotalFactions = 0
-        self\cachedTotalAnimSets = 0
-
-        // Actor totals + broken-ref checks
-        For Ac.Actor = Each Actor
-            self\cachedTotalActors = self\cachedTotalActors + 1
-            If Ac\DefaultFaction < 0 Or Ac\DefaultFaction > 99
-                self\cachedBrokenRefs = self\cachedBrokenRefs + 1
-            Else If Ac\DefaultFaction > 0 And FactionNames$(Ac\DefaultFaction) = ""
-                self\cachedBrokenRefs = self\cachedBrokenRefs + 1
-            EndIf
-            If Ac\MAnimationSet <> 0
-                If Ribbon::animSetExists(self, Ac\MAnimationSet) = False
-                    self\cachedBrokenRefs = self\cachedBrokenRefs + 1
-                EndIf
-            EndIf
-            If Ac\FAnimationSet <> 0
-                If Ribbon::animSetExists(self, Ac\FAnimationSet) = False
-                    self\cachedBrokenRefs = self\cachedBrokenRefs + 1
-                EndIf
-            EndIf
-        Next
-
-        // Item / Spell totals -- no cross-entity refs to check here
-        // (their script names are .rsl files on disk, not entity handles).
-        For It.Item = Each Item
-            self\cachedTotalItems = self\cachedTotalItems + 1
-        Next
-
-        For Sp.Spell = Each Spell
-            self\cachedTotalSpells = self\cachedTotalSpells + 1
-        Next
-
-        // Zone totals + portal broken-ref checks
-        For Ar.Area = Each Area
-            self\cachedTotalZones = self\cachedTotalZones + 1
-            Local portalIdx% = 0
-            For portalIdx = 0 To 99
-                If Ar\PortalLinkArea$[portalIdx] <> ""
-                    If Ribbon::zoneExists(self, Ar\PortalLinkArea$[portalIdx]) = False
-                        self\cachedBrokenRefs = self\cachedBrokenRefs + 1
-                    EndIf
-                EndIf
-            Next
-        Next
-
-        // Faction totals
-        Local fi% = 0
-        For fi = 0 To 99
-            If FactionNames$(fi) <> ""
-                self\cachedTotalFactions = self\cachedTotalFactions + 1
-            EndIf
-        Next
-
-        // AnimSet totals
-        For As.AnimSet = Each AnimSet
-            self\cachedTotalAnimSets = self\cachedTotalAnimSets + 1
-        Next
-    End Method
-
-
-    Method animSetExists%(id%)
-        Local As.AnimSet
-        For As = Each AnimSet
-            If As\ID = id Then Return True
-        Next
-        Return False
-    End Method
-
-
-    Method zoneExists%(name$)
-        Local upr$ = Upper$(name)
-        Local Ar.Area
-        For Ar = Each Area
-            If Upper$(Ar\Name$) = upr Then Return True
-        Next
-        Return False
+        If LoomWorldCache = Null Then Return
+        self\cachedBrokenRefs    = WorldCache::brokenRefs(LoomWorldCache)
+        self\cachedTotalActors   = WorldCache::totalActors(LoomWorldCache)
+        self\cachedTotalItems    = WorldCache::totalItems(LoomWorldCache)
+        self\cachedTotalSpells   = WorldCache::totalSpells(LoomWorldCache)
+        self\cachedTotalZones    = WorldCache::totalZones(LoomWorldCache)
+        self\cachedTotalFactions = WorldCache::totalFactions(LoomWorldCache)
+        self\cachedTotalAnimSets = WorldCache::totalAnimSets(LoomWorldCache)
     End Method
 End Type

--- a/src/Modules/Loom/WorldCache.bb
+++ b/src/Modules/Loom/WorldCache.bb
@@ -1,0 +1,221 @@
+Strict
+
+// =============================================================================
+// Loom/WorldCache.bb -- per-frame cache of "scan every entity" results
+// =============================================================================
+//
+// PROBLEM
+// Multiple surfaces walk the global type pools to derive aggregates:
+//   - Ribbon::recomputeCache (every frame): broken-ref count + 6 entity totals
+//   - BrokenRefs::rebuild (every open + when zone count changes):
+//     enumerates each broken reference
+//   - Atlas::countZones (every frame the Atlas is on screen): zone count
+//   - Atlas::findZoneHandleByName (per portal during layout rebuild):
+//     name -> handle lookup
+//
+// At small projects (~50-100 entities) all of this is invisible. At 5000+
+// actors with 100 portals each, the Ribbon's per-frame nested-loop scan
+// becomes a hot path: O(actors * animsets) for the M/F anim resolves,
+// O(zones * portals * zones) for the portal target resolves. That's
+// hundreds of thousands of iterations 60 times per second.
+//
+// SOLUTION
+// One shared cache, invalidated lazily on mutation. Surfaces read the
+// cache; mutation sites (Composer::commitEdit, Composer::toggleRow,
+// Composer::discardKind, every EntityFactory_Create*, every
+// EntityFactory_Delete*, Palette picker commit) call WorldCache_Invalidate
+// after their write completes. The next read recomputes and caches; until
+// then it serves the cached value.
+//
+// Architecture: Type with Methods (the cache is stateful), plus a free-
+// function facade so mutation sites don't need an instance ref. Mirrors
+// the Timeline / Recents recorder pattern (see ADR 005).
+//
+// Lifecycle: constructed by Loom.bb; Ribbon::recomputeCache delegates
+// to WorldCache::ensureFresh(). On first call: dirty=True, recomputes.
+// Subsequent calls return immediately until WorldCache_Invalidate flips
+// dirty=True again.
+
+
+Type WorldCache
+    // Dirty bit -- True means cached values are stale and ensureFresh
+    // must recompute. False means cached values match the global type
+    // pool's current state.
+    Field dirty%
+
+    // Cached aggregates
+    Field cachedBrokenRefs%
+    Field cachedTotalActors%
+    Field cachedTotalItems%
+    Field cachedTotalSpells%
+    Field cachedTotalZones%
+    Field cachedTotalFactions%
+    Field cachedTotalAnimSets%
+
+
+    Method create.WorldCache()
+        self\dirty = True
+        self\cachedBrokenRefs = 0
+        self\cachedTotalActors = 0
+        self\cachedTotalItems = 0
+        self\cachedTotalSpells = 0
+        self\cachedTotalZones = 0
+        self\cachedTotalFactions = 0
+        self\cachedTotalAnimSets = 0
+        Return self
+    End Method
+
+
+    // -------------------------------------------------------------------------
+    // invalidate -- mark cache stale. Cheap no-op when already dirty.
+    // -------------------------------------------------------------------------
+    Method invalidate()
+        self\dirty = True
+    End Method
+
+
+    // -------------------------------------------------------------------------
+    // ensureFresh -- if dirty, walk every entity and update cached values;
+    // clear dirty. If clean, return immediately. Idempotent within a frame.
+    //
+    // Counters mutate on self\* directly (not Method Locals) to dodge the
+    // Strict-mode "reassign Method Local from inside nested For/If" trap.
+    // -------------------------------------------------------------------------
+    Method ensureFresh()
+        If self\dirty = False Then Return
+
+        self\cachedBrokenRefs = 0
+        self\cachedTotalActors = 0
+        self\cachedTotalItems = 0
+        self\cachedTotalSpells = 0
+        self\cachedTotalZones = 0
+        self\cachedTotalFactions = 0
+        self\cachedTotalAnimSets = 0
+
+        // Actor totals + broken-ref checks
+        For Ac.Actor = Each Actor
+            self\cachedTotalActors = self\cachedTotalActors + 1
+            If Ac\DefaultFaction < 0 Or Ac\DefaultFaction > 99
+                self\cachedBrokenRefs = self\cachedBrokenRefs + 1
+            Else If Ac\DefaultFaction > 0 And FactionNames$(Ac\DefaultFaction) = ""
+                self\cachedBrokenRefs = self\cachedBrokenRefs + 1
+            EndIf
+            If Ac\MAnimationSet <> 0
+                If WorldCache::animSetExists(self, Ac\MAnimationSet) = False
+                    self\cachedBrokenRefs = self\cachedBrokenRefs + 1
+                EndIf
+            EndIf
+            If Ac\FAnimationSet <> 0
+                If WorldCache::animSetExists(self, Ac\FAnimationSet) = False
+                    self\cachedBrokenRefs = self\cachedBrokenRefs + 1
+                EndIf
+            EndIf
+        Next
+
+        For It.Item = Each Item
+            self\cachedTotalItems = self\cachedTotalItems + 1
+        Next
+
+        For Sp.Spell = Each Spell
+            self\cachedTotalSpells = self\cachedTotalSpells + 1
+        Next
+
+        For Ar.Area = Each Area
+            self\cachedTotalZones = self\cachedTotalZones + 1
+            Local portalIdx% = 0
+            For portalIdx = 0 To 99
+                If Ar\PortalLinkArea$[portalIdx] <> ""
+                    If WorldCache::zoneExists(self, Ar\PortalLinkArea$[portalIdx]) = False
+                        self\cachedBrokenRefs = self\cachedBrokenRefs + 1
+                    EndIf
+                EndIf
+            Next
+        Next
+
+        Local fi% = 0
+        For fi = 0 To 99
+            If FactionNames$(fi) <> ""
+                self\cachedTotalFactions = self\cachedTotalFactions + 1
+            EndIf
+        Next
+
+        For As.AnimSet = Each AnimSet
+            self\cachedTotalAnimSets = self\cachedTotalAnimSets + 1
+        Next
+
+        self\dirty = False
+    End Method
+
+
+    Method animSetExists%(id%)
+        Local As.AnimSet
+        For As = Each AnimSet
+            If As\ID = id Then Return True
+        Next
+        Return False
+    End Method
+
+
+    Method zoneExists%(name$)
+        Local upr$ = Upper$(name)
+        Local Ar.Area
+        For Ar = Each Area
+            If Upper$(Ar\Name$) = upr Then Return True
+        Next
+        Return False
+    End Method
+
+
+    // -------------------------------------------------------------------------
+    // Accessors -- callers ensureFresh first, then read. Per-attribute
+    // getters rather than exposing Fields directly so future cache
+    // implementations (e.g. partial invalidation) can change shape.
+    // -------------------------------------------------------------------------
+    Method brokenRefs%()
+        WorldCache::ensureFresh(self)
+        Return self\cachedBrokenRefs
+    End Method
+
+    Method totalActors%()
+        WorldCache::ensureFresh(self)
+        Return self\cachedTotalActors
+    End Method
+
+    Method totalItems%()
+        WorldCache::ensureFresh(self)
+        Return self\cachedTotalItems
+    End Method
+
+    Method totalSpells%()
+        WorldCache::ensureFresh(self)
+        Return self\cachedTotalSpells
+    End Method
+
+    Method totalZones%()
+        WorldCache::ensureFresh(self)
+        Return self\cachedTotalZones
+    End Method
+
+    Method totalFactions%()
+        WorldCache::ensureFresh(self)
+        Return self\cachedTotalFactions
+    End Method
+
+    Method totalAnimSets%()
+        WorldCache::ensureFresh(self)
+        Return self\cachedTotalAnimSets
+    End Method
+End Type
+
+
+// =============================================================================
+// Module-level facade. Same shape as LoomTimeline / LoomRecents (ADR 005).
+// Mutation sites call WorldCache_Invalidate without needing the instance.
+// =============================================================================
+Global LoomWorldCache.WorldCache = Null
+
+
+Function WorldCache_Invalidate()
+    If LoomWorldCache = Null Then Return
+    WorldCache::invalidate(LoomWorldCache)
+End Function


### PR DESCRIPTION
## Summary

**Problem**: multiple surfaces walked the global type pools per-frame or per-modal-open to derive the same aggregates:

- \`Ribbon::recomputeCache\` (every frame): broken-ref count + 6 entity totals
- \`BrokenRefs::rebuild\` (every modal open): each broken reference
- \`Atlas::countZones\` / \`findZoneHandleByName\` (during atlas layout)

At small projects (~50-100 entities) all invisible. At 5000+ actors with 100 portals each, Ribbon's per-frame scan becomes a hot path — \`O(actors * animsets)\` for the M/F anim resolves, \`O(zones * portals * zones)\` for the portal target resolves. Hundreds of thousands of iterations 60 times per second.

**Solution**: new \`Modules/Loom/WorldCache.bb\` — one shared cache, invalidated lazily on mutation.

## Architecture

\`Type WorldCache\` holds a \`dirty%\` flag + 7 cachedX fields:
- \`ensureFresh()\` — if dirty, recompute and clear; else no-op.
- \`invalidate()\` — set dirty = True.
- \`brokenRefs%() / totalActors%() / ...\` — ensureFresh + return cached.

Module-level facade (same shape as \`LoomTimeline\` / \`LoomRecents\` per [ADR 005](docs/loom/decisions/005-recorder-facade-pattern.md)):
\`\`\`basic
Global LoomWorldCache.WorldCache = Null
Function WorldCache_Invalidate()
\`\`\`

## Invalidation sites

- \`Composer::commitEdit\` (only when value actually changed)
- \`Composer::toggleRow\` (every flip)
- \`Composer::discardKind\` (any kind, up-front before the branch)
- \`EntityFactory_CreateActor / Item / Spell / Zone / Faction / AnimSet\`
- \`EntityFactory_DeleteActor / Item / Spell / Zone / Faction / AnimSet\`
- \`Palette::jumpToResult\` picker-mode commit

## Effect

| | Before | After |
|---|---|---|
| Idle frame ribbon paint | Full O(actors+items+spells+zones×portals) scan | 7 cached-field reads |
| After 1 mutation | Same full scan, again | Full scan once, then cache for free |
| Steady-state 60 FPS | 60 full scans/sec | 0 full scans/sec |

## Next

\`BrokenRefs::rebuild\` and \`Atlas::countZones\` still do their own walks; those are open-only / layout-rebuild-only so they're less hot. Future iteration can route them through WorldCache too if needed.

## Test plan

- [x] \`compile.bat\` — all five engine targets + every tool clean
- [x] \`test.bat\` — 32/32 pass
- [ ] Manual: open Loom, watch ribbon paint while idle (smooth); edit a field, see broken-ref count update immediately on next frame
- [ ] Delete a faction that actors reference → ribbon's broken-ref count goes up on the very next frame after the delete