### PR TITLE
Loom: texture the actor mesh preview with body + face textures

### DIFF
--- a/src/Modules/Loom/Composer.bb
+++ b/src/Modules/Loom/Composer.bb
@@ -2445,9 +2445,15 @@ Type Composer
         // shorter so the preview sits cleanly to the right.
         Local previewX% = panelX + panelW - LOOM_PREVIEW_SIZE - CMP_PAD
         Local previewY% = y
+        // Publish actor ID so MeshPreview can drape body/face textures
+        // on the mesh during load (instead of showing bare gray).
+        // Set BEFORE the draw call; cleared after to avoid bleeding
+        // into the item preview's bare-mesh expectation.
+        PreviewActorID = A\ID
         If Composer::canPaintRow(self, y, LOOM_PREVIEW_SIZE) = True
             Loom_DrawMeshPreview(A\MeshIDs[0], previewX, previewY, LOOM_PREVIEW_SIZE)
         EndIf
+        PreviewActorID = 0
 
         y = Composer::editableIntRow(self, panelX, panelW, y, "Male base",     "actor", A\ID, "mesh_0", A\MeshIDs[0], mx, my, clicked)
         y = Composer::editableIntRow(self, panelX, panelW, y, "Female base",   "actor", A\ID, "mesh_1", A\MeshIDs[1], mx, my, clicked)

--- a/src/Modules/Loom/ImageCache.bb
+++ b/src/Modules/Loom/ImageCache.bb
@@ -72,6 +72,12 @@ Global LoomFrameMouseWheel        = 0
 Global LoomZoneHighlightKind$ = ""
 Global LoomZoneHighlightIdx   = -1
 
+; Actor-context publish for MeshPreview: composer sets this to the
+; current actor's ID before Loom_DrawMeshPreview so the loader can
+; drape the actor's body/face textures over the bare mesh. Declared
+; here for the same Strict-mode write reason.
+Global PreviewActorID = 0
+
 
 ; =============================================================================
 ; Loom_BeginFrame -- called once per frame at the top of renderFrame.

--- a/src/Modules/Loom/MeshPreview.bb
+++ b/src/Modules/Loom/MeshPreview.bb
@@ -56,6 +56,10 @@ Global PreviewSpinTime#  = 0.0
 Global PreviewLastTickMs = 0          ; for delta calc
 Global PreviewMeshScale# = 1.0        ; auto-fit scale for current mesh
 
+; PreviewActorID lives in ImageCache.bb (included BEFORE Composer)
+; so the Strict Composer module can write it without the dim-write-
+; from-Strict trap. See feedback_loom_module_include_order.
+
 ; ---- Manual orbit state ----------------------------------------------------
 ; Drag-to-orbit: while LMB is held inside the preview rect, the mesh's
 ; Y/X rotation tracks the mouse delta. Releases the auto-spin while
@@ -147,6 +151,18 @@ Function Loom_LoadPreviewMesh(meshID)
     PositionEntity ent, LOOM_PREVIEW_CAM_X#, LOOM_PREVIEW_CAM_Y#, LOOM_PREVIEW_CAM_Z#
     ShowEntity ent
 
+    ; Texture pass -- when PreviewActorID > 0, the composer is showing
+    ; an actor and we should drape the actor's first defined body
+    ; texture over the mesh so the preview looks like the actual
+    ; character. First cut: whole-entity EntityTexture with body[0];
+    ; multi-surface face/body distinction is the follow-up.
+    If PreviewActorID > 0 And PreviewActorID < 65536
+        Local Ac.Actor = ActorList(PreviewActorID)
+        If Ac <> Null
+            Loom_ApplyActorTextures(ent, Ac)
+        EndIf
+    EndIf
+
     PreviewMesh = ent
     PreviewMeshID = meshID
     ; New mesh = fresh view. Reset orbit + zoom so the user doesn't
@@ -154,6 +170,72 @@ Function Loom_LoadPreviewMesh(meshID)
     Loom_ResetPreviewOrbit()
     WriteLog(LoomLog, "MeshPreview: loaded mesh ID " + meshID)
     Return True
