### PR TITLE
Loom: render mesh preview directly into its box (fix top-left 3D bleed)

### DIFF
--- a/src/Modules/Loom/MeshPreview.bb
+++ b/src/Modules/Loom/MeshPreview.bb
@@ -364,14 +364,21 @@ Function Loom_DrawMeshPreview(meshID, x, y, size)
         RotateEntity PreviewMesh, 0, PreviewSpinTime#, 0
     EndIf
 
-    ; ---- Render to texture --------------------------------------------------
+    ; ---- Render directly to the back buffer at the on-screen rect ----------
+    ; Render-to-texture (SetBuffer TextureBuffer + RenderWorld) does NOT
+    ; capture 3D in this BlitzForge build: RenderWorld lands on the BACK
+    ; BUFFER at the camera's viewport regardless of SetBuffer (confirmed from
+    ; a user screenshot -- the mesh painted at the top-left 0,0 box while the
+    ; CopyRect'd texture stayed black). So aim the camera's viewport AT the
+    ; on-screen box and render straight to the back buffer. CameraViewport
+    ; confines RenderWorld's clear + draw to the box, leaving the rest of the
+    ; 2D composer frame intact.
+    CameraViewport PreviewCam, x, y, size, size
     ShowEntity PreviewCam
-    SetBuffer TextureBuffer(PreviewRT)
     RenderWorld
-    SetBuffer BackBuffer()
     HideEntity PreviewCam
-
-    Loom_BlitPreviewTexture(PreviewRT, x, y, size)
+    ; Brass border on top (used to live in Loom_BlitPreviewTexture).
+    LoomBorder x, y, size, size, LOOM_BRASS_500_R, LOOM_BRASS_500_G, LOOM_BRASS_500_B
 
     ; Hover hint: tiny text in the bottom-left corner of the widget
     ; describing the controls. Only painted when the mouse is inside


### PR DESCRIPTION
## Why

Your screenshots nailed it: the actor/item/mesh 3D preview painted at the **top-left (0,0)** while the composer's box stayed **black**. Root cause — **render-to-texture does not capture 3D in this BlitzForge build**: `SetBuffer(TextureBuffer) + RenderWorld` lands on the back buffer at the camera's *viewport rect* regardless of the SetBuffer target. #418 had pinned that viewport to `0,0`, so the mesh rendered top-left; the `CopyRect`'d (empty) texture gave the black box. (2D `Line`/`CopyRect` *do* respect SetBuffer — which is exactly why the zone schematic's wireframe showed in its box but its terrain rendered top-left. Same bug.)

## Fix

Drop the broken RTT path; aim the camera's viewport **at the on-screen box** (`CameraViewport PreviewCam, x, y, size, size`) and `RenderWorld` straight to the back buffer. `CameraViewport` confines the clear + draw to the box, leaving the rest of the 2D composer frame intact. Border drawn on top.

## Scope

This PR fixes the **actor / item / mesh** preview (the box). The **zone full-screen fly-around** you asked for is a separate, larger follow-up — same direct-render mechanism, but full-screen rect + camera/overlay coordinate handling — coming next.

## Verification

- `compile.bat -t` clean (5/5 targets). **GUI behavior needs your eyes** — agent-launched Blitz apps can't init Graphics3D here, so I can't screenshot it; this is exactly the fix your screenshot pointed to.

🤖 Generated with [Claude Code](https://claude.com/claude-code)