### PR TITLE
Loom: fix actor-select stack overflow (negative array index via non-SC And)

### DIFF
--- a/src/Modules/Loom/Composer.bb
+++ b/src/Modules/Loom/Composer.bb
@@ -2964,10 +2964,16 @@ Type Composer
             Local i%
             For i = 0 To n - 1
                 // Boundary: close the previous group with a heading, then gap.
-                If i > 0 And self\twKind[i] <> self\twKind[i - 1]
-                    Composer::drawTypeLabel(self, cx, cy, (grpStartAng# + curAng# - perNode#) / 2.0, radius# + 50.0, self\twKind[i - 1])
-                    curAng# = curAng# + gapDeg#
-                    grpStartAng# = curAng#
+                // NESTED If (not `i > 0 And ...`): BlitzForge's And is
+                // non-short-circuit, so the single-line form read twKind[i-1]
+                // = twKind[-1] when i=0 -- a negative array index that
+                // corrupted memory / stack-overflowed on actor select.
+                If i > 0
+                    If self\twKind[i] <> self\twKind[i - 1]
+                        Composer::drawTypeLabel(self, cx, cy, (grpStartAng# + curAng# - perNode#) / 2.0, radius# + 50.0, self\twKind[i - 1])
+                        curAng# = curAng# + gapDeg#
+                        grpStartAng# = curAng#
+                    EndIf
                 EndIf
                 // Chip sized to its label (matches renderChip's text layout).
                 Local nm$ = Threads::lookupName(self\threads, self\twKind[i], self\twRefID[i])


### PR DESCRIPTION
## Why

Selecting an actor crashed with "Stack overflow!". The #433 grouping loop opened with `If i > 0 And self\twKind[i] <> self\twKind[i - 1]`. BlitzForge's `And` is **non-short-circuit**, so at `i = 0` it still evaluated `self\twKind[i - 1]` = `self\twKind[-1]` — a **negative array index**, reading/dereferencing out-of-bounds memory → crash the instant a non-zone entity was selected.

## Fix

Nested `If` so `twKind[i-1]` is only read when `i > 0`. Same non-short-circuit-`And` family as the earlier faction-focus crash — this time the second operand was an array index rather than a Null deref. (Noting the pattern in memory so it stops recurring.)

## Verification — needs your eyes

`compile.bat -t` clean (5/5). Local `bin\Loom.exe` rebuilt. Select an actor — it should show the grouped web (no crash).

🤖 Generated with [Claude Code](https://claude.com/claude-code)