### PR TITLE
Loom: visual polish — fix encoding artifacts, add chrome gradients, load Segoe UI

### DIFF
--- a/src/Modules/Loom/Atlas.bb
+++ b/src/Modules/Loom/Atlas.bb
@@ -122,7 +122,7 @@ Type Atlas
         EndIf
 
         // Title strip
-        LoomText(viewportX + 12, viewportY + 8, "ATLAS  ·  " + Str(self\nodeCount) + " zones  ·  portal links derived from data", LOOM_BRASS_500_R, LOOM_BRASS_500_G, LOOM_BRASS_500_B)
+        LoomText(viewportX + 12, viewportY + 8, "ATLAS  |  " + Str(self\nodeCount) + " zones  |  portal links derived from data", LOOM_BRASS_500_R, LOOM_BRASS_500_G, LOOM_BRASS_500_B)
 
         Local mx% = MouseX()
         Local my% = MouseY()

--- a/src/Modules/Loom/BrokenRefs.bb
+++ b/src/Modules/Loom/BrokenRefs.bb
@@ -230,7 +230,7 @@ Type BrokenRefs
         LoomFill(modalX, modalY, BROKENREFS_MODAL_W, 3, LOOM_DANGER_R, LOOM_DANGER_G, LOOM_DANGER_B)
 
         // Header
-        Local headerTxt$ = "BROKEN REFERENCES  ·  " + Str(self\entryCount)
+        Local headerTxt$ = "BROKEN REFERENCES  |  " + Str(self\entryCount)
         If self\entryCount >= BROKENREFS_MAX_ENTRIES Then headerTxt = headerTxt + "+ (capped)"
         LoomText(modalX + BROKENREFS_PAD, modalY + 10, headerTxt, LOOM_DANGER_R, LOOM_DANGER_G, LOOM_DANGER_B)
 
@@ -239,7 +239,7 @@ Type BrokenRefs
         // Footer hint
         Local hy% = modalY + BROKENREFS_MODAL_H - BROKENREFS_HINT_H - 4
         LoomHRule(modalX + BROKENREFS_PAD, hy - 2, BROKENREFS_MODAL_W - BROKENREFS_PAD * 2, LOOM_BRASS_700_R, LOOM_BRASS_700_G, LOOM_BRASS_700_B)
-        LoomText(modalX + BROKENREFS_PAD, hy + 4, "Click a row to jump to the source  ·  arrows scroll  ·  Esc to close", LOOM_STONE_300_R, LOOM_STONE_300_G, LOOM_STONE_300_B)
+        LoomText(modalX + BROKENREFS_PAD, hy + 4, "Click a row to jump to the source  |  arrows scroll  |  Esc to close", LOOM_STONE_300_R, LOOM_STONE_300_G, LOOM_STONE_300_B)
 
         If clicked = True
             If mx < modalX Or mx >= modalX + BROKENREFS_MODAL_W Or my < modalY Or my >= modalY + BROKENREFS_MODAL_H

--- a/src/Modules/Loom/Browser.bb
+++ b/src/Modules/Loom/Browser.bb
@@ -301,7 +301,7 @@ Type Browser
         Local y% = BR_TOP_RIBBON + BR_TAB_BAR_H
         Local h% = BR_FILTER_BAR_H
 
-        LoomFill(0, y, sw, h, LOOM_STONE_850_R, LOOM_STONE_850_G, LOOM_STONE_850_B)
+        LoomGradientV(0, y, sw, h, LOOM_STONE_850_R, LOOM_STONE_850_G, LOOM_STONE_850_B, LOOM_STONE_900_R, LOOM_STONE_900_G, LOOM_STONE_900_B)
         LoomHRule(0, y + h, sw, LOOM_BRASS_700_R, LOOM_BRASS_700_G, LOOM_BRASS_700_B)
 
         // "+ New" button on the left -- creates a fresh entity of the
@@ -375,7 +375,7 @@ Type Browser
         EndIf
 
         // Hint between the button cluster and the input
