### PR TITLE
Loom/GUE: extract GetFilename$ to shared Modules/Path.bb (ADR-004 Phase A)

### DIFF
--- a/src/GUE.bb
+++ b/src/GUE.bb
@@ -8,6 +8,7 @@ ChangeDir RootDir$
 
 ; Includes --------------------------------------------------------------------------------------------------------------------------
 
+Include "Modules\Path.bb"
 Include "Modules\RCEnet.bb"
 Include "Modules\Media.bb"
 Include "Modules\MediaImport.bb"
@@ -9699,15 +9700,9 @@ Function RepositionWaypointLinks(WP, Parent = True)
 
 End Function
 
-; Gets the stripped filename from a path
-Function GetFilename$(Path$)
-
-	For i = Len(Path$) To 1 Step -1
-		If Mid$(Path$, i, 1) = "\" Or Mid$(Path$, i, 1) = "/" Then Return Mid$(Path$, i + 1)
-	Next
-	Return Path$
-
-End Function
+; GetFilename$ moved to Modules\Path.bb (ADR-004 Phase A) so Loom + the
+; shared zone loader can use it without depending on GUE.bb. Included near
+; the top of this file; callers below resolve to it unchanged.
 
 ; Displays the saving dialog
 Function SaveDialog()

--- a/src/Loom.bb
+++ b/src/Loom.bb
@@ -79,6 +79,7 @@ Global EnvironmentSaved = True
 //
 // Order matters for Type declarations -- mirror GUE.bb's order.
 // -----------------------------------------------------------------------------
+Include "Modules\Path.bb"
 Include "Modules\RCEnet.bb"
 Include "Modules\Media.bb"
 Include "Modules\MediaImport.bb"

--- a/src/Modules/Path.bb
+++ b/src/Modules/Path.bb
@@ -1,0 +1,18 @@
+; =============================================================================
+; Modules/Path.bb -- shared filesystem-path string helpers
+; =============================================================================
+;
+; Extracted from GUE.bb (ADR-004 Phase A) so both GUE and Loom -- and the
+; future shared LoadAreaData zone-loading path -- can use GetFilename$ without
+; pulling in GUE.bb. Non-Strict to match the legacy data/UI modules and the
+; `For i = ...` implicit-Local idiom this function uses.
+
+; Gets the stripped filename from a path (the text after the last \ or /).
+Function GetFilename$(Path$)
+
+	For i = Len(Path$) To 1 Step -1
+		If Mid$(Path$, i, 1) = "\" Or Mid$(Path$, i, 1) = "/" Then Return Mid$(Path$, i + 1)
+	Next
+	Return Path$
+
+End Function


### PR DESCRIPTION
## Why

Phase A of the agreed path to render the real 3D world in Loom's zone viewport (reuse GUE's loader). GUE's `LoadArea` and ~40 GUE UI sites call `GetFilename$`, which lived *inside* GUE.bb — so Loom couldn't reach the loader without depending on GUE.bb.

## Change

Moved the 5-line pure helper to a new dependency-free `Modules/Path.bb`, included by both GUE.bb and Loom.bb. Blitz functions are global, so GUE's existing callers resolve to the moved definition **unchanged** (no edits to the ~40 sites). Pure relocation, no behavior change.

## Next

- **Phase B**: carve `LoadArea`'s data path (terrain mesh + scenery parse) out of its Gooey/loading-screen UI into a shared loader both editors call.
- **Phase C**: a Loom `WorldView` renders the loaded Area in the zone viewport.

## Verification

`compile.bat -t` clean — all 5 targets (Server/Client/GUE/Loom/Project Manager) build, `GetFilename$` resolves with no duplicate. Pure refactor; CI's full compile is the gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)