### PR TITLE
Loom: fix mesh-preview full-screen bleed + re-introduce viewports (pinned)

### DIFF
--- a/src/Modules/Loom/Composer.bb
+++ b/src/Modules/Loom/Composer.bb
@@ -313,10 +313,15 @@ Type Composer
         //
         // Gated to the cursor being over THIS panel (mx >= panel left) so
         // scrolling here doesn't also scroll the browser card grid behind
-        // the composer. Loom_ConsumeWheel() then zeroes the cached delta
-        // so no other surface this frame double-applies the same tick.
+        // the composer. Also gated OUT when the cursor is over the pinned
+        // viewport band -- there the wheel is the viewport's zoom, not body
+        // scroll (the viewport calls Loom_ConsumeWheel itself when it draws,
+        // but it draws AFTER this handler, so we must skip here too).
+        // Loom_ConsumeWheel() then zeroes the cached delta so no other
+        // surface this frame double-applies the same tick.
+        Local overVP% = Composer::cursorOverViewportBand(self, kind, sw)
         Local wheelTicks% = Loom_MouseWheel()
-        If wheelTicks <> 0 And self\collapsed = False And MouseX() >= (sw - CMP_W)
+        If wheelTicks <> 0 And self\collapsed = False And overVP = False And MouseX() >= (sw - CMP_W)
             self\scrollOffset = self\scrollOffset - wheelTicks * CMP_SCROLL_STEP
             If self\scrollOffset < 0 Then self\scrollOffset = 0
             // Clamp to last-frame's measured content height -- if the
@@ -424,10 +429,28 @@ Type Composer
         // frame can clamp scrollOffset.
         Local bodyY% = y + CMP_PAD + 50
         Local bodyH% = h - (bodyY - y) - 24
-        self\bodyTop    = bodyY
+
+        // Pinned viewport band. Kinds with a 3D viewport (actor / item /
+        // mesh / zone) reserve a fixed, NON-scrolling band at the top of
+        // the body; the field rows scroll BELOW it. Pinning (vs. letting
+        // the viewport scroll with the body) means: the RenderWorld/CopyRect
+        // rect never lands over the header (no bleed), the preview stays
+        // visible while you edit fields, and the wheel split is clean
+        // (cursor-over-viewport = zoom, cursor-over-fields = scroll).
+        Local vpBandH% = 0
+        If Composer::kindHasViewport(self, kind) = True
+            vpBandH = Composer::viewportSize(self, kind) + 10
+        EndIf
+
+        self\bodyTop    = bodyY + vpBandH
         self\bodyBottom = bodyY + bodyH
-        Local scrolledBodyY% = bodyY - self\scrollOffset
+        Local scrolledBodyY% = self\bodyTop - self\scrollOffset
         self\chipHit = False
+
+        // Draw the pinned viewport first, at the fixed band top (unscrolled).
+        If vpBandH > 0
+            Composer::drawPinnedViewport(self, kind, refID, x, w, bodyY)
+        EndIf
 
         If kind = "actor"
             Composer::renderActor(self, x, scrolledBodyY, w, bodyH, mx, my, clicked, rightClicked)
@@ -2768,6 +2791,74 @@ Type Composer
         If kind = "faction" Then Return "FACTION"
         If kind = "animset" Then Return "ANIMATION SET"
         Return Upper$(kind)
+    End Method
+
+
+    // -------------------------------------------------------------------------
+    // Pinned-viewport helpers. The 3D preview surfaces (actor/item/mesh mesh
+    // preview, zone schematic) live in a fixed, non-scrolling band at the
+    // top of the composer body. These helpers tell renderAndUpdate which
+    // kinds get a band, how tall it is, whether the cursor is over it (so
+    // the wheel zooms instead of scrolls), and dispatch the actual draw.
+    // -------------------------------------------------------------------------
+    Method kindHasViewport%(kind$)
+        If kind = "actor" Then Return True
+        If kind = "item"  Then Return True
+        If kind = "mesh"  Then Return True
+        If kind = "zone"  Then Return True
+        Return False
+    End Method
+
+    // Square edge of the viewport for this kind. Zone uses the larger
+    // schematic (VP_RT_SIZE); the others use the mesh-preview square.
+    Method viewportSize%(kind$)
+        If kind = "zone" Then Return VP_RT_SIZE
+        If Composer::kindHasViewport(self, kind) = True Then Return LOOM_PREVIEW_SIZE
+        Return 0
+    End Method
+
+    // True when the cursor is inside the pinned viewport rect for the
+    // focused kind. Computed from constants (panel is right-anchored at
+    // sw - CMP_W; the band top is bodyY = CMP_TOP + CMP_PAD + 50) so the
+    // scroll handler can call it BEFORE the body layout runs.
+    Method cursorOverViewportBand%(kind$, sw%)
+        If Composer::kindHasViewport(self, kind) = False Then Return False
+        If self\collapsed = True Then Return False
+        Local vpSize% = Composer::viewportSize(self, kind)
+        Local vpX% = (sw - CMP_W) + (CMP_W - vpSize) / 2
+        Local vpY% = CMP_TOP + CMP_PAD + 50
+        Local mxp% = MouseX()
+        Local myp% = MouseY()
+        If mxp >= vpX And mxp < vpX + vpSize And myp >= vpY And myp < vpY + vpSize Then Return True
+        Return False
+    End Method
+
+    // Draw the pinned viewport at the fixed band (centered in the panel).
+    // Re-resolves the entity by refID and dispatches to the right widget.
+    Method drawPinnedViewport(kind$, refID%, panelX%, panelW%, vpY%)
+        Local vpSize% = Composer::viewportSize(self, kind)
+        Local vpX% = panelX + (panelW - vpSize) / 2
+        If kind = "actor"
+            If refID >= 0 And refID <= 65535
+                Local A.Actor = ActorList(refID)
+                If A <> Null
+                    PreviewActorID = A\ID
+                    Loom_DrawMeshPreview(A\MeshIDs[0], vpX, vpY, LOOM_PREVIEW_SIZE)
+                    PreviewActorID = 0
+                EndIf
+            EndIf
+        Else If kind = "item"
+            If refID >= 0 And refID <= 65535
+                Local It.Item = ItemList(refID)
+                If It <> Null Then Loom_DrawMeshPreview(It\MMeshID, vpX, vpY, LOOM_PREVIEW_SIZE)
+            EndIf
+        Else If kind = "mesh"
+            Local mh.MeshEntry = Meshes_GetByIndex(refID)
+            If mh <> Null Then Loom_DrawMeshPreview(mh\ID, vpX, vpY, LOOM_PREVIEW_SIZE)
+        Else If kind = "zone"
+            Local Ar.Area = Object.Area(refID)
+            If Ar <> Null Then Loom_DrawZoneViewport(refID, vpX, vpY)
+        EndIf
     End Method
 
 