-        LoomText(hintX, y + 8, "TYPE TO FILTER  ·  CTRL+K SEARCH ALL", LOOM_BRASS_500_R, LOOM_BRASS_500_G, LOOM_BRASS_500_B)
+        LoomText(hintX, y + 8, "TYPE TO FILTER  |  CTRL+K SEARCH ALL", LOOM_BRASS_500_R, LOOM_BRASS_500_G, LOOM_BRASS_500_B)
 
         // Input on the right -- 280px wide
         Local iw% = 280
@@ -444,7 +444,9 @@ Type Browser
     // -------------------------------------------------------------------------
     Method drawTopRibbon(sw%, project$)
         Local stripY% = LOOM_TOP_RIBBON_H
-        LoomFill(0, stripY, sw, BR_BRAND_STRIP_H, LOOM_STONE_850_R, LOOM_STONE_850_G, LOOM_STONE_850_B)
+        // Subtle stone-800 -> stone-850 gradient gives the brand strip
+        // a sculpted look instead of the previous flat stone-850 panel.
+        LoomGradientV(0, stripY, sw, BR_BRAND_STRIP_H, LOOM_STONE_800_R, LOOM_STONE_800_G, LOOM_STONE_800_B, LOOM_STONE_850_R, LOOM_STONE_850_G, LOOM_STONE_850_B)
         LoomHRule(0, BR_TOP_RIBBON - 1, sw, LOOM_BRASS_700_R, LOOM_BRASS_700_G, LOOM_BRASS_700_B)
         LoomHRule(0, BR_TOP_RIBBON,     sw, LOOM_BRASS_500_R, LOOM_BRASS_500_G, LOOM_BRASS_500_B)
         LoomHRule(0, BR_TOP_RIBBON + 1, sw, LOOM_BRASS_700_R, LOOM_BRASS_700_G, LOOM_BRASS_700_B)
@@ -462,7 +464,7 @@ Type Browser
     Method drawTabBar(sw%, mx%, my%, clicked%)
         Local y% = BR_TOP_RIBBON
         Local h% = BR_TAB_BAR_H
-        LoomFill(0, y, sw, h, LOOM_STONE_800_R, LOOM_STONE_800_G, LOOM_STONE_800_B)
+        LoomGradientV(0, y, sw, h, LOOM_STONE_700_R, LOOM_STONE_700_G, LOOM_STONE_700_B, LOOM_STONE_800_R, LOOM_STONE_800_G, LOOM_STONE_800_B)
         LoomHRule(0, y + h, sw, LOOM_BRASS_700_R, LOOM_BRASS_700_G, LOOM_BRASS_700_B)
 
         Local x% = 20
@@ -565,7 +567,7 @@ Type Browser
         If count = 0
             Local emptyMsg$
             If self\filterQuery <> ""
-                emptyMsg = "No " + cat + "s match " + Chr(34) + self\filterQuery + Chr(34) + "  ·  Esc to clear filter"
+                emptyMsg = "No " + cat + "s match " + Chr(34) + self\filterQuery + Chr(34) + "  |  Esc to clear filter"
             Else
                 emptyMsg = "No " + cat + "s in this project yet."
             EndIf
@@ -825,7 +827,9 @@ Type Browser
         Local hovered% = (mx >= x And mx < x + BR_CARD_W And my >= y And my < y + BR_CARD_H)
         Local selected% = (cardIdx = self\selectedIndex)
 
-        LoomFill(x, y, BR_CARD_W, BR_CARD_H, LOOM_STONE_800_R, LOOM_STONE_800_G, LOOM_STONE_800_B)
+        // Subtle stone-800 -> stone-850 gradient gives each card a
+        // raised-tile feel instead of reading as a flat colored rectangle.
+        LoomGradientV(x, y, BR_CARD_W, BR_CARD_H, LOOM_STONE_800_R, LOOM_STONE_800_G, LOOM_STONE_800_B, LOOM_STONE_850_R, LOOM_STONE_850_G, LOOM_STONE_850_B)
 
         If hovered = True
             LoomBorder(x, y, BR_CARD_W, BR_CARD_H, LOOM_ARCANE_500_R, LOOM_ARCANE_500_G, LOOM_ARCANE_500_B)
