### PR TITLE
Loom: scroll runaway fix + remove composer 3D viewports + scrollable cards + issues-modal overlap

### DIFF
--- a/src/Modules/Loom/BrokenRefs.bb
+++ b/src/Modules/Loom/BrokenRefs.bb
@@ -746,15 +746,32 @@ Type BrokenRefs
         // emitted. Click cycles between filter-this-category and
         // filter-clear (All). The header text always reflects the
         // active filter so designers see the scope at a glance.
+        // drawCategoryChips returns the bottom Y of the (possibly
+        // multi-row) chip strip; the list starts below it.
         Local chipsY% = modalY + BROKENREFS_HEADER_H - 4
-        BrokenRefs::drawCategoryChips(self, modalX + BROKENREFS_PAD, chipsY, mx, my, clicked)
+        Local chipsBottom% = BrokenRefs::drawCategoryChips(self, modalX + BROKENREFS_PAD, chipsY, mx, my, clicked)
 
-        BrokenRefs::drawEntries(self, modalX, modalY + BROKENREFS_HEADER_H + 22, mx, my, clicked)
-
-        // Footer hint
+        // Footer position -- the list must stop above it.
         Local hy% = modalY + BROKENREFS_MODAL_H - BROKENREFS_HINT_H - 4
+
+        // Entries list flows from below the chips to just above the footer.
+        Local listY% = chipsBottom + 10
+        Local listH% = (hy - 8) - listY
+        If listH < BROKENREFS_ROW_H Then listH = BROKENREFS_ROW_H
+
+        // Mouse-wheel scroll (row-indexed scrollOffset, same as arrow keys).
+        Local wheel% = Loom_MouseWheel()
+        If wheel <> 0
+            self\scrollOffset = self\scrollOffset - wheel
+            If self\scrollOffset < 0 Then self\scrollOffset = 0
+            If self\scrollOffset >= self\entryCount Then self\scrollOffset = self\entryCount - 1
+            If self\scrollOffset < 0 Then self\scrollOffset = 0
+            Loom_ConsumeWheel()
+        EndIf
+
+        BrokenRefs::drawEntries(self, modalX, listY, listH, mx, my, clicked)
         LoomHRule(modalX + BROKENREFS_PAD, hy - 2, BROKENREFS_MODAL_W - BROKENREFS_PAD * 2, LOOM_BRASS_700_R, LOOM_BRASS_700_G, LOOM_BRASS_700_B)
-        LoomText(modalX + BROKENREFS_PAD, hy + 4, "Click a row to jump to the source  |  arrows scroll  |  Esc to close", LOOM_STONE_300_R, LOOM_STONE_300_G, LOOM_STONE_300_B)
+        LoomText(modalX + BROKENREFS_PAD, hy + 4, "Click a row to jump to the source  |  wheel / arrows scroll  |  Esc to close", LOOM_STONE_300_R, LOOM_STONE_300_G, LOOM_STONE_300_B)
 
         If clicked = True
             If mx < modalX Or mx >= modalX + BROKENREFS_MODAL_W Or my < modalY Or my >= modalY + BROKENREFS_MODAL_H
@@ -766,12 +783,12 @@ Type BrokenRefs
     End Method
 
 
-    Method drawEntries(modalX%, listY%, mx%, my%, clicked%)
-        // Shrink visible-list height by the chip-row strip added in
-        // renderAndUpdate so the list doesn't paint past the bottom
-        // hint area.
-        Local listH% = BROKENREFS_MODAL_H - BROKENREFS_HEADER_H - BROKENREFS_HINT_H - 34
+    Method drawEntries(modalX%, listY%, listH%, mx%, my%, clicked%)
+        // listH is computed by the caller from the actual chip-strip
+        // bottom so the list never overlaps the (possibly multi-row)
+        // chips above or the footer below.
         Local rowsVisible% = listH / BROKENREFS_ROW_H
+        If rowsVisible < 1 Then rowsVisible = 1
         Local rx% = modalX + BROKENREFS_PAD
         Local rw% = BROKENREFS_MODAL_W - BROKENREFS_PAD * 2
 
@@ -816,7 +833,7 @@ Type BrokenRefs
     // issue type) are still rendered as "(0)" stone-grey so the chip
     // bar layout stays stable across sessions.
     // -------------------------------------------------------------------------
