### PR TITLE
Loom: Project Stats tab (iter 74)

### DIFF
--- a/src/Modules/Loom/Browser.bb
+++ b/src/Modules/Loom/Browser.bb
@@ -183,6 +183,10 @@ Type Browser
         // music IDs aren't statically referenced from data Loom edits.
         // Audition + browse only.
         Browser::addCategory(self, "music",   "Music")
+        // Stats tab: singleton read-only dashboard showing project
+        // health at a glance. Entity counts, top zones by spawn
+        // density, asset catalog sizes, issue breakdown.
+        Browser::addCategory(self, "stats",   "Stats")
         // Settings tab: project-level configuration singleton (Misc.dat /
         // Other.dat / Money.dat / Hosts.dat). Clicking the tab focuses
         // the singleton composer view directly -- no card grid since
@@ -437,7 +441,7 @@ Type Browser
         Local nbW% = 96
         Local nbH% = 22
         Local nbHover% = False
-        If self\category <> "tools" And self\category <> "script" And self\category <> "texture" And self\category <> "mesh" And self\category <> "sound" And self\category <> "music"
+        If self\category <> "tools" And self\category <> "script" And self\category <> "texture" And self\category <> "mesh" And self\category <> "sound" And self\category <> "music" And self\category <> "stats"
             nbHover = (mx >= nbX And mx < nbX + nbW And my >= nbY And my < nbY + nbH)
 
             If nbHover = True
@@ -552,6 +556,7 @@ Type Browser
         If kind = "mesh"    Then Return "Mesh"
         If kind = "sound"   Then Return "Sound"
         If kind = "music"   Then Return "Music"
+        If kind = "stats"   Then Return "Stats"
         Return kind
     End Method
 
@@ -715,6 +720,9 @@ Type Browser
         EndIf
         If cat = "music"
             count = Browser::drawMusicGrid(self, sw, sh, mx, my, clicked, gridX, gridY, cols)
+        EndIf
+        If cat = "stats"
+            count = Browser::drawStatsCard(self, sw, sh, mx, my, clicked, gridX, gridY)
         EndIf
         If cat = "settings"
             count = Browser::drawSettingsCard(self, sw, sh, mx, my, clicked, gridX, gridY)
@@ -924,6 +932,41 @@ Type Browser
             WriteLog(LoomLog, "Browser: opened Settings singleton")
         EndIf
 
+        Return 1
+    End Method
+
+
+    // -------------------------------------------------------------------------
+    // drawStatsCard -- Stats tab body. Singleton "Project Stats" card
+    // that focuses the read-only dashboard composer view on click.
+    // Mirrors drawSettingsCard's shape.
+    // -------------------------------------------------------------------------
+    Method drawStatsCard%(sw%, sh%, mx%, my%, clicked%, gridX%, gridY%)
+        Local cx% = gridX
+        Local cy% = gridY
+        Local cw% = BR_CARD_W * 2 + BR_CARD_GAP
+        Local ch% = BR_CARD_H
+        Local hovered% = (mx >= cx And mx < cx + cw And my >= cy And my < cy + ch)
+
+        LoomShadowCard(cx, cy, cw, ch)
+        If hovered = True
+            LoomFill(cx, cy, cw, ch, LOOM_STONE_700_R, LOOM_STONE_700_G, LOOM_STONE_700_B)
+        Else
+            LoomFill(cx, cy, cw, ch, LOOM_STONE_800_R, LOOM_STONE_800_G, LOOM_STONE_800_B)
+        EndIf
+        LoomBorder(cx, cy, cw, ch, LOOM_BRASS_500_R, LOOM_BRASS_500_G, LOOM_BRASS_500_B)
+        LoomFill(cx, cy, cw, 3, LOOM_BRASS_500_R, LOOM_BRASS_500_G, LOOM_BRASS_500_B)
+
+        LoomTheme_UseDisplay()
+        LoomText(cx + 16, cy + 16, "PROJECT STATS", LOOM_BRASS_500_R, LOOM_BRASS_500_G, LOOM_BRASS_500_B)
+        LoomTheme_UseBody()
+        LoomText(cx + 16, cy + 44, "Entity counts | top zones | asset catalog sizes | issue breakdown", LOOM_STONE_200_R, LOOM_STONE_200_G, LOOM_STONE_200_B)
+        LoomText(cx + 16, cy + ch - 24, "Click to open >>", LOOM_BRASS_500_R, LOOM_BRASS_500_G, LOOM_BRASS_500_B)
+
+        If hovered = True And clicked = True
+            Threads::focus(self\threads, "stats", 0)
+            WriteLog(LoomLog, "Browser: opened Stats singleton")
+        EndIf
         Return 1
     End Method
 

--- a/src/Modules/Loom/Composer.bb
+++ b/src/Modules/Loom/Composer.bb
@@ -429,6 +429,8 @@ Type Composer
             Composer::renderSound(self, x, scrolledBodyY, w, bodyH, mx, my, clicked, rightClicked)
         Else If kind = "music"
             Composer::renderMusic(self, x, scrolledBodyY, w, bodyH, mx, my, clicked, rightClicked)
+        Else If kind = "stats"
+            Composer::renderStats(self, x, scrolledBodyY, w, bodyH, mx, my, clicked)
         EndIf
 
         // Scrollbar indicator -- thin brass thumb on the right edge,
@@ -4194,6 +4196,174 @@ Type Composer
         // wonder where the "Used by" section went.
         If Composer::canPaintRow(self, y, CMP_ROW_H) = True
             LoomText(panelX + CMP_PAD, y + 4, "(music tracks have no in-data references)", LOOM_STONE_300_R, LOOM_STONE_300_G, LOOM_STONE_300_B)
+        EndIf
+        y = y + CMP_ROW_H
+
+        Composer::recordContentBottom(self, y)
+    End Method
+
+
+    // -------------------------------------------------------------------------
+    // renderStats -- read-only project dashboard. Counts entities,
+    // assets, issues; highlights top 5 zones by spawn density; surfaces
+    // top issue categories. Designed for "open Loom, hit Stats tab, get
+    // an immediate read on project health." No editable rows.
+    // -------------------------------------------------------------------------
+    Method renderStats(panelX%, bodyY%, panelW%, bodyH%, mx%, my%, clicked%)
+        Local y% = bodyY
+
+        // Entity counts. Use the same counting walks BrokenRefs and
+        // WorldCache use; cheap at typical project scale.
+        Local actorCount% = 0
+        Local Ac.Actor
+        For Ac = Each Actor
+            actorCount = actorCount + 1
+        Next
+        Local itemCount% = 0
+        Local It.Item
+        For It = Each Item
+            itemCount = itemCount + 1
+        Next
+        Local spellCount% = 0
+        Local Sp.Spell
+        For Sp = Each Spell
+            spellCount = spellCount + 1
+        Next
+        Local zoneCount% = 0
+        Local Ar.Area
+        For Ar = Each Area
+            zoneCount = zoneCount + 1
+        Next
+        Local factionCount% = 0
+        Local fi% = 0
+        For fi = 0 To 99
+            If FactionNames$(fi) <> "" Then factionCount = factionCount + 1
+        Next
+        Local animsetCount% = 0
+        Local As.AnimSet
+        For As = Each AnimSet
+            animsetCount = animsetCount + 1
+        Next
+
+        y = Composer::sectionHeader(self, panelX, panelW, y, "Entities")
+        y = Composer::row(self, panelX, panelW, y, "Actors",      Str(actorCount))
+        y = Composer::row(self, panelX, panelW, y, "Items",       Str(itemCount))
+        y = Composer::row(self, panelX, panelW, y, "Spells",      Str(spellCount))
+        y = Composer::row(self, panelX, panelW, y, "Zones",       Str(zoneCount))
+        y = Composer::row(self, panelX, panelW, y, "Factions",    Str(factionCount))
+        y = Composer::row(self, panelX, panelW, y, "Anim Sets",   Str(animsetCount))
+
+        // Asset catalog counts -- come straight from the *_Init module
+        // globals (TexturesTotalCount etc.). These already cost nothing
+        // to read since they're maintained at boot.
+        y = Composer::sectionHeader(self, panelX, panelW, y, "Asset catalogs")
+        y = Composer::row(self, panelX, panelW, y, "Scripts",     Str(ScriptsTotalCount)  + " .rsl files")
+        y = Composer::row(self, panelX, panelW, y, "Textures",    Str(TexturesTotalCount) + " in Textures.dat")
+        y = Composer::row(self, panelX, panelW, y, "Meshes",      Str(MeshesTotalCount)   + " in Meshes.dat")
+        y = Composer::row(self, panelX, panelW, y, "Sounds",      Str(SoundsTotalCount)   + " in Sounds.dat")
+        y = Composer::row(self, panelX, panelW, y, "Music",       Str(MusicTotalCount)    + " in Music.dat")
+
+        // Top 5 zones by spawn count. Walk Area pool, compute total
+        // defined SpawnActor slots per zone, surface the largest.
+        y = Composer::sectionHeader(self, panelX, panelW, y, "Top zones by spawn density")
+        Local zi% = 0
+        Local topName$[5]
+        Local topCount%[5]
+        Local topHandle%[5]
+        For zi = 0 To 4
+            topName[zi] = "" : topCount[zi] = 0 : topHandle[zi] = 0
+        Next
+        For Ar = Each Area
+            Local spawnSum% = 0
+            Local sci% = 0
+            For sci = 0 To 999
+                If Ar\SpawnActor[sci] > 0 Then spawnSum = spawnSum + 1
+            Next
+            // Insertion into top-5
+            Local insertAt% = -1
+            Local ti% = 0
+            For ti = 0 To 4
+                If spawnSum > topCount[ti]
+                    insertAt = ti
+                    Exit
+                EndIf
+            Next
+            If insertAt >= 0
+                // Shift down
+                Local sj% = 4
+                For sj = 4 To insertAt + 1 Step -1
+                    topName[sj]   = topName[sj - 1]
+                    topCount[sj]  = topCount[sj - 1]
+                    topHandle[sj] = topHandle[sj - 1]
+                Next
+                topName[insertAt] = Ar\Name$
+                topCount[insertAt] = spawnSum
+                topHandle[insertAt] = Handle(Ar)
+            EndIf
+        Next
+        For zi = 0 To 4
+            If topCount[zi] > 0
+                y = Composer::row(self, panelX, panelW, y, topName[zi], Str(topCount[zi]) + " spawns")
+            EndIf
+        Next
+        If topCount[0] = 0
+            If Composer::canPaintRow(self, y, CMP_ROW_H) = True
+                LoomText(panelX + CMP_PAD, y + 4, "(no zones with spawns)", LOOM_STONE_300_R, LOOM_STONE_300_G, LOOM_STONE_300_B)
+            EndIf
+            y = y + CMP_ROW_H
+        EndIf
+
+        // Issues breakdown by category. Walk the BrokenRef pool that
+        // BrokenRefs::rebuild populates (cached -- no fresh scan here).
+        y = Composer::sectionHeader(self, panelX, panelW, y, "Issues breakdown")
+        Local brBroken% = 0
+        Local brEmpty% = 0
+        Local brOrphanZone% = 0
+        Local brMissingTex% = 0
+        Local brMissingMesh% = 0
+        Local brMissingSound% = 0
+        Local brBrokenScript% = 0
+        Local brOrphanScript% = 0
+        Local brOrphanTex% = 0
+        Local brOrphanMesh% = 0
+        Local brOrphanSound% = 0
+        Local brPlayability% = 0
+        Local brOther% = 0
+        Local br.BrokenRef
+        For br = Each BrokenRef
+            // Sequential Ifs because BlitzForge doesn't chain ElseIf
+            // after a single-line Then. Each compares one category.
+            Local matched% = False
+            If br\Category = "broken-ref"      Then brBroken        = brBroken + 1        : matched = True
+            If br\Category = "empty-field"     Then brEmpty         = brEmpty + 1         : matched = True
+            If br\Category = "orphan-zone"     Then brOrphanZone    = brOrphanZone + 1    : matched = True
+            If br\Category = "missing-texture" Then brMissingTex    = brMissingTex + 1    : matched = True
+            If br\Category = "missing-mesh"    Then brMissingMesh   = brMissingMesh + 1   : matched = True
+            If br\Category = "missing-sound"   Then brMissingSound  = brMissingSound + 1  : matched = True
+            If br\Category = "broken-script"   Then brBrokenScript  = brBrokenScript + 1  : matched = True
+            If br\Category = "orphan-script"   Then brOrphanScript  = brOrphanScript + 1  : matched = True
+            If br\Category = "orphan-texture"  Then brOrphanTex     = brOrphanTex + 1     : matched = True
+            If br\Category = "orphan-mesh"     Then brOrphanMesh    = brOrphanMesh + 1    : matched = True
+            If br\Category = "orphan-sound"    Then brOrphanSound   = brOrphanSound + 1   : matched = True
+            If br\Category = "playability"     Then brPlayability   = brPlayability + 1   : matched = True
+            If matched = False Then brOther = brOther + 1
+        Next
+        y = Composer::row(self, panelX, panelW, y, "Broken refs",     Str(brBroken))
+        y = Composer::row(self, panelX, panelW, y, "Empty fields",    Str(brEmpty))
+        y = Composer::row(self, panelX, panelW, y, "Broken scripts",  Str(brBrokenScript))
+        y = Composer::row(self, panelX, panelW, y, "Missing texture", Str(brMissingTex))
+        y = Composer::row(self, panelX, panelW, y, "Missing mesh",    Str(brMissingMesh))
+        y = Composer::row(self, panelX, panelW, y, "Missing sound",   Str(brMissingSound))
+        y = Composer::row(self, panelX, panelW, y, "Orphan zone",     Str(brOrphanZone))
+        y = Composer::row(self, panelX, panelW, y, "Orphan script",   Str(brOrphanScript))
+        y = Composer::row(self, panelX, panelW, y, "Orphan texture",  Str(brOrphanTex))
+        y = Composer::row(self, panelX, panelW, y, "Orphan mesh",     Str(brOrphanMesh))
+        y = Composer::row(self, panelX, panelW, y, "Orphan sound",    Str(brOrphanSound))
+        y = Composer::row(self, panelX, panelW, y, "Playability",     Str(brPlayability))
+
+        // Open Issues hint -- Ctrl+H shortcut to drill into details
+        If Composer::canPaintRow(self, y, CMP_ROW_H) = True
+            LoomText(panelX + CMP_PAD, y + 4, "Ctrl+H opens the Issues modal for per-entry detail.", LOOM_STONE_300_R, LOOM_STONE_300_G, LOOM_STONE_300_B)
         EndIf
         y = y + CMP_ROW_H
 

--- a/src/Modules/Loom/Threads.bb
+++ b/src/Modules/Loom/Threads.bb
@@ -241,6 +241,10 @@ Type Threads
             Return mu\Filename$ + " #" + Str(mu\ID)
         EndIf
 
+        If kind = "stats"
+            Return "Project Stats"
+        EndIf
+
         Return ""
     End Method
 


### PR DESCRIPTION
## Summary
New singleton **Stats** browser tab opens a read-only project-health dashboard. Open Loom, hit Stats, get an immediate read on scope + cleanup candidates without drilling tabs.

### What's new
- **Entities** section — counts per kind (Actor / Item / Spell / Zone / Faction / AnimSet)
- **Asset catalogs** — Scripts / Textures / Meshes / Sounds / Music sizes from the catalog *_Init globals
- **Top zones by spawn density** — insertion-sorted top 5 with spawn counts
- **Issues breakdown** — tally of every BrokenRef category from the last Issues rebuild (broken-ref / empty-field / broken-script / missing-{tex,mesh,sound} / orphan-{zone,script,tex,mesh,sound} / playability)

Cross-promotes Ctrl+H Issues modal in the footer for per-entry drill-down.

### Test plan
- [x] Source-clean compile
- [x] Full engine build
- [x] 32/32 tests pass
- [ ] CI green

### Strict-mode gotcha logged
Single-line \`Then\` ends the If, so \`Else If\` can't chain. Worked around with sequential Ifs + a \`matched\` boolean for the \"Other\" bucket.

Iter 74.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>