### PR TITLE
Loom hotfix: thumbnail scaling + first-frame input freeze

### DIFF
--- a/src/Loom.bb
+++ b/src/Loom.bb
@@ -262,6 +262,12 @@ Type Loom
     Method renderFrame%()
         Cls
 
+        // Reset per-frame image load budget (ImageCache.bb). Bounds how
+        // many fresh disk loads any one frame does so a tab switch with
+        // many uncached thumbnails doesn't freeze the frame and tank
+        // input responsiveness. Subsequent frames warm the cache.
+        Loom_BeginFrame()
+
         // Ctrl+K opens the palette / Ctrl+H opens the timeline (each
         // no-ops if already open). Detect BEFORE any other input handler
         // so openModal's FlushKeys swallows the K/H keystroke before it

--- a/src/Modules/Loom/Atlas.bb
+++ b/src/Modules/Loom/Atlas.bb
@@ -126,7 +126,7 @@ Type Atlas
 
         Local mx% = MouseX()
         Local my% = MouseY()
-        Local clicked% = MouseHit(1)
+        Local clicked% = Loom_MouseClicked()
 
         // Draw edges first so node disks paint on top of them.
         Atlas::drawEdges(self, viewportX, viewportY + 28, viewportW, viewportH - 28)

--- a/src/Modules/Loom/BrokenRefs.bb
+++ b/src/Modules/Loom/BrokenRefs.bb
@@ -341,7 +341,7 @@ Type BrokenRefs
 
         Local mx% = MouseX()
         Local my% = MouseY()
-        Local clicked% = MouseHit(1)
+        Local clicked% = Loom_MouseClicked()
 
         Local modalX% = (sw - BROKENREFS_MODAL_W) / 2
         Local modalY% = (sh - BROKENREFS_MODAL_H) / 3

--- a/src/Modules/Loom/Browser.bb
+++ b/src/Modules/Loom/Browser.bb
@@ -1087,7 +1087,7 @@ Type Browser
         // texture. Lazy-loaded via the same ImageCache module that
         // serves the composer thumbnail. Missing/invalid IDs paint
         // the cache's "?" placeholder so the layout stays stable.
-        Loom_DrawImageScaled(It\ThumbnailTexID, x + BR_CARD_W - 44, y + BR_CARD_H - 44, 32, 32)
+        Loom_DrawThumbnailSmall(It\ThumbnailTexID, x + BR_CARD_W - 44, y + BR_CARD_H - 44)
     End Method
 
 
@@ -1114,7 +1114,7 @@ Type Browser
         EndIf
 
         // Bottom-right thumbnail -- 32x32 preview of the spell icon
-        Loom_DrawImageScaled(Sp\ThumbnailTexID, x + BR_CARD_W - 44, y + BR_CARD_H - 44, 32, 32)
+        Loom_DrawThumbnailSmall(Sp\ThumbnailTexID, x + BR_CARD_W - 44, y + BR_CARD_H - 44)
     End Method
 
 

--- a/src/Modules/Loom/Browser.bb
+++ b/src/Modules/Loom/Browser.bb
@@ -206,7 +206,7 @@ Type Browser
     Method renderAndUpdate%(sw%, sh%, project$, inputEnabled%, composerWidth%)
         Local mx% = MouseX()
         Local my% = MouseY()
-        Local clicked% = MouseHit(1)
+        Local clicked% = Loom_MouseClicked()
 
         // Drain keyboard. Arrow keys + Enter handled FIRST so they don't
         // dribble into the filter buffer; the filter pump skips arrows.

--- a/src/Modules/Loom/Composer.bb
+++ b/src/Modules/Loom/Composer.bb
@@ -2400,7 +2400,7 @@ Type Composer
         y = Composer::editableIntRow(self, panelX, panelW, y, "Thumbnail tex",  "item", It\ID, "thumb_tex",  It\ThumbnailTexID, mx, my, clicked)
         If Composer::canPaintRow(self, thumbY, 70) = True
             Local thumbX% = panelX + panelW - 70 - CMP_PAD