-    Method drawCategoryChips(chipsX%, chipsY%, mx%, my%, clicked%)
+    Method drawCategoryChips%(chipsX%, chipsY%, mx%, my%, clicked%)
         Local cats$[13]
         cats[0]  = "broken-ref"
         cats[1]  = "broken-script"
@@ -898,6 +915,11 @@ Type BrokenRefs
             EndIf
             cx = cx + chipW + 4
         Next
+
+        // Bottom Y of the chip strip (last row baseline + height). The
+        // caller starts the entries list below this so wrapped chip rows
+        // never overlap the list -- the original overlap bug.
+        Return cy + ch
     End Method
 
 

--- a/src/Modules/Loom/Browser.bb
+++ b/src/Modules/Loom/Browser.bb
@@ -30,6 +30,9 @@ Const BR_BRAND_STRIP_H = 56
 Const BR_TOP_RIBBON    = LOOM_TOP_RIBBON_H + BR_BRAND_STRIP_H    // 28 + 56 = 84
 Const BR_TAB_BAR_H     = 36
 Const BR_FILTER_BAR_H  = 30
+// Y where the filter bar starts (just below the tab bar). cardVisible
+// and the card-grid scroll math derive the grid's top clip from this.
+Const BR_FILTER_BAR_Y  = BR_TOP_RIBBON + BR_TAB_BAR_H
 Const BR_BOT_RIBBON    = 36
 Const BR_SECTION_PAD   = 28
 Const BR_CARD_W        = 300
@@ -134,6 +137,18 @@ Type Browser
     // selectedIndex card, dispatching Threads::focus then clearing.
     Field pendingEnter%
 
+    // Vertical scroll for the card grid (pixels). Without it, a category
+    // with more rows than fit on screen silently clipped the overflow
+    // with no way to reach it. Driven by the mouse wheel (gated to the
+    // cursor being over the grid). cardScrollMax / lastGridRows are
+    // measured from the prior frame's card count so the clamp is correct.
+    // lastScrollCat / lastScrollFilter reset the scroll to the top when
+    // the visible set changes (category switch or filter edit).
+    Field cardScroll%
+    Field lastGridRows%
+    Field lastScrollCat$
+    Field lastScrollFilter$
+
 
     Method create.Browser(threads.Threads)
         self\threads = threads
@@ -147,6 +162,10 @@ Type Browser
         self\lastCount = 0
         self\pendingEnter = False
         self\selectionCount = 0
+        self\cardScroll = 0
+        self\lastGridRows = 0
+        self\lastScrollCat = ""
+        self\lastScrollFilter = ""
 
         // Build the ordered category list. Iterated via `Each BrowserCategory`
         // in insertion order (Blitz3D's global type pool is FIFO) -- also the
@@ -671,11 +690,52 @@ Type Browser
 
         Local cat$ = self\category
 
+        // The Zones tab in Atlas mode swaps the card grid for the spatial
+        // portal-graph view, which owns its own wheel (zoom) and origin.
+        // Card-grid scroll must NOT run in that mode.
+        Local atlasActive% = (cat = "zone" And self\atlasMode = True And self\atlas <> Null)
+
+        // ---- Card-grid vertical scroll -------------------------------------
+        // Reset to the top whenever the visible set changes (category switch
+        // or filter edit) so a fresh list never opens mid-scroll.
+        If self\category <> self\lastScrollCat Or self\filterQuery <> self\lastScrollFilter
+            self\cardScroll = 0
+        EndIf
+        self\lastScrollCat = self\category
+        self\lastScrollFilter = self\filterQuery
+
+        // Wheel scroll, gated to the cursor being over the grid. `sw` here
+        // is already reduced by the composer width (drawCardGrid is called
+        // with sw - composerWidth), so `mx < sw` means "left of the composer
+        // panel" and the composer owns the wheel when the cursor is on it.
+        // Loom_MouseWheel() is a true per-frame delta after the BeginFrame
+        // MouseZ fix; Loom_ConsumeWheel() stops any later surface re-applying.
+        Local rowPitch% = BR_CARD_H + BR_CARD_GAP
+        Local gridViewTop% = BR_FILTER_BAR_Y + BR_FILTER_BAR_H + 2
+        Local gridViewBottom% = sh - BR_BOT_RIBBON
+        Local wheel% = Loom_MouseWheel()
+        If wheel <> 0 And atlasActive = False And mx < sw And my >= gridViewTop And my < gridViewBottom
+            self\cardScroll = self\cardScroll - wheel * rowPitch
+            If self\cardScroll < 0 Then self\cardScroll = 0
+            Local contentH% = self\lastGridRows * rowPitch
+            Local viewH% = gridViewBottom - gridViewTop
+            Local maxScroll% = contentH - viewH
+            If maxScroll < 0 Then maxScroll = 0
+            If self\cardScroll > maxScroll Then self\cardScroll = maxScroll
+            Loom_ConsumeWheel()
+        EndIf
+
+        // Apply the scroll offset to the grid origin so rows shift up as
+        // the user scrolls down. cardVisible() clips rows that move above
+        // the grid top or below the bottom ribbon. (Not in atlas mode --
+        // the atlas places its own viewport at the unscrolled gridY.)
+        If atlasActive = False Then gridY = gridY - self\cardScroll
+
         // Zone tab + atlasMode = swap the card grid for the spatial atlas.
         // Atlas owns its own paint + hit-test inside the viewport rect.
         // (Filter applies to the card view only -- the atlas always shows
         //  every zone since spatial context is what it's for.)
