### PR TITLE
Loom hotfix: openModal consumes click so modal doesn't self-close

### DIFF
--- a/src/Modules/Loom/BrokenRefs.bb
+++ b/src/Modules/Loom/BrokenRefs.bb
@@ -87,6 +87,10 @@ Type BrokenRefs
         self\scrollOffset = 0
         BrokenRefs::rebuild(self)
         FlushKeys
+        // Eat the opening click so the modal's "click outside closes"
+        // check doesn't fire on the same frame (MouseHit cache makes
+        // all surfaces see the same click; see ImageCache.bb).
+        Loom_ConsumeClick()
         WriteLog(LoomLog, "BrokenRefs: open (" + Str(self\entryCount) + " entries)")
     End Method
 

--- a/src/Modules/Loom/Help.bb
+++ b/src/Modules/Loom/Help.bb
@@ -47,6 +47,7 @@ Type Help
     Method openModal()
         self\open = True
         FlushKeys
+        Loom_ConsumeClick()
         WriteLog(LoomLog, "Help: open")
     End Method
 

--- a/src/Modules/Loom/ImageCache.bb
+++ b/src/Modules/Loom/ImageCache.bb
@@ -87,6 +87,31 @@ End Function
 
 
 ; =============================================================================
+; Loom_ConsumeClick -- mark the current frame's click as handled so no
+; subsequent renderer in this frame reacts to it. Call this when an action
+; fires that conceptually "uses up" the click, e.g. openModal triggered
+; from a ribbon button.
+;
+; Why it's needed: before the MouseHit-cache hotfix, Blitz3D's
+; MouseHit(b) drained on first call -- the modal that opened from a
+; ribbon click never saw the click again, because Ribbon::MouseHit had
+; already drained it. With the cache, every surface sees the SAME
+; click; the newly-opened modal's "click outside modal = close"
+; check then fires on the very click that opened it. The modal opens
+; and immediately closes on the same frame.
+;
+; Sites: every openModal that's triggered by a click (BrokenRefs /
+; Palette / Timeline / Recents / Help / ExitPrompt). Keyboard
+; activations (Ctrl+K / F1 etc) don't need this since they don't set
+; LoomFrameMouseClicked in the first place.
+; =============================================================================
+Function Loom_ConsumeClick()
+    LoomFrameMouseClicked      = False
+    LoomFrameMouseRightClicked = False
+End Function
+
+
+; =============================================================================
 ; Loom_GetThumbnailSized -- internal helper that returns a cached image
 ; handle pre-scaled to (size x size). Lazy loads + scales on first
 ; request per (ID, size). Returns 0 if can't be loaded (missing file,

--- a/src/Modules/Loom/Palette.bb
+++ b/src/Modules/Loom/Palette.bb
@@ -141,6 +141,7 @@ Type Palette
         self\pickerTargetFieldId = ""
         Palette::clearResults(self)
         FlushKeys
+        Loom_ConsumeClick()
         WriteLog(LoomLog, "Palette: open (navigator)")
     End Method
 
@@ -166,6 +167,7 @@ Type Palette
         self\pickerTargetFieldId = targetFieldId
         Palette::clearResults(self)
         FlushKeys
+        Loom_ConsumeClick()
         WriteLog(LoomLog, "Palette: open (picker " + pickerKind + " -> " + targetKind + "#" + Str(targetRefID) + "." + targetFieldId + ")")
     End Method
 

--- a/src/Modules/Loom/Recents.bb
+++ b/src/Modules/Loom/Recents.bb
@@ -89,6 +89,7 @@ Type Recents
         self\open = True
         self\scrollOffset = 0
         FlushKeys
+        Loom_ConsumeClick()
         WriteLog(LoomLog, "Recents: open (" + Str(self\entryCount) + " entries)")
     End Method
 

--- a/src/Modules/Loom/SaveAll.bb
+++ b/src/Modules/Loom/SaveAll.bb
@@ -132,6 +132,7 @@ Type ExitPrompt
         self\open = True
         self\exitConfirmed = False
         FlushKeys
+        Loom_ConsumeClick()
         WriteLog(LoomLog, "ExitPrompt: open (dirty kinds present)")
     End Method
 

--- a/src/Modules/Loom/Timeline.bb
+++ b/src/Modules/Loom/Timeline.bb
@@ -103,6 +103,7 @@ Type Timeline
         self\open = True
         self\scrollOffset = 0
         FlushKeys
+        Loom_ConsumeClick()
         WriteLog(LoomLog, "Timeline: open (" + Str(self\entryCount) + " entries)")
     End Method
 


### PR DESCRIPTION
User report: clicking the Issues chip in the ribbon opened the modal which then disappeared instantly.

**Root cause**: regression from the MouseHit-cache hotfix (#371). Before the cache, `MouseHit(b)` drained on first call — the newly-opened modal never saw the click again because Ribbon had already drained it. With the cache, every surface sees the SAME cached click value; the modal's "click outside = close" check fires on the very click that opened it.

**Fix**: new `Loom_ConsumeClick()` in ImageCache.bb that zeros the cached values. Every openModal calls it after FlushKeys:
- BrokenRefs / Help / Palette (openModal + openAsPicker) / Recents / SaveAll (ExitPrompt) / Timeline

Keyboard-triggered opens (Ctrl+K, F1 etc) don't need the consume but the unconditional call is harmless and keeps the openModal contract uniform across all modals.