### PR TITLE
Loom: zone viewport wheel/zoom fix (browser was stealing the wheel)

### DIFF
--- a/src/Modules/Loom/Browser.bb
+++ b/src/Modules/Loom/Browser.bb
@@ -276,6 +276,18 @@ Type Browser
 
         // Card grid -- shrink the effective width by composerWidth so
         // cards never end up half-hidden behind the composer panel.
+        //
+        // When a ZONE is focused, the composer renders a full-screen 3D
+        // viewport over the entire left content area -- the card grid is
+        // completely hidden behind it. Skip the grid entirely in that case
+        // so it doesn't steal the wheel (zoom) / clicks meant for the
+        // viewport: the grid runs BEFORE the composer in the frame, and its
+        // wheel handler was consuming the tick before the viewport could
+        // read it (cursor-over-viewport zoom did nothing as a result).
+        self\cardClickLatch = False
+        If self\threads <> Null And self\threads\focusKind = "zone"
+            Return False
+        EndIf
         Browser::drawCardGrid(self, sw - composerWidth, sh, mx, my, clicked)
         Return self\cardClickLatch
     End Method


### PR DESCRIPTION
## Why

You reported: in the full-screen zone viewport, scroll-wheel zoom does nothing when the cursor is over the viewport, but scrolling over the composer panel affected both. Root cause found in the input arbitration.

When a zone is focused, the composer draws a full-screen 3D viewport over the whole left content area — hiding the browser card grid behind it. But the browser still ran its card-grid handler every frame **before** the composer, and its wheel handler consumed the per-frame wheel delta whenever the cursor was in the left area (i.e. over the hidden viewport). The zone viewport's own zoom handler runs later (in the composer body), so it always saw a zeroed wheel.

## Fix

When `threads.focusKind = "zone"`, `Browser::renderAndUpdate` skips the card grid entirely (it's fully occluded by the viewport). The grid no longer grabs the wheel/clicks meant for the viewport, so wheel-zoom now reaches the viewport over its own area; the composer panel on the right still scrolls its zone fields.

## Controls (for reference)

LMB-drag = orbit · MMB-drag = pan · wheel = zoom · RMB-drag a marker = move it (shift = Y axis) · shift+LMB = add portal · ctrl+LMB = delete marker · shift+RMB on ground = add trigger.

## Verification — needs your eyes

`compile.bat -t` clean (5/5). Local `bin\Loom.exe` rebuilt. Please re-test: wheel-zoom over the viewport should now work; composer scroll over the panel should still work and NOT zoom the viewport.

🤖 Generated with [Claude Code](https://claude.com/claude-code)