### PR TITLE
Loom: Scripts browser tab + script-file viewer (iter 60)

### DIFF
--- a/src/Loom.bb
+++ b/src/Loom.bb
@@ -121,6 +121,7 @@ Include "Modules\Loom\Ribbon.bb"
 Include "Modules\Loom\Atlas.bb"
 Include "Modules\Loom\Timeline.bb"
 Include "Modules\Loom\Tools.bb"
+Include "Modules\Loom\ScriptsCatalog.bb"
 Include "Modules\Loom\Recents.bb"
 Include "Modules\Loom\EntityFactory.bb"
 Include "Modules\Loom\SaveAll.bb"
@@ -417,6 +418,12 @@ WriteLog(LoomLog, "Project name: " + projectName$)
 
 LoomTheme_Init()
 Tools_Init()
+; Scripts catalog: scan Data\Server Data\Scripts\*.rsl so the Scripts
+; browser tab + reverse-ref scanners have something to walk. Tolerant
+; of a missing dir (fresh project); logs ScriptsScanError$ for ribbon
+; surfacing on a permission/disk failure.
+Scripts_Init()
+WriteLog(LoomLog, "Scripts catalog: " + Str(ScriptsTotalCount) + " .rsl files indexed")
 
 
 // -----------------------------------------------------------------------------

--- a/src/Modules/Loom/Browser.bb
+++ b/src/Modules/Loom/Browser.bb
@@ -161,6 +161,11 @@ Type Browser
         // Editor, etc.). Not an entity kind, so the composer / new / save
         // affordances don't apply on this tab -- it's pure launch surface.
         Browser::addCategory(self, "tools",   "Tools")
+        // Scripts tab: every .rsl file in Data\Server Data\Scripts\ as
+        // a clickable card. Composer view shows content preview + reverse
+        // refs (which Zone/Item/Spell references this script). Closes
+        // the "what scripts exist?" gap that GUE doesn't fill either.
+        Browser::addCategory(self, "script",  "Scripts")
         // Settings tab: project-level configuration singleton (Misc.dat /
         // Other.dat / Money.dat / Hosts.dat). Clicking the tab focuses
         // the singleton composer view directly -- no card grid since
@@ -415,7 +420,7 @@ Type Browser
         Local nbW% = 96
         Local nbH% = 22
         Local nbHover% = False
-        If self\category <> "tools"
+        If self\category <> "tools" And self\category <> "script"
             nbHover = (mx >= nbX And mx < nbX + nbW And my >= nbY And my < nbY + nbH)
 
             If nbHover = True
@@ -525,6 +530,7 @@ Type Browser
         If kind = "zone"    Then Return "Zone"
         If kind = "faction" Then Return "Faction"
         If kind = "animset" Then Return "Anim Set"
+        If kind = "script"  Then Return "Script"
         Return kind
     End Method
 
@@ -673,6 +679,9 @@ Type Browser
         EndIf
         If cat = "tools"
             count = Browser::drawToolsGrid(self, sw, sh, mx, my, clicked, gridX, gridY, cols)
+        EndIf
+        If cat = "script"
+            count = Browser::drawScriptsGrid(self, sw, sh, mx, my, clicked, gridX, gridY, cols)
         EndIf
         If cat = "settings"
             count = Browser::drawSettingsCard(self, sw, sh, mx, my, clicked, gridX, gridY)
@@ -969,6 +978,77 @@ Type Browser
         // Keyboard Enter on the selected tool card -- same dispatch.
         If selected = True And self\pendingEnter = True
             Tools_Launch(t)