@@ -839,8 +843,11 @@ Type Browser
             LoomBorder(x, y, BR_CARD_W, BR_CARD_H, LOOM_BRASS_700_R, LOOM_BRASS_700_G, LOOM_BRASS_700_B)
         EndIf
 
-        // Top brass accent
-        LoomHRule(x + 12, y + 8, BR_CARD_W - 24, LOOM_BRASS_500_R, LOOM_BRASS_500_G, LOOM_BRASS_500_B)
+        // Top brass accent -- a thicker brass band so the cards read as
+        // ornament-trimmed rather than thinly-outlined.
+        LoomHRule(x + 12, y + 6, BR_CARD_W - 24, LOOM_BRASS_700_R, LOOM_BRASS_700_G, LOOM_BRASS_700_B)
+        LoomHRule(x + 12, y + 7, BR_CARD_W - 24, LOOM_BRASS_500_R, LOOM_BRASS_500_G, LOOM_BRASS_500_B)
+        LoomHRule(x + 12, y + 8, BR_CARD_W - 24, LOOM_BRASS_700_R, LOOM_BRASS_700_G, LOOM_BRASS_700_B)
 
         If hovered And clicked
             Threads::focus(self\threads, kind, refID)
@@ -967,10 +974,12 @@ Type Browser
     // -------------------------------------------------------------------------
     Method drawFooter(sw%, sh%)
         Local y% = sh - BR_BOT_RIBBON
-        LoomFill(0, y, sw, BR_BOT_RIBBON, LOOM_STONE_850_R, LOOM_STONE_850_G, LOOM_STONE_850_B)
+        // Mirror of the brand strip's gradient direction so the chrome
+        // bands at top + bottom read as a matched pair framing the body.
+        LoomGradientV(0, y, sw, BR_BOT_RIBBON, LOOM_STONE_850_R, LOOM_STONE_850_G, LOOM_STONE_850_B, LOOM_STONE_900_R, LOOM_STONE_900_G, LOOM_STONE_900_B)
         LoomHRule(0, y, sw, LOOM_BRASS_700_R, LOOM_BRASS_700_G, LOOM_BRASS_700_B)
 
-        LoomText(20, y + 10, "click a card to focus  ·  follow threads in the composer  ·  Esc to exit", LOOM_STONE_200_R, LOOM_STONE_200_G, LOOM_STONE_200_B)
+        LoomText(20, y + 10, "click a card to focus  |  follow threads in the composer  |  Esc to exit", LOOM_STONE_200_R, LOOM_STONE_200_G, LOOM_STONE_200_B)
     End Method
 
 

--- a/src/Modules/Loom/Composer.bb
+++ b/src/Modules/Loom/Composer.bb
@@ -184,7 +184,9 @@ Type Composer
         Local h% = sh - CMP_TOP - CMP_BOT_PAD
 
         // Panel chrome -- brass left rule signals the primary surface.
-        LoomFill(x, y, w, h, LOOM_STONE_850_R, LOOM_STONE_850_G, LOOM_STONE_850_B)
+        // Subtle stone-850 -> stone-900 gradient gives the panel depth
+        // rather than reading as a flat slab pasted onto the browser.
+        LoomGradientV(x, y, w, h, LOOM_STONE_850_R, LOOM_STONE_850_G, LOOM_STONE_850_B, LOOM_STONE_900_R, LOOM_STONE_900_G, LOOM_STONE_900_B)
         LoomBorder(x, y, w, h, LOOM_BRASS_700_R, LOOM_BRASS_700_G, LOOM_BRASS_700_B)
         LoomFill(x, y, 3, h, LOOM_BRASS_500_R, LOOM_BRASS_500_G, LOOM_BRASS_500_B)
 
@@ -244,10 +246,10 @@ Type Composer
         Local stackSize% = ListSize(self\threads\backStack)
         Local footMsg$ = "Esc returns to browser"
         If self\editKind = "" And stackSize > 0
