### PR TITLE
Loom: persist chrome immersion mode across sessions

### DIFF
--- a/src/Modules/Loom/Ribbon.bb
+++ b/src/Modules/Loom/Ribbon.bb
@@ -196,6 +196,10 @@ Type Ribbon
         EndIf
         If chromeHover And clicked
             Loom_CycleChromeMode()
+            ; Persist immediately (no Save All needed) so the new mode
+            ; survives a restart. Same set-and-forget shape as a
+            ; browser zoom toggle.
+            Loom_SaveChromeMode()
             consumed = True
             WriteLog(LoomLog, "Ribbon: chrome mode -> " + Loom_ChromeMode())
         EndIf

--- a/src/Modules/Loom/Settings.bb
+++ b/src/Modules/Loom/Settings.bb
@@ -142,8 +142,48 @@ Function Loom_LoadSettings()
         CloseFile(F)
     EndIf
 
+    ; --- Loom-private chrome mode (Data\Loom\chrome.txt) ----------------------
+    ; Optional; if file missing or unreadable, mode stays at the declared
+    ; "balanced" default. Stored in Loom's private dir so other engine
+    ; binaries (Server/Client/GUE) never touch it.
+    Loom_LoadChromeMode()
+
     SettingsSaved = True
     WriteLog(LoomLog, "Settings: loaded project config (game=" + LoomCfg_GameName$ + ", port=" + LoomCfg_ServerPort + ")")
+End Function
+
+
+; =============================================================================
+; Loom_LoadChromeMode -- read Data\Loom\chrome.txt into LoomChromeMode$
+; (declared in ImageCache.bb). Tolerant of missing file or unrecognized
+; value -- leaves the global at whatever it was (default "balanced").
+; =============================================================================
+Function Loom_LoadChromeMode()
+    Local f = ReadFile("Data\Loom\chrome.txt")
+    If f = 0 Then Return
+    Local mode$ = Trim$(ReadLine$(f))
+    CloseFile(f)
+    If mode = "tool" Or mode = "balanced" Or mode = "in-world"
+        LoomChromeMode$ = mode
+        WriteLog(LoomLog, "Settings: chrome mode restored to " + mode)
+    EndIf
+End Function
+
+
+; =============================================================================
+; Loom_SaveChromeMode -- persist current LoomChromeMode$ to chrome.txt.
+; Creates Data\Loom\ if missing (mirrors Recents.bb's pattern).
+; Atomic-write via SafeWriteOpen/Commit so a crash mid-write doesn't
+; corrupt the file.
+; =============================================================================
+Function Loom_SaveChromeMode()
+    If FileType("Data\Loom") <> 2 Then CreateDir "Data\Loom"
+    Local finalPath$ = "Data\Loom\chrome.txt"
+    Local tempPath$ = SafeWriteOpen$(finalPath$)
+    Local f = WriteFile(tempPath$)
+    If f = 0 Then Return False
+    WriteLine f, LoomChromeMode$
+    Return SafeWriteCommit%(tempPath$, finalPath$, f)
 End Function
 
 


### PR DESCRIPTION
Iter 39 shipped the chrome toggle as session-only -- restart of Loom reset to balanced. Toggle now survives restart via Data\Loom\chrome.txt (Loom-private; no other engine binary touches the file).

## Settings.bb additions

- **Loom_LoadChromeMode** reads chrome.txt at boot via Loom_LoadSettings. Tolerant of missing file or unrecognized value; leaves the global at whatever it was (defaults to balanced).
- **Loom_SaveChromeMode** writes via SafeWriteOpen / SafeWriteCommit so a mid-write crash doesnt corrupt the file. Creates Data\Loom\ if missing (mirrors Recents.bb CreateDir pattern).

## Set-and-forget UX

Ribbon chrome-toggle click path now calls Loom_SaveChromeMode right after Loom_CycleChromeMode. User clicks the mode pill, change persists immediately without needing Ctrl+S. Same shape as a browser zoom toggle.

## Include-order note

Loom_CycleChromeMode stays in ImageCache.bb where the chrome globals live; the save call lives in Ribbon.bb (included later) so the forward reference works without a Strict-include-order workaround.