-        If cat = "zone" And self\atlasMode = True And self\atlas <> Null
+        If atlasActive = True
             Local viewportH% = sh - gridY - BR_BOT_RIBBON - BR_SECTION_PAD
             Local hit% = Atlas::renderAndUpdate(self\atlas, gridX, gridY, gridW, viewportH)
             If hit = True Then self\cardClickLatch = True
@@ -731,6 +791,10 @@ Type Browser
         // Cache for next frame's pumpNavKeyboard.
         self\lastCount = count
 
+        // Rows laid out this frame -> next frame's scroll clamp. ceil(count/cols).
+        If cols < 1 Then cols = 1
+        self\lastGridRows = (count + cols - 1) / cols
+
         // Pending Enter is consumed by drawCardChrome when the iteration
         // reaches selectedIndex; if it didn't (e.g. selectedIndex past the
         // visible/filtered subset), clear it anyway so it doesn't fire
@@ -759,6 +823,21 @@ Type Browser
     // cards rendered (for the dispatcher's empty-state check).
     // -------------------------------------------------------------------------
 
+    // -------------------------------------------------------------------------
+    // cardVisible -- shared clip test for the scrollable card grid. A card
+    // at screen-y `cy` is visible iff it overlaps the band between the
+    // filter bar (top) and the bottom status ribbon. Replaces the old
+    // bottom-only clip so cards scrolled above the grid don't paint over
+    // the tab/filter chrome.
+    // -------------------------------------------------------------------------
+    Method cardVisible%(cy%, sh%)
+        Local gridTop% = BR_FILTER_BAR_Y + BR_FILTER_BAR_H + 2
+        If cy + BR_CARD_H <= gridTop Then Return False
+        If cy >= sh - BR_BOT_RIBBON Then Return False
+        Return True
+    End Method
+
+
     Method drawActorGrid%(sw%, sh%, mx%, my%, clicked%, gridX%, gridY%, cols%)
         Local col% = 0
         Local row% = 0
@@ -768,7 +847,7 @@ Type Browser
             If Browser::matchesFilter(self, aName) = True
                 Local cx% = gridX + col * (BR_CARD_W + BR_CARD_GAP)
                 Local cy% = gridY + row * (BR_CARD_H + BR_CARD_GAP)
-                If cy + BR_CARD_H < sh - BR_BOT_RIBBON
+                If Browser::cardVisible(self, cy, sh) = True
                     Browser::drawCardChrome(self, "actor", Ac\ID, cx, cy, mx, my, clicked, count)
                     Browser::drawActorCardBody(self, Ac, cx, cy)
                 EndIf
@@ -789,7 +868,7 @@ Type Browser
             If Browser::matchesFilter(self, It\Name$) = True
                 Local cx% = gridX + col * (BR_CARD_W + BR_CARD_GAP)
                 Local cy% = gridY + row * (BR_CARD_H + BR_CARD_GAP)
-                If cy + BR_CARD_H < sh - BR_BOT_RIBBON
+                If Browser::cardVisible(self, cy, sh) = True
                     Browser::drawCardChrome(self, "item", It\ID, cx, cy, mx, my, clicked, count)
                     Browser::drawItemCardBody(self, It, cx, cy)
                 EndIf