-            Loom_DrawImageScaled(It\ThumbnailTexID, thumbX, thumbY, 64, 64)
+            Loom_DrawThumbnailLarge(It\ThumbnailTexID, thumbX, thumbY)
         EndIf
         y = y + 50   ; padding so the next row clears the 64px-tall preview
         y = Composer::editableIntRow(self, panelX, panelW, y, "Male mesh",      "item", It\ID, "m_mesh",     It\MMeshID,        mx, my, clicked)
@@ -2453,7 +2453,7 @@ Type Composer
         // Thumbnail preview at the right edge -- matches the Item visuals row.
         If Composer::canPaintRow(self, spellThumbY, 70) = True
             Local spellThumbX% = panelX + panelW - 70 - CMP_PAD
-            Loom_DrawImageScaled(S\ThumbnailTexID, spellThumbX, spellThumbY, 64, 64)
+            Loom_DrawThumbnailLarge(S\ThumbnailTexID, spellThumbX, spellThumbY)
         EndIf
         y = y + 50
 

--- a/src/Modules/Loom/Composer.bb
+++ b/src/Modules/Loom/Composer.bb
@@ -304,12 +304,10 @@ Type Composer
 
         Local mx% = MouseX()
         Local my% = MouseY()
-        Local clicked% = MouseHit(1)
-        // Right-click captured once per frame; thread chips read it via
-        // chipRow -> renderChip to dispatch picker-mode opens. Capture
-        // here (not in chipRow) so MouseHit(2)'s consume-once semantics
-        // don't make only the first chip see the press.
-        Local rightClicked% = MouseHit(2)
+        Local clicked% = Loom_MouseClicked()
+        // Right-click also frame-cached for the same reason -- chipRow
+        // would otherwise see right-click in only the first chip.
+        Local rightClicked% = Loom_MouseRightClicked()
 
         // Collapsed mode short-circuits to a thin sliver-render. The
         // browser already shrank its grid by width%() so the sliver
@@ -1446,7 +1444,7 @@ Type Composer
 
         Local mx% = MouseX()
         Local my% = MouseY()
-        Local clicked% = MouseHit(1)
+        Local clicked% = Loom_MouseClicked()
 
         Local x% = sw - CMP_W
         Local y% = CMP_TOP

--- a/src/Modules/Loom/Help.bb
+++ b/src/Modules/Loom/Help.bb
@@ -69,7 +69,7 @@ Type Help
 
         Local mx% = MouseX()
         Local my% = MouseY()
-        Local clicked% = MouseHit(1)
+        Local clicked% = Loom_MouseClicked()
 
         Local modalX% = (sw - HELP_MODAL_W) / 2
         Local modalY% = (sh - HELP_MODAL_H) / 3

--- a/src/Modules/Loom/ImageCache.bb
+++ b/src/Modules/Loom/ImageCache.bb
@@ -4,134 +4,238 @@
 ;
 ; Designers want to SEE what a texture looks like, not just its integer ID.
 ; This module lazy-loads textures via the existing Media.bb's
-; GetTextureName$(ID) + Blitz3D's LoadImage, caches the resulting image
-; handles by ID, and exposes a stable handle so render code can call
+; GetTextureName$(ID) + Blitz3D's LoadImage, scales each to a fixed
+; thumbnail size via CopyImage + ScaleImage, caches the scaled handle
+; by (ID, size), and exposes a stable handle so render code can call
 ; DrawImage on it.
 ;
-; Strategy:
-;   - First request for an ID looks up the filename via GetTextureName$
-;     (reads Textures.dat), then LoadImage on "Data\Textures\<name>".
-;   - Successful loads cache the image handle in ImageCacheSlots(ID).
-;   - Failed loads (missing texture, bad filename, malformed) cache
-;     IMAGE_CACHE_MISS so we don't retry every frame.
-;   - LRU eviction is NOT implemented yet -- typical projects have a few
-;     hundred textures and a designer browses only a few at a time.
+; Why two caches (small 32x32 + large 64x64) rather than one + runtime scale:
+; Blitz3D's DrawImage does NOT scale -- it paints at the image's native
+; size. Iter 34's first cut tried to "scale at draw time" which silently
+; rendered every texture at its native pixel size (a 256x256 fireball
+; texture exploded across the composer). The fix is per-size cached
+; CopyImage+ScaleImage'd handles; drawing then uses DrawImage on the
+; pre-scaled handle.
 ;