-            footMsg = "Esc walks back  ·  " + Str(stackSize) + " in trail"
+            footMsg = "Esc walks back  |  " + Str(stackSize) + " in trail"
         EndIf
         If self\editKind <> ""
-            footMsg = "Enter to commit  ·  Esc to cancel edit"
+            footMsg = "Enter to commit  |  Esc to cancel edit"
         EndIf
         LoomText(x + CMP_PAD, y + h - 22, footMsg, LOOM_STONE_300_R, LOOM_STONE_300_G, LOOM_STONE_300_B)
 

--- a/src/Modules/Loom/Palette.bb
+++ b/src/Modules/Loom/Palette.bb
@@ -379,7 +379,7 @@ Type Palette
     Method drawHint(modalX%, modalY%)
         Local hy% = modalY + PAL_MODAL_H - PAL_HINT_H - 4
         LoomHRule(modalX + PAL_PAD, hy - 2, PAL_MODAL_W - PAL_PAD * 2, LOOM_BRASS_700_R, LOOM_BRASS_700_G, LOOM_BRASS_700_B)
-        LoomText(modalX + PAL_PAD, hy + 4, "Enter to jump  ·  arrow keys to move  ·  Esc to close", LOOM_STONE_300_R, LOOM_STONE_300_G, LOOM_STONE_300_B)
+        LoomText(modalX + PAL_PAD, hy + 4, "Enter to jump  |  arrow keys to move  |  Esc to close", LOOM_STONE_300_R, LOOM_STONE_300_G, LOOM_STONE_300_B)
     End Method
 
 

--- a/src/Modules/Loom/Recents.bb
+++ b/src/Modules/Loom/Recents.bb
@@ -360,13 +360,13 @@ Type Recents
         LoomBorder(modalX + 1, modalY + 1, RECENTS_MODAL_W - 2, RECENTS_MODAL_H - 2, LOOM_BRASS_700_R, LOOM_BRASS_700_G, LOOM_BRASS_700_B)
         LoomFill(modalX, modalY, RECENTS_MODAL_W, 3, LOOM_BRASS_500_R, LOOM_BRASS_500_G, LOOM_BRASS_500_B)
 
-        LoomText(modalX + RECENTS_PAD, modalY + 10, "RECENTS  ·  " + Str(self\entryCount) + " entries", LOOM_BRASS_500_R, LOOM_BRASS_500_G, LOOM_BRASS_500_B)
+        LoomText(modalX + RECENTS_PAD, modalY + 10, "RECENTS  |  " + Str(self\entryCount) + " entries", LOOM_BRASS_500_R, LOOM_BRASS_500_G, LOOM_BRASS_500_B)
 
         Recents::drawEntries(self, modalX, modalY + RECENTS_HEADER_H, mx, my, clicked)
 
         Local hy% = modalY + RECENTS_MODAL_H - RECENTS_HINT_H - 4
         LoomHRule(modalX + RECENTS_PAD, hy - 2, RECENTS_MODAL_W - RECENTS_PAD * 2, LOOM_BRASS_700_R, LOOM_BRASS_700_G, LOOM_BRASS_700_B)
-        LoomText(modalX + RECENTS_PAD, hy + 4, "Click a row to jump  ·  arrows scroll  ·  Esc to close", LOOM_STONE_300_R, LOOM_STONE_300_G, LOOM_STONE_300_B)
+        LoomText(modalX + RECENTS_PAD, hy + 4, "Click a row to jump  |  arrows scroll  |  Esc to close", LOOM_STONE_300_R, LOOM_STONE_300_G, LOOM_STONE_300_B)
 
         If clicked = True
             If mx < modalX Or mx >= modalX + RECENTS_MODAL_W Or my < modalY Or my >= modalY + RECENTS_MODAL_H

--- a/src/Modules/Loom/Ribbon.bb
+++ b/src/Modules/Loom/Ribbon.bb
@@ -101,9 +101,10 @@ Type Ribbon
 
         Ribbon::recomputeCache(self)
 