+            self\cardClickLatch = True
+            self\pendingEnter = False
+        EndIf
+    End Method
+
+
+    // -------------------------------------------------------------------------
+    // drawScriptsGrid -- one card per .rsl file in the project's Scripts
+    // dir (populated at boot by Scripts_Init). Hover/click focuses the
+    // composer to a script preview + reverse-ref view. Filter applies
+    // against the script basename.
+    // -------------------------------------------------------------------------
+    Method drawScriptsGrid%(sw%, sh%, mx%, my%, clicked%, gridX%, gridY%, cols%)
+        Local col% = 0
+        Local row% = 0
+        Local count% = 0
+        For sf.ScriptFile = Each ScriptFile
+            If Browser::matchesFilter(self, sf\Name$) = True
+                Local cx% = gridX + col * (BR_CARD_W + BR_CARD_GAP)
+                Local cy% = gridY + row * (BR_CARD_H + BR_CARD_GAP)
+                If cy + BR_CARD_H < sh - BR_BOT_RIBBON
+                    Browser::drawScriptCard(self, sf, cx, cy, mx, my, clicked, count)
+                EndIf
+                count = count + 1
+                col = col + 1
+                If col >= cols Then col = 0 : row = row + 1
+            EndIf
+        Next
+        Return count
+    End Method
+
+
+    // -------------------------------------------------------------------------
+    // drawScriptCard -- one .rsl file card. Shape mirrors the entity-card
+    // chrome (shadow + brass border + top accent rule + body). Click
+    // focuses the composer to the script preview via Threads::focus.
+    // -------------------------------------------------------------------------
+    Method drawScriptCard(sf.ScriptFile, x%, y%, mx%, my%, clicked%, cardIdx%)
+        Local hovered% = (mx >= x And mx < x + BR_CARD_W And my >= y And my < y + BR_CARD_H)
+        Local selected% = (cardIdx = self\selectedIndex)
+
+        LoomShadowCard(x, y, BR_CARD_W, BR_CARD_H)
+        LoomFill(x, y, BR_CARD_W, BR_CARD_H, LOOM_STONE_800_R, LOOM_STONE_800_G, LOOM_STONE_800_B)
+
+        If hovered = True
+            LoomBorder(x, y, BR_CARD_W, BR_CARD_H, LOOM_ARCANE_500_R, LOOM_ARCANE_500_G, LOOM_ARCANE_500_B)
+            LoomBorder(x + 1, y + 1, BR_CARD_W - 2, BR_CARD_H - 2, LOOM_ARCANE_500_R, LOOM_ARCANE_500_G, LOOM_ARCANE_500_B)
+        Else If selected = True
+            LoomBorder(x, y, BR_CARD_W, BR_CARD_H, LOOM_BRASS_500_R, LOOM_BRASS_500_G, LOOM_BRASS_500_B)
+            LoomBorder(x + 1, y + 1, BR_CARD_W - 2, BR_CARD_H - 2, LOOM_BRASS_500_R, LOOM_BRASS_500_G, LOOM_BRASS_500_B)
+        Else
+            LoomBorder(x, y, BR_CARD_W, BR_CARD_H, LOOM_BRASS_700_R, LOOM_BRASS_700_G, LOOM_BRASS_700_B)
+        EndIf
+
+        // Top brass accent rule
+        LoomHRule(x + 12, y + 8, BR_CARD_W - 24, LOOM_BRASS_500_R, LOOM_BRASS_500_G, LOOM_BRASS_500_B)
+
+        // Body: name (truncated) + size + line count + filetype hint
+        Local nm$ = sf\Name$
+        If Len(nm) > 22 Then nm = Left$(nm, 21) + "~"
+        LoomText(x + 12, y + 18, nm, LOOM_PARCHMENT_100_R, LOOM_PARCHMENT_100_G, LOOM_PARCHMENT_100_B)
+        LoomText(x + 12, y + 44, Scripts_FormatSize(sf\SizeBytes) + " | " + Str(sf\LineCount) + " lines", LOOM_STONE_200_R, LOOM_STONE_200_G, LOOM_STONE_200_B)
+        LoomText(x + BR_CARD_W - 50, y + 72, ".rsl", LOOM_BRASS_500_R, LOOM_BRASS_500_G, LOOM_BRASS_500_B)
+
+        If hovered And clicked
+            Threads::focus(self\threads, "script", sf\Index)
+            self\cardClickLatch = True
+        EndIf
+
+        If selected = True And self\pendingEnter = True
+            Threads::focus(self\threads, "script", sf\Index)
             self\cardClickLatch = True
             self\pendingEnter = False
         EndIf

