### PR TITLE
Loom: Music browser tab + audition (iter 71)

### DIFF
--- a/src/Loom.bb
+++ b/src/Loom.bb
@@ -126,6 +126,7 @@ Include "Modules\Loom\ScriptSearch.bb"
 Include "Modules\Loom\TextureCatalog.bb"
 Include "Modules\Loom\MeshCatalog.bb"
 Include "Modules\Loom\SoundCatalog.bb"
+Include "Modules\Loom\MusicCatalog.bb"
 Include "Modules\Loom\Recents.bb"
 Include "Modules\Loom\EntityFactory.bb"
 Include "Modules\Loom\SaveAll.bb"
@@ -453,6 +454,10 @@ WriteLog(LoomLog, "Mesh catalog: " + Str(MeshesTotalCount) + " meshes indexed")
 ; button for in-place audition -- not present in GUE at all.
 Sounds_Init()
 WriteLog(LoomLog, "Sound catalog: " + Str(SoundsTotalCount) + " sounds indexed")
+; Music catalog: final media family. No reverse refs (music isn't
+; statically referenced from data Loom edits); audition + browse only.
+Music_Init()
+WriteLog(LoomLog, "Music catalog: " + Str(MusicTotalCount) + " tracks indexed")
 
 
 // -----------------------------------------------------------------------------

--- a/src/Modules/Loom/Browser.bb
+++ b/src/Modules/Loom/Browser.bb
@@ -179,6 +179,10 @@ Type Browser
         // as a card. Composer view adds a Play button for in-place
         // audition -- a feature GUE doesn't expose at all.
         Browser::addCategory(self, "sound",   "Sounds")
+        // Music tab: every defined music track. No reverse refs since
+        // music IDs aren't statically referenced from data Loom edits.
+        // Audition + browse only.
+        Browser::addCategory(self, "music",   "Music")
         // Settings tab: project-level configuration singleton (Misc.dat /
         // Other.dat / Money.dat / Hosts.dat). Clicking the tab focuses
         // the singleton composer view directly -- no card grid since
@@ -433,7 +437,7 @@ Type Browser
         Local nbW% = 96
         Local nbH% = 22
         Local nbHover% = False
-        If self\category <> "tools" And self\category <> "script" And self\category <> "texture" And self\category <> "mesh" And self\category <> "sound"
+        If self\category <> "tools" And self\category <> "script" And self\category <> "texture" And self\category <> "mesh" And self\category <> "sound" And self\category <> "music"
             nbHover = (mx >= nbX And mx < nbX + nbW And my >= nbY And my < nbY + nbH)
 
             If nbHover = True
@@ -547,6 +551,7 @@ Type Browser
         If kind = "texture" Then Return "Texture"
         If kind = "mesh"    Then Return "Mesh"
         If kind = "sound"   Then Return "Sound"
+        If kind = "music"   Then Return "Music"
         Return kind
     End Method
 
@@ -707,6 +712,9 @@ Type Browser
         EndIf
         If cat = "sound"
             count = Browser::drawSoundsGrid(self, sw, sh, mx, my, clicked, gridX, gridY, cols)
+        EndIf
+        If cat = "music"
+            count = Browser::drawMusicGrid(self, sw, sh, mx, my, clicked, gridX, gridY, cols)
         EndIf
         If cat = "settings"
             count = Browser::drawSettingsCard(self, sw, sh, mx, my, clicked, gridX, gridY)
@@ -1288,6 +1296,68 @@ Type Browser
         EndIf
         If selected = True And self\pendingEnter = True
             Threads::focus(self\threads, "sound", se\Index)