--- a/src/Modules/Loom/MeshPreview.bb
+++ b/src/Modules/Loom/MeshPreview.bb
@@ -102,6 +102,15 @@ Function Loom_InitMeshPreview()
     PointEntity   PreviewCam, 0   ; will be re-pointed at the mesh each frame
     CameraClsColor PreviewCam, 16, 16, 22   ; dark stone-950 background
     CameraRange    PreviewCam, 0.1, 1000.0
+    ; CRITICAL: confine the camera to the render-target's pixel rect.
+    ; CreateCamera() seeds a camera's viewport from the CURRENT buffer at
+    ; creation time (bbCreateCamera -> gx_canvas->getViewport) -- which is
+    ; the full back buffer here. Without this override, RenderWorld paints
+    ; PreviewCam across the WHOLE window (the grey-mesh bleed), because the
+    ; viewport stays full-screen even when SetBuffer points at the small RT.
+    ; ZoneViewport's VPCam already does this; MeshPreview didn't, which is
+    ; the entire bug. Match the RT dimensions exactly.
+    CameraViewport PreviewCam, 0, 0, LOOM_PREVIEW_SIZE, LOOM_PREVIEW_SIZE
     HideEntity     PreviewCam     ; only show when actively rendering
 
     ; Single directional light so the mesh is visible.


### PR DESCRIPTION
## Why

Follow-up to #417. Removing the composer viewports was an over-correction — you still want the viewport, it just needs to render in its box. This makes it work.

## Root cause of the grey-mesh bleed (proven, not guessed)

`bbCreateCamera` seeds a new camera's viewport from the **current buffer at creation time** (`bbCreateCamera` → `gx_canvas->getViewport`). `PreviewCam` is created while the back buffer is active, so it inherits a **full-window** viewport. MeshPreview never called `CameraViewport`, so even with `SetBuffer` pointed at the small render-target texture, `RenderWorld` painted `PreviewCam` across the whole window. ZoneViewport's `VPCam` *does* set `CameraViewport 0,0,VP_RT_SIZE,VP_RT_SIZE` — which is exactly why it stayed inside its box (screenshot 4) and the mesh preview didn't (screenshot 3).

**Fix:** `CameraViewport PreviewCam, 0, 0, LOOM_PREVIEW_SIZE, LOOM_PREVIEW_SIZE` at init. One line; the rest is the re-introduction.

## Viewports re-introduced — now pinned

The viewports are back for actor / item / mesh (mesh preview) and zone (schematic), but **pinned** as a fixed, non-scrolling band at the top of the composer body. Pinning fixes three things vs. the old in-body placement:

- the `RenderWorld`/`CopyRect` rect can never scroll up over the header (no second bleed),
- the preview stays visible while you scroll and edit the fields below it,
- the wheel splits cleanly — cursor over the viewport = orbit/zoom (the widget owns the wheel via `Loom_ConsumeWheel`), cursor over the fields = body scroll. The composer scroll handler now skips when the cursor is over the viewport band, so it no longer fights the zoom.

New `Composer` helpers: `kindHasViewport` / `viewportSize` / `cursorOverViewportBand` / `drawPinnedViewport`. Body reserves `viewportSize+10` px at the top; rows scroll below; scroll-clamp math unchanged.

## Verification

- `compile.bat -t` clean — all 5 targets build (exit 0).
- Still **cannot run it from here** to screenshot (agent-launched Blitz apps fail at `Graphics3D` — GUE fails identically; it's the launch context, not the code). The fix is high-confidence: root cause confirmed in the runtime source, and it makes MeshPreview behave exactly like the already-working ZoneViewport. A visual confirm is owed — happy to drive it if you launch Loom and approve computer-use access.

🤖 Generated with [Claude Code](https://claude.com/claude-code)