### PR TITLE
Loom: zone viewport ground grid + compass (iter 78)

### DIFF
--- a/src/Modules/Loom/ZoneViewport.bb
+++ b/src/Modules/Loom/ZoneViewport.bb
@@ -1135,6 +1135,55 @@ Function Loom_DrawZoneViewport(zoneHandle, x, y)
         ShowEntity VPCam
         SetBuffer TextureBuffer(VPRT)
         RenderWorld
+
+        ; ---- Ground grid overlay -----------------------------------------------
+        ; Paint axis-aligned grid lines on top of the rendered scene to
+        ; convey scale. CameraProject converts world (x, scene_y, z) to
+        ; RT-local screen coords; we draw 2D Lines between projected
+        ; endpoints. Lines outside the RT clip naturally because the
+        ; buffer is bounded.
+        ;
+        ; Step 250 world units = 16 lines across the 4000-unit ground
+        ; we render -- dense enough to read but not noisy.
+        Color 70, 70, 80      ; muted stone-grey for grid
+        Local gridSpan# = 2000.0
+        Local gridStep# = 250.0
+        Local g# = -gridSpan#
+        While g# <= gridSpan#
+            ; X-direction line: constant z = g, x varies -gridSpan..+gridSpan
+            CameraProject VPCam, -gridSpan#, VP_SCENE_Y_OFFSET#, g#
+            Local ax = ProjectedX()
+            Local ay = ProjectedY()
+            CameraProject VPCam,  gridSpan#, VP_SCENE_Y_OFFSET#, g#
+            Local bx = ProjectedX()
+            Local by = ProjectedY()
+            Line ax, ay, bx, by
+            ; Z-direction line: constant x = g, z varies
+            CameraProject VPCam, g#, VP_SCENE_Y_OFFSET#, -gridSpan#
+            Local cx2 = ProjectedX()
+            Local cy2 = ProjectedY()
+            CameraProject VPCam, g#, VP_SCENE_Y_OFFSET#,  gridSpan#
+            Local dx2 = ProjectedX()
+            Local dy2 = ProjectedY()
+            Line cx2, cy2, dx2, dy2
+            g# = g# + gridStep#
+        Wend
+
+        ; Compass labels at +N (north) +S +E +W positions on the ground.
+        ; In Loom's coord convention +Z is "north" (mirrors how the GUE
+        ; in-game camera + minimap orient). Letters projected through
+        ; the same camera so they tilt with view -- gives an intuitive
+        ; "you are facing N" cue when orbit changes.
+        Color 200, 200, 110   ; brass-light for compass letters
+        CameraProject VPCam, 0,             VP_SCENE_Y_OFFSET#,  gridSpan#
+        Text ProjectedX(), ProjectedY(), "N", True, True
+        CameraProject VPCam, 0,             VP_SCENE_Y_OFFSET#, -gridSpan#
+        Text ProjectedX(), ProjectedY(), "S", True, True
+        CameraProject VPCam,  gridSpan#,    VP_SCENE_Y_OFFSET#, 0
+        Text ProjectedX(), ProjectedY(), "E", True, True
+        CameraProject VPCam, -gridSpan#,    VP_SCENE_Y_OFFSET#, 0
+        Text ProjectedX(), ProjectedY(), "W", True, True
+
         SetBuffer BackBuffer()
         HideEntity VPCam
 


### PR DESCRIPTION
## Summary
Follow-up polish to the viewport hotfix. User feedback: the schematic felt abstract with markers floating in an empty void. Now there's a visible reference grid + compass.

### What's new
- **Ground grid** — 250-unit axis-aligned lines, -2000..+2000, muted stone-grey. 16 lines per axis. Gives instant sense of scale (most portals/spawns are 50-500 units apart, so the grid places a tick between most marker pairs)
- **Compass letters** (N/S/E/W) painted at ±2000 on each axis. Projected through the camera so they tilt with view — orbit and you can still tell which way is north

Both overlays painted via \`CameraProject\` + 2D \`Line\`/\`Text\` between \`RenderWorld\` and \`SetBuffer BackBuffer\` so they cache with the rest of the dirty-flag-gated RT.

### Test plan
- [x] Source-clean compile
- [x] Full engine build
- [x] 32/32 tests pass (1 known pool-walker flake on retry — clean second run)
- [ ] CI green

Iter 78.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>