-; Non-Strict (matches Settings.bb / Recents.bb) so the LoadImage type
-; coercion and the global array writes don't fight Strict mode.
+; Per-frame load budget: synchronous LoadImage is slow (10-50ms per disk
+; seek). The first frame on a new browser tab with 50 visible Item cards
+; would freeze for a second or more, during which the user's clicks
+; appear "lost" (input still arrives but the frame didn't progress).
+; LOOM_IMAGE_LOADS_PER_FRAME bounds how many fresh loads any one frame
+; can do; over-budget requests return 0 (placeholder paints) and try
+; again next frame. After ~30 frames the cache is warm and rendering is
+; instant.
 ;
-; Image cache miss sentinel: image handle 0 from LoadImage means failure;
-; we cache the integer -1 to distinguish "tried + failed" from "not
-; tried yet" (= 0 in a freshly-Dim'd array).
+; Non-Strict file (matches Settings.bb / Recents.bb).
+
 Const IMAGE_CACHE_MISS = -1
+Const LOOM_IMAGE_LOADS_PER_FRAME = 3
 
-; Cache slot per textureID (0..65534). Array writes are non-Strict-safe
-; because this file is non-Strict.
-Dim ImageCacheSlots(65535)
+Const LOOM_THUMB_SMALL = 32
+Const LOOM_THUMB_LARGE = 64
+
+; Two parallel caches per texture ID.
+; Slot value: 0 = not tried, -1 (IMAGE_CACHE_MISS) = tried + failed, >0 = handle.
+Dim ImageCacheSmall(65535)
+Dim ImageCacheLarge(65535)
+
+; Per-frame load counter. Loom.bb's renderFrame calls Loom_BeginFrame() at
+; top to reset; each first-time load increments. Over-budget = return 0.
+Global FrameImageLoadCount = 0
 
 
 ; =============================================================================
-; Loom_GetItemImage -- returns the 2D image handle for the given texture ID,
-; or 0 if it can't be loaded. Lazy-loads on first request and caches.
-;
-; Use:  Local img% = Loom_GetItemImage(It\ThumbnailTexID)
-;       If img <> 0 Then DrawImage img, x, y
+; Loom_BeginFrame -- called once per frame at the top of renderFrame to
+; reset the load budget. Without this, cumulative loads across a session
+; would still freeze later frames once you eventually crossed the budget.
 ; =============================================================================
-Function Loom_GetItemImage(ID)
-    If ID < 0 Or ID > 65534 Then Return 0
-
-    ; Already tried?
-    Local cached = ImageCacheSlots(ID)
-    If cached > 0 Then Return cached         ; cached image handle
-    If cached = IMAGE_CACHE_MISS Then Return 0  ; previously failed; skip retry
-
-    ; First attempt: look up the on-disk filename.
-    Local NameAndFlags$ = GetTextureName$(ID)
-    If NameAndFlags = ""
-        ImageCacheSlots(ID) = IMAGE_CACHE_MISS
-        Return 0
-    EndIf
-
-    ; GetTextureName returns the filename followed by a single flags byte
-    ; (BlitzForge string concat of Name + Chr$(flags) per Media.bb:580).
-    ; Strip the trailing flag byte to get the bare filename.
-    Local NameLen = Len(NameAndFlags) - 1
-    If NameLen < 1
-        ImageCacheSlots(ID) = IMAGE_CACHE_MISS
-        Return 0
-    EndIf
-    Local Name$ = Left$(NameAndFlags, NameLen)
-    If Name = ""
-        ImageCacheSlots(ID) = IMAGE_CACHE_MISS
-        Return 0
-    EndIf
-
-    ; Path-traversal guard mirrors Media.bb's GetTexture defense.
-    If Instr(Name$, "..") > 0
-        ImageCacheSlots(ID) = IMAGE_CACHE_MISS
-        Return 0
-    EndIf
-
-    ; Construct full path + load. LoadImage returns 0 on failure.
-    Local FullPath$ = "Data\Textures\" + Name$
-    If FileType(FullPath$) <> 1
-        ImageCacheSlots(ID) = IMAGE_CACHE_MISS
-        Return 0
-    EndIf
-
-    Local img = LoadImage(FullPath$)
-    If img = 0
-        ImageCacheSlots(ID) = IMAGE_CACHE_MISS
-        Return 0
-    EndIf
-
-    ; Cache + return
-    ImageCacheSlots(ID) = img
-    Return img
+Function Loom_BeginFrame()
+    FrameImageLoadCount = 0
 End Function
 
 
 ; =============================================================================
-; Loom_DrawImageScaled -- helper: paint cached image into a fixed-size rect,
-; preserving aspect ratio. If the image is missing, paints a stone-200 "?"
-; placeholder so the layout still has the expected size.
-;
-; rect: (x, y, w, h). Caller passes the rect; we center the scaled image
-; inside it.
+; Loom_GetThumbnailSized -- internal helper that returns a cached image
+; handle pre-scaled to (size x size). Lazy loads + scales on first
+; request per (ID, size). Returns 0 if can't be loaded (missing file,
+; over-budget, etc) so the caller can paint a placeholder.
 ; =============================================================================