@@ -810,7 +889,7 @@ Type Browser
             If Browser::matchesFilter(self, Sp\Name$) = True
                 Local cx% = gridX + col * (BR_CARD_W + BR_CARD_GAP)
                 Local cy% = gridY + row * (BR_CARD_H + BR_CARD_GAP)
-                If cy + BR_CARD_H < sh - BR_BOT_RIBBON
+                If Browser::cardVisible(self, cy, sh) = True
                     Browser::drawCardChrome(self, "spell", Sp\ID, cx, cy, mx, my, clicked, count)
                     Browser::drawSpellCardBody(self, Sp, cx, cy)
                 EndIf
@@ -831,7 +910,7 @@ Type Browser
             If Browser::matchesFilter(self, Ar\Name$) = True
                 Local cx% = gridX + col * (BR_CARD_W + BR_CARD_GAP)
                 Local cy% = gridY + row * (BR_CARD_H + BR_CARD_GAP)
-                If cy + BR_CARD_H < sh - BR_BOT_RIBBON
+                If Browser::cardVisible(self, cy, sh) = True
                     Browser::drawCardChrome(self, "zone", Handle(Ar), cx, cy, mx, my, clicked, count)
                     Browser::drawZoneCardBody(self, Ar, cx, cy)
                 EndIf
@@ -854,7 +933,7 @@ Type Browser
                 If Browser::matchesFilter(self, FactionNames$(i)) = True
                     Local cx% = gridX + col * (BR_CARD_W + BR_CARD_GAP)
                     Local cy% = gridY + row * (BR_CARD_H + BR_CARD_GAP)
-                    If cy + BR_CARD_H < sh - BR_BOT_RIBBON
+                    If Browser::cardVisible(self, cy, sh) = True
                         Browser::drawCardChrome(self, "faction", i, cx, cy, mx, my, clicked, count)
                         Browser::drawFactionCardBody(self, i, cx, cy)
                     EndIf
@@ -876,7 +955,7 @@ Type Browser
             If Browser::matchesFilter(self, As\Name$) = True
                 Local cx% = gridX + col * (BR_CARD_W + BR_CARD_GAP)
                 Local cy% = gridY + row * (BR_CARD_H + BR_CARD_GAP)
-                If cy + BR_CARD_H < sh - BR_BOT_RIBBON
+                If Browser::cardVisible(self, cy, sh) = True
                     Browser::drawCardChrome(self, "animset", As\ID, cx, cy, mx, my, clicked, count)
                     Browser::drawAnimSetCardBody(self, As, cx, cy)
                 EndIf
@@ -981,7 +1060,7 @@ Type Browser
             If Browser::matchesFilter(self, t\Name$) = True
                 Local cx% = gridX + col * (BR_CARD_W + BR_CARD_GAP)
                 Local cy% = gridY + row * (BR_CARD_H + BR_CARD_GAP)
-                If cy + BR_CARD_H < sh - BR_BOT_RIBBON
+                If Browser::cardVisible(self, cy, sh) = True
                     Browser::drawToolCard(self, t, cx, cy, mx, my, clicked, count)
                 EndIf
                 count = count + 1
@@ -1074,7 +1153,7 @@ Type Browser
             If Browser::matchesFilter(self, sf\Name$) = True
                 Local cx% = gridX + col * (BR_CARD_W + BR_CARD_GAP)
                 Local cy% = gridY + row * (BR_CARD_H + BR_CARD_GAP)
-                If cy + BR_CARD_H < sh - BR_BOT_RIBBON
+                If Browser::cardVisible(self, cy, sh) = True
                     Browser::drawScriptCard(self, sf, cx, cy, mx, my, clicked, count)
                 EndIf
                 count = count + 1
@@ -1145,7 +1224,7 @@ Type Browser
             If Browser::matchesFilter(self, te\Filename$) = True
                 Local cx% = gridX + col * (BR_CARD_W + BR_CARD_GAP)
                 Local cy% = gridY + row * (BR_CARD_H + BR_CARD_GAP)
-                If cy + BR_CARD_H < sh - BR_BOT_RIBBON
+                If Browser::cardVisible(self, cy, sh) = True
                     Browser::drawTextureCard(self, te, cx, cy, mx, my, clicked, count)
                 EndIf
                 count = count + 1
