### PR TITLE
Loom: zone viewport click jumps composer to sub-section

### DIFF
--- a/src/Loom.bb
+++ b/src/Loom.bb
@@ -182,6 +182,10 @@ Type Loom
         // clicks call Threads::jump.
         self\browser = New Browser(self\threads)
         self\composer = New Composer(self\threads)
+        // Module-level facade so non-Strict modules (e.g. ZoneViewport)
+        // can dispatch into the composer without holding a reference.
+        // Same recorder-facade pattern as LoomWorldCache (ADR 005).
+        LoomComposer = self\composer
         self\palette = New Palette(self\threads)
 
         // Cross-link Palette <-> Composer for ref-field picker mode. The

--- a/src/Modules/Loom/Composer.bb
+++ b/src/Modules/Loom/Composer.bb
@@ -142,6 +142,17 @@ Type Composer
     Field bulkEditField$
     Field bulkEditBuffer$
 
+    // Per-zone-sub-entity Y anchors captured at render time so the
+    // viewport's click-pick can scroll the composer to the right
+    // section. Stored in unscrolled body coordinates (the y BEFORE
+    // self\scrollOffset is subtracted) so scrollToZoneSubEntity can
+    // just set scrollOffset = anchor - bodyTop. Refreshed every
+    // frame the zone is being rendered; stale slots are harmless
+    // because scrollToZoneSubEntity guards by source-data defined-ness.
+    Field zoneAnchorPortal[99]
+    Field zoneAnchorTrigger[149]
+    Field zoneAnchorSpawn[999]
+
     // Edit-buffer state. editKind = "" means no edit in progress.
     // (kind, refID, fieldId) together identify which field of which entity
     // the user is currently typing into. editBuffer is the in-progress value
@@ -1300,6 +1311,45 @@ Type Composer
         If kind = "zone"     Then ZoneSaved = False
         If kind = "animset"  Then AnimsSaved = False
         If kind = "settings" Then SettingsSaved = False
+    End Method
+
+
+    // -------------------------------------------------------------------------
+    // scrollToZoneSubEntity -- called from the ZoneViewport when a marker
+    // is clicked. Looks up the previously-captured Y anchor for the
+    // (kind, index) sub-entity and sets scrollOffset so that anchor
+    // becomes the top of the visible body region.
+    //
+    // Returns True if it scrolled, False if the anchor wasn't recorded
+    // yet (zone not currently focused, or the slot was empty last frame).
+    // The viewport's pick filters by source-data defined-ness before
+    // calling here, so a False return mostly means "you haven't rendered
+    // this zone yet this session".
+    // -------------------------------------------------------------------------
+    Method scrollToZoneSubEntity%(kind$, idx%)
+        // Resolve anchor via per-kind helper to dodge the Strict-mode
+        // "reassign Local from nested If" trap.
+        Local anchor% = Composer::zoneSubEntityAnchor(self, kind, idx)
+        If anchor < 0 Then Return False
+
+        // Set scrollOffset so anchor lands at body top. Subtract bodyTop
+        // since y values in the render are body-relative.
+        Local target% = anchor - self\bodyTop - 8
+        If target < 0 Then target = 0
+        // Clamp to content bottom so we don't scroll past the end
+        Local maxScroll% = self\lastContentBottom - self\bodyBottom
+        If maxScroll < 0 Then maxScroll = 0
+        If target > maxScroll Then target = maxScroll
+        self\scrollOffset = target
+        Return True
+    End Method
+
+
+    Method zoneSubEntityAnchor%(kind$, idx%)
+        If kind = "portal" And idx >= 0 And idx <= 99 Then Return self\zoneAnchorPortal[idx]
+        If kind = "trigger" And idx >= 0 And idx <= 149 Then Return self\zoneAnchorTrigger[idx]
+        If kind = "spawn" And idx >= 0 And idx <= 999 Then Return self\zoneAnchorSpawn[idx]
+        Return -1
     End Method
 
 
@@ -2851,6 +2901,9 @@ Type Composer
         Local p%
         For p = 0 To 99
             If Ar\PortalName$[p] <> ""
+                // Capture pre-scroll Y anchor so the zone-viewport pick
+                // can scroll the composer to this portal's section.
+                self\zoneAnchorPortal[p] = y + self\scrollOffset
                 // Sub-header + delete button
                 If Composer::canPaintRow(self, y, CMP_ROW_H) = True
                     LoomText(panelX + CMP_PAD, y + 4, "Portal " + Str(p), LOOM_ARCANE_500_R, LOOM_ARCANE_500_G, LOOM_ARCANE_500_B)
