### PR TITLE
Loom: extract palette name-ranking into pure SearchScore.bb + unit test

### DIFF
--- a/src/Loom.bb
+++ b/src/Loom.bb
@@ -110,6 +110,8 @@ Include "Modules\Loom\Theme.bb"
 // Included early; no deps.
 Include "Modules\Loom\NameUtil.bb"
 Include "Modules\Loom\Clamp.bb"
+// SearchScore -- pure command-palette name ranking; Palette delegates to it.
+Include "Modules\Loom\SearchScore.bb"
 Include "Modules\Loom\Threads.bb"
 // Settings BEFORE Composer so the LoomCfg_* / SettingsSaved globals
 // are declared by the time Strict Composer methods reference them.

--- a/src/Modules/Loom/Palette.bb
+++ b/src/Modules/Loom/Palette.bb
@@ -48,10 +48,9 @@ Const PAL_MAX_RESULTS   = 12
 Const PAL_HINT_H        = 24
 Const PAL_CURSOR_PERIOD = 1000
 
-// Scoring constants (higher = better)
-Const PAL_SCORE_PREFIX = 1000
-Const PAL_SCORE_SUBSTR = 100
-Const PAL_SCORE_EXACT  = 5000
+// Scoring constants + the scoreName ranking logic now live in
+// SearchScore.bb (pure + unit-tested via SearchScoreTest.bb);
+// Palette::scoreName delegates to Loom_ScoreName.
 
 
 // -----------------------------------------------------------------------------
@@ -596,21 +595,12 @@ Type Palette
 
 
     // -------------------------------------------------------------------------
-    // scoreName -- substring score with prefix + exact bonuses. q must be
-    // already lower-cased and trimmed by the caller; this function lowers
-    // name. Returns 0 for no match.
+    // scoreName -- thin delegate to the pure, unit-tested Loom_ScoreName in
+    // SearchScore.bb. q must be already lower-cased and trimmed by the
+    // caller. Kept as a method so the scoreOrBaseline call site is unchanged.
     // -------------------------------------------------------------------------
     Method scoreName%(q$, name$)
-        If name = "" Then Return 0
-        Local lname$ = Lower$(name)
-
-        If lname = q Then Return PAL_SCORE_EXACT
-        If Left$(lname, Len(q)) = q Then Return PAL_SCORE_PREFIX + (200 - Len(name))
-
-        // Substring -- Instr returns 1-based index, 0 = not found
-        Local pos% = Instr(lname, q)
-        If pos > 0 Then Return PAL_SCORE_SUBSTR + (100 - pos)
-        Return 0
+        Return Loom_ScoreName(q, name)
     End Method
 
 

--- a/src/Modules/Loom/SearchScore.bb
+++ b/src/Modules/Loom/SearchScore.bb
@@ -1,0 +1,47 @@
+Strict
+
+// =============================================================================
+// Loom/SearchScore.bb -- pure name-ranking score for the command palette
+// =============================================================================
+//
+// Zero dependencies (only Blitz string built-ins) so the ranking is unit-
+// testable in isolation -- see src/Tests/Modules/Loom/SearchScoreTest.bb.
+//
+// This is the ranking behind the Ctrl+K find-anywhere palette: every entity
+// name is scored against the query and the highest scores surface first. If
+// the tiers ever invert (a substring match outranking a prefix match), the
+// palette silently shows the wrong results first -- exactly the kind of UX
+// rot that's invisible until a test catches it. The contract:
+//
+//   exact match      -> LOOM_SCORE_EXACT                       (highest)
+//   prefix match     -> LOOM_SCORE_PREFIX + (200 - len(name))  (shorter wins)
+//   substring match  -> LOOM_SCORE_SUBSTR + (100 - pos)        (earlier wins)
+//   no match         -> 0
+//
+// With EXACT=5000, PREFIX base=1000 (so prefix scores ~1000..1199 for normal
+// name lengths), SUBSTR base=100 (~1..199), the tiers never cross: any exact
+// outranks any prefix outranks any substring outranks no-match. The within-
+// tier bonuses break ties (shorter prefix-name first; earlier substring
+// position first).
+//
+// Caller contract: `q` is already lower-cased and trimmed; this function
+// lower-cases `name`. (The palette lower/trims the query once before scoring
+// the whole roster, rather than per-candidate.)
+
+Const LOOM_SCORE_PREFIX = 1000
+Const LOOM_SCORE_SUBSTR = 100
+Const LOOM_SCORE_EXACT  = 5000
+
+
+Function Loom_ScoreName%(q$, name$)
+    If name = "" Then Return 0
+    Local lname$ = Lower$(name)
+
+    If lname = q Then Return LOOM_SCORE_EXACT
+    If Left$(lname, Len(q)) = q Then Return LOOM_SCORE_PREFIX + (200 - Len(name))
+
+    // Substring -- Instr returns 1-based index, 0 = not found
+    Local pos% = Instr(lname, q)
+    If pos > 0 Then Return LOOM_SCORE_SUBSTR + (100 - pos)
+    Return 0
+End Function

--- a/src/Tests/Modules/Loom/SearchScoreTest.bb
+++ b/src/Tests/Modules/Loom/SearchScoreTest.bb
@@ -1,0 +1,66 @@
+Strict
+EnableGC
+
+// =============================================================================
+// SearchScoreTest -- unit tests for Loom/SearchScore.bb's palette ranking.
+// =============================================================================
+//
+// SearchScore.bb has ZERO dependencies, so this Includes it with no stubs.
+// The tests pin the tier ordering (exact > prefix > substring > none) and
+// the within-tier tie-breakers (shorter prefix-name first, earlier substring
+// position first) -- the contract the Ctrl+K palette relies on to surface
+// the right results first. Query is passed already-lowercased (caller
+// contract).
+
+Include "Modules\Loom\SearchScore.bb"
+
+
+// No match returns 0.
+Test testNoMatchIsZero()
+    Assert(Loom_ScoreName%("zzz", "Goblin") = 0)
+    Assert(Loom_ScoreName%("sword", "") = 0)
+End Test
+
+
+// Exact match scores highest.
+Test testExactBeatsPrefix()
+    Local exact% = Loom_ScoreName%("sword", "Sword")
+    Local prefix% = Loom_ScoreName%("sword", "Swordsman")
+    Assert(exact > prefix)
+End Test
+
+
+// Prefix match beats substring match, for ANY name lengths within range.
+Test testPrefixBeatsSubstring()
+    // "sword" is a prefix of "Swordfish" and a mid-substring of "Greatsword".
+    Local prefix% = Loom_ScoreName%("sword", "Swordfish")
+    Local substr% = Loom_ScoreName%("sword", "Greatsword")
+    Assert(prefix > substr)
+    Assert(substr > 0)
+End Test
+
+
+// Within the prefix tier, a shorter name ranks higher (closer to an exact
+// match -- "Axe" should beat "Axehandle" for query "axe").
+Test testShorterPrefixRanksHigher()
+    Local shortName% = Loom_ScoreName%("axe", "Axes")
+    Local longName%  = Loom_ScoreName%("axe", "Axehandle of Doom")
+    Assert(shortName > longName)
+End Test
+
+
+// Within the substring tier, an earlier match position ranks higher.
+Test testEarlierSubstringRanksHigher()
+    // "ron" at pos 2 in "Iron" vs pos 5 in "Best ron" -- earlier wins.
+    Local early% = Loom_ScoreName%("ron", "Iron")
+    Local late%  = Loom_ScoreName%("ron", "Best ron")
+    Assert(early > late)
+    Assert(late > 0)
+End Test
+
+
+// Matching is case-insensitive on the name side (caller lowercases query).
+Test testCaseInsensitiveName()
+    Assert(Loom_ScoreName%("goblin", "GOBLIN") = LOOM_SCORE_EXACT)
+    Assert(Loom_ScoreName%("gob", "GOBLIN") >= LOOM_SCORE_PREFIX)
+End Test


### PR DESCRIPTION
## Why

Conservative, executably-verifiable iteration (GUI changes can't be runtime-verified here; logic can, via `test.bat`). Third pure-logic extraction (after NameUtil #419, Clamp #420), hardening the Ctrl+K palette's ranking.

`Loom_ScoreName` decides which results surface first in the find-anywhere palette: **exact > prefix > substring > none**, with shorter prefix-names and earlier substring positions winning ties. It was inline as `Palette::scoreName` + the `PAL_SCORE_*` constants, so it couldn't be tested — and a silent tier inversion would just make the palette show the wrong results first, invisible without a test.

## Change

- New `Modules/Loom/SearchScore.bb` — pure, **zero-dependency** `Loom_ScoreName` + the `LOOM_SCORE_*` constants.
- `Palette::scoreName` is now a thin delegate → `scoreOrBaseline` call site unchanged, **behavior identical**.
- New `src/Tests/Modules/Loom/SearchScoreTest.bb` (Strict + EnableGC, no stubs) pins: no-match=0, exact>prefix, prefix>substring, shorter prefix-name ranks higher, earlier substring position ranks higher, case-insensitive name side.

## Verification (executed)

- `compile.bat -t` clean — all 5 targets (exit 0).
- `test.bat SearchScoreTest` → **1 passed, 0 failed, 0 unreleased objects.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)