@@ -1222,7 +1301,7 @@ Type Browser
             If Browser::matchesFilter(self, me\Filename$) = True
                 Local cx% = gridX + col * (BR_CARD_W + BR_CARD_GAP)
                 Local cy% = gridY + row * (BR_CARD_H + BR_CARD_GAP)
-                If cy + BR_CARD_H < sh - BR_BOT_RIBBON
+                If Browser::cardVisible(self, cy, sh) = True
                     Browser::drawMeshCard(self, me, cx, cy, mx, my, clicked, count)
                 EndIf
                 count = count + 1
@@ -1291,7 +1370,7 @@ Type Browser
             If Browser::matchesFilter(self, se\Filename$) = True
                 Local cx% = gridX + col * (BR_CARD_W + BR_CARD_GAP)
                 Local cy% = gridY + row * (BR_CARD_H + BR_CARD_GAP)
-                If cy + BR_CARD_H < sh - BR_BOT_RIBBON
+                If Browser::cardVisible(self, cy, sh) = True
                     Browser::drawSoundCard(self, se, cx, cy, mx, my, clicked, count)
                 EndIf
                 count = count + 1
@@ -1358,7 +1437,7 @@ Type Browser
             If Browser::matchesFilter(self, mu\Filename$) = True
                 Local cx% = gridX + col * (BR_CARD_W + BR_CARD_GAP)
                 Local cy% = gridY + row * (BR_CARD_H + BR_CARD_GAP)
-                If cy + BR_CARD_H < sh - BR_BOT_RIBBON
+                If Browser::cardVisible(self, cy, sh) = True
                     Browser::drawMusicCard(self, mu, cx, cy, mx, my, clicked, count)
                 EndIf
                 count = count + 1

--- a/src/Modules/Loom/Composer.bb
+++ b/src/Modules/Loom/Composer.bb
@@ -306,17 +306,17 @@ Type Composer
         // advance the active edit on Tab.
         self\rowFieldCount = 0
 
-        // Mouse wheel scroll. MouseZ() returns ticks since last poll;
-        // each tick is CMP_SCROLL_STEP pixels. Inverted: wheel-down is
-        // positive Z, which should scroll the content UP (offset
-        // increases, later rows come into view).
-        // Use the per-frame cached wheel. Direct MouseZ() returns 0 here
-        // because Loom_BeginFrame drained it at frame start; viewports
-        // (MeshPreview / ZoneViewport / Atlas) Loom_ConsumeWheel() when
-        // the cursor is inside their rect so this scroll handler sees
-        // 0 and the wheel feels like "owned by whatever's under cursor."
+        // Mouse wheel scroll. Loom_MouseWheel() is the per-frame wheel
+        // DELTA (Loom_BeginFrame derives it from MouseZ's cumulative
+        // value); each tick is CMP_SCROLL_STEP pixels. Inverted: wheel-up
+        // is positive, which scrolls content toward the top.
+        //
+        // Gated to the cursor being over THIS panel (mx >= panel left) so
+        // scrolling here doesn't also scroll the browser card grid behind
+        // the composer. Loom_ConsumeWheel() then zeroes the cached delta
+        // so no other surface this frame double-applies the same tick.
         Local wheelTicks% = Loom_MouseWheel()
-        If wheelTicks <> 0
+        If wheelTicks <> 0 And self\collapsed = False And MouseX() >= (sw - CMP_W)
             self\scrollOffset = self\scrollOffset - wheelTicks * CMP_SCROLL_STEP
             If self\scrollOffset < 0 Then self\scrollOffset = 0
             // Clamp to last-frame's measured content height -- if the
@@ -327,6 +327,7 @@ Type Composer
             Local maxScroll% = self\lastContentBottom - self\bodyBottom
             If maxScroll < 0 Then maxScroll = 0
             If self\scrollOffset > maxScroll Then self\scrollOffset = maxScroll
+            Loom_ConsumeWheel()
         EndIf
 
         // Drain keyboard into editBuffer if an edit is active. Consumes Esc
@@ -1950,19 +1951,18 @@ Type Composer
         // typed buffer is up-to-date when the Apply button reads it.
         If self\bulkEditField <> "" Then Composer::pumpBulkKeyboard(self)
 
