### PR TITLE
Loom: camera-follow highlighted marker in zone viewport

### DIFF
--- a/src/Modules/Loom/ZoneViewport.bb
+++ b/src/Modules/Loom/ZoneViewport.bb
@@ -1092,13 +1092,27 @@ Function Loom_DrawZoneViewport(zoneHandle, x, y)
     ; if the highlight didn't change, no scaling work at all.
     If LoomZoneHighlightKind$ <> VPPrevHighlightKind$ Or LoomZoneHighlightIdx <> VPPrevHighlightIdx
         Local hm.ZoneViewportMarker
+        Local newCenterX# = VPSceneCenterX#
+        Local newCenterZ# = VPSceneCenterZ#
+        Local centerChanged = False
         For hm = Each ZoneViewportMarker
             If hm\Kind = VPPrevHighlightKind$ And hm\IndexN = VPPrevHighlightIdx And VPPrevHighlightKind$ <> ""
                 ScaleEntity hm\EN, hm\BaseScale, hm\BaseScale, hm\BaseScale
             Else If hm\Kind = LoomZoneHighlightKind$ And hm\IndexN = LoomZoneHighlightIdx And LoomZoneHighlightKind$ <> ""
                 ScaleEntity hm\EN, hm\BaseScale * 1.6, hm\BaseScale * 1.6, hm\BaseScale * 1.6
+                ; Camera-follow: pan the orbit center to the new marker
+                ; so it lands inside the visible frustum even when it
+                ; was previously off-screen. Don't touch zoom/yaw/pitch
+                ; -- user keeps their viewing angle.
+                newCenterX# = EntityX#(hm\EN)
+                newCenterZ# = EntityZ#(hm\EN)
+                centerChanged = True
             EndIf
         Next
+        If centerChanged = True
+            VPSceneCenterX# = newCenterX#
+            VPSceneCenterZ# = newCenterZ#
+        EndIf
         VPPrevHighlightKind$ = LoomZoneHighlightKind$
         VPPrevHighlightIdx   = LoomZoneHighlightIdx
         VPDirty = True


### PR DESCRIPTION
The bidirectional highlight (iter 46) scales the matching marker 1.6x when the composer scrolls past its section, but the marker itself might be off-screen (camera focused elsewhere). User sees no visible feedback.

## Fix

On highlight transition, also pan VPSceneCenter to the matching markers world XZ. The orbit camera then re-positions in the next-frame render math so the marker lands inside the visible frustum. Yaw / pitch / zoom stay where the user put them.

## Implementation

- In the existing highlight-transition loop, when scaling the new marker, also capture its EntityX# / EntityZ# into newCenterX/Z
- Apply to VPSceneCenterX/Z after the loop. centerChanged flag guards against the zero-case (no new highlight)
- VPDirty was already True from the scale change; no extra wiring

## Net effect

Scroll composer to a portal -> camera glides to that portal in the viewport on the next frame. Combined with the floating marker-name label (iter 49), the cross-reference is now both visually obvious and spatially aligned.