### PR TITLE
Loom: extract zone-name dedup into pure NameUtil + add unit test

### DIFF
--- a/src/Loom.bb
+++ b/src/Loom.bb
@@ -105,6 +105,9 @@ Include "Modules\Logging.bb"
 // its dirty-badge save dispatch) -> EntityFactory (free functions, last
 // since it calls Threads::focus + reads the *Saved globals).
 Include "Modules\Loom\Theme.bb"
+// NameUtil -- pure, dependency-free name-dedup helpers (used by
+// EntityFactory for zone-name uniqueness). Included early; no deps.
+Include "Modules\Loom\NameUtil.bb"
 Include "Modules\Loom\Threads.bb"
 // Settings BEFORE Composer so the LoomCfg_* / SettingsSaved globals
 // are declared by the time Strict Composer methods reference them.

--- a/src/Modules/Loom/EntityFactory.bb
+++ b/src/Modules/Loom/EntityFactory.bb
@@ -180,16 +180,17 @@ End Function
 // EntityFactory_UniqueZoneName -- return a name with " 2" / " 3" / ...
 // appended until no existing zone matches. ServerSaveArea uses Name$ as the
 // filename, so a duplicate would silently overwrite an existing zone file.
+//
+// The dedup logic itself lives in NameUtil.bb (pure + unit-tested); here we
+// just build the set of existing zone names from the live Area list and
+// hand it to Loom_NextUniqueName.
 // -----------------------------------------------------------------------------
 Function EntityFactory_UniqueZoneName$(base$)
-    If EntityFactory_ZoneNameExists%(base) = False Then Return base
-    Local i% = 2
-    While i < 1000
-        Local candidate$ = base + " " + Str(i)
-        If EntityFactory_ZoneNameExists%(candidate) = False Then Return candidate
-        i = i + 1
-    Wend
-    Return base + " " + Str(MilliSecs())     // unreachable in practice
+    Local setStr$ = ""
+    For A.Area = Each Area
+        setStr = Loom_AddNameToSet$(setStr, A\Name$)
+    Next
+    Return Loom_NextUniqueName$(base, setStr)
 End Function
 
 

--- a/src/Modules/Loom/NameUtil.bb
+++ b/src/Modules/Loom/NameUtil.bb
@@ -1,0 +1,61 @@
+Strict
+
+// =============================================================================
+// Loom/NameUtil.bb -- pure name-deduplication helpers
+// =============================================================================
+//
+// Zero dependencies (only Blitz string built-ins) so the logic is unit-
+// testable in isolation -- see src/Tests/Modules/Loom/NameUtilTest.bb.
+//
+// Why this exists: zone files are saved as "<Name$>.dat" (ServerSaveArea
+// uses the zone name as the on-disk filename). Creating or duplicating a
+// zone whose name collides with an existing zone would silently OVERWRITE
+// that zone's .dat -- data loss. EntityFactory_UniqueZoneName uses these to
+// pick a non-colliding name ("New Zone" -> "New Zone 2" -> ...). The
+// dedup logic used to live inline in EntityFactory (coupled to a
+// `For A.Area = Each Area` walk, so untestable); it is now a pure function
+// over a name-set string, with the Area walk reduced to building that set.
+//
+// The "set" is encoded as a Chr(1)-delimited, uppercased string with a
+// leading + trailing delimiter ("\1FOO\1BAR\1"). The bounding delimiters
+// make membership an exact match -- "Foo" cannot false-match inside
+// "Foobar" -- which a naive Instr(set, name) would get wrong. Chr(1) is the
+// delimiter because it never appears in a legitimate entity name.
+
+
+// -----------------------------------------------------------------------------
+// Loom_AddNameToSet -- append `name` (uppercased) to a set string, keeping
+// the leading/trailing-delimiter invariant. Pass "" as the initial set.
+// -----------------------------------------------------------------------------
+Function Loom_AddNameToSet$(setStr$, name$)
+    If setStr = "" Then setStr = Chr(1)
+    Return setStr + Upper$(name) + Chr(1)
+End Function
+
+
+// -----------------------------------------------------------------------------
+// Loom_NameInSet -- True if `name` is present in `setStr` (case-insensitive,
+// whole-name match). Empty set is never a match.
+// -----------------------------------------------------------------------------
+Function Loom_NameInSet%(name$, setStr$)
+    If setStr = "" Then Return False
+    Return Instr(setStr, Chr(1) + Upper$(name) + Chr(1)) > 0
+End Function
+
+
+// -----------------------------------------------------------------------------
+// Loom_NextUniqueName -- return `base` if it is not in the set, else the
+// first of "base 2", "base 3", ... that is free. Case-insensitive (the
+// filesystem is). Bounded at 999 tries; the final fallback appends the
+// loop counter so the return is always defined (unreachable in practice).
+// -----------------------------------------------------------------------------
+Function Loom_NextUniqueName$(base$, setStr$)
+    If Loom_NameInSet%(base, setStr) = False Then Return base
+    Local i% = 2
+    While i < 1000
+        Local candidate$ = base + " " + Str(i)
+        If Loom_NameInSet%(candidate, setStr) = False Then Return candidate
+        i = i + 1
+    Wend
+    Return base + " " + Str(i)
+End Function

--- a/src/Tests/Modules/Loom/NameUtilTest.bb
+++ b/src/Tests/Modules/Loom/NameUtilTest.bb
@@ -1,0 +1,68 @@
+Strict
+EnableGC
+
+// =============================================================================
+// NameUtilTest -- unit tests for Loom/NameUtil.bb's pure name-dedup helpers.
+// =============================================================================
+//
+// NameUtil.bb has ZERO dependencies (only Blitz string built-ins), so this
+// test Includes it directly with no stubs. The logic it covers prevents a
+// real data-loss bug: a new/duplicated zone whose Name$ collides with an
+// existing zone would overwrite that zone's <Name$>.dat on save.
+
+Include "Modules\Loom\NameUtil.bb"
+
+
+// A name not already present comes back unchanged.
+Test testReturnsBaseWhenNotTaken()
+    Local setStr$ = ""
+    setStr = Loom_AddNameToSet$(setStr, "Plains")
+    setStr = Loom_AddNameToSet$(setStr, "Test Zone")
+    Assert(Loom_NextUniqueName$("New Zone", setStr) = "New Zone")
+End Test
+
+
+// First collision appends " 2".
+Test testAppendsTwoOnFirstCollision()
+    Local setStr$ = ""
+    setStr = Loom_AddNameToSet$(setStr, "New Zone")
+    Assert(Loom_NextUniqueName$("New Zone", setStr) = "New Zone 2")
+End Test
+
+
+// Runs of taken suffixes are skipped to the first free one.
+Test testSkipsToNextFreeSuffix()
+    Local setStr$ = ""
+    setStr = Loom_AddNameToSet$(setStr, "New Zone")
+    setStr = Loom_AddNameToSet$(setStr, "New Zone 2")
+    setStr = Loom_AddNameToSet$(setStr, "New Zone 3")
+    Assert(Loom_NextUniqueName$("New Zone", setStr) = "New Zone 4")
+End Test
+
+
+// Matching is case-insensitive (the filesystem is, and zone names map to
+// filenames).
+Test testCaseInsensitive()
+    Local setStr$ = ""
+    setStr = Loom_AddNameToSet$(setStr, "PLAINS")
+    Assert(Loom_NameInSet%("plains", setStr) = True)
+    Assert(Loom_NextUniqueName$("Plains", setStr) = "Plains 2")
+End Test
+
+
+// A base must not be considered taken just because a longer name contains
+// it as a substring ("Foo" vs "Foobar"). The bounding delimiters guarantee
+// whole-name matching.
+Test testNoSubstringFalseMatch()
+    Local setStr$ = ""
+    setStr = Loom_AddNameToSet$(setStr, "Foobar")
+    Assert(Loom_NameInSet%("Foo", setStr) = False)
+    Assert(Loom_NextUniqueName$("Foo", setStr) = "Foo")
+End Test
+
+
+// Empty set: nothing is taken, base returns unchanged.
+Test testEmptySetReturnsBase()
+    Assert(Loom_NameInSet%("Anything", "") = False)
+    Assert(Loom_NextUniqueName$("Anything", "") = "Anything")
+End Test


### PR DESCRIPTION
## Why

Conservative, verifiable iteration (UI changes aren't runtime-verifiable in this environment — see #417/#418 notes). This hardens a real **data-loss** invariant and gives Loom its first unit test.

`EntityFactory_UniqueZoneName` keeps a new/duplicated zone from colliding with an existing zone's name — `ServerSaveArea` writes `"<Name$>.dat"`, so a name collision would silently **overwrite** another zone's file on save. The logic was inline and coupled to a `For A.Area = Each Area` walk, so it couldn't be tested.

## Change

- New `Modules/Loom/NameUtil.bb` — pure, **zero-dependency** helpers: `Loom_AddNameToSet` / `Loom_NameInSet` / `Loom_NextUniqueName`. Set membership is a `Chr(1)`-delimited, uppercased string with bounding delimiters, so matching is whole-name exact ("Foo" doesn't false-match inside "Foobar").
- `EntityFactory_UniqueZoneName` now builds the name set from the live Area list and calls `Loom_NextUniqueName`. **Behavior unchanged.**
- New `src/Tests/Modules/Loom/NameUtilTest.bb` (Strict + EnableGC, no stubs needed) — 6 cases: not-taken, first collision → " 2", run-skip, case-insensitivity, no substring false-match, empty set.

## Verification (actually executed this time)

- `compile.bat -t` clean — all 5 targets (exit 0).
- `test.bat NameUtilTest` → **1 passed, 0 failed, 0 unreleased objects**. Tests are console programs (`blitzcc -t`), so they run here even though GUI Blitz apps can't init `Graphics3D` in this environment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)