-        // Mouse wheel scroll -- same shape as focused-entity composer.
-        // Use the per-frame cached wheel. Direct MouseZ() returns 0 here
-        // because Loom_BeginFrame drained it at frame start; viewports
-        // (MeshPreview / ZoneViewport / Atlas) Loom_ConsumeWheel() when
-        // the cursor is inside their rect so this scroll handler sees
-        // 0 and the wheel feels like "owned by whatever's under cursor."
+        // Mouse wheel scroll -- same shape (and same cursor-region gate +
+        // consume) as the focused-entity composer. Loom_MouseWheel() is a
+        // true per-frame delta; gate to the panel so the browser grid
+        // behind it doesn't scroll too.
         Local wheelTicks% = Loom_MouseWheel()
-        If wheelTicks <> 0
+        If wheelTicks <> 0 And MouseX() >= (sw - CMP_W)
             self\scrollOffset = self\scrollOffset - wheelTicks * CMP_SCROLL_STEP
             If self\scrollOffset < 0 Then self\scrollOffset = 0
             Local maxScroll% = self\lastContentBottom - self\bodyBottom
             If maxScroll < 0 Then maxScroll = 0
             If self\scrollOffset > maxScroll Then self\scrollOffset = maxScroll
+            Loom_ConsumeWheel()
         EndIf
 
         Local mx% = MouseX()
@@ -2784,21 +2784,12 @@ Type Composer
 
         Local y% = bodyY
 
-        // 3D mesh preview pinned to the TOP of the composer body so
-        // it's the FIRST thing the designer sees and the LMB-drag /
-        // wheel-zoom hit-rect doesn't overlap any int input cell.
-        // Centered horizontally; field rows flow below.
-        Local actorPreviewX% = panelX + (panelW - LOOM_PREVIEW_SIZE) / 2
-        Local actorPreviewY% = y
-        // Publish actor ID so MeshPreview drapes body texture on the
-        // mesh. Cleared after the draw call to avoid bleeding into
-        // other previews.
-        PreviewActorID = A\ID
-        If Composer::canPaintRow(self, y, LOOM_PREVIEW_SIZE) = True
-            Loom_DrawMeshPreview(A\MeshIDs[0], actorPreviewX, actorPreviewY, LOOM_PREVIEW_SIZE)
-        EndIf
-        PreviewActorID = 0
-        y = y + LOOM_PREVIEW_SIZE + 8
+        // No 3D mesh preview here. The embedded MeshPreview camera had no
+        // CameraViewport sub-rect, so its RenderWorld painted the mesh to
+        // the FULL backbuffer (the grey mesh bleeding across the whole
+        // window) and it consumed the wheel, fighting the body scroll.
+        // 3D inspection belongs in a dedicated surface, not the scrollable
+        // property panel -- see ADR 004. Mesh IDs render as plain rows.
 
         y = Composer::row(self, panelX, panelW, y, "ID",            Str(A\ID))
         y = Composer::editableRow(self, panelX, panelW, y,    "Race",          "actor", A\ID, "race",          A\Race$,        mx, my, clicked)
@@ -3100,18 +3091,11 @@ Type Composer
             Local thumbX% = panelX + panelW - 70 - CMP_PAD
             Loom_DrawThumbnailLarge(It\ThumbnailTexID, thumbX, thumbY)
         EndIf
-        y = y + 50   ; padding so the next row clears the 64px-tall preview
+        y = y + 50   ; padding so the next row clears the 64px-tall thumbnail
 
-        // 3D mesh preview of the male item mesh (sword model, etc.).
-        // Same widget shape as the actor composer; sits anchored to the
-        // right of the int rows. Skipped if MMeshID is 0 (placeholder
-        // paints in that case via Loom_DrawMeshPreview's own check).
-        Local itemPreviewX% = panelX + panelW - LOOM_PREVIEW_SIZE - CMP_PAD
-        Local itemPreviewY% = y
-        If Composer::canPaintRow(self, y, LOOM_PREVIEW_SIZE) = True
-            Loom_DrawMeshPreview(It\MMeshID, itemPreviewX, itemPreviewY, LOOM_PREVIEW_SIZE)
-        EndIf
-
+        // No embedded 3D mesh preview (removed: full-backbuffer bleed +
+        // wheel conflict with the body scroll -- see renderActor). The
+        // 2D thumbnail above stays; mesh IDs render as plain asset rows.
         y = Composer::assetIntRow(self, panelX, panelW, y, "Male mesh",      "item", It\ID, "m_mesh",     It\MMeshID,        "mesh",    mx, my, clicked, rightClicked)
         y = Composer::assetIntRow(self, panelX, panelW, y, "Female mesh",    "item", It\ID, "f_mesh",     It\FMeshID,        "mesh",    mx, my, clicked, rightClicked)
         y = Composer::assetIntRow(self, panelX, panelW, y, "Image (img-typ)","item", It\ID, "image_id",   It\ImageID,        "texture", mx, my, clicked, rightClicked)