+            self\cardClickLatch = True
+            self\pendingEnter = False
+        EndIf
+    End Method
+
+
+    // -------------------------------------------------------------------------
+    // drawMusicGrid / drawMusicCard -- final media catalog tab. Cards
+    // are text-only with the filename + ID; composer view holds the
+    // play button.
+    // -------------------------------------------------------------------------
+    Method drawMusicGrid%(sw%, sh%, mx%, my%, clicked%, gridX%, gridY%, cols%)
+        Local col% = 0
+        Local row% = 0
+        Local count% = 0
+        For mu.MusicEntry = Each MusicEntry
+            If Browser::matchesFilter(self, mu\Filename$) = True
+                Local cx% = gridX + col * (BR_CARD_W + BR_CARD_GAP)
+                Local cy% = gridY + row * (BR_CARD_H + BR_CARD_GAP)
+                If cy + BR_CARD_H < sh - BR_BOT_RIBBON
+                    Browser::drawMusicCard(self, mu, cx, cy, mx, my, clicked, count)
+                EndIf
+                count = count + 1
+                col = col + 1
+                If col >= cols Then col = 0 : row = row + 1
+            EndIf
+        Next
+        Return count
+    End Method
+
+
+    Method drawMusicCard(mu.MusicEntry, x%, y%, mx%, my%, clicked%, cardIdx%)
+        Local hovered% = (mx >= x And mx < x + BR_CARD_W And my >= y And my < y + BR_CARD_H)
+        Local selected% = (cardIdx = self\selectedIndex)
+
+        LoomShadowCard(x, y, BR_CARD_W, BR_CARD_H)
+        LoomFill(x, y, BR_CARD_W, BR_CARD_H, LOOM_STONE_800_R, LOOM_STONE_800_G, LOOM_STONE_800_B)
+
+        If hovered = True
+            LoomBorder(x, y, BR_CARD_W, BR_CARD_H, LOOM_ARCANE_500_R, LOOM_ARCANE_500_G, LOOM_ARCANE_500_B)
+            LoomBorder(x + 1, y + 1, BR_CARD_W - 2, BR_CARD_H - 2, LOOM_ARCANE_500_R, LOOM_ARCANE_500_G, LOOM_ARCANE_500_B)
+        Else If selected = True
+            LoomBorder(x, y, BR_CARD_W, BR_CARD_H, LOOM_BRASS_500_R, LOOM_BRASS_500_G, LOOM_BRASS_500_B)
+            LoomBorder(x + 1, y + 1, BR_CARD_W - 2, BR_CARD_H - 2, LOOM_BRASS_500_R, LOOM_BRASS_500_G, LOOM_BRASS_500_B)
+        Else
+            LoomBorder(x, y, BR_CARD_W, BR_CARD_H, LOOM_BRASS_700_R, LOOM_BRASS_700_G, LOOM_BRASS_700_B)
+        EndIf
+
+        LoomHRule(x + 12, y + 8, BR_CARD_W - 24, LOOM_BRASS_500_R, LOOM_BRASS_500_G, LOOM_BRASS_500_B)
+
+        Local nm$ = mu\Filename$
+        If Len(nm) > 22 Then nm = Left$(nm, 21) + "~"
+        LoomText(x + 12, y + 18, nm, LOOM_PARCHMENT_100_R, LOOM_PARCHMENT_100_G, LOOM_PARCHMENT_100_B)
+        LoomText(x + 12, y + 44, "id " + Str(mu\ID), LOOM_STONE_200_R, LOOM_STONE_200_G, LOOM_STONE_200_B)
+        LoomText(x + BR_CARD_W - 56, y + 72, "music", LOOM_BRASS_500_R, LOOM_BRASS_500_G, LOOM_BRASS_500_B)
+
+        If hovered And clicked
+            Threads::focus(self\threads, "music", mu\Index)
+            self\cardClickLatch = True
+        EndIf
+        If selected = True And self\pendingEnter = True
+            Threads::focus(self\threads, "music", mu\Index)
             self\cardClickLatch = True
             self\pendingEnter = False
         EndIf

--- a/src/Modules/Loom/Composer.bb
+++ b/src/Modules/Loom/Composer.bb
@@ -427,6 +427,8 @@ Type Composer
             Composer::renderMesh(self, x, scrolledBodyY, w, bodyH, mx, my, clicked, rightClicked)
         Else If kind = "sound"
             Composer::renderSound(self, x, scrolledBodyY, w, bodyH, mx, my, clicked, rightClicked)
+        Else If kind = "music"
+            Composer::renderMusic(self, x, scrolledBodyY, w, bodyH, mx, my, clicked, rightClicked)
         EndIf
 
         // Scrollbar indicator -- thin brass thumb on the right edge,
@@ -4036,6 +4038,57 @@ Type Composer
         EndIf
         If Composer::canPaintRow(self, y, CMP_ROW_H) = True
             LoomText(panelX + CMP_PAD, y + 4, Str(actorHits) + " actor(s)", LOOM_BRASS_500_R, LOOM_BRASS_500_G, LOOM_BRASS_500_B)