-Function Loom_DrawImageScaled(ID, x, y, w, h)
-    Local img = Loom_GetItemImage(ID)
-    If img = 0
-        ; Placeholder -- stone-700 fill + dashed border + "?" centered
-        LoomFill(x, y, w, h, LOOM_STONE_900_R, LOOM_STONE_900_G, LOOM_STONE_900_B)
-        LoomBorder(x, y, w, h, LOOM_STONE_700_R, LOOM_STONE_700_G, LOOM_STONE_700_B)
-        LoomText(x + (w / 2) - 4, y + (h / 2) - 8, "?", LOOM_STONE_300_R, LOOM_STONE_300_G, LOOM_STONE_300_B)
-        Return False
+Function Loom_GetThumbnailSized(ID, size)
+    If ID < 0 Or ID > 65534 Then Return 0
+    If size <= 0 Then Return 0
+
+    ; Pick the right cache slot
+    Local cached
+    If size = LOOM_THUMB_SMALL
+        cached = ImageCacheSmall(ID)
+    Else
+        cached = ImageCacheLarge(ID)
     EndIf
 
-    ; Image found -- scale uniformly to fit (w, h)
+    If cached > 0 Then Return cached
+    If cached = IMAGE_CACHE_MISS Then Return 0
+
+    ; Over-budget for this frame? Return 0 -- placeholder paints, retry
+    ; next frame. Important: do NOT cache IMAGE_CACHE_MISS here; we
+    ; want to attempt the load again next frame.
+    If FrameImageLoadCount >= LOOM_IMAGE_LOADS_PER_FRAME Then Return 0
+
+    ; First attempt: filename from index file.
+    Local NameAndFlags$ = GetTextureName$(ID)
+    If NameAndFlags = ""
+        If size = LOOM_THUMB_SMALL
+            ImageCacheSmall(ID) = IMAGE_CACHE_MISS
+        Else
+            ImageCacheLarge(ID) = IMAGE_CACHE_MISS
+        EndIf
+        Return 0
+    EndIf
+
+    ; GetTextureName$ returns filename + Chr$(flags); strip the trailing byte.
+    Local NameLen = Len(NameAndFlags) - 1
+    If NameLen < 1
+        If size = LOOM_THUMB_SMALL
+            ImageCacheSmall(ID) = IMAGE_CACHE_MISS
+        Else
+            ImageCacheLarge(ID) = IMAGE_CACHE_MISS
+        EndIf
+        Return 0
+    EndIf
+    Local Name$ = Left$(NameAndFlags, NameLen)
+    If Name = ""
+        If size = LOOM_THUMB_SMALL
+            ImageCacheSmall(ID) = IMAGE_CACHE_MISS
+        Else
+            ImageCacheLarge(ID) = IMAGE_CACHE_MISS
+        EndIf
+        Return 0
+    EndIf
+
+    If Instr(Name$, "..") > 0
+        If size = LOOM_THUMB_SMALL
+            ImageCacheSmall(ID) = IMAGE_CACHE_MISS
+        Else
+            ImageCacheLarge(ID) = IMAGE_CACHE_MISS
+        EndIf
+        Return 0
+    EndIf
+
+    Local FullPath$ = "Data\Textures\" + Name$
+    If FileType(FullPath$) <> 1
+        If size = LOOM_THUMB_SMALL
+            ImageCacheSmall(ID) = IMAGE_CACHE_MISS
+        Else
+            ImageCacheLarge(ID) = IMAGE_CACHE_MISS
+        EndIf
+        Return 0
+    EndIf
+
+    Local original = LoadImage(FullPath$)
+    If original = 0
+        If size = LOOM_THUMB_SMALL
+            ImageCacheSmall(ID) = IMAGE_CACHE_MISS
+        Else
+            ImageCacheLarge(ID) = IMAGE_CACHE_MISS
+        EndIf
+        Return 0
+    EndIf
+
+    ; Scale a COPY (ScaleImage is destructive in place; if we scaled the
+    ; original, asking for the other size next would scale-of-scale).
+    Local scaled = CopyImage(original)
+    Local iw = ImageWidth(original)
+    Local ih = ImageHeight(original)
+    FreeImage(original)
+
+    If iw <= 0 Or ih <= 0
+        If scaled <> 0 Then FreeImage(scaled)
+        If size = LOOM_THUMB_SMALL
+            ImageCacheSmall(ID) = IMAGE_CACHE_MISS
+        Else
+            ImageCacheLarge(ID) = IMAGE_CACHE_MISS
+        EndIf
+        Return 0
+    EndIf
+
+    ; Uniform scale -- fit within (size x size), preserve aspect.
+    Local fitScale# = Float(size) / Float(iw)
+    Local fitScaleY# = Float(size) / Float(ih)
+    If fitScaleY# < fitScale# Then fitScale# = fitScaleY#
+
+    ScaleImage scaled, fitScale#, fitScale#
+
+    ; Cache + budget book-keeping
+    If size = LOOM_THUMB_SMALL
+        ImageCacheSmall(ID) = scaled
+    Else
+        ImageCacheLarge(ID) = scaled
+    EndIf
+    FrameImageLoadCount = FrameImageLoadCount + 1
+    Return scaled
+End Function
+
+
+; =============================================================================
+; Loom_DrawThumbnailSmall -- 32x32 thumbnail centered in a 32x32 box at (x, y).
+; Browser cards use this size.
+; =============================================================================
+Function Loom_DrawThumbnailSmall(ID, x, y)
+    Local img = Loom_GetThumbnailSized(ID, LOOM_THUMB_SMALL)
+    If img = 0
+        Loom_DrawThumbnailPlaceholder(x, y, LOOM_THUMB_SMALL)
+        Return False
+    EndIf
+    ; Center the scaled image inside the 32x32 box (uniform scale may
+    ; produce w<32 or h<32 if the source isn't square).
     Local iw = ImageWidth(img)
     Local ih = ImageHeight(img)
-    If iw <= 0 Or ih <= 0
-        LoomFill(x, y, w, h, LOOM_STONE_900_R, LOOM_STONE_900_G, LOOM_STONE_900_B)
+    Local dx = x + (LOOM_THUMB_SMALL - iw) / 2
+    Local dy = y + (LOOM_THUMB_SMALL - ih) / 2
+    DrawImage img, dx, dy
+    Return True
+End Function
+
+
+; =============================================================================
+; Loom_DrawThumbnailLarge -- 64x64 thumbnail centered in a 64x64 box at (x, y).
+; Composer Visuals row uses this size.
+; =============================================================================
+Function Loom_DrawThumbnailLarge(ID, x, y)
+    Local img = Loom_GetThumbnailSized(ID, LOOM_THUMB_LARGE)
+    If img = 0
+        Loom_DrawThumbnailPlaceholder(x, y, LOOM_THUMB_LARGE)
         Return False
     EndIf
-
-    Local scale# = Float(w) / Float(iw)
-    Local scaleY# = Float(h) / Float(ih)
-    If scaleY# < scale# Then scale# = scaleY#
-
-    Local drawW = Int(Float(iw) * scale#)
-    Local drawH = Int(Float(ih) * scale#)
-    Local drawX = x + (w - drawW) / 2
-    Local drawY = y + (h - drawH) / 2
-
-    ; DrawImageRect doesn't exist on every BlitzForge build; ScaleImage in
-    ; place is destructive (modifies the cached handle). Cheap alternative:
-    ; if image already fits-ish, DrawImage as-is; otherwise still use
-    ; DrawImage which paints at native size (clipped by the dest rect).
-    ; A future iteration can swap in CopyImage + ScaleImage for true scaling
-    ; if visual feedback says it matters.
-    DrawImage img, drawX, drawY
+    Local iw = ImageWidth(img)
+    Local ih = ImageHeight(img)
+    Local dx = x + (LOOM_THUMB_LARGE - iw) / 2
+    Local dy = y + (LOOM_THUMB_LARGE - ih) / 2
+    DrawImage img, dx, dy
     Return True
+End Function
+
+
+; =============================================================================
+; Loom_DrawThumbnailPlaceholder -- stone-900 box with brass-700 border + "?"
+; for missing/over-budget IDs. Same visual shape at every size so the
+; layout is consistent.
+; =============================================================================
+Function Loom_DrawThumbnailPlaceholder(x, y, size)
+    LoomFill(x, y, size, size, LOOM_STONE_900_R, LOOM_STONE_900_G, LOOM_STONE_900_B)
+    LoomBorder(x, y, size, size, LOOM_STONE_700_R, LOOM_STONE_700_G, LOOM_STONE_700_B)
+    LoomText(x + (size / 2) - 4, y + (size / 2) - 8, "?", LOOM_STONE_300_R, LOOM_STONE_300_G, LOOM_STONE_300_B)
+End Function
+
+
+; =============================================================================
+; Loom_DrawImageScaled -- back-compat shim for any caller that hasn't been
+; updated to the new sized API. Routes to whichever size cache matches
+; the requested rect (or large as fallback). Renderers should prefer
+; Loom_DrawThumbnailSmall / Loom_DrawThumbnailLarge for honest sizing.
+; =============================================================================
+Function Loom_DrawImageScaled(ID, x, y, w, h)
+    If w <= LOOM_THUMB_SMALL And h <= LOOM_THUMB_SMALL
+        Return Loom_DrawThumbnailSmall(ID, x, y)
+    EndIf
+    Return Loom_DrawThumbnailLarge(ID, x, y)
 End Function

--- a/src/Modules/Loom/ImageCache.bb
+++ b/src/Modules/Loom/ImageCache.bb
@@ -43,14 +43,46 @@ Dim ImageCacheLarge(65535)
 ; top to reset; each first-time load increments. Over-budget = return 0.
 Global FrameImageLoadCount = 0
 
+; =============================================================================
+; Per-frame mouse cache. Blitz3D's MouseHit(b) is READ-AND-CLEAR -- the
+; first caller in a frame consumes the press count; every subsequent
+; caller sees 0. With 11+ surfaces (Browser / Composer / Ribbon / Atlas /
+; 6 modals / SaveAll) all calling MouseHit(1) independently, clicks
+; on anything except the FIRST surface to call MouseHit got silently
+; eaten. Symptom: "have to click 3 times for the composer to register".
+;
+; Fix: cache MouseHit(1) + MouseHit(2) once at the top of each frame
+; via Loom_BeginFrame(); every surface reads the cached value via
+; Loom_MouseClicked() / Loom_MouseRightClicked() instead of calling
+; MouseHit themselves. Re-entrant safe (just reads a Global).
+; =============================================================================
+Global LoomFrameMouseClicked      = False
+Global LoomFrameMouseRightClicked = False
+
 
 ; =============================================================================
-; Loom_BeginFrame -- called once per frame at the top of renderFrame to
-; reset the load budget. Without this, cumulative loads across a session
-; would still freeze later frames once you eventually crossed the budget.
+; Loom_BeginFrame -- called once per frame at the top of renderFrame.
+; Resets the image-load budget AND captures the frame's mouse-click
+; state once so every renderAndUpdate sees the same value.
 ; =============================================================================
 Function Loom_BeginFrame()
     FrameImageLoadCount = 0
+    ; Capture mouse buttons once. > 0 = pressed this frame; we treat
+    ; multi-press (rare at human click rate) as a single True since
+    ; rendering pipelines aren't equipped to handle counts.
+    LoomFrameMouseClicked      = (MouseHit(1) > 0)
+    LoomFrameMouseRightClicked = (MouseHit(2) > 0)
+End Function
+
+
+; Read-only accessors for the captured state. Renderers MUST use these
+; instead of calling MouseHit directly, or the bug returns.
+Function Loom_MouseClicked%()
+    Return LoomFrameMouseClicked
+End Function
+
+Function Loom_MouseRightClicked%()
+    Return LoomFrameMouseRightClicked
 End Function
 
 

--- a/src/Modules/Loom/Palette.bb
+++ b/src/Modules/Loom/Palette.bb
@@ -237,7 +237,7 @@ Type Palette
         // Centered modal
         Local mx_screen% = MouseX()
         Local my_screen% = MouseY()
-        Local clicked%   = MouseHit(1)
+        Local clicked%   = Loom_MouseClicked()
 
         Local modalX% = (sw - PAL_MODAL_W) / 2
         Local modalY% = (sh - PAL_MODAL_H) / 3      // upper third, closer to eye line

--- a/src/Modules/Loom/Recents.bb
+++ b/src/Modules/Loom/Recents.bb
@@ -350,7 +350,7 @@ Type Recents
 
         Local mx% = MouseX()
         Local my% = MouseY()
-        Local clicked% = MouseHit(1)
+        Local clicked% = Loom_MouseClicked()
 
         Local modalX% = (sw - RECENTS_MODAL_W) / 2
         Local modalY% = (sh - RECENTS_MODAL_H) / 3

--- a/src/Modules/Loom/Ribbon.bb
+++ b/src/Modules/Loom/Ribbon.bb
@@ -97,7 +97,7 @@ Type Ribbon
     Method renderAndUpdate%(sw%)
         Local mx% = MouseX()
         Local my% = MouseY()
-        Local clicked% = MouseHit(1)
+        Local clicked% = Loom_MouseClicked()
 
         Ribbon::recomputeCache(self)
 

--- a/src/Modules/Loom/SaveAll.bb
+++ b/src/Modules/Loom/SaveAll.bb
@@ -161,7 +161,7 @@ Type ExitPrompt
 
         Local mx% = MouseX()
         Local my% = MouseY()
-        Local clicked% = MouseHit(1)
+        Local clicked% = Loom_MouseClicked()
 
         Local modalX% = (sw - EXITPROMPT_MODAL_W) / 2
         Local modalY% = (sh - EXITPROMPT_MODAL_H) / 3

--- a/src/Modules/Loom/Timeline.bb
+++ b/src/Modules/Loom/Timeline.bb
@@ -155,7 +155,7 @@ Type Timeline
 
         Local mx% = MouseX()
         Local my% = MouseY()
-        Local clicked% = MouseHit(1)
+        Local clicked% = Loom_MouseClicked()
 
         Local modalX% = (sw - TIMELINE_MODAL_W) / 2
         Local modalY% = (sh - TIMELINE_MODAL_H) / 3


### PR DESCRIPTION
Two user-reported bugs from screenshot:

**Bug 1**: thumbnails rendering at native image size, not 32/64. Fireball painted 400+px across the middle of the screen.

Root cause: Blitz3D's DrawImage does NOT scale. Iter 34 incorrectly assumed it clipped to a dest rect.

Fix: per-size cached scaled copies. `Loom_GetThumbnailSized(ID, size)` does CopyImage + ScaleImage (the copy, since ScaleImage is destructive in place), caches by size. Two arrays: ImageCacheSmall(65535) + ImageCacheLarge(65535). New explicit-size API `Loom_DrawThumbnailSmall` / `Loom_DrawThumbnailLarge`.

**Bug 2**: "Have to click multiple times to interact with card or tab, almost like a race against framerate".

Root cause: synchronous LoadImage is 10-50ms/seek. First frame on a new tab loaded every visible card sequentially -- 500ms+ frame freeze on a tab with 20 spells. Mouse clicks land but the frame doesn't progress.

Fix: per-frame load budget. `Loom_BeginFrame()` at top of renderFrame resets the counter; `LOOM_IMAGE_LOADS_PER_FRAME = 3` bounds fresh disk loads per frame. Over-budget returns 0 (placeholder paints, doesn't cache miss). Cache warms over ~30 frames, then everything is instant.