--- a/src/Modules/Loom/Composer.bb
+++ b/src/Modules/Loom/Composer.bb
@@ -419,6 +419,8 @@ Type Composer
             Composer::renderAnimSet(self, x, scrolledBodyY, w, bodyH, mx, my, clicked, rightClicked)
         Else If kind = "settings"
             Composer::renderSettings(self, x, scrolledBodyY, w, bodyH, mx, my, clicked)
+        Else If kind = "script"
+            Composer::renderScript(self, x, scrolledBodyY, w, bodyH, mx, my, clicked, rightClicked)
         EndIf
 
         // Scrollbar indicator -- thin brass thumb on the right edge,
@@ -3401,6 +3403,170 @@ Type Composer
             y = Composer::toggleRow(self,   panelX, panelW, y, "Hidden", "settings", 0, "attr_hidden_" + Str(ai), AttributeHidden(ai),    mx, my, clicked)
             y = y + 4
         Next
+
+        Composer::recordContentBottom(self, y)
+    End Method
+
+
+    // -------------------------------------------------------------------------
+    // renderScript -- preview a .rsl file's content + show every entity
+    // that references it. refID is the ScriptFile catalog index from
+    // Scripts_Init. Read-only view (no inline editing of script source --
+    // designers use an external editor for that).
+    //
+    // Reverse-ref scanners walk every Area's 5 script-string field
+    // families (Entry/Exit/Trigger/SpawnScript/SpawnActorScript/SpawnDeathScript)
+    // plus Items.Script + Spells.Script. Each hit emits a chip that
+    // focuses the referencing entity. Case-insensitive + extension-tolerant
+    // match via Scripts_NormalizeName$.
+    // -------------------------------------------------------------------------
+    Method renderScript(panelX%, bodyY%, panelW%, bodyH%, mx%, my%, clicked%, rightClicked%)
+        Local sf.ScriptFile = Scripts_GetByIndex(self\threads\focusID)
+        If sf = Null Then Return
+
+        Local y% = bodyY
+        y = Composer::row(self, panelX, panelW, y, "Name",      sf\Name$)
+        y = Composer::row(self, panelX, panelW, y, "Path",      sf\FullPath$)
+        y = Composer::row(self, panelX, panelW, y, "Size",      Scripts_FormatSize(sf\SizeBytes))
+        y = Composer::row(self, panelX, panelW, y, "Lines",     Str(sf\LineCount))
+
+        // -- Source preview (read-only) ---------------------------------------
+        // Lazy-loaded on every paint -- the read is cheap (typical script
+        // is < 5KB) and avoids stashing potentially-stale content in a
+        // cache that would have to invalidate on file change.
+        y = Composer::sectionHeader(self, panelX, panelW, y, "Source preview")
+        Local content$ = Scripts_GetContent(sf\Name$)
+        If content = ""
+            If Composer::canPaintRow(self, y, CMP_ROW_H) = True
+                LoomText(panelX + CMP_PAD, y + 4, "(could not read file)", LOOM_DANGER_R, LOOM_DANGER_G, LOOM_DANGER_B)
+            EndIf
+            y = y + CMP_ROW_H
+        Else
+            // Render line-by-line until we run out of content or hit a
+            // reasonable preview cap (200 lines). Long scripts get a
+            // truncation footer.
+            Local maxLines% = 200
+            Local lineNum% = 0
+            Local cursor% = 1
+            Local clen% = Len(content)
+            While cursor <= clen And lineNum < maxLines
+                Local nl% = cursor
+                While nl <= clen And Mid$(content, nl, 1) <> Chr(10)
+                    nl = nl + 1
+                Wend
+                Local L$ = Mid$(content, cursor, nl - cursor)
+                // Tabs -> 4 spaces for legibility; LoomText is monospace
+                // friendly via the body font.
+                L = Replace$(L, Chr(9), "    ")
+                If Composer::canPaintRow(self, y, 16) = True
+                    // Faded line number gutter (col 4..30), code in
+                    // parchment from col 38.
+                    LoomText(panelX + CMP_PAD, y + 2, Str(lineNum + 1), LOOM_STONE_300_R, LOOM_STONE_300_G, LOOM_STONE_300_B)
+                    LoomText(panelX + CMP_PAD + 36, y + 2, L, LOOM_PARCHMENT_100_R, LOOM_PARCHMENT_100_G, LOOM_PARCHMENT_100_B)
+                EndIf
+                y = y + 16
+                cursor = nl + 1
+                lineNum = lineNum + 1
+            Wend
+            If lineNum >= maxLines And cursor <= clen
+                If Composer::canPaintRow(self, y, CMP_ROW_H) = True
+                    LoomText(panelX + CMP_PAD, y + 4, "(+ more lines -- open externally to see the rest)", LOOM_STONE_300_R, LOOM_STONE_300_G, LOOM_STONE_300_B)
+                EndIf
+                y = y + CMP_ROW_H
+            EndIf
+        EndIf
+
+        // -- Reverse references -----------------------------------------------
+        // Walk every Zone's 5 script-string field families + every Item +
+        // every Spell looking for a normalised-name match. Each hit emits
+        // a chip that focuses the referencing entity. Cap each section
+        // at 50 to keep the panel scrollable even for a heavily-shared
+        // script like "In-game Commands".
+        y = Composer::sectionHeader(self, panelX, panelW, y, "Used by")
+
+        Local key$ = Scripts_NormalizeName$(sf\Name$)
+        Local hitsTotal% = 0
+
+        // Items
+        Local itemHits% = 0
+        For It.Item = Each Item
+            If It\Script$ <> ""
+                If Scripts_NormalizeName$(It\Script$) = key
+                    If itemHits < 50
+                        y = Composer::chipRow(self, panelX, panelW, y, "Item", "item", It\ID, mx, my, clicked, rightClicked, "")
+                    EndIf
+                    itemHits = itemHits + 1
+                EndIf
+            EndIf
+        Next
+
+        // Spells
+        Local spellHits% = 0
+        For Sp.Spell = Each Spell
+            If Sp\Script$ <> ""
+                If Scripts_NormalizeName$(Sp\Script$) = key
+                    If spellHits < 50
+                        y = Composer::chipRow(self, panelX, panelW, y, "Spell", "spell", Sp\ID, mx, my, clicked, rightClicked, "")
+                    EndIf
+                    spellHits = spellHits + 1
+                EndIf
+            EndIf
+        Next
+
+        // Zones -- 5 script families per zone. Emit ONE chip per zone
+        // (not one per script slot) and tag the source family in the
+        // label so designers see "Trigger / Entry / SpawnAct / SpawnDth".
+        Local zoneHits% = 0
+        Local zIter.Area = Null
+        For zIter = Each Area
+            Local label$ = ""
+            // EntryScript / ExitScript
+            If zIter\EntryScript$ <> "" And Scripts_NormalizeName$(zIter\EntryScript$) = key Then label = label + "Entry "
+            If zIter\ExitScript$  <> "" And Scripts_NormalizeName$(zIter\ExitScript$)  = key Then label = label + "Exit "
+            // Triggers (150)
+            Local trIdx% = 0
+            For trIdx = 0 To 149
+                If zIter\TriggerScript$[trIdx] <> "" And Scripts_NormalizeName$(zIter\TriggerScript$[trIdx]) = key
+                    label = label + "Trigger "
+                    trIdx = 149 : Exit   ; one mention per zone is enough
+                EndIf
+            Next
+            // Spawn scripts (1000 each, three families)
+            Local spIdx% = 0
+            For spIdx = 0 To 999
+                If zIter\SpawnScript$[spIdx] <> "" And Scripts_NormalizeName$(zIter\SpawnScript$[spIdx]) = key
+                    label = label + "Spawn " : spIdx = 999 : Exit
+                EndIf
+            Next
+            For spIdx = 0 To 999
+                If zIter\SpawnActorScript$[spIdx] <> "" And Scripts_NormalizeName$(zIter\SpawnActorScript$[spIdx]) = key
+                    label = label + "SpAct " : spIdx = 999 : Exit
+                EndIf
+            Next
+            For spIdx = 0 To 999
+                If zIter\SpawnDeathScript$[spIdx] <> "" And Scripts_NormalizeName$(zIter\SpawnDeathScript$[spIdx]) = key
+                    label = label + "SpDth " : spIdx = 999 : Exit
+                EndIf
+            Next
+            If label <> ""
+                If zoneHits < 50
+                    y = Composer::chipRow(self, panelX, panelW, y, label, "zone", Handle(zIter), mx, my, clicked, rightClicked, "")
+                EndIf
+                zoneHits = zoneHits + 1
+            EndIf
+        Next
+
+        hitsTotal = itemHits + spellHits + zoneHits
+        If hitsTotal = 0
+            If Composer::canPaintRow(self, y, CMP_ROW_H) = True
+                LoomText(panelX + CMP_PAD, y + 4, "(unused -- safe to delete)", LOOM_WARNING_R, LOOM_WARNING_G, LOOM_WARNING_B)
+            EndIf
+            y = y + CMP_ROW_H
+        EndIf
+        If Composer::canPaintRow(self, y, CMP_ROW_H) = True
+            LoomText(panelX + CMP_PAD, y + 4, Str(itemHits) + " item(s) | " + Str(spellHits) + " spell(s) | " + Str(zoneHits) + " zone(s)", LOOM_BRASS_500_R, LOOM_BRASS_500_G, LOOM_BRASS_500_B)
+        EndIf
+        y = y + CMP_ROW_H
 
         Composer::recordContentBottom(self, y)
     End Method