+End Function
+
+
+; =============================================================================
+; Loom_ApplyActorTextures -- drape the actor's body/face textures over the
+; loaded mesh. Mirrors a stripped-down version of Actors3D.bb's
+; multi-surface paint:
+;   - If mesh has 2+ surfaces, paint body onto one and face onto the other,
+;     guessed from texture-name "HEAD" hint.
+;   - Otherwise EntityTexture the whole entity with body.
+; Failures are silent (no toast) -- a missing texture just leaves the
+; surface at the mesh's default appearance.
+; =============================================================================
+Function Loom_ApplyActorTextures(ent, Ac.Actor)
+    ; Pick first non-empty body / face slot; bound to 0..4
+    Local bodyIdx = 0
+    Local faceIdx = 0
+    Local bi
+    For bi = 0 To 4
+        If Ac\MaleBodyIDs[bi] > 0 And Ac\MaleBodyIDs[bi] < 65535 Then bodyIdx = bi : Exit
+    Next
+    Local fi
+    For fi = 0 To 4
+        If Ac\MaleFaceIDs[fi] > 0 And Ac\MaleFaceIDs[fi] < 65535 Then faceIdx = fi : Exit
+    Next
+
+    Local bodyTexID = Ac\MaleBodyIDs[bodyIdx]
+    Local faceTexID = Ac\MaleFaceIDs[faceIdx]
+
+    Local bodyTex = 0
+    Local faceTex = 0
+    If bodyTexID > 0 And bodyTexID < 65535 Then bodyTex = GetTexture(bodyTexID)
+    If faceTexID > 0 And faceTexID < 65535 Then faceTex = GetTexture(faceTexID)
+
+    If CountSurfaces(ent) > 1 And faceTex <> 0
+        ; Distinguish head vs body surface via texture-name hint
+        ; (mirrors the Actors3D dispatch). Default: surface 1=body, 2=face.
+        Local headSurface = GetSurface(ent, 2)
+        Local bodySurface = GetSurface(ent, 1)
+        Local probeBrush = GetSurfaceBrush(GetSurface(ent, 1))
+        Local probeTex = GetBrushTexture(probeBrush)
+        Local probeName$ = TextureName$(probeTex)
+        If probeTex <> 0 Then FreeTexture probeTex
+        If probeBrush <> 0 Then FreeBrush probeBrush
+        If Instr(Upper$(probeName$), "HEAD") > 0
+            headSurface = GetSurface(ent, 1)
+            bodySurface = GetSurface(ent, 2)
+        EndIf
+
+        Local brush = CreateBrush()
+        If bodyTex <> 0
+            BrushTexture brush, bodyTex
+            PaintSurface bodySurface, brush
+        EndIf
+        If faceTex <> 0
+            BrushTexture brush, faceTex
+            PaintSurface headSurface, brush
+        EndIf
+        FreeBrush brush
+    Else If bodyTex <> 0
+        EntityTexture ent, bodyTex
+    EndIf
+
+    ; Note: GetTexture returns CopyEntity-like handles; we don't free
+    ; them here because the brush still references them. The textures
+    ; live until the mesh entity is freed (FreeEntity cascades).
 End Function
 
 


### PR DESCRIPTION
**50th iteration milestone.** Actor mesh preview was bare gray. Now it shows the actors first defined body texture (and face texture if the mesh has a separate head surface) so designers see their character looking like it will in-game.

## Architecture

- New PreviewActorID global in ImageCache.bb (placed there so Strict Composer can write it without the dim-write trap; see feedback_loom_module_include_order).
- Composer renderActor sets PreviewActorID = A\ID before Loom_DrawMeshPreview, clears after. Item composer doesnt set it so the bare-mesh expectation for items is preserved.
- Loom_LoadPreviewMesh checks PreviewActorID > 0 and calls Loom_ApplyActorTextures.

## Loom_ApplyActorTextures

Mirrors a stripped-down Actors3D paint:
- Pick first non-empty MaleBodyIDs / MaleFaceIDs slot
- GetTexture for both
- If mesh has 2+ surfaces and face texture loaded, paint body onto one surface and face onto the other (guessing head surface via texture-name HEAD probe - matches Actors3D dispatch)
- Otherwise EntityTexture the whole entity with body

## Failure modes

Silent: missing texture leaves the surface at the meshes default appearance. Designers still see geometry.