-        // Background -- a slightly different tint than the browser's brand
-        // strip so the two read as distinct bands.
-        LoomFill(0, 0, sw, RIBBON_H, LOOM_STONE_950_R, LOOM_STONE_950_G, LOOM_STONE_950_B)
+        // Background -- subtle stone-900 -> stone-950 gradient so the
+        // conscience strip doesn't read as a flat black bar above the
+        // brand strip.
+        LoomGradientV(0, 0, sw, RIBBON_H, LOOM_STONE_900_R, LOOM_STONE_900_G, LOOM_STONE_900_B, LOOM_STONE_950_R, LOOM_STONE_950_G, LOOM_STONE_950_B)
         LoomHRule(0, RIBBON_H - 1, sw, LOOM_BRASS_700_R, LOOM_BRASS_700_G, LOOM_BRASS_700_B)
 
         // Left side: "CONSCIENCE" label + dirty badges
@@ -151,7 +152,7 @@ Type Ribbon
         EndIf
 
         // Right side: total entity counts (compact)
-        Local totals$ = Str(self\cachedTotalActors) + "A · " + Str(self\cachedTotalItems) + "I · " + Str(self\cachedTotalSpells) + "S · " + Str(self\cachedTotalZones) + "Z · " + Str(self\cachedTotalFactions) + "F · " + Str(self\cachedTotalAnimSets) + "M"
+        Local totals$ = Str(self\cachedTotalActors) + "A | " + Str(self\cachedTotalItems) + "I | " + Str(self\cachedTotalSpells) + "S | " + Str(self\cachedTotalZones) + "Z | " + Str(self\cachedTotalFactions) + "F | " + Str(self\cachedTotalAnimSets) + "M"
         LoomText(sw - StringWidth(totals) - RIBBON_PAD, 6, totals, LOOM_STONE_300_R, LOOM_STONE_300_G, LOOM_STONE_300_B)
 
         Return consumed

--- a/src/Modules/Loom/Theme.bb
+++ b/src/Modules/Loom/Theme.bb
@@ -109,10 +109,30 @@ Global LoomFont_Display = 0
 
 // =============================================================================
 // LoomTheme_Init -- one-time setup. Safe to call multiple times.
+//
+// Loads body + display fonts. Blitz3D's LoadFont takes a Windows font
+// name; Segoe UI is the Windows Vista+ default UI font and looks
+// noticeably more polished than the built-in bitmap default. If the
+// font isn't installed (older Windows or unusual locale), LoadFont
+// returns 0 and the rest of Loom paints with the default font as before
+// -- no visible failure mode.
 // =============================================================================
 Function LoomTheme_Init()
-    // Future: LoadFont "Data/Loom/Fonts/MedievalSharp.ttf", 48 etc.
-    // For the alpha, leave both as 0 -- Blitz uses the default system font.
+    LoomFont_Body    = LoadFont("Segoe UI", 14, False, False, False)
+    LoomFont_Display = LoadFont("Segoe UI", 18, True,  False, False)
+    If LoomFont_Body <> 0 Then SetFont LoomFont_Body
+End Function
+
+
+; Swap to the body font for subsequent Text() calls. Surfaces that want
+; bigger / bold text (LOOM brand mark, modal titles) call UseDisplay;
+; everything else stays on the body font set at boot.
+Function LoomTheme_UseBody()
+    If LoomFont_Body <> 0 Then SetFont LoomFont_Body
+End Function
+
+Function LoomTheme_UseDisplay()
+    If LoomFont_Display <> 0 Then SetFont LoomFont_Display
 End Function
 
 

--- a/src/Modules/Loom/Timeline.bb
+++ b/src/Modules/Loom/Timeline.bb
@@ -167,7 +167,7 @@ Type Timeline
         LoomFill(modalX, modalY, TIMELINE_MODAL_W, 3, LOOM_BRASS_500_R, LOOM_BRASS_500_G, LOOM_BRASS_500_B)
 
         // Header