@@ -3185,34 +3169,13 @@ Type Composer
         If Ar = Null Then Return
         Local h% = Handle(Ar)
 
-        // Reset the viewport-highlight publish slot for this frame.
-        // Per-sub-section renderers below set it when their header
-        // lands inside the body viewport; if nothing is visible,
-        // viewport renders without a highlighted marker.
-        LoomZoneHighlightKind$ = ""
-        LoomZoneHighlightIdx   = -1
-
         Local y% = bodyY
 
-        // 3D schematic viewport at the top of the composer body. Sized
-        // to fit inside the panel width (VP_RT_SIZE = 320 leaves
-        // CMP_PAD on each side of CMP_W = 380). Centered horizontally
-        // so the panel breathing room is symmetric.
-        //
-        // Field rows flow BELOW the viewport (y += viewport height +
-        // padding) -- earlier layout had them overlapping with the
-        // viewport's overlay text, producing the "jumbled" composer
-        // a user reported.
-        Local vpW = VP_RT_SIZE
-        Local zvX% = panelX + (panelW - vpW) / 2
-        Local zvY% = y
-        If Composer::canPaintRow(self, y, vpW) = True
-            Loom_DrawZoneViewport(h, zvX, zvY)
-        EndIf
-        // Push past the viewport (with a small gap) regardless of
-        // whether it painted -- the field-flow layout below assumes
-        // a fixed offset so all zones see the same vertical rhythm.
-        y = y + vpW + 8
+        // No embedded 3D zone viewport here. Like the actor/item mesh
+        // preview, the VPCam RenderWorld competed for the wheel with the
+        // body scroll and the spatial view belongs on its own surface
+        // (the Zones tab "Atlas" toggle already gives a 2D portal-graph
+        // view). The composer shows zone metadata + portal-target chips.
 
         y = Composer::editableRow(self,    panelX, panelW, y, "Name",     "zone", h, "name",     Ar\Name$,    mx, my, clicked)
         y = Composer::toggleRow(self,      panelX, panelW, y, "Outdoors", "zone", h, "outdoors", Ar\Outdoors, mx, my, clicked)