+        EndIf
+        y = y + CMP_ROW_H
+
+        Composer::recordContentBottom(self, y)
+    End Method
+
+
+    // -------------------------------------------------------------------------
+    // renderMusic -- composer view for a focused music track. Shape
+    // mirrors renderSound but without the "Used by" section -- music
+    // isn't statically referenced from data Loom edits. The Play
+    // button still earns its keep: designers cataloging their music
+    // library no longer have to launch the full Server + Client to
+    // hear a specific track.
+    // -------------------------------------------------------------------------
+    Method renderMusic(panelX%, bodyY%, panelW%, bodyH%, mx%, my%, clicked%, rightClicked%)
+        Local mu.MusicEntry = Music_GetByIndex(self\threads\focusID)
+        If mu = Null Then Return
+
+        Local y% = bodyY
+        y = Composer::row(self, panelX, panelW, y, "Filename", mu\Filename$)
+        y = Composer::row(self, panelX, panelW, y, "ID",       Str(mu\ID))
+        y = Composer::row(self, panelX, panelW, y, "Path",     "Data\Music\" + mu\Filename$)
+
+        y = Composer::sectionHeader(self, panelX, panelW, y, "Audition")
+        Local btnW% = 80
+        Local btnH% = 26
+        Local btnX% = panelX + CMP_PAD
+        Local btnY% = y
+        Local btnHovered% = (mx >= btnX And mx < btnX + btnW And my >= btnY And my < btnY + btnH)
+        If Composer::canPaintRow(self, y, btnH) = True
+            If btnHovered = True
+                LoomFill(btnX, btnY, btnW, btnH, LOOM_BRASS_500_R, LOOM_BRASS_500_G, LOOM_BRASS_500_B)
+                LoomBorder(btnX, btnY, btnW, btnH, LOOM_PARCHMENT_100_R, LOOM_PARCHMENT_100_G, LOOM_PARCHMENT_100_B)
+                LoomText(btnX + 18, btnY + 6, "> play", LOOM_PARCHMENT_100_R, LOOM_PARCHMENT_100_G, LOOM_PARCHMENT_100_B)
+            Else
+                LoomFill(btnX, btnY, btnW, btnH, LOOM_STONE_700_R, LOOM_STONE_700_G, LOOM_STONE_700_B)
+                LoomBorder(btnX, btnY, btnW, btnH, LOOM_BRASS_500_R, LOOM_BRASS_500_G, LOOM_BRASS_500_B)
+                LoomText(btnX + 18, btnY + 6, "> play", LOOM_BRASS_500_R, LOOM_BRASS_500_G, LOOM_BRASS_500_B)
+            EndIf
+        EndIf
+        If btnHovered = True And clicked = True
+            Music_Play(self\threads\focusID)
+        EndIf
+        y = y + btnH + 4
+
+        // No reverse refs section -- music isn't referenced from data
+        // Loom edits. The composer footer notes this so designers don't
+        // wonder where the "Used by" section went.
+        If Composer::canPaintRow(self, y, CMP_ROW_H) = True
+            LoomText(panelX + CMP_PAD, y + 4, "(music tracks have no in-data references)", LOOM_STONE_300_R, LOOM_STONE_300_G, LOOM_STONE_300_B)
         EndIf
         y = y + CMP_ROW_H
 

--- a/src/Modules/Loom/MusicCatalog.bb
+++ b/src/Modules/Loom/MusicCatalog.bb
@@ -1,0 +1,93 @@
+Strict
+
+// =============================================================================
+// Loom/MusicCatalog.bb -- catalog of every defined music track in
+// Data\Game Data\Music.dat, browseable as first-class entities.
+// =============================================================================
+//
+// Final piece of the media-asset trio (Textures + Meshes + Sounds + Music).
+// Same architecture as SoundCatalog (iter 68). Music tracks are
+// referenced from client-side SoundZone records inside zone files,
+// which Loom doesn't currently edit -- so no reverse refs for now.
+// The audition button + browseable list still earn their keep:
+// designers exporting their music collection no longer have to grep
+// a binary .dat file to see what's defined.
+
+
+// ---- Constants -------------------------------------------------------------
+Const MUSIC_MAX_ID = 65534
+
+
+// ---- Type ------------------------------------------------------------------
+Type MusicEntry
+    Field ID%           // engine-side music track ID
+    Field Filename$     // basename relative to Data\Music\
+    Field Index%        // 0-based catalog index for Threads::focus refID
+End Type
+
+
+// ---- Module state ----------------------------------------------------------
+Global MusicTotalCount% = 0
+
+
+// =============================================================================
+// Music_Init -- walk every slot in Data\Game Data\Music.dat. Music
+// entries lack the trailing flag byte that sounds/meshes/textures
+// carry, so the GetMusicName$ return is the basename verbatim.
+// =============================================================================
+Function Music_Init()
+    If LockMusic() = 0 Then Return
+
+    Local idx% = 0
+    Local id% = 0
+    For id = 0 To MUSIC_MAX_ID
+        Local name$ = GetMusicName$(id)
+        If name <> ""
+            Local mu.MusicEntry = New MusicEntry()
+            mu\ID = id
+            mu\Filename = name
+            mu\Index = idx
+            idx = idx + 1
+        EndIf
+    Next
+    UnlockMusic()
+    MusicTotalCount = idx
+End Function
+
+
+// =============================================================================
+// Music_GetByIndex.MusicEntry / Music_GetByID.MusicEntry -- standard
+// lookup helpers mirroring the sibling catalogs.
+// =============================================================================
+Function Music_GetByIndex.MusicEntry(idx%)
+    For mu.MusicEntry = Each MusicEntry
+        If mu\Index = idx Then Return mu
+    Next
+    Return Null
+End Function
+
+
+Function Music_GetByID.MusicEntry(id%)
+    For mu.MusicEntry = Each MusicEntry
+        If mu\ID = id Then Return mu
+    Next
+    Return Null
+End Function
+
+
+// =============================================================================
+// Music_Play -- audition a track. Uses LoadSound + PlaySound directly
+// (engine plays music via the sound channel, not a CD track), matching
+// the path used in ClientAreas.bb for the loading-screen music.
+// =============================================================================
+Function Music_Play%(idx%)
+    Local mu.MusicEntry = Music_GetByIndex(idx)
+    If mu = Null Then Return False
+    Local path$ = "Data\Music\" + mu\Filename$
+    Local sndH.BBSound = LoadSound(path)
+    If sndH = Null Then Return False
+    PlaySound(sndH)
+    // Same caveat as Sounds_Play: no FreeSound (would cut playback).
+    // Minor leak per audition, acceptable for editor session lifetime.
+    Return True
+End Function

--- a/src/Modules/Loom/Palette.bb
+++ b/src/Modules/Loom/Palette.bb
@@ -465,6 +465,7 @@ Type Palette
         Local emitTexture% = (self\pickerMode = False Or self\pickerKind = "texture")
         Local emitMesh% = (self\pickerMode = False Or self\pickerKind = "mesh")
         Local emitSound% = (self\pickerMode = False Or self\pickerKind = "sound")
+        Local emitMusic% = (self\pickerMode = False Or self\pickerKind = "music")
 
         If emitActor = True
             For Ac.Actor = Each Actor
@@ -561,6 +562,15 @@ Type Palette
                 Local soundScore% = Palette::scoreOrBaseline(self, q, sd\Filename$, showAllBaseline)
                 If soundScore > 0
                     Palette::addResult(self, "sound", sd\Index, sd\Filename$ + " #" + Str(sd\ID), "sound", soundScore)
+                EndIf
+            Next
+        EndIf
+
+        If emitMusic = True
+            For mu.MusicEntry = Each MusicEntry
+                Local musicScore% = Palette::scoreOrBaseline(self, q, mu\Filename$, showAllBaseline)
+                If musicScore > 0
+                    Palette::addResult(self, "music", mu\Index, mu\Filename$ + " #" + Str(mu\ID), "music", musicScore)
                 EndIf
             Next
         EndIf
@@ -741,6 +751,7 @@ Type Palette
         If kind = "texture" Then Return "T"
         If kind = "mesh"    Then Return "m"
         If kind = "sound"   Then Return "s"
+        If kind = "music"   Then Return "M"
         Return "?"
     End Method
 End Type

--- a/src/Modules/Loom/Threads.bb
+++ b/src/Modules/Loom/Threads.bb
@@ -234,6 +234,13 @@ Type Threads
             Return sd\Filename$ + " #" + Str(sd\ID)
         EndIf
 
+        If kind = "music"
+            // refID is the MusicEntry\Index from Music_Init.
+            Local mu.MusicEntry = Music_GetByIndex(refID)
+            If mu = Null Then Return ""
+            Return mu\Filename$ + " #" + Str(mu\ID)
+        EndIf
+
         Return ""
     End Method
 
@@ -330,6 +337,7 @@ Type Threads
         If kind = "texture" Then Return "T"
         If kind = "mesh"    Then Return "m"
         If kind = "sound"   Then Return "s"
+        If kind = "music"   Then Return "M"
         Return "?"
     End Method
 End Type


### PR DESCRIPTION
## Summary
Final piece of the media-asset family. Music tracks now browseable + auditionable. With this iter Loom indexes **5 catalogs** (Textures + Meshes + Sounds + Music + Scripts) — every asset family in the project is browseable, threadable, and previewable.

### What's new
- **\`Modules/Loom/MusicCatalog.bb\`** (Strict, ~90 lines) — same pattern as SoundCatalog but no flag byte (Music.dat entries are filename-only)
- **Browser Music tab** between Sounds and Settings
- **Composer renderMusic** — metadata + play button + footer note (no reverse refs since music isn't referenced from Loom-edited data)
- **Threads/Palette** — \"music\" glyph \"M\", Ctrl+K finds music tracks

### Test plan
- [x] Source-clean compile
- [x] Full engine build
- [x] 32/32 tests pass
- [ ] CI green

Iter 71.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>