@@ -2903,6 +2956,7 @@ Type Composer
         Local t%
         For t = 0 To 149
             If Ar\TriggerScript$[t] <> ""
+                self\zoneAnchorTrigger[t] = y + self\scrollOffset
                 If Composer::canPaintRow(self, y, CMP_ROW_H) = True
                     LoomText(panelX + CMP_PAD, y + 4, "Trigger " + Str(t), LOOM_ARCANE_500_R, LOOM_ARCANE_500_G, LOOM_ARCANE_500_B)
                 EndIf
@@ -2939,6 +2993,7 @@ Type Composer
         Local s%
         For s = 0 To 999
             If Ar\SpawnActor[s] > 0
+                self\zoneAnchorSpawn[s] = y + self\scrollOffset
                 If Composer::canPaintRow(self, y, CMP_ROW_H) = True
                     LoomText(panelX + CMP_PAD, y + 4, "Spawn " + Str(s), LOOM_ARCANE_500_R, LOOM_ARCANE_500_G, LOOM_ARCANE_500_B)
                 EndIf

--- a/src/Modules/Loom/ZoneViewport.bb
+++ b/src/Modules/Loom/ZoneViewport.bb
@@ -77,6 +77,11 @@ Global VPCountTriggers = 0
 Global VPCountWaypoints = 0
 Global VPCountLines    = 0     ; total connection lines emitted
 
+; Module-level Composer pointer set by Loom.bb after construction.
+; Lets Loom_PickZoneMarker dispatch into Composer::scrollToZoneSubEntity
+; without holding a per-call reference. Same shape as LoomWorldCache.
+Global LoomComposer.Composer = Null
+
 
 ; =============================================================================
 ; Loom_InitZoneViewport -- one-time setup at boot.
@@ -220,7 +225,20 @@ Function Loom_PickZoneMarker(localX, localY)
     For m = Each ZoneViewportMarker
         If m\EN = picked
             If m\Kind <> ""
-                Toast_Show("Picked " + m\Kind + " " + Str(m\IndexN), "info")
+                ; Dispatch to composer scroll-to-section if available
+                ; (waypoint clicks don't have a section to scroll to;
+                ; they're rendered inline with other waypoints rather
+                ; than as per-slot sub-sections, so we still toast).
+                If LoomComposer <> Null And (m\Kind = "portal" Or m\Kind = "trigger" Or m\Kind = "spawn")
+                    Local ok = Composer::scrollToZoneSubEntity(LoomComposer, m\Kind, m\IndexN)
+                    If ok = True
+                        Toast_Show("Jumped to " + m\Kind + " " + Str(m\IndexN), "info")
+                    Else
+                        Toast_Show("Picked " + m\Kind + " " + Str(m\IndexN) + " (anchor not ready)", "warning")
+                    EndIf
+                Else
+                    Toast_Show("Picked " + m\Kind + " " + Str(m\IndexN), "info")
+                EndIf
                 WriteLog(LoomLog, "ZoneViewport: picked " + m\Kind + " " + Str(m\IndexN))
             EndIf
             Return


### PR DESCRIPTION
Turns iter-44 marker pick into a real navigation action: clicking a portal/trigger/spawn marker in the 3D viewport scrolls the composer panel to that sub-entitys section.

## Composer additions

- Three new Fields tracking Y anchors per zone sub-entity slot: zoneAnchorPortal[99], zoneAnchorTrigger[149], zoneAnchorSpawn[999]
- Written each frame during renderZonePortals / renderZoneTriggers / renderZoneSpawns at the start of each defined slots sub-section (y + scrollOffset = unscrolled body-relative position)
- New scrollToZoneSubEntity(kind, idx) sets scrollOffset so the anchor lands at the top of the body region. Clamped 0..maxScroll.
- Helper zoneSubEntityAnchor(kind, idx) returns the right anchor; splitting kind lookup into its own method dodges the Strict-mode reassign Method-local from nested If trap.

## ZoneViewport additions

- New Global LoomComposer.Composer (same shape as LoomWorldCache -- Loom.bb wires it at boot after Composer construction)
- Loom_PickZoneMarker now dispatches Composer::scrollToZoneSubEntity on portal/trigger/spawn picks
- Waypoints stay toast-only since theyre rendered inline (not per-slot sub-sections)
- Toast distinguishes Jumped to ... (anchor available) from Picked ... (anchor not ready) so user knows whether the scroll fired

This is the first end-to-end interaction between the 2D editor and the 3D viewport: 3D click -> 2D scroll. Future iters can do the reverse (focus an entity in composer -> highlight its marker in viewport).