@@ -4110,21 +4073,9 @@ Type Composer
         y = Composer::row(self, panelX, panelW, y, "Animated",  Composer::boolLabel(self, mh\IsAnim))
         y = Composer::row(self, panelX, panelW, y, "Path",      "Data\Meshes\" + mh\Filename$)
 
-        // 3D preview -- reuse the orbit/zoom MeshPreview widget so
-        // designers can spin / inspect the mesh in 3D. Same widget
-        // backs the Actor + Item composer mesh previews; we just
-        // hand it the focused mesh's ID + a centered rect.
-        y = Composer::sectionHeader(self, panelX, panelW, y, "Preview")
-        Local previewX% = panelX + (panelW - LOOM_PREVIEW_SIZE) / 2
-        Local previewY% = y
-        // PreviewActorID = 0 ensures the mesh draws bare (no body
-        // texture overlay) -- we don't know which actor would
-        // "own" this mesh in catalog view.
-        PreviewActorID = 0
-        If Composer::canPaintRow(self, y, LOOM_PREVIEW_SIZE) = True
-            Loom_DrawMeshPreview(mh\ID, previewX, previewY, LOOM_PREVIEW_SIZE)
-        EndIf
-        y = y + LOOM_PREVIEW_SIZE + 8
+        // No 3D preview here (removed: full-backbuffer bleed + wheel
+        // conflict with the body scroll -- see renderActor / ADR 004).
+        // The catalog row + "Used by" reverse-refs are the value here.
 
         // Reverse refs
         y = Composer::sectionHeader(self, panelX, panelW, y, "Used by")

--- a/src/Modules/Loom/ImageCache.bb
+++ b/src/Modules/Loom/ImageCache.bb
@@ -58,11 +58,17 @@ Global FrameImageLoadCount = 0
 ; =============================================================================
 Global LoomFrameMouseClicked      = False
 Global LoomFrameMouseRightClicked = False
-; MouseZ() is also read-and-clear (cumulative wheel delta since last
-; call). Same per-frame cache shape as the click state -- without
-; caching, two renderers calling MouseZ in the same frame would
-; double-consume the wheel tick.
+; MouseZ() returns the CUMULATIVE wheel position (a running total since
+; program start), NOT a per-frame delta -- verified in BlitzForge's
+; gxinput.cpp (wm_mousewheel does axis_states[2] += dz; MouseZ reads
+; that accumulator without resetting). The earlier code treated MouseZ
+; as a delta and multiplied it by the scroll step every frame, so a
+; single non-zero wheel position drove scrollOffset to its clamp on
+; every subsequent frame -- the "won't scroll, then jumps to the
+; bottom" bug. Fix: cache the per-frame DELTA here (current absolute
+; minus last frame's absolute) so Loom_MouseWheel() returns true ticks.
 Global LoomFrameMouseWheel        = 0
+Global LoomPrevMouseWheelAbs      = 0
 
 ; Zone viewport <-> composer highlight sync. Composer's renderZone
 ; sub-section renderers set these when their header lands inside
@@ -91,7 +97,11 @@ Function Loom_BeginFrame()
     ; rendering pipelines aren't equipped to handle counts.
     LoomFrameMouseClicked      = (MouseHit(1) > 0)
     LoomFrameMouseRightClicked = (MouseHit(2) > 0)
-    LoomFrameMouseWheel        = MouseZ()
+    ; Per-frame wheel delta = current cumulative position - last frame's.
+    ; MouseZ() never resets, so this is the only correct way to read it.
+    Local rawWheel% = MouseZ()
+    LoomFrameMouseWheel = rawWheel - LoomPrevMouseWheelAbs
+    LoomPrevMouseWheelAbs = rawWheel
 End Function
 
 


### PR DESCRIPTION
## Why

Direct response to reported unusability: the composer scroll was a "won't move then jumps to the bottom" nightmare, a 3D viewport was bleeding across the whole window, the card grid couldn't scroll when full, and the Issues modal's chips overlapped the list.

## Changes

1. **Scroll runaway (root cause).** `MouseZ()` returns a **cumulative** wheel position, not a per-frame delta — verified in BlitzForge `gxinput.cpp` (`wm_mousewheel` does `axis_states[2] += dz`, read without reset; `MouseZSpeed`/`g_mouse_dz` is the read-and-clear delta). The old code treated it as a delta and multiplied by the scroll step every frame, so any nonzero wheel position drove `scrollOffset` to its clamp on every subsequent frame. `Loom_BeginFrame` now derives the true per-frame delta. This also fixes every wheel-zoom (Atlas / previews) that read the same cached value.

2. **3D viewports removed from the Composer** (the user's explicit ask). `MeshPreview`'s camera had **no `CameraViewport` sub-rect**, so `RenderWorld` painted the mesh to the full backbuffer — the grey mesh bleeding across the window — and the viewports consumed the wheel, fighting the body scroll. Removed the actor/item/mesh mesh-preview and the zone schematic viewport from the composer (ADR 004: no 3D in the scrollable property panel). 2D thumbnails retained. With no caller, `RenderWorld` is never invoked for those cameras, so the bleed is gone.

3. **Card grid is now scrollable.** Added `cardScroll` + wheel handling, clamped to measured content height, reset on category/filter change. Wheel is cursor-region gated (the grid's `sw` is already reduced by the composer width) so the grid and composer never both scroll. **Also defined the missing `BR_FILTER_BAR_Y` const** the prior iteration left dangling — `cardVisible` referenced it, so the working tree did not compile.

4. **Issues modal overlap.** `drawCategoryChips` now returns its bottom Y; the entries list starts below the (possibly multi-row) chip strip instead of a fixed offset, and list height derives from the real chip bottom. Added mouse-wheel scroll.

## Verification

- `compile.bat -t` clean — all 5 engine targets build (exit 0).
- **Runtime/visual verification could not be performed in this environment**: `Graphics3D` fails for any Blitz3D app launched here (GUE.exe fails identically with the same `Graphics3D(...,0,2)` call — so it is the environment, e.g. the running Oculus/`OVRServer` GPU state, not these changes), and the computer-use access dialog requires interactive approval (times out while unattended). The fixes are root-cause-driven and compile-clean; a visual pass is still owed once the display environment allows it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)