### PR TITLE
Loom hotfix: zone viewport layout + render perf

### DIFF
--- a/src/Modules/Loom/Composer.bb
+++ b/src/Modules/Loom/Composer.bb
@@ -2716,15 +2716,25 @@ Type Composer
 
         Local y% = bodyY
 
-        // 3D schematic viewport at the top of the composer body. Shows
-        // portal/spawn/trigger/waypoint markers in 3D space with mouse
-        // orbit + zoom. Anchored to the panel right; the editable
-        // field rows flow down the left side underneath.
-        Local zvX% = panelX + panelW - 384 - CMP_PAD
+        // 3D schematic viewport at the top of the composer body. Sized
+        // to fit inside the panel width (VP_RT_SIZE = 320 leaves
+        // CMP_PAD on each side of CMP_W = 380). Centered horizontally
+        // so the panel breathing room is symmetric.
+        //
+        // Field rows flow BELOW the viewport (y += viewport height +
+        // padding) -- earlier layout had them overlapping with the
+        // viewport's overlay text, producing the "jumbled" composer
+        // a user reported.
+        Local vpW = VP_RT_SIZE
+        Local zvX% = panelX + (panelW - vpW) / 2
         Local zvY% = y
-        If Composer::canPaintRow(self, y, 384) = True
+        If Composer::canPaintRow(self, y, vpW) = True
             Loom_DrawZoneViewport(h, zvX, zvY)
         EndIf
+        // Push past the viewport (with a small gap) regardless of
+        // whether it painted -- the field-flow layout below assumes
+        // a fixed offset so all zones see the same vertical rhythm.
+        y = y + vpW + 8
 
         y = Composer::editableRow(self,    panelX, panelW, y, "Name",     "zone", h, "name",     Ar\Name$,    mx, my, clicked)
         y = Composer::toggleRow(self,      panelX, panelW, y, "Outdoors", "zone", h, "outdoors", Ar\Outdoors, mx, my, clicked)

--- a/src/Modules/Loom/ZoneViewport.bb
+++ b/src/Modules/Loom/ZoneViewport.bb
@@ -37,7 +37,12 @@
 ; Non-Strict (matches MeshPreview / Settings / Recents).
 
 
-Const VP_RT_SIZE          = 384
+; Sized to fit inside the 380px composer panel (CMP_W) with the
+; standard CMP_PAD breathing room. Previously 384 which leaked
+; left of the panel and produced the overlapping-text bug a user
+; reported (composer fields and viewport overlay both drew in the
+; same X column).
+Const VP_RT_SIZE          = 320
 Const VP_SCENE_Y_OFFSET#  = 20000.0      ; isolate from mesh preview at y=10000
 Const VP_DEFAULT_CAM_DIST# = 400.0
 Const VP_MARKER_SIZE#     = 4.0
@@ -86,6 +91,17 @@ Global VPCountSpawns   = 0
 Global VPCountTriggers = 0
 Global VPCountWaypoints = 0
 Global VPCountLines    = 0     ; total connection lines emitted
+
+; Render-on-change flag. Set True any time camera / markers / highlight
+; change; consumed by Loom_DrawZoneViewport which only does
+; RenderWorld + CopyRect when True. Cached pixels persist between
+; frames so a static viewport costs ~0.
+Global VPDirty         = True
+
+; Last-frame highlight so we only ScaleEntity on TRANSITIONS instead
+; of every frame's full marker walk. Empty/-1 = no previous highlight.
+Global VPPrevHighlightKind$ = ""
+Global VPPrevHighlightIdx   = -1
 
 ; Module-level Composer pointer set by Loom.bb after construction.
 ; Lets Loom_PickZoneMarker dispatch into Composer::scrollToZoneSubEntity
@@ -514,6 +530,7 @@ Function Loom_DrawZoneViewport(zoneHandle, x, y)
     If zoneHandle <> VPLoadedZoneH
         Loom_LoadZoneMarkers(Ar)
         VPLoadedZoneH = zoneHandle
+        VPDirty = True
         WriteLog(LoomLog, "ZoneViewport: loaded zone " + Ar\Name$)
     EndIf
 