--- a/src/Modules/Loom/ScriptsCatalog.bb
+++ b/src/Modules/Loom/ScriptsCatalog.bb
@@ -1,0 +1,197 @@
+Strict
+
+// =============================================================================
+// Loom/ScriptsCatalog.bb -- catalog of .rsl script files under
+// Data\Server Data\Scripts\, browseable as first-class entities in Loom.
+// =============================================================================
+//
+// Why this exists: many entity fields (Item\Script$, Spell\Script$,
+// Area\EntryScript$ / ExitScript$ / TriggerScript$[150] / SpawnScript$[1000]
+// / SpawnActorScript$[1000] / SpawnDeathScript$[1000]) reference scripts
+// by basename, but until now Loom had NO surface where a designer could
+// see what scripts exist, let alone preview one or find what references
+// it. GUE has the same gap. This module closes it for Loom.
+//
+// Catalog shape: at boot we scan `Data\Server Data\Scripts\*.rsl` and
+// allocate one ScriptFile per match. Each holds the basename (without
+// .rsl extension -- matches the reference shape), size in bytes, and
+// line count (cheap pre-scan; needed for the composer header).
+//
+// File content is loaded LAZILY -- only when the composer asks via
+// Scripts_GetContent$(name). A first-line read on the catalog scan would
+// flatten ~40 files at boot time for content that's never inspected;
+// the lazy path keeps cold boot snappy.
+//
+// Reference matching: entity Script$ fields can be stored with OR
+// without the .rsl extension (legacy data drift across projects).
+// Scripts_NormalizeName$ strips .rsl from both sides before compare.
+//
+// Strict module. Pure free-functions + a Type ScriptFile populated at
+// boot (same shape as Tools.bb's ToolDef pattern).
+
+
+// =============================================================================
+// Type ScriptFile -- one entry per .rsl in the project's Scripts folder.
+// =============================================================================
+Type ScriptFile
+    Field Name$         // basename without .rsl extension (matches refs)
+    Field FullPath$     // absolute path on disk for Read/Open
+    Field SizeBytes%    // file size from FileSize() at scan time
+    Field LineCount%    // counted at scan time; one ReadLine pass per file
+    Field Index%        // 0-based catalog index; used as refID by Threads
+End Type
+
+
+// =============================================================================
+// Module state -- the catalog itself is the global ScriptFile type pool;
+// we only need a few summary counters for the browser footer / ribbon.
+// =============================================================================
+Global ScriptsTotalCount% = 0
+Global ScriptsScanError$  = ""    // populated if ReadDir fails
+
+
+// =============================================================================
+// Scripts_Init -- scan Data\Server Data\Scripts\ for *.rsl, populate
+// the ScriptFile pool. Called once at boot from Loom.bb after the data
+// loaders run.
+//
+// Failure modes:
+//   - Scripts dir doesn't exist (fresh project): silent; catalog is empty.
+//   - ReadDir returns 0 (permission denied / disk error): logged to
+//     ScriptsScanError$ for the ribbon to surface; catalog is empty.
+//   - Individual file scan fails: skipped + logged; other files still
+//     populate.
+// =============================================================================
+Function Scripts_Init()
+    Local dir$ = "Data\Server Data\Scripts"
+    Local D.BBDir = ReadDir(dir$)
+    If D = Null
+        ScriptsScanError$ = "Could not read " + dir$
+        Return
+    EndIf
+
+    Local idx% = 0
+    Local f$
+    Repeat
+        f$ = NextFile$(D)
+        If f$ <> "" And f$ <> "." And f$ <> ".."
+            // Filter to .rsl source files only. .rcscript is the compiled
+            // bytecode that the server runtime loads; it's regenerated
+            // from .rsl on demand and not a source-of-truth artifact.
+            If Right$(Lower$(f$), 4) = ".rsl"
+                Local full$ = dir$ + "\" + f$
+                If FileType(full) = 1
+                    Local sf.ScriptFile = New ScriptFile()
+                    sf\Name = Left$(f$, Len(f$) - 4)
+                    sf\FullPath = full
+                    sf\SizeBytes = FileSize(full)
+                    sf\LineCount = Scripts_CountLines(full)
+                    sf\Index = idx
+                    idx = idx + 1
+                EndIf
+            EndIf
+        EndIf
+    Until f$ = ""
+    CloseDir(D)
+
+    ScriptsTotalCount = idx
+End Function
+
+
+// =============================================================================
+// Scripts_CountLines -- cheap one-pass ReadLine count. Used for the
+// composer header "N lines" badge.
+// =============================================================================
+Function Scripts_CountLines%(path$)
+    Local F.BBStream = ReadFile(path)
+    If F = Null Then Return 0
+    Local n% = 0
+    While Not Eof(F)
+        ReadLine(F)
+        n = n + 1
+    Wend
+    CloseFile(F)
+    Return n
+End Function
+
+
+// =============================================================================
+// Scripts_NormalizeName$ -- strip .rsl extension if present, return
+// lowercase. Both sides of a reference compare go through this so
+// "In-game Commands.rsl" == "In-game Commands" == "in-game commands".
+// =============================================================================
+Function Scripts_NormalizeName$(name$)
+    Local n$ = Lower$(name$)
+    If Right$(n, 4) = ".rsl" Then n = Left$(n, Len(n) - 4)
+    Return n
+End Function
+
+
+// =============================================================================
+// Scripts_GetByIndex.ScriptFile -- O(N) walk to find the i-th entry.
+// Used by Threads::focus("script", i) -> composer dispatch. Walks the
+// pool in insertion order (which == idx assignment order).
+// =============================================================================
+Function Scripts_GetByIndex.ScriptFile(idx%)
+    For sf.ScriptFile = Each ScriptFile
+        If sf\Index = idx Then Return sf
+    Next
+    Return Null
+End Function
+
+
+// =============================================================================
+// Scripts_GetByName.ScriptFile -- case-insensitive lookup by basename,
+// extension-tolerant on the query. Used by the broken-ref scanner and
+// by future "click a Script chip to focus" flows.
+// =============================================================================
+Function Scripts_GetByName.ScriptFile(name$)
+    Local key$ = Scripts_NormalizeName$(name)
+    If key = "" Then Return Null
+    For sf.ScriptFile = Each ScriptFile
+        If Lower$(sf\Name) = key Then Return sf
+    Next
+    Return Null
+End Function
+
+
+// =============================================================================
+// Scripts_GetContent$ -- read the .rsl file from disk (lazy). Cap at
+// SCRIPTS_PREVIEW_MAX_BYTES so a runaway script doesn't blow up the
+// composer paint loop. Caller chunks by Chr(10) for line rendering.
+// =============================================================================
+Const SCRIPTS_PREVIEW_MAX_BYTES% = 65536    // 64KB cap; ~1500 typical lines
+Function Scripts_GetContent$(name$)
+    Local sf.ScriptFile = Scripts_GetByName(name)
+    If sf = Null Then Return ""
+
+    Local F.BBStream = ReadFile(sf\FullPath)
+    If F = Null Then Return ""
+
+    Local out$ = ""
+    Local bytes% = 0
+    While Not Eof(F) And bytes < SCRIPTS_PREVIEW_MAX_BYTES
+        Local L$ = ReadLine(F)
+        out = out + L + Chr(10)
+        bytes = bytes + Len(L) + 1
+    Wend
+    CloseFile(F)
+
+    If bytes >= SCRIPTS_PREVIEW_MAX_BYTES
+        out = out + Chr(10) + "[truncated: " + sf\Name + ".rsl exceeds 64KB preview cap]"
+    EndIf
+    Return out
+End Function
+
+
+// =============================================================================
+// Scripts_FormatSize$ -- humanize FileSize bytes into "1.2KB" / "640B"
+// for the composer/card header.
+// =============================================================================
+Function Scripts_FormatSize$(bytes%)
+    If bytes < 1024 Then Return Str(bytes) + "B"
+    Local k% = bytes / 1024
+    If k < 1024 Then Return Str(k) + "KB"
+    Local m% = k / 1024
+    Return Str(m) + "MB"
+End Function

