### PR TITLE
Loom hotfix: viewport interactions + actor preview placement

### DIFF
--- a/src/Modules/Loom/Atlas.bb
+++ b/src/Modules/Loom/Atlas.bb
@@ -180,6 +180,10 @@ Type Atlas
                 self\viewZoom# = self\viewZoom# * (1.0 + Float(wheel) * 0.1)
                 If self\viewZoom# < 0.25 Then self\viewZoom# = 0.25
                 If self\viewZoom# > 4.0  Then self\viewZoom# = 4.0
+                // Atlas is browser-pane so doesn't conflict with the
+                // composer scroll, but consuming anyway keeps the
+                // facade contract consistent.
+                Loom_ConsumeWheel()
             EndIf
 
             // MMB pan -- edge-detect: MouseDown(3) press initiates,

--- a/src/Modules/Loom/Composer.bb
+++ b/src/Modules/Loom/Composer.bb
@@ -310,7 +310,12 @@ Type Composer
         // each tick is CMP_SCROLL_STEP pixels. Inverted: wheel-down is
         // positive Z, which should scroll the content UP (offset
         // increases, later rows come into view).
-        Local wheelTicks% = MouseZ()
+        // Use the per-frame cached wheel. Direct MouseZ() returns 0 here
+        // because Loom_BeginFrame drained it at frame start; viewports
+        // (MeshPreview / ZoneViewport / Atlas) Loom_ConsumeWheel() when
+        // the cursor is inside their rect so this scroll handler sees
+        // 0 and the wheel feels like "owned by whatever's under cursor."
+        Local wheelTicks% = Loom_MouseWheel()
         If wheelTicks <> 0
             self\scrollOffset = self\scrollOffset - wheelTicks * CMP_SCROLL_STEP
             If self\scrollOffset < 0 Then self\scrollOffset = 0
@@ -1946,7 +1951,12 @@ Type Composer
         If self\bulkEditField <> "" Then Composer::pumpBulkKeyboard(self)
 
         // Mouse wheel scroll -- same shape as focused-entity composer.
-        Local wheelTicks% = MouseZ()
+        // Use the per-frame cached wheel. Direct MouseZ() returns 0 here
+        // because Loom_BeginFrame drained it at frame start; viewports
+        // (MeshPreview / ZoneViewport / Atlas) Loom_ConsumeWheel() when
+        // the cursor is inside their rect so this scroll handler sees
+        // 0 and the wheel feels like "owned by whatever's under cursor."
+        Local wheelTicks% = Loom_MouseWheel()
         If wheelTicks <> 0
             self\scrollOffset = self\scrollOffset - wheelTicks * CMP_SCROLL_STEP
             If self\scrollOffset < 0 Then self\scrollOffset = 0
@@ -2773,6 +2783,23 @@ Type Composer
         If A = Null Then Return
 
         Local y% = bodyY
+
+        // 3D mesh preview pinned to the TOP of the composer body so
+        // it's the FIRST thing the designer sees and the LMB-drag /
+        // wheel-zoom hit-rect doesn't overlap any int input cell.
+        // Centered horizontally; field rows flow below.
+        Local actorPreviewX% = panelX + (panelW - LOOM_PREVIEW_SIZE) / 2
+        Local actorPreviewY% = y
+        // Publish actor ID so MeshPreview drapes body texture on the
+        // mesh. Cleared after the draw call to avoid bleeding into
+        // other previews.
+        PreviewActorID = A\ID
+        If Composer::canPaintRow(self, y, LOOM_PREVIEW_SIZE) = True
+            Loom_DrawMeshPreview(A\MeshIDs[0], actorPreviewX, actorPreviewY, LOOM_PREVIEW_SIZE)
+        EndIf
+        PreviewActorID = 0
+        y = y + LOOM_PREVIEW_SIZE + 8
+
         y = Composer::row(self, panelX, panelW, y, "ID",            Str(A\ID))
         y = Composer::editableRow(self, panelX, panelW, y,    "Race",          "actor", A\ID, "race",          A\Race$,        mx, my, clicked)
         y = Composer::editableRow(self, panelX, panelW, y,    "Class",         "actor", A\ID, "class",         A\Class$,       mx, my, clicked)
@@ -2826,23 +2853,10 @@ Type Composer
         // rows since mesh preview requires a 3D viewport (ADR 004).
         y = Composer::sectionHeader(self, panelX, panelW, y, "Body meshes")
 