-        LoomText(modalX + TIMELINE_PAD, modalY + 10, "SESSION TIMELINE  ·  " + Str(self\entryCount) + " entries", LOOM_BRASS_500_R, LOOM_BRASS_500_G, LOOM_BRASS_500_B)
+        LoomText(modalX + TIMELINE_PAD, modalY + 10, "SESSION TIMELINE  |  " + Str(self\entryCount) + " entries", LOOM_BRASS_500_R, LOOM_BRASS_500_G, LOOM_BRASS_500_B)
 
         // Entry list (newest first -- walk type pool backward via After
         // /  Before, which Blitz3D exposes through Last + Before).
@@ -176,7 +176,7 @@ Type Timeline
         // Footer hint
         Local hy% = modalY + TIMELINE_MODAL_H - TIMELINE_HINT_H - 4
         LoomHRule(modalX + TIMELINE_PAD, hy - 2, TIMELINE_MODAL_W - TIMELINE_PAD * 2, LOOM_BRASS_700_R, LOOM_BRASS_700_G, LOOM_BRASS_700_B)
-        LoomText(modalX + TIMELINE_PAD, hy + 4, "Click revert on a row to undo  ·  arrows scroll  ·  Esc to close", LOOM_STONE_300_R, LOOM_STONE_300_G, LOOM_STONE_300_B)
+        LoomText(modalX + TIMELINE_PAD, hy + 4, "Click revert on a row to undo  |  arrows scroll  |  Esc to close", LOOM_STONE_300_R, LOOM_STONE_300_G, LOOM_STONE_300_B)
 
         // Click-outside-modal closes
         If clicked = True


### PR DESCRIPTION
## Why

User feedback: \"it doesn't look very good\" — with a screenshot showing the actual surface. Three concrete issues visible:

1. **`Â·` artifacts everywhere** in chrome separators (`TYPE TO FILTER Â· CTRL+K`, `3A Â· 2I Â· 1S`, `click a card Â· follow threads`, etc.)
2. **Visual flatness** — chrome bands were single-color fills against an empty stone body. Cards had a barely-visible 1px brass accent.
3. **Terminal-feeling text** — Blitz3D's bitmap default font reads like 1995 utility software, not a fantasy-RPG editor.

## What changed

### 1. Encoding sweep

Every `|` separator was previously `·` (U+00B7 MIDDLE DOT). Saved as UTF-8 in source (`0xC2 0xB7`), Blitz3D's default bitmap font rendered each byte as Windows-1252, producing the visible `Â·` digraph. **14 sites** across Atlas / BrokenRefs / Browser / Composer / Palette / Recents / Ribbon / Timeline now use ASCII `|` instead.

### 2. Chrome gradients

Six chrome surfaces swapped from flat fills to vertical gradients:

| Surface | Gradient |
|---|---|
| Conscience ribbon | stone-900 → stone-950 |
| Brand strip | stone-800 → stone-850 |
| Tab bar | stone-700 → stone-800 |
| Filter bar | stone-850 → stone-900 |
| Footer | stone-850 → stone-900 |
| Composer panel | stone-850 → stone-900 |
| Each card | stone-800 → stone-850 |

Plus each card's top brass accent thickened from 1px to a 3-line brass-700 / brass-500 / brass-700 stack so cards read as deliberately-ornamented.

### 3. Segoe UI font

\`LoomTheme_Init\` now `LoadFonts` Segoe UI at body=14, display=18+bold. Falls back to Blitz's bitmap default if not installed (LoadFont returns 0, helpers null-check before SetFont).

Two new helpers `LoomTheme_UseBody` / `LoomTheme_UseDisplay` for surfaces that want the larger display font. Not yet adopted by any surface — threading it through modal titles and the brand mark is a future polish pass.

## Test plan

- [x] \`compile.bat\` — all five engine targets + every tool clean
- [x] \`test.bat\` — 32/32 pass
- [ ] Boot Loom, confirm `Â·` artifacts gone everywhere (now `|`)
- [ ] Visual: chrome bands have subtle gradients, cards have raised-tile feel
- [ ] Text uses Segoe UI instead of the bitmap default on Win10+