### PR TITLE
Loom: Meshes browser tab + 3D preview (iter 67)

### DIFF
--- a/src/Loom.bb
+++ b/src/Loom.bb
@@ -124,6 +124,7 @@ Include "Modules\Loom\Tools.bb"
 Include "Modules\Loom\ScriptsCatalog.bb"
 Include "Modules\Loom\ScriptSearch.bb"
 Include "Modules\Loom\TextureCatalog.bb"
+Include "Modules\Loom\MeshCatalog.bb"
 Include "Modules\Loom\Recents.bb"
 Include "Modules\Loom\EntityFactory.bb"
 Include "Modules\Loom\SaveAll.bb"
@@ -444,6 +445,9 @@ WriteLog(LoomLog, "Scripts catalog: " + Str(ScriptsTotalCount) + " .rsl files in
 ; the file warm; powers the Textures browser tab.
 Textures_Init()
 WriteLog(LoomLog, "Texture catalog: " + Str(TexturesTotalCount) + " textures indexed")
+; Mesh catalog: same shape as the texture scan, against Meshes.dat.
+Meshes_Init()
+WriteLog(LoomLog, "Mesh catalog: " + Str(MeshesTotalCount) + " meshes indexed")
 
 
 // -----------------------------------------------------------------------------

--- a/src/Modules/Loom/Browser.bb
+++ b/src/Modules/Loom/Browser.bb
@@ -171,6 +171,10 @@ Type Browser
         // reverse refs (every Item/Spell/Actor field that points to it).
         // Powered by TextureCatalog.bb (populated at boot).
         Browser::addCategory(self, "texture", "Textures")
+        // Meshes tab: every defined mesh from Data\Game Data\Meshes.dat
+        // as a card. Composer shows full 3D orbit/zoom preview via the
+        // existing MeshPreview widget. Sibling of Textures from iter 66.
+        Browser::addCategory(self, "mesh",    "Meshes")
         // Settings tab: project-level configuration singleton (Misc.dat /
         // Other.dat / Money.dat / Hosts.dat). Clicking the tab focuses
         // the singleton composer view directly -- no card grid since
@@ -425,7 +429,7 @@ Type Browser
         Local nbW% = 96
         Local nbH% = 22
         Local nbHover% = False
-        If self\category <> "tools" And self\category <> "script" And self\category <> "texture"
+        If self\category <> "tools" And self\category <> "script" And self\category <> "texture" And self\category <> "mesh"
             nbHover = (mx >= nbX And mx < nbX + nbW And my >= nbY And my < nbY + nbH)
 
             If nbHover = True
@@ -537,6 +541,7 @@ Type Browser
         If kind = "animset" Then Return "Anim Set"
         If kind = "script"  Then Return "Script"
         If kind = "texture" Then Return "Texture"
+        If kind = "mesh"    Then Return "Mesh"
         Return kind
     End Method
 
@@ -691,6 +696,9 @@ Type Browser
         EndIf
         If cat = "texture"
             count = Browser::drawTexturesGrid(self, sw, sh, mx, my, clicked, gridX, gridY, cols)
+        EndIf
+        If cat = "mesh"
+            count = Browser::drawMeshesGrid(self, sw, sh, mx, my, clicked, gridX, gridY, cols)
         EndIf
         If cat = "settings"
             count = Browser::drawSettingsCard(self, sw, sh, mx, my, clicked, gridX, gridY)
@@ -1135,6 +1143,76 @@ Type Browser
         EndIf
         If selected = True And self\pendingEnter = True
             Threads::focus(self\threads, "texture", te\Index)
+            self\cardClickLatch = True
+            self\pendingEnter = False
+        EndIf
+    End Method
+
+
+    // -------------------------------------------------------------------------
+    // drawMeshesGrid -- one card per defined mesh in the project.
+    // Cards are text-only (no inline 3D preview -- the composer's
+    // existing Loom_DrawMeshPreview widget handles full orbit/zoom
+    // once the mesh is focused; per-card 3D preview is too expensive).
+    // -------------------------------------------------------------------------
+    Method drawMeshesGrid%(sw%, sh%, mx%, my%, clicked%, gridX%, gridY%, cols%)
+        Local col% = 0
+        Local row% = 0
+        Local count% = 0
+        For me.MeshEntry = Each MeshEntry
+            If Browser::matchesFilter(self, me\Filename$) = True
+                Local cx% = gridX + col * (BR_CARD_W + BR_CARD_GAP)
+                Local cy% = gridY + row * (BR_CARD_H + BR_CARD_GAP)
+                If cy + BR_CARD_H < sh - BR_BOT_RIBBON
+                    Browser::drawMeshCard(self, me, cx, cy, mx, my, clicked, count)
+                EndIf
+                count = count + 1
+                col = col + 1
+                If col >= cols Then col = 0 : row = row + 1
+            EndIf
+        Next
+        Return count
+    End Method
+
+
+    // -------------------------------------------------------------------------
+    // drawMeshCard -- card chrome + filename + ID + anim badge.
+    // -------------------------------------------------------------------------
+    Method drawMeshCard(me.MeshEntry, x%, y%, mx%, my%, clicked%, cardIdx%)
+        Local hovered% = (mx >= x And mx < x + BR_CARD_W And my >= y And my < y + BR_CARD_H)
+        Local selected% = (cardIdx = self\selectedIndex)
+
+        LoomShadowCard(x, y, BR_CARD_W, BR_CARD_H)
+        LoomFill(x, y, BR_CARD_W, BR_CARD_H, LOOM_STONE_800_R, LOOM_STONE_800_G, LOOM_STONE_800_B)
+
+        If hovered = True
+            LoomBorder(x, y, BR_CARD_W, BR_CARD_H, LOOM_ARCANE_500_R, LOOM_ARCANE_500_G, LOOM_ARCANE_500_B)
+            LoomBorder(x + 1, y + 1, BR_CARD_W - 2, BR_CARD_H - 2, LOOM_ARCANE_500_R, LOOM_ARCANE_500_G, LOOM_ARCANE_500_B)
+        Else If selected = True
+            LoomBorder(x, y, BR_CARD_W, BR_CARD_H, LOOM_BRASS_500_R, LOOM_BRASS_500_G, LOOM_BRASS_500_B)
+            LoomBorder(x + 1, y + 1, BR_CARD_W - 2, BR_CARD_H - 2, LOOM_BRASS_500_R, LOOM_BRASS_500_G, LOOM_BRASS_500_B)
+        Else
+            LoomBorder(x, y, BR_CARD_W, BR_CARD_H, LOOM_BRASS_700_R, LOOM_BRASS_700_G, LOOM_BRASS_700_B)
+        EndIf
+
+        LoomHRule(x + 12, y + 8, BR_CARD_W - 24, LOOM_BRASS_500_R, LOOM_BRASS_500_G, LOOM_BRASS_500_B)
+
+        Local nm$ = me\Filename$
+        If Len(nm) > 22 Then nm = Left$(nm, 21) + "~"
+        LoomText(x + 12, y + 18, nm, LOOM_PARCHMENT_100_R, LOOM_PARCHMENT_100_G, LOOM_PARCHMENT_100_B)
+        LoomText(x + 12, y + 44, "id " + Str(me\ID), LOOM_STONE_200_R, LOOM_STONE_200_G, LOOM_STONE_200_B)
+        // Anim badge -- only shown for animated meshes (most actor
+        // models). Static meshes (props, scenery) skip it.
+        If me\IsAnim <> 0
+            LoomText(x + BR_CARD_W - 50, y + 72, "anim", LOOM_BRASS_500_R, LOOM_BRASS_500_G, LOOM_BRASS_500_B)
+        EndIf
+
+        If hovered And clicked
+            Threads::focus(self\threads, "mesh", me\Index)
+            self\cardClickLatch = True
+        EndIf
+        If selected = True And self\pendingEnter = True
+            Threads::focus(self\threads, "mesh", me\Index)
             self\cardClickLatch = True
             self\pendingEnter = False
         EndIf

--- a/src/Modules/Loom/Composer.bb
+++ b/src/Modules/Loom/Composer.bb
@@ -423,6 +423,8 @@ Type Composer
             Composer::renderScript(self, x, scrolledBodyY, w, bodyH, mx, my, clicked, rightClicked)
         Else If kind = "texture"
             Composer::renderTexture(self, x, scrolledBodyY, w, bodyH, mx, my, clicked, rightClicked)
+        Else If kind = "mesh"
+            Composer::renderMesh(self, x, scrolledBodyY, w, bodyH, mx, my, clicked, rightClicked)
         EndIf
 
         // Scrollbar indicator -- thin brass thumb on the right edge,
@@ -3747,6 +3749,102 @@ Type Composer
         EndIf
         If Composer::canPaintRow(self, y, CMP_ROW_H) = True
             LoomText(panelX + CMP_PAD, y + 4, Str(itemHits) + " item(s) | " + Str(spellHits) + " spell(s) | " + Str(actorHits) + " actor(s)", LOOM_BRASS_500_R, LOOM_BRASS_500_G, LOOM_BRASS_500_B)
+        EndIf
+        y = y + CMP_ROW_H
+
+        Composer::recordContentBottom(self, y)
+    End Method
+
+
+    // -------------------------------------------------------------------------
+    // renderMesh -- composer view for a focused mesh from the
+    // MeshCatalog. Shows metadata + 3D orbit/zoom preview (via the
+    // existing Loom_DrawMeshPreview widget from iter 40) + every
+    // entity that references this mesh ID.
+    //
+    // Reverse-ref scanners walk:
+    //   - Item\MMeshID / Item\FMeshID
+    //   - Actor\MeshIDs[0..7] (base + 6 gubbins)
+    //   - Actor\BeardIDs[0..4]
+    //   - Actor\MaleHairIDs[0..4] / FemaleHairIDs[0..4]
+    // -------------------------------------------------------------------------
+    Method renderMesh(panelX%, bodyY%, panelW%, bodyH%, mx%, my%, clicked%, rightClicked%)
+        Local mh.MeshEntry = Meshes_GetByIndex(self\threads\focusID)
+        If mh = Null Then Return
+
+        Local y% = bodyY
+        y = Composer::row(self, panelX, panelW, y, "Filename",  mh\Filename$)
+        y = Composer::row(self, panelX, panelW, y, "ID",        Str(mh\ID))
+        y = Composer::row(self, panelX, panelW, y, "Animated",  Composer::boolLabel(self, mh\IsAnim))
+        y = Composer::row(self, panelX, panelW, y, "Path",      "Data\Meshes\" + mh\Filename$)
+
+        // 3D preview -- reuse the orbit/zoom MeshPreview widget so
+        // designers can spin / inspect the mesh in 3D. Same widget
+        // backs the Actor + Item composer mesh previews; we just
+        // hand it the focused mesh's ID + a centered rect.
+        y = Composer::sectionHeader(self, panelX, panelW, y, "Preview")
+        Local previewX% = panelX + (panelW - LOOM_PREVIEW_SIZE) / 2
+        Local previewY% = y
+        // PreviewActorID = 0 ensures the mesh draws bare (no body
+        // texture overlay) -- we don't know which actor would
+        // "own" this mesh in catalog view.
+        PreviewActorID = 0
+        If Composer::canPaintRow(self, y, LOOM_PREVIEW_SIZE) = True
+            Loom_DrawMeshPreview(mh\ID, previewX, previewY, LOOM_PREVIEW_SIZE)
+        EndIf
+        y = y + LOOM_PREVIEW_SIZE + 8
+
+        // Reverse refs
+        y = Composer::sectionHeader(self, panelX, panelW, y, "Used by")
+        Local itemHits% = 0
+        Local actorHits% = 0
+
+        For It.Item = Each Item
+            If It\MMeshID = mh\ID Or It\FMeshID = mh\ID
+                If itemHits < 50
+                    Local label$ = ""
+                    If It\MMeshID = mh\ID Then label = label + "Male "
+                    If It\FMeshID = mh\ID Then label = label + "Female "
+                    y = Composer::chipRow(self, panelX, panelW, y, label, "item", It\ID, mx, my, clicked, rightClicked, "")
+                EndIf
+                itemHits = itemHits + 1
+            EndIf
+        Next
+
+        // Actors -- check all 8 MeshIDs + beard + hair slot families
+        Local actorIdx% = 0
+        For actorIdx = 0 To 65535
+            Local Ac.Actor = ActorList(actorIdx)
+            If Ac <> Null
+                Local slotLabel$ = ""
+                Local mi% = 0
+                For mi = 0 To 7
+                    If Ac\MeshIDs[mi] = mh\ID Then slotLabel = slotLabel + "Mesh[" + Str(mi) + "] "
+                Next
+                Local bi% = 0
+                For bi = 0 To 4
+                    If Ac\BeardIDs[bi]      = mh\ID Then slotLabel = slotLabel + "Beard[" + Str(bi) + "] "
+                    If Ac\MaleHairIDs[bi]   = mh\ID Then slotLabel = slotLabel + "MHair[" + Str(bi) + "] "
+                    If Ac\FemaleHairIDs[bi] = mh\ID Then slotLabel = slotLabel + "FHair[" + Str(bi) + "] "
+                Next
+                If slotLabel <> ""
+                    If actorHits < 50
+                        y = Composer::chipRow(self, panelX, panelW, y, slotLabel, "actor", Ac\ID, mx, my, clicked, rightClicked, "")
+                    EndIf
+                    actorHits = actorHits + 1
+                EndIf
+            EndIf
+        Next
+
+        Local totalHits% = itemHits + actorHits
+        If totalHits = 0
+            If Composer::canPaintRow(self, y, CMP_ROW_H) = True
+                LoomText(panelX + CMP_PAD, y + 4, "(unused -- safe to remove from the catalog)", LOOM_WARNING_R, LOOM_WARNING_G, LOOM_WARNING_B)
+            EndIf
+            y = y + CMP_ROW_H
+        EndIf
+        If Composer::canPaintRow(self, y, CMP_ROW_H) = True
+            LoomText(panelX + CMP_PAD, y + 4, Str(itemHits) + " item(s) | " + Str(actorHits) + " actor(s)", LOOM_BRASS_500_R, LOOM_BRASS_500_G, LOOM_BRASS_500_B)
         EndIf
         y = y + CMP_ROW_H
 

--- a/src/Modules/Loom/MeshCatalog.bb
+++ b/src/Modules/Loom/MeshCatalog.bb
@@ -1,0 +1,88 @@
+Strict
+
+// =============================================================================
+// Loom/MeshCatalog.bb -- catalog of every defined mesh in
+// Data\Game Data\Meshes.dat, browseable as first-class entities.
+// =============================================================================
+//
+// Sibling of TextureCatalog.bb (iter 66). Walks Meshes.dat with the
+// engine's LockMeshes/GetMeshName$/UnlockMeshes path. Allocates one
+// MeshEntry per defined slot. The composer view reuses the existing
+// Loom_DrawMeshPreview widget (iters 40/41) so designers get a full
+// 3D orbit/zoom preview of any mesh in the project -- this is the
+// piece GUE's classic "Mesh Dialog" never offered.
+
+
+// ---- Constants -------------------------------------------------------------
+Const MESHES_MAX_ID = 65534
+
+
+// ---- Type ------------------------------------------------------------------
+Type MeshEntry
+    Field ID%           // engine-side mesh ID
+    Field Filename$     // basename relative to Data\Meshes\
+    Field IsAnim%       // animation flag byte (1 = animated mesh, 0 = static)
+    Field Index%        // 0-based catalog index for Threads::focus refID
+End Type
+
+
+// ---- Module state ----------------------------------------------------------
+Global MeshesTotalCount% = 0
+
+
+// =============================================================================
+// Meshes_Init -- walk every slot in Data\Game Data\Meshes.dat, allocate
+// a MeshEntry per populated one. Called once from Loom.bb after Textures_Init.
+//
+// Failure modes:
+//   - Index file missing: catalog stays empty (fresh project).
+//   - LockMeshes returns 0: silent; same as missing file.
+// =============================================================================
+Function Meshes_Init()
+    If LockMeshes() = 0 Then Return
+
+    Local idx% = 0
+    Local id% = 0
+    For id = 0 To MESHES_MAX_ID
+        Local raw$ = GetMeshName$(id)
+        If raw <> ""
+            // Strip the trailing Chr(IsAnim) byte GetMeshName$ appends.
+            Local nameLen% = Len(raw) - 1
+            If nameLen < 0 Then nameLen = 0
+            Local name$ = Left$(raw, nameLen)
+            Local isAnim% = Asc(Right$(raw, 1))
+
+            Local me.MeshEntry = New MeshEntry()
+            me\ID = id
+            me\Filename = name
+            me\IsAnim = isAnim
+            me\Index = idx
+            idx = idx + 1
+        EndIf
+    Next
+    UnlockMeshes()
+    MeshesTotalCount = idx
+End Function
+
+
+// =============================================================================
+// Meshes_GetByIndex.MeshEntry -- O(N) walk used by Threads::focus dispatch.
+// =============================================================================
+Function Meshes_GetByIndex.MeshEntry(idx%)
+    For me.MeshEntry = Each MeshEntry
+        If me\Index = idx Then Return me
+    Next
+    Return Null
+End Function
+
+
+// =============================================================================
+// Meshes_GetByID.MeshEntry -- lookup by engine-side ID (not Index).
+// Used by reverse-ref scanners.
+// =============================================================================
+Function Meshes_GetByID.MeshEntry(id%)
+    For me.MeshEntry = Each MeshEntry
+        If me\ID = id Then Return me
+    Next
+    Return Null
+End Function

--- a/src/Modules/Loom/Palette.bb
+++ b/src/Modules/Loom/Palette.bb
@@ -463,6 +463,7 @@ Type Palette
         Local emitAnimSet% = (self\pickerMode = False Or self\pickerKind = "animset")
         Local emitScript% = (self\pickerMode = False Or self\pickerKind = "script")
         Local emitTexture% = (self\pickerMode = False Or self\pickerKind = "texture")
+        Local emitMesh% = (self\pickerMode = False Or self\pickerKind = "mesh")
 
         If emitActor = True
             For Ac.Actor = Each Actor
@@ -541,6 +542,15 @@ Type Palette
                 Local texScore% = Palette::scoreOrBaseline(self, q, te\Filename$, showAllBaseline)
                 If texScore > 0
                     Palette::addResult(self, "texture", te\Index, te\Filename$ + " #" + Str(te\ID), "texture", texScore)
+                EndIf
+            Next
+        EndIf
+
+        If emitMesh = True
+            For mh.MeshEntry = Each MeshEntry
+                Local meshScore% = Palette::scoreOrBaseline(self, q, mh\Filename$, showAllBaseline)
+                If meshScore > 0
+                    Palette::addResult(self, "mesh", mh\Index, mh\Filename$ + " #" + Str(mh\ID), "mesh", meshScore)
                 EndIf
             Next
         EndIf
@@ -719,6 +729,7 @@ Type Palette
         If kind = "animset" Then Return "M"
         If kind = "script"  Then Return "x"
         If kind = "texture" Then Return "T"
+        If kind = "mesh"    Then Return "m"
         Return "?"
     End Method
 End Type

--- a/src/Modules/Loom/Threads.bb
+++ b/src/Modules/Loom/Threads.bb
@@ -220,6 +220,13 @@ Type Threads
             Return te\Filename$ + " #" + Str(te\ID)
         EndIf
 
+        If kind = "mesh"
+            // refID is the MeshEntry\Index from Meshes_Init.
+            Local mh.MeshEntry = Meshes_GetByIndex(refID)
+            If mh = Null Then Return ""
+            Return mh\Filename$ + " #" + Str(mh\ID)
+        EndIf
+
         Return ""
     End Method
 
@@ -314,6 +321,7 @@ Type Threads
         If kind = "animset" Then Return "M"
         If kind = "script"  Then Return "x"      ; ".rsl" looks like an x-ish glyph
         If kind = "texture" Then Return "T"
+        If kind = "mesh"    Then Return "m"
         Return "?"
     End Method
 End Type


### PR DESCRIPTION
## Summary
Sibling of iter 66 (Textures tab); same architecture applied to meshes. Two of GUE's three asset families (textures + meshes) now have full catalog/browse/preview/reverse-refs surfaces in Loom.

### What's new
- **\`Modules/Loom/MeshCatalog.bb\`** (Strict, ~90 lines) — walks Meshes.dat with LockMeshes; allocates MeshEntry per defined slot
- **Browser Meshes tab** between Textures and Settings — name + ID + anim badge per card
- **Composer renderMesh** — metadata + full 3D orbit/zoom preview via the existing \`Loom_DrawMeshPreview\` widget + reverse refs across Item.MMeshID/FMeshID + Actor.MeshIDs[0..7]/BeardIDs/MaleHairIDs/FemaleHairIDs
- **Threads/Palette** — \"mesh\" kind glyph \"m\", lookupName \"name #ID\", Ctrl+K finds meshes by filename

### Why this matters
The composer-side 3D preview is the killer feature here — GUE shows a mesh in a tiny dialog popup, gone the moment you click anywhere. Loom keeps it pinned in the composer with orbit + zoom + back-stack so you can navigate \"actor uses this mesh; click mesh; see preview; Esc back to actor\" smoothly.

### Test plan
- [x] Source-clean compile
- [x] Full engine build
- [x] 32/32 tests pass
- [ ] CI green

Iter 67.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>