@@ -532,10 +549,13 @@ Function Loom_DrawZoneViewport(zoneHandle, x, y)
         Else
             Local dx = mx - VPLastMX
             Local dy = my - VPLastMY
-            VPYaw# = VPYaw# + Float(dx) * 0.5
-            VPPitch# = VPPitch# + Float(dy) * 0.5
-            If VPPitch# > 89.0 Then VPPitch# = 89.0
-            If VPPitch# < -89.0 Then VPPitch# = -89.0
+            If dx <> 0 Or dy <> 0
+                VPYaw# = VPYaw# + Float(dx) * 0.5
+                VPPitch# = VPPitch# + Float(dy) * 0.5
+                If VPPitch# > 89.0 Then VPPitch# = 89.0
+                If VPPitch# < -89.0 Then VPPitch# = -89.0
+                VPDirty = True
+            EndIf
             VPLastMX = mx
             VPLastMY = my
         EndIf
@@ -594,6 +614,7 @@ Function Loom_DrawZoneViewport(zoneHandle, x, y)
                 ; Update the underlying Area field via the existing zone
                 ; setter dispatch (handles Strict-mode dim-write trap).
                 Loom_CommitMarkerCoord(VPMarkerDragArH, VPMarkerDragKind$, VPMarkerDragIdx, newX#, newZ#)
+                VPDirty = True
             EndIf
         EndIf
     Else
@@ -616,40 +637,54 @@ Function Loom_DrawZoneViewport(zoneHandle, x, y)
             VPDistance# = VPDistance# - Float(wheel) * (VPDistance# * 0.08)
             If VPDistance# < 20.0 Then VPDistance# = 20.0
             If VPDistance# > 5000.0 Then VPDistance# = 5000.0
+            VPDirty = True
         EndIf
     EndIf
 
     ; ---- Position camera by orbit math -------------------------------------
     Local yawRad# = VPYaw# * 3.14159 / 180.0
-    Local pitchRad# = VPPitch# * 3.14159 / 180.0
-    Local cx# = VPSceneCenterX# + Cos(VPPitch#) * Sin(VPYaw#) * VPDistance#
-    Local cy# = VP_SCENE_Y_OFFSET# + VPSceneCenterY# + Sin(VPPitch#) * VPDistance#
-    Local cz# = VPSceneCenterZ# - Cos(VPPitch#) * Cos(VPYaw#) * VPDistance#
-    PositionEntity VPCam, cx#, cy#, cz#
-    PointEntity VPCam, VPGround   ; PointEntity at ground center keeps camera level
+    ; ---- Highlight transition: only scale on change -----------------------
+    ; Per-frame iteration over every marker was expensive on big zones
+    ; (3000+ entities -> 3000+ ScaleEntity calls per frame). Now only
+    ; the OLD highlighted marker shrinks back and the NEW one grows;
+    ; if the highlight didn't change, no scaling work at all.
+    If LoomZoneHighlightKind$ <> VPPrevHighlightKind$ Or LoomZoneHighlightIdx <> VPPrevHighlightIdx
+        Local hm.ZoneViewportMarker
+        For hm = Each ZoneViewportMarker
+            If hm\Kind = VPPrevHighlightKind$ And hm\IndexN = VPPrevHighlightIdx And VPPrevHighlightKind$ <> ""
+                ScaleEntity hm\EN, hm\BaseScale, hm\BaseScale, hm\BaseScale
+            Else If hm\Kind = LoomZoneHighlightKind$ And hm\IndexN = LoomZoneHighlightIdx And LoomZoneHighlightKind$ <> ""
+                ScaleEntity hm\EN, hm\BaseScale * 1.6, hm\BaseScale * 1.6, hm\BaseScale * 1.6
+            EndIf
+        Next
+        VPPrevHighlightKind$ = LoomZoneHighlightKind$
+        VPPrevHighlightIdx   = LoomZoneHighlightIdx
+        VPDirty = True
+    EndIf
 
-    ; ---- Highlight pass: scale the focused marker 1.5x ---------------------
-    ; The composer publishes LoomZoneHighlightKind/Idx during render
-    ; (set when scrolling past a sub-section). We re-scale the matching
-    ; marker bigger so it pops in the viewport. Others stay at BaseScale.
-    Local hm.ZoneViewportMarker
-    For hm = Each ZoneViewportMarker
-        If hm\Kind = LoomZoneHighlightKind$ And hm\IndexN = LoomZoneHighlightIdx And LoomZoneHighlightKind$ <> ""
-            ScaleEntity hm\EN, hm\BaseScale * 1.6, hm\BaseScale * 1.6, hm\BaseScale * 1.6
-        Else If hm\BaseScale > 0.0
-            ; Restore base scale (might have been highlighted last frame).
-            ScaleEntity hm\EN, hm\BaseScale, hm\BaseScale, hm\BaseScale
-        EndIf
-    Next
+    ; ---- Re-render to texture only when something changed ------------------
+    ; Camera orbit/pan/zoom + marker drags + highlight transitions all
+    ; set VPDirty = True. Static frames skip RenderWorld + the camera
+    ; re-position math; the cached texture from the last render gets
+    ; CopyRect'd to the back buffer below.
+    If VPDirty = True
+        Local cx# = VPSceneCenterX# + Cos(VPPitch#) * Sin(VPYaw#) * VPDistance#
+        Local cy# = VP_SCENE_Y_OFFSET# + VPSceneCenterY# + Sin(VPPitch#) * VPDistance#
+        Local cz# = VPSceneCenterZ# - Cos(VPPitch#) * Cos(VPYaw#) * VPDistance#
+        PositionEntity VPCam, cx#, cy#, cz#
+        PointEntity VPCam, VPGround
 
-    ; ---- Render -------------------------------------------------------------
-    ShowEntity VPCam
-    SetBuffer TextureBuffer(VPRT)
-    RenderWorld
-    SetBuffer BackBuffer()
-    HideEntity VPCam
+        ShowEntity VPCam
+        SetBuffer TextureBuffer(VPRT)
+        RenderWorld
+        SetBuffer BackBuffer()
+        HideEntity VPCam
 
-    ; Blit to back buffer
+        VPDirty = False
+    EndIf
+
+    ; Blit cached texture to back buffer every frame (back buffer is
+    ; cleared at the top of renderFrame so we always need to repaint).
     CopyRect 0, 0, VP_RT_SIZE, VP_RT_SIZE, x, y, TextureBuffer(VPRT), BackBuffer()
     LoomBorder x, y, VP_RT_SIZE, VP_RT_SIZE, LOOM_BRASS_500_R, LOOM_BRASS_500_G, LOOM_BRASS_500_B
 


### PR DESCRIPTION
User-reported visual bug from a screenshot: viewport leaked left of the composer panel and composer field text overlapped the viewports overlay. Plus performance: RenderWorld + per-marker ScaleEntity every frame even on static views.

## Layout fixes

- VP_RT_SIZE 384 -> 320 so the viewport fits INSIDE the 380-wide composer panel with CMP_PAD breathing room on each side.
- Composer renderZone now CENTERS the viewport horizontally inside the panel (was right-anchored, leaked left because viewport was wider than panel).
- Field rows pushed BELOW the viewport via y += vpW + 8 so Name / Outdoors / PvP / Gravity text no longer collides with the viewports overlay.

## Performance fixes

- **VPDirty flag** gates RenderWorld + camera-positioning math. Set True on: orbit (only when mouse delta non-zero), pan, zoom, drag-edit position update, zone load, highlight transition. Static frames skip the entire 3D render -- CopyRect of the cached texture costs ~0.
- **Highlight scaling**: was iterating EVERY marker every frame (3000+ ScaleEntity calls per frame on big zones). Now only scales the OLD highlighted marker (back to base) and the NEW one (up to 1.6x) on TRANSITIONS. Static highlight = no work.
- Tracked via VPPrevHighlightKind/Idx.

Net: a focused zone with no user input now does CopyRect only (one pixel-rect copy per frame). Frame budget freed for the rest of the editor.