### PR TITLE
Loom: extract composer parse-and-clamp into pure Clamp.bb + unit test

### DIFF
--- a/src/Loom.bb
+++ b/src/Loom.bb
@@ -105,9 +105,11 @@ Include "Modules\Logging.bb"
 // its dirty-badge save dispatch) -> EntityFactory (free functions, last
 // since it calls Threads::focus + reads the *Saved globals).
 Include "Modules\Loom\Theme.bb"
-// NameUtil -- pure, dependency-free name-dedup helpers (used by
-// EntityFactory for zone-name uniqueness). Included early; no deps.
+// NameUtil + Clamp -- pure, dependency-free helpers (name-dedup for
+// EntityFactory; parse-and-clamp for the Composer numeric fields).
+// Included early; no deps.
 Include "Modules\Loom\NameUtil.bb"
+Include "Modules\Loom\Clamp.bb"
 Include "Modules\Loom\Threads.bb"
 // Settings BEFORE Composer so the LoomCfg_* / SettingsSaved globals
 // are declared by the time Strict Composer methods reference them.

--- a/src/Modules/Loom/Clamp.bb
+++ b/src/Modules/Loom/Clamp.bb
@@ -1,0 +1,50 @@
+Strict
+
+// =============================================================================
+// Loom/Clamp.bb -- pure parse-and-clamp helpers for composer field edits
+// =============================================================================
+//
+// Zero dependencies (only Blitz built-ins: Trim$ / Int / Float) so the logic
+// is unit-testable in isolation -- see src/Tests/Modules/Loom/ClampTest.bb.
+//
+// Why this matters: every editable numeric field in the composer routes its
+// typed string through one of these before writing it to the entity, with a
+// per-field [lo, hi] range (~80 call sites across actor / item / spell / zone
+// / animset / settings). The clamp is the only thing standing between a
+// fat-fingered "999999999999" or "-5" or "abc" and a poisoned field
+// (negative max-HP, scale 0 that freezes the actor, an out-of-range mesh ID).
+// The contract:
+//   - empty / whitespace-only string  -> keep the existing value (fallback)
+//   - otherwise parse, then clamp into [lo, hi]
+//   - garbage (non-numeric) parses to 0 via Int()/Float() and then clamps,
+//     so it can never write something wilder than the field's own bounds.
+//
+// The logic used to live inline as Composer methods (untestable -- Composer
+// pulls in the whole UI). It now lives here; the Composer methods are thin
+// wrappers that delegate, so the ~80 call sites are unchanged.
+
+
+// -----------------------------------------------------------------------------
+// Loom_ParseIntClamped -- parse s as an int and clamp to [lo, hi]; empty
+// string keeps `fallback`.
+// -----------------------------------------------------------------------------
+Function Loom_ParseIntClamped%(s$, fallback%, lo%, hi%)
+    If Trim$(s) = "" Then Return fallback
+    Local v% = Int(s)
+    If v < lo Then v = lo
+    If v > hi Then v = hi
+    Return v
+End Function
+
+
+// -----------------------------------------------------------------------------
+// Loom_ParseFloatClamped -- parse s as a float and clamp to [lo, hi]; empty
+// string keeps `fallback`.
+// -----------------------------------------------------------------------------
+Function Loom_ParseFloatClamped#(s$, fallback#, lo#, hi#)
+    If Trim$(s) = "" Then Return fallback
+    Local v# = Float(s)
+    If v# < lo# Then v# = lo#
+    If v# > hi# Then v# = hi#
+    Return v#
+End Function

--- a/src/Modules/Loom/Composer.bb
+++ b/src/Modules/Loom/Composer.bb
@@ -1684,21 +1684,16 @@ Type Composer
     // -> clamp-to-lo is minimal -- the user sees the wrong value and
     // re-edits. The clamp is the real protection here, not the validator.
     // -------------------------------------------------------------------------
+    // Thin delegates to the pure, unit-tested helpers in Clamp.bb. Kept as
+    // methods so the ~80 Composer::parseIntClamped(self, ...) call sites are
+    // unchanged; the clamping contract is pinned by ClampTest.bb.
     Method parseIntClamped%(s$, fallback%, lo%, hi%)
-        If Trim$(s) = "" Then Return fallback
-        Local v% = Int(s)
-        If v < lo Then v = lo
-        If v > hi Then v = hi
-        Return v
+        Return Loom_ParseIntClamped(s, fallback, lo, hi)
     End Method
 
 
     Method parseFloatClamped#(s$, fallback#, lo#, hi#)
-        If Trim$(s) = "" Then Return fallback
-        Local v# = Float(s)
-        If v# < lo# Then v# = lo#
-        If v# > hi# Then v# = hi#
-        Return v#
+        Return Loom_ParseFloatClamped(s, fallback, lo, hi)
     End Method
 
 

--- a/src/Tests/Modules/Loom/ClampTest.bb
+++ b/src/Tests/Modules/Loom/ClampTest.bb
@@ -1,0 +1,66 @@
+Strict
+EnableGC
+
+// =============================================================================
+// ClampTest -- unit tests for Loom/Clamp.bb's parse-and-clamp helpers.
+// =============================================================================
+//
+// Clamp.bb has ZERO dependencies (only Blitz built-ins), so this Includes it
+// directly with no stubs. The logic it covers is the last line of defense
+// against a typed field value poisoning an entity: every numeric composer
+// field routes through these with a per-field [lo, hi].
+
+Include "Modules\Loom\Clamp.bb"
+
+
+// ---- Int ----
+
+// A valid in-range value passes through unchanged.
+Test testIntInRange()
+    Assert(Loom_ParseIntClamped%("42", 0, 0, 100) = 42)
+End Test
+
+// Empty / whitespace keeps the existing value (fallback), NOT 0 -- so
+// clearing a field and tabbing away doesn't silently zero it.
+Test testIntEmptyKeepsFallback()
+    Assert(Loom_ParseIntClamped%("", 7, 0, 100) = 7)
+    Assert(Loom_ParseIntClamped%("   ", 7, 0, 100) = 7)
+End Test
+
+// Below the low bound clamps up to lo; above the high bound clamps down.
+Test testIntClampsToBounds()
+    Assert(Loom_ParseIntClamped%("-5", 0, 0, 100) = 0)
+    Assert(Loom_ParseIntClamped%("999999", 0, 0, 100) = 100)
+End Test
+
+// Garbage parses to 0 (Int()) then clamps -- can never exceed the field's
+// own range. With lo=1 it clamps up to 1, not 0.
+Test testIntGarbageClampsIntoRange()
+    Assert(Loom_ParseIntClamped%("abc", 50, 1, 100) = 1)
+End Test
+
+// Negative ranges (used by attribute Value/Max) work both directions.
+Test testIntNegativeRange()
+    Assert(Loom_ParseIntClamped%("-1000", 0, -100, 100) = -100)
+    Assert(Loom_ParseIntClamped%("-50", 0, -100, 100) = -50)
+End Test
+
+
+// ---- Float ----
+
+// Valid in-range float passes through. Values chosen to be exactly
+// representable so the equality assert is safe.
+Test testFloatInRange()
+    Assert(Loom_ParseFloatClamped#("3.5", 1.0, 0.0, 100.0) = 3.5)
+End Test
+
+Test testFloatEmptyKeepsFallback()
+    Assert(Loom_ParseFloatClamped#("", 2.5, 0.0, 100.0) = 2.5)
+End Test
+
+// Scale field guard: lo=0.01 keeps an actor from being scaled to 0 (invisible
+// / degenerate). "0" clamps up to the floor.
+Test testFloatClampsToBounds()
+    Assert(Loom_ParseFloatClamped#("-5", 1.0, 0.01, 100.0) = 0.01)
+    Assert(Loom_ParseFloatClamped#("250", 1.0, 0.0, 100.0) = 100.0)
+End Test


### PR DESCRIPTION
## Why

Conservative, executably-verifiable iteration (GUI changes can't be runtime-verified in this env; logic can, via `test.bat`). Hardens a data-integrity guard and adds test coverage.

Every numeric composer field routes its typed string through `parseIntClamped` / `parseFloatClamped` with a per-field `[lo, hi]` (~80 call sites). It's the only thing between a fat-fingered `-5` / `999999999` / `abc` and a poisoned field — negative max-HP, `scale` 0 that freezes an actor, an out-of-range mesh ID. The logic was inline as `Composer` methods, so it couldn't be tested.

## Change

- New `Modules/Loom/Clamp.bb` — pure, **zero-dependency** `Loom_ParseIntClamped` / `Loom_ParseFloatClamped`.
- `Composer::parseIntClamped` / `parseFloatClamped` are now thin delegates → **all ~80 call sites unchanged, behavior identical.**
- New `src/Tests/Modules/Loom/ClampTest.bb` (Strict + EnableGC, no stubs) pins the contract: in-range passthrough, empty/whitespace keeps the existing value (does **not** zero the field), clamp-to-lo / clamp-to-hi, garbage → 0 → clamps into range, negative ranges (attribute Value/Max), scale floor 0.01.

## Verification (executed)

- `compile.bat -t` clean — all 5 targets (exit 0).
- `test.bat ClampTest` → **1 passed, 0 failed, 0 unreleased objects.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)