--- a/src/Modules/Loom/Threads.bb
+++ b/src/Modules/Loom/Threads.bb
@@ -206,6 +206,13 @@ Type Threads
             Return "Project Settings"
         EndIf
 
+        If kind = "script"
+            // refID is the ScriptFile\Index from Scripts_Init.
+            Local sf.ScriptFile = Scripts_GetByIndex(refID)
+            If sf = Null Then Return ""
+            Return sf\Name$ + ".rsl"
+        EndIf
+
         Return ""
     End Method
 


### PR DESCRIPTION
## Summary
Big sweep — new browser tab + composer surface for .rsl script files.

### What's new
- **\`Modules/Loom/ScriptsCatalog.bb\`** (Strict): scans \`Data\Server Data\Scripts\*.rsl\` at boot, lazy content read on demand, normalised-name lookup
- **Browser Scripts tab** between Tools and Settings — card per .rsl with size + line count
- **Composer renderScript**: metadata + first-200-lines preview with line-number gutter + Used by reverse-refs (every Item/Spell/Zone script field family) + cleanup-friendly \"(unused — safe to delete)\" empty state
- **Threads::lookupName(\"script\", idx)** for back-stack chip labels

### Why this matters
Designers previously had no way in Loom *or* GUE to see what scripts exist or who references them — required grepping .rsl files and entity .dat files by hand. The reverse-ref scan in particular makes \"this script is no longer used, drop it\" a one-click decision instead of a 30-min audit.

### Test plan
- [x] Source-clean compile
- [x] Full engine build (compile.bat -t)
- [x] 32/32 tests pass (1st run clean)
- [ ] CI green

### BlitzForge Strict-mode gotchas surfaced
- \`ReadDir\` returns \`BBDir\`, \`ReadFile\` returns \`BBStream\` — Local must use \`.BBDir\` / \`.BBStream\` sigil + compare to \`Null\` not \`0\`
- \`New X\` requires parentheses under Strict

Iter 60.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>