-        // 3D mesh preview widget -- LOOM_PREVIEW_SIZE square, anchored to
-        // the panel's right side. Renders A\MeshIDs[0] (male base) with
-        // an auto-spinning camera. The editable int rows for the 8 mesh
-        // slots flow down the LEFT side of the panel underneath; the
-        // preview overlaps with them visually but the int inputs are
-        // shorter so the preview sits cleanly to the right.
-        Local previewX% = panelX + panelW - LOOM_PREVIEW_SIZE - CMP_PAD
-        Local previewY% = y
-        // Publish actor ID so MeshPreview can drape body/face textures
-        // on the mesh during load (instead of showing bare gray).
-        // Set BEFORE the draw call; cleared after to avoid bleeding
-        // into the item preview's bare-mesh expectation.
-        PreviewActorID = A\ID
-        If Composer::canPaintRow(self, y, LOOM_PREVIEW_SIZE) = True
-            Loom_DrawMeshPreview(A\MeshIDs[0], previewX, previewY, LOOM_PREVIEW_SIZE)
-        EndIf
-        PreviewActorID = 0
+        // 3D mesh preview now lives at the TOP of renderActor's body
+        // (above ID/Race/Class etc.) so it's always visible without
+        // scrolling and its hit-rect can't shadow any int input cell
+        // here. See the actorPreview* block at the top of renderActor.
 
         y = Composer::assetIntRow(self, panelX, panelW, y, "Male base",     "actor", A\ID, "mesh_0", A\MeshIDs[0], "mesh", mx, my, clicked, rightClicked)
         y = Composer::assetIntRow(self, panelX, panelW, y, "Female base",   "actor", A\ID, "mesh_1", A\MeshIDs[1], "mesh", mx, my, clicked, rightClicked)

--- a/src/Modules/Loom/ImageCache.bb
+++ b/src/Modules/Loom/ImageCache.bb
@@ -109,6 +109,15 @@ Function Loom_MouseWheel%()
     Return LoomFrameMouseWheel
 End Function
 
+; Loom_ConsumeWheel -- zero the per-frame wheel cache so later
+; surfaces in the same frame see 0. Used by viewports (MeshPreview,
+; ZoneViewport, Atlas) when the cursor is inside their rect and
+; they're handling the wheel for zoom -- prevents the composer's
+; scroll handler from ALSO consuming the same tick.
+Function Loom_ConsumeWheel()
+    LoomFrameMouseWheel = 0
+End Function
+
 
 ; =============================================================================
 ; Chrome immersion toggle (Tool / Balanced / In-world). Three-mode slider

--- a/src/Modules/Loom/MeshPreview.bb
+++ b/src/Modules/Loom/MeshPreview.bb
@@ -55,6 +55,12 @@ Global PreviewInitOK     = False      ; True once the camera + RT exist
 Global PreviewSpinTime#  = 0.0
 Global PreviewLastTickMs = 0          ; for delta calc
 Global PreviewMeshScale# = 1.0        ; auto-fit scale for current mesh
+Global PreviewLookTarget = 0          ; hidden pivot at character CENTER;
+                                      ; camera PointEntity-s this so the
+                                      ; view frames the body's middle, not
+                                      ; the mesh origin (which is at feet
+                                      ; for character meshes -> looking at
+                                      ; the floor is the wrong default).
 
 ; PreviewActorID lives in ImageCache.bb (included BEFORE Composer)
 ; so the Strict Composer module can write it without the dim-write-
@@ -103,6 +109,14 @@ Function Loom_InitMeshPreview()
     PositionEntity PreviewLight, LOOM_PREVIEW_CAM_X#, LOOM_PREVIEW_CAM_Y# + 20.0, LOOM_PREVIEW_CAM_Z# - 10.0
     RotateEntity   PreviewLight, 45, -30, 0
     LightColor     PreviewLight, 255, 255, 230
+
+    ; Hidden pivot the camera points at. Position set per-mesh in
+    ; Loom_LoadPreviewMesh to mesh.origin + meshHeight/2 so the view
+    ; frames the body's middle, not the feet. Until then, parked at
+    ; the camera-region origin.
+    PreviewLookTarget = CreatePivot()
+    PositionEntity PreviewLookTarget, LOOM_PREVIEW_CAM_X#, LOOM_PREVIEW_CAM_Y#, LOOM_PREVIEW_CAM_Z#
+    HideEntity PreviewLookTarget
 
     PreviewInitOK = True
     PreviewLastTickMs = MilliSecs()
@@ -165,10 +179,20 @@ Function Loom_LoadPreviewMesh(meshID)
 
     PreviewMesh = ent
     PreviewMeshID = meshID
+
+    ; Reposition the look-target pivot at the character's vertical
+    ; midline. MeshHeight returns the unscaled bbox extent in mesh
+    ; units; for typical RC actor meshes this is roughly the height
+    ; in world units after scale, so half is the centre. Cameras then
+    ; PointEntity this pivot and frame the body not the feet.
+    Local mh# = MeshHeight#(ent)
+    If mh# <= 0.0 Then mh# = 10.0   ; sane default if mesh has no bbox
+    PositionEntity PreviewLookTarget, LOOM_PREVIEW_CAM_X#, LOOM_PREVIEW_CAM_Y# + mh# / 2.0, LOOM_PREVIEW_CAM_Z#
+
     ; New mesh = fresh view. Reset orbit + zoom so the user doesn't
     ; jump into a previous mesh's last camera angle.
     Loom_ResetPreviewOrbit()
-    WriteLog(LoomLog, "MeshPreview: loaded mesh ID " + meshID)
+    WriteLog(LoomLog, "MeshPreview: loaded mesh ID " + meshID + " (height " + mh# + ")")
     Return True
 End Function
 
@@ -306,8 +330,11 @@ Function Loom_DrawMeshPreview(meshID, x, y, size)
             If PreviewCamDistance# > 500.0 Then PreviewCamDistance# = 500.0
             ; Reposition the camera at the new distance from the mesh
             PositionEntity PreviewCam, LOOM_PREVIEW_CAM_X#, LOOM_PREVIEW_CAM_Y# + 5.0, LOOM_PREVIEW_CAM_Z# - PreviewCamDistance#
-            PointEntity PreviewCam, PreviewMesh
+            PointEntity PreviewCam, PreviewLookTarget
             PreviewManualActive = True
+            ; Consume the wheel so the composer's scroll handler doesn't
+            ; ALSO see the same tick and scroll the body while we zoom.
+            Loom_ConsumeWheel()
         EndIf
     EndIf
 
@@ -361,7 +388,7 @@ Function Loom_ResetPreviewOrbit()
     PreviewCamDistance# = LOOM_PREVIEW_CAM_RANGE#
     If PreviewCam <> 0
         PositionEntity PreviewCam, LOOM_PREVIEW_CAM_X#, LOOM_PREVIEW_CAM_Y# + 5.0, LOOM_PREVIEW_CAM_Z# - PreviewCamDistance#
-        If PreviewMesh <> 0 Then PointEntity PreviewCam, PreviewMesh
+        If PreviewMesh <> 0 Then PointEntity PreviewCam, PreviewLookTarget
     EndIf
 End Function
 

--- a/src/Modules/Loom/ZoneViewport.bb
+++ b/src/Modules/Loom/ZoneViewport.bb
@@ -1035,6 +1035,8 @@ Function Loom_DrawZoneViewport(zoneHandle, x, y)
             If VPDistance# < 20.0 Then VPDistance# = 20.0
             If VPDistance# > 5000.0 Then VPDistance# = 5000.0
             VPDirty = True
+            ; Consume so composer scroll doesn't also fire.
+            Loom_ConsumeWheel()
         EndIf
     EndIf
 


### PR DESCRIPTION
## Summary
User-reported alpha bugs:

1. **Actor 3D preview hidden** in the Body Meshes section deep in the composer scroll; clicking it begins editing the underlying int rows instead of orbiting
2. **Actor camera looks at feet** (mesh origin) instead of body — preview shows legs not head
3. **Zone viewport can't accept wheel** — composer scroll handler drained MouseZ before viewport saw it

### Fixes
- **Placement**: actor mesh preview moved to TOP of renderActor body. Always visible without scrolling; hit-rect no longer overlaps any int input cell
- **Camera look-target**: new \`PreviewLookTarget\` pivot positioned at \`mesh.origin + MeshHeight/2\` per-load. View frames the body, not the feet. Adapts per-mesh
- **Wheel cache**: new \`Loom_ConsumeWheel()\` facade (mirrors \`Loom_ConsumeClick\`); MeshPreview / ZoneViewport / Atlas consume when wheel fires inside their rect. Composer scroll handler switched from \`MouseZ()\` to \`Loom_MouseWheel()\` so it sees the cached value but gets 0 when a viewport consumed it. Wheel feels owned by whatever's under the cursor.

### Test plan
- [x] Source-clean compile
- [x] Full engine build
- [x] 32/32 tests pass
- [ ] CI green
- [ ] Manual: open actor composer, preview should be at top, wheel zoom works, drag orbits
- [ ] Manual: zone composer, wheel zooms viewport, composer body still scrolls when cursor is over field rows

Hotfix following user screenshot feedback.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>