### PR TITLE
Loom: zone viewport renders full-screen (fly-around editor)

### DIFF
--- a/src/Modules/Loom/Composer.bb
+++ b/src/Modules/Loom/Composer.bb
@@ -430,26 +430,31 @@ Type Composer
         Local bodyY% = y + CMP_PAD + 50
         Local bodyH% = h - (bodyY - y) - 24
 
-        // Pinned viewport band. Kinds with a 3D viewport (actor / item /
-        // mesh / zone) reserve a fixed, NON-scrolling band at the top of
-        // the body; the field rows scroll BELOW it. Pinning (vs. letting
-        // the viewport scroll with the body) means: the RenderWorld/CopyRect
-        // rect never lands over the header (no bleed), the preview stays
-        // visible while you edit fields, and the wheel split is clean
-        // (cursor-over-viewport = zoom, cursor-over-fields = scroll).
+        // Pinned viewport band. Mesh-preview kinds (actor / item / mesh)
+        // reserve a fixed, NON-scrolling band at the top of the body; the
+        // field rows scroll BELOW it. viewportSize()=0 for zone, so it
+        // reserves NO band -- zone renders full-screen on the left instead
+        // (see the zone branch below), and its fields fill the full panel.
+        Local vpSz% = Composer::viewportSize(self, kind)
         Local vpBandH% = 0
-        If Composer::kindHasViewport(self, kind) = True
-            vpBandH = Composer::viewportSize(self, kind) + 10
-        EndIf
+        If vpSz > 0 Then vpBandH = vpSz + 10
 
         self\bodyTop    = bodyY + vpBandH
         self\bodyBottom = bodyY + bodyH
         Local scrolledBodyY% = self\bodyTop - self\scrollOffset
         self\chipHit = False
 
-        // Draw the pinned viewport first, at the fixed band top (unscrolled).
+        // Draw the pinned mesh-preview box first, at the fixed band top.
         If vpBandH > 0
             Composer::drawPinnedViewport(self, kind, refID, x, w, bodyY)
+        EndIf
+
+        // Zone gets a full-screen fly-around viewport in the left content
+        // area (left of the composer panel). Direct-to-back-buffer; the
+        // composer panel overlays on the right so the zone fields stay
+        // editable while flying.
+        If kind = "zone"
+            Composer::drawZoneFullscreen(self, refID, sw, sh)
         EndIf
 
         If kind = "actor"
@@ -2804,10 +2809,13 @@ Type Composer
         Return False
     End Method
 
-    // Square edge of the viewport for this kind. Zone uses the larger
-    // schematic (VP_RT_SIZE); the others use the mesh-preview square.
+    // Square edge of the PINNED-BOX viewport for this kind (mesh preview).
+    // Zone returns 0: it doesn't use a composer band -- it renders as a
+    // full-screen fly-around viewport in the left content area instead
+    // (see the zone branch in renderAndUpdate). 0 means no band reserved,
+    // so the zone fields fill the full composer height on the right.
     Method viewportSize%(kind$)
-        If kind = "zone" Then Return VP_RT_SIZE
+        If kind = "zone" Then Return 0
         If Composer::kindHasViewport(self, kind) = True Then Return LOOM_PREVIEW_SIZE
         Return 0
     End Method
@@ -2850,10 +2858,26 @@ Type Composer
         Else If kind = "mesh"
             Local mh.MeshEntry = Meshes_GetByIndex(refID)
             If mh <> Null Then Loom_DrawMeshPreview(mh\ID, vpX, vpY, LOOM_PREVIEW_SIZE)
-        Else If kind = "zone"
-            Local Ar.Area = Object.Area(refID)
-            If Ar <> Null Then Loom_DrawZoneViewport(refID, vpX, vpY)
         EndIf
+        // Zone is intentionally NOT here -- it renders full-screen via
+        // Composer::drawZoneFullscreen in renderAndUpdate, not as a box.
+    End Method
+
+
+    // Full-screen zone fly-around viewport. Fills the left content area --
+    // everything left of the composer panel, between the browser filter bar
+    // (tabs/filter stay usable above) and the footer. Loom_DrawZoneViewport
+    // renders the 3D scene directly to the back buffer at this rect with
+    // orbit / pan / zoom + click-to-edit markers. The composer panel
+    // overlays on the right, so zone fields stay editable while flying.
+    Method drawZoneFullscreen(refID%, sw%, sh%)
+        Local zvX% = 0
+        Local zvY% = BR_TOP_RIBBON + BR_TAB_BAR_H + BR_FILTER_BAR_H
+        Local zvW% = sw - CMP_W
+        Local zvH% = sh - zvY - BR_BOT_RIBBON
+        If zvW < 120 Or zvH < 120 Then Return
+        Local Ar.Area = Object.Area(refID)
+        If Ar <> Null Then Loom_DrawZoneViewport(refID, zvX, zvY, zvW, zvH)
     End Method
 
 

--- a/src/Modules/Loom/ZoneViewport.bb
+++ b/src/Modules/Loom/ZoneViewport.bb
@@ -1159,36 +1159,47 @@ Function Loom_DrawZoneViewport(zoneHandle, x, y, w, h)
     Local gridStep# = 250.0
     Local g# = -gridSpan#
     While g# <= gridSpan#
-        ; X-direction line: constant z = g, x varies -gridSpan..+gridSpan
+        ; X-direction line: constant z = g, x varies -gridSpan..+gridSpan.
+        ; CameraProject is a void command; it leaves ProjectedZ()=0 (and
+        ; X/Y at 0) for points outside the frustum (behind the camera / past
+        ; the far plane). Drawing those produced the fan of lines converging
+        ; on the top-left corner. ProjectedZ()>0 means the point is in view;
+        ; capture each endpoint's values before the next CameraProject
+        ; overwrites them, and only draw when BOTH endpoints are visible.
         CameraProject VPCam, -gridSpan#, VP_SCENE_Y_OFFSET#, g#
         Local ax = x + ProjectedX()
         Local ay = y + ProjectedY()
+        Local az# = ProjectedZ#()
         CameraProject VPCam,  gridSpan#, VP_SCENE_Y_OFFSET#, g#
         Local bx = x + ProjectedX()
         Local by = y + ProjectedY()
-        Line ax, ay, bx, by
+        Local bz# = ProjectedZ#()
+        If az# > 0.0 And bz# > 0.0 Then Line ax, ay, bx, by
         ; Z-direction line: constant x = g, z varies
         CameraProject VPCam, g#, VP_SCENE_Y_OFFSET#, -gridSpan#
         Local cx2 = x + ProjectedX()
         Local cy2 = y + ProjectedY()
+        Local cz2# = ProjectedZ#()
         CameraProject VPCam, g#, VP_SCENE_Y_OFFSET#,  gridSpan#
         Local dx2 = x + ProjectedX()
         Local dy2 = y + ProjectedY()
-        Line cx2, cy2, dx2, dy2
+        Local dz2# = ProjectedZ#()
+        If cz2# > 0.0 And dz2# > 0.0 Then Line cx2, cy2, dx2, dy2
         g# = g# + gridStep#
     Wend
 
     ; Compass labels at +N/+S/+E/+W on the ground (project through the same
-    ; camera so they tilt with the view).
+    ; camera so they tilt with the view). Only draw when in view, else they'd
+    ; stack in the top-left corner like the grid lines did.
     Color 200, 200, 110   ; brass-light for compass letters
-    CameraProject VPCam, 0,             VP_SCENE_Y_OFFSET#,  gridSpan#
-    Text x + ProjectedX(), y + ProjectedY(), "N", True, True
-    CameraProject VPCam, 0,             VP_SCENE_Y_OFFSET#, -gridSpan#
-    Text x + ProjectedX(), y + ProjectedY(), "S", True, True
-    CameraProject VPCam,  gridSpan#,    VP_SCENE_Y_OFFSET#, 0
-    Text x + ProjectedX(), y + ProjectedY(), "E", True, True
-    CameraProject VPCam, -gridSpan#,    VP_SCENE_Y_OFFSET#, 0
-    Text x + ProjectedX(), y + ProjectedY(), "W", True, True
+    CameraProject VPCam, 0, VP_SCENE_Y_OFFSET#, gridSpan#
+    If ProjectedZ#() > 0.0 Then Text x + ProjectedX(), y + ProjectedY(), "N", True, True
+    CameraProject VPCam, 0, VP_SCENE_Y_OFFSET#, -gridSpan#
+    If ProjectedZ#() > 0.0 Then Text x + ProjectedX(), y + ProjectedY(), "S", True, True
+    CameraProject VPCam, gridSpan#, VP_SCENE_Y_OFFSET#, 0
+    If ProjectedZ#() > 0.0 Then Text x + ProjectedX(), y + ProjectedY(), "E", True, True
+    CameraProject VPCam, -gridSpan#, VP_SCENE_Y_OFFSET#, 0
+    If ProjectedZ#() > 0.0 Then Text x + ProjectedX(), y + ProjectedY(), "W", True, True
     Viewport 0, 0, GraphicsWidth(), GraphicsHeight()
 
     LoomBorder x, y, w, h, LOOM_BRASS_500_R, LOOM_BRASS_500_G, LOOM_BRASS_500_B

--- a/src/Modules/Loom/ZoneViewport.bb
+++ b/src/Modules/Loom/ZoneViewport.bb
@@ -863,18 +863,26 @@ End Function
 ; zone if the zone handle changed since last frame. Then handles orbit/
 ; zoom input, repositions the camera, renders to RT, blits to back buffer.
 ; =============================================================================
-Function Loom_DrawZoneViewport(zoneHandle, x, y)
+; Loom_DrawZoneViewport -- render the zone 3D scene into the screen rect
+; (x, y, w, h). Full-screen capable: the composer passes the whole left area
+; so the designer can fly around and edit markers directly. Renders the
+; camera DIRECTLY to the back buffer at (x,y,w,h) -- render-to-texture does
+; not capture 3D in this BlitzForge build (see MeshPreview note), so we aim
+; the camera's viewport at the on-screen rect instead. CameraPick coords are
+; viewport-relative (mx-x, my-y); CameraProject results are too, so the 2D
+; grid/compass overlays are offset by (x,y) when drawn to the back buffer.
+Function Loom_DrawZoneViewport(zoneHandle, x, y, w, h)
     If VPInitOK = False
-        LoomFill x, y, VP_RT_SIZE, VP_RT_SIZE, LOOM_STONE_900_R, LOOM_STONE_900_G, LOOM_STONE_900_B
-        LoomBorder x, y, VP_RT_SIZE, VP_RT_SIZE, LOOM_STONE_700_R, LOOM_STONE_700_G, LOOM_STONE_700_B
+        LoomFill x, y, w, h, LOOM_STONE_900_R, LOOM_STONE_900_G, LOOM_STONE_900_B
+        LoomBorder x, y, w, h, LOOM_STONE_700_R, LOOM_STONE_700_G, LOOM_STONE_700_B
         LoomText x + 8, y + 8, "viewport init failed", LOOM_STONE_300_R, LOOM_STONE_300_G, LOOM_STONE_300_B
         Return False
     EndIf
 
     Local Ar.Area = Object.Area(zoneHandle)
     If Ar = Null
-        LoomFill x, y, VP_RT_SIZE, VP_RT_SIZE, LOOM_STONE_900_R, LOOM_STONE_900_G, LOOM_STONE_900_B
-        LoomBorder x, y, VP_RT_SIZE, VP_RT_SIZE, LOOM_STONE_700_R, LOOM_STONE_700_G, LOOM_STONE_700_B
+        LoomFill x, y, w, h, LOOM_STONE_900_R, LOOM_STONE_900_G, LOOM_STONE_900_B
+        LoomBorder x, y, w, h, LOOM_STONE_700_R, LOOM_STONE_700_G, LOOM_STONE_700_B
         LoomText x + 8, y + 8, "no zone focused", LOOM_STONE_300_R, LOOM_STONE_300_G, LOOM_STONE_300_B
         Return False
     EndIf
@@ -886,10 +894,15 @@ Function Loom_DrawZoneViewport(zoneHandle, x, y)
         WriteLog(LoomLog, "ZoneViewport: loaded zone " + Ar\Name$)
     EndIf
 
+    ; Aim the camera's viewport at the on-screen rect up front so the
+    ; CameraPick calls below (which run before this frame's RenderWorld)
+    ; use the current rect. Picks are viewport-relative -> (mx-x, my-y).
+    CameraViewport VPCam, x, y, w, h
+
     ; ---- Input handling -----------------------------------------------------
     Local mx = MouseX()
     Local my = MouseY()
-    Local inside = (mx >= x And mx < x + VP_RT_SIZE And my >= y And my < y + VP_RT_SIZE)
+    Local inside = (mx >= x And mx < x + w And my >= y And my < y + h)
 
     If MouseDown(1) = True And inside = True
         If VPDragging = False
@@ -1120,80 +1133,65 @@ Function Loom_DrawZoneViewport(zoneHandle, x, y)
         VPDirty = True
     EndIf
 
-    ; ---- Re-render to texture only when something changed ------------------
-    ; Camera orbit/pan/zoom + marker drags + highlight transitions all
-    ; set VPDirty = True. Static frames skip RenderWorld + the camera
-    ; re-position math; the cached texture from the last render gets
-    ; CopyRect'd to the back buffer below.
-    If VPDirty = True
-        Local cx# = VPSceneCenterX# + Cos(VPPitch#) * Sin(VPYaw#) * VPDistance#
-        Local cy# = VP_SCENE_Y_OFFSET# + VPSceneCenterY# + Sin(VPPitch#) * VPDistance#
-        Local cz# = VPSceneCenterZ# - Cos(VPPitch#) * Cos(VPYaw#) * VPDistance#
-        PositionEntity VPCam, cx#, cy#, cz#
-        PointEntity VPCam, VPGround
+    ; ---- Render the scene directly to the back buffer, every frame ---------
+    ; The back buffer is cleared at the top of renderFrame, so unlike the old
+    ; render-to-texture path (which doesn't capture 3D in this BlitzForge
+    ; build anyway) we re-render each frame. CameraViewport (set above)
+    ; confines RenderWorld's clear + draw to the (x,y,w,h) rect.
+    Local cx# = VPSceneCenterX# + Cos(VPPitch#) * Sin(VPYaw#) * VPDistance#
+    Local cy# = VP_SCENE_Y_OFFSET# + VPSceneCenterY# + Sin(VPPitch#) * VPDistance#
+    Local cz# = VPSceneCenterZ# - Cos(VPPitch#) * Cos(VPYaw#) * VPDistance#
+    PositionEntity VPCam, cx#, cy#, cz#
+    PointEntity VPCam, VPGround
 
-        ShowEntity VPCam
-        SetBuffer TextureBuffer(VPRT)
-        RenderWorld
+    ShowEntity VPCam
+    RenderWorld
+    HideEntity VPCam
+    VPDirty = False
 
-        ; ---- Ground grid overlay -----------------------------------------------
-        ; Paint axis-aligned grid lines on top of the rendered scene to
-        ; convey scale. CameraProject converts world (x, scene_y, z) to
-        ; RT-local screen coords; we draw 2D Lines between projected
-        ; endpoints. Lines outside the RT clip naturally because the
-        ; buffer is bounded.
-        ;
-        ; Step 250 world units = 16 lines across the 4000-unit ground
-        ; we render -- dense enough to read but not noisy.
-        Color 70, 70, 80      ; muted stone-grey for grid
-        Local gridSpan# = 2000.0
-        Local gridStep# = 250.0
-        Local g# = -gridSpan#
-        While g# <= gridSpan#
-            ; X-direction line: constant z = g, x varies -gridSpan..+gridSpan
-            CameraProject VPCam, -gridSpan#, VP_SCENE_Y_OFFSET#, g#
-            Local ax = ProjectedX()
-            Local ay = ProjectedY()
-            CameraProject VPCam,  gridSpan#, VP_SCENE_Y_OFFSET#, g#
-            Local bx = ProjectedX()
-            Local by = ProjectedY()
-            Line ax, ay, bx, by
-            ; Z-direction line: constant x = g, z varies
-            CameraProject VPCam, g#, VP_SCENE_Y_OFFSET#, -gridSpan#
-            Local cx2 = ProjectedX()
-            Local cy2 = ProjectedY()
-            CameraProject VPCam, g#, VP_SCENE_Y_OFFSET#,  gridSpan#
-            Local dx2 = ProjectedX()
-            Local dy2 = ProjectedY()
-            Line cx2, cy2, dx2, dy2
-            g# = g# + gridStep#
-        Wend
+    ; ---- 2D overlays (grid + compass) on the back buffer -------------------
+    ; CameraProject results are viewport-relative, so offset by (x,y). The 2D
+    ; Viewport clips them to the rect so projected lines/labels can't bleed
+    ; onto the composer panel or window chrome. Reset to full buffer after.
+    Viewport x, y, w, h
+    Color 70, 70, 80      ; muted stone-grey for grid
+    Local gridSpan# = 2000.0
+    Local gridStep# = 250.0
+    Local g# = -gridSpan#
+    While g# <= gridSpan#
+        ; X-direction line: constant z = g, x varies -gridSpan..+gridSpan
+        CameraProject VPCam, -gridSpan#, VP_SCENE_Y_OFFSET#, g#
+        Local ax = x + ProjectedX()
+        Local ay = y + ProjectedY()
+        CameraProject VPCam,  gridSpan#, VP_SCENE_Y_OFFSET#, g#
+        Local bx = x + ProjectedX()
+        Local by = y + ProjectedY()
+        Line ax, ay, bx, by
+        ; Z-direction line: constant x = g, z varies
+        CameraProject VPCam, g#, VP_SCENE_Y_OFFSET#, -gridSpan#
+        Local cx2 = x + ProjectedX()
+        Local cy2 = y + ProjectedY()
+        CameraProject VPCam, g#, VP_SCENE_Y_OFFSET#,  gridSpan#
+        Local dx2 = x + ProjectedX()
+        Local dy2 = y + ProjectedY()
+        Line cx2, cy2, dx2, dy2
+        g# = g# + gridStep#
+    Wend
 
-        ; Compass labels at +N (north) +S +E +W positions on the ground.
-        ; In Loom's coord convention +Z is "north" (mirrors how the GUE
-        ; in-game camera + minimap orient). Letters projected through
-        ; the same camera so they tilt with view -- gives an intuitive
-        ; "you are facing N" cue when orbit changes.
-        Color 200, 200, 110   ; brass-light for compass letters
-        CameraProject VPCam, 0,             VP_SCENE_Y_OFFSET#,  gridSpan#
-        Text ProjectedX(), ProjectedY(), "N", True, True
-        CameraProject VPCam, 0,             VP_SCENE_Y_OFFSET#, -gridSpan#
-        Text ProjectedX(), ProjectedY(), "S", True, True
-        CameraProject VPCam,  gridSpan#,    VP_SCENE_Y_OFFSET#, 0
-        Text ProjectedX(), ProjectedY(), "E", True, True
-        CameraProject VPCam, -gridSpan#,    VP_SCENE_Y_OFFSET#, 0
-        Text ProjectedX(), ProjectedY(), "W", True, True
+    ; Compass labels at +N/+S/+E/+W on the ground (project through the same
+    ; camera so they tilt with the view).
+    Color 200, 200, 110   ; brass-light for compass letters
+    CameraProject VPCam, 0,             VP_SCENE_Y_OFFSET#,  gridSpan#
+    Text x + ProjectedX(), y + ProjectedY(), "N", True, True
+    CameraProject VPCam, 0,             VP_SCENE_Y_OFFSET#, -gridSpan#
+    Text x + ProjectedX(), y + ProjectedY(), "S", True, True
+    CameraProject VPCam,  gridSpan#,    VP_SCENE_Y_OFFSET#, 0
+    Text x + ProjectedX(), y + ProjectedY(), "E", True, True
+    CameraProject VPCam, -gridSpan#,    VP_SCENE_Y_OFFSET#, 0
+    Text x + ProjectedX(), y + ProjectedY(), "W", True, True
+    Viewport 0, 0, GraphicsWidth(), GraphicsHeight()
 
-        SetBuffer BackBuffer()
-        HideEntity VPCam
-
-        VPDirty = False
-    EndIf
-
-    ; Blit cached texture to back buffer every frame (back buffer is
-    ; cleared at the top of renderFrame so we always need to repaint).
-    CopyRect 0, 0, VP_RT_SIZE, VP_RT_SIZE, x, y, TextureBuffer(VPRT), BackBuffer()
-    LoomBorder x, y, VP_RT_SIZE, VP_RT_SIZE, LOOM_BRASS_500_R, LOOM_BRASS_500_G, LOOM_BRASS_500_B
+    LoomBorder x, y, w, h, LOOM_BRASS_500_R, LOOM_BRASS_500_G, LOOM_BRASS_500_B
 
     ; Legend overlay with live counts. Capitalized labels mirror the
     ; composer section names so the user can mentally map widget colors
@@ -1203,15 +1201,15 @@ Function Loom_DrawZoneViewport(zoneHandle, x, y)
     LoomText x + 8, y + 40, "triggers "  + Str(VPCountTriggers),  LOOM_WARNING_R, LOOM_WARNING_G, LOOM_WARNING_B
     LoomText x + 8, y + 56, "waypoints " + Str(VPCountWaypoints), 200, 200, 210
     ; X/Y/Z axis legend (matches the colored lines at scene origin)
-    LoomText x + VP_RT_SIZE - 60, y + 26, "X", 220, 60, 60
-    LoomText x + VP_RT_SIZE - 48, y + 26, "Y", 60, 220, 60
-    LoomText x + VP_RT_SIZE - 36, y + 26, "Z", 60, 120, 220
+    LoomText x + w - 60, y + 26, "X", 220, 60, 60
+    LoomText x + w - 48, y + 26, "Y", 60, 220, 60
+    LoomText x + w - 36, y + 26, "Z", 60, 120, 220
 
     ; Reset View pill -- top-right corner. Click restores auto-fit
     ; camera + clears orbit/zoom for the loaded zone. Useful when
     ; the user has spun the camera so far they can't find anything.
     Local rsW = 60
-    Local rsX = x + VP_RT_SIZE - rsW - 6
+    Local rsX = x + w - rsW - 6
     Local rsY = y + 6
     Local rsHover = (mx >= rsX And mx < rsX + rsW And my >= rsY And my < rsY + 16)
     If rsHover = True
@@ -1243,7 +1241,7 @@ Function Loom_DrawZoneViewport(zoneHandle, x, y)
                     ; Clamp inside widget rect so the text doesn't
                     ; leak outside the viewport border.
                     If pxL < x + 4 Then pxL = x + 4
-                    If pxL + lblW > x + VP_RT_SIZE - 4 Then pxL = x + VP_RT_SIZE - lblW - 4
+                    If pxL + lblW > x + w - 4 Then pxL = x + w - lblW - 4
                     If pyL < y + 4 Then pyL = y + 4
                     LoomFill pxL, pyL, lblW, 14, LOOM_STONE_900_R, LOOM_STONE_900_G, LOOM_STONE_900_B
                     LoomBorder pxL, pyL, lblW, 14, LOOM_BRASS_500_R, LOOM_BRASS_500_G, LOOM_BRASS_500_B
@@ -1255,7 +1253,7 @@ Function Loom_DrawZoneViewport(zoneHandle, x, y)
     EndIf
 
     If inside = True
-        LoomText x + 8, y + VP_RT_SIZE - 18, "LMB=orbit RMB=move(shift+Y) wheel=zoom shift+click=add ctrl+click=del", LOOM_STONE_300_R, LOOM_STONE_300_G, LOOM_STONE_300_B
+        LoomText x + 8, y + h - 18, "LMB=orbit RMB=move(shift+Y) wheel=zoom shift+click=add ctrl+click=del", LOOM_STONE_300_R, LOOM_STONE_300_G, LOOM_STONE_300_B
     EndIf
 
     Return True


### PR DESCRIPTION
## Why

Your feedback: zone editing should be a **full-screen fly-around**, not a small box; and the 3D was rendering in the top-left. Same root cause as the mesh fix (#422) — 3D `RenderWorld` doesn't capture to a texture in this BlitzForge build (it lands on the back buffer at the camera's viewport), which is why the terrain painted top-left while only the 2D wireframe showed in the box.

## Change

**ZoneViewport** — `Loom_DrawZoneViewport(zoneHandle, x, y)` → `(zoneHandle, x, y, w, h)`:
- Renders directly to the back buffer every frame via `CameraViewport(x,y,w,h)` + `RenderWorld` (dropped the failing RTT/`CopyRect` path).
- 2D grid/compass offset by `(x,y)` (`CameraProject` is viewport-relative — confirmed in `bbCameraProject`) and clipped with the 2D `Viewport` command so they can't bleed onto the panel.
- `CameraPick` stays viewport-relative (`mx-x, my-y`) — orbit/pan/zoom/click-to-edit unchanged.

**Composer** — zone reserves no pinned band (`viewportSize("zone")=0`); fields fill the panel on the right. New `drawZoneFullscreen` renders the viewport in the **left content area** (left of the panel, below the browser filter bar so tabs stay usable, down to the footer). You fly on the left, edit fields on the right.

Mesh/item/actor previews stay pinned boxes (#422, unchanged).

## Verification — needs your eyes

`compile.bat -t` clean (5/5). I **can't** run the GUI here (agent-launched Blitz can't init Graphics3D). **The local `bin/Loom.exe` is already rebuilt with this** — focus a zone and check: the 3D scene fills the left area, you can orbit/pan/zoom/click-edit, and the grid/compass stay inside the viewport. Tell me what you see and I'll iterate (e.g. if you want it even larger / over the tab bar too).

🤖 Generated with [Claude Code](https://claude.com/claude-code)