### PR TITLE
Loom: clip+scroll Help modal, compact Issues filter chips

### DIFF
--- a/src/Modules/Loom/BrokenRefs.bb
+++ b/src/Modules/Loom/BrokenRefs.bb
@@ -849,6 +849,25 @@ Type BrokenRefs
         cats[11] = "orphan-texture"
         cats[12] = "orphan-mesh"
 
+        // Compact display labels -- the verbose category keys wrapped the
+        // chip strip to 3-4 rows (too tall). Short labels keep the strip to
+        // ~2 full-width rows; the header text still spells out the active
+        // filter's full key so nothing is lost. Index-aligned with cats[].
+        Local shorts$[13]
+        shorts[0]  = "refs"
+        shorts[1]  = "scripts"
+        shorts[2]  = "miss-tex"
+        shorts[3]  = "miss-mesh"
+        shorts[4]  = "miss-snd"
+        shorts[5]  = "empty"
+        shorts[6]  = "play"
+        shorts[7]  = "weapon"
+        shorts[8]  = "spell"
+        shorts[9]  = "orph-zone"
+        shorts[10] = "orph-scr"
+        shorts[11] = "orph-tex"
+        shorts[12] = "orph-mesh"
+
         Local cx% = chipsX
         Local cy% = chipsY
         Local ch% = 18
@@ -878,7 +897,7 @@ Type BrokenRefs
         For ci = 0 To 12
             Local catName$ = cats[ci]
             Local count% = BrokenRefs::countCategory(self, catName)
-            Local label$ = catName + " " + Str(count)
+            Local label$ = shorts[ci] + " " + Str(count)
             Local chipW% = StringWidth(label) + 12
             // Wrap to a second row if we'd overflow the modal width
             If cx + chipW > BROKENREFS_MODAL_W - BROKENREFS_PAD

--- a/src/Modules/Loom/Help.bb
+++ b/src/Modules/Loom/Help.bb
@@ -31,10 +31,19 @@ Const HELP_KEY_COL_W = 200
 // =============================================================================
 Type Help
     Field open%
+    // Body scroll offset in pixels. The keybinding table is taller than the
+    // modal body, so the rows scroll under a clipped viewport while the
+    // chrome (header / footer / border) stays fixed. Measured-then-clamped:
+    // lastContentH is filled in during render and used to clamp scroll on
+    // the next frame (same pattern as the composer body).
+    Field scroll%
+    Field lastContentH%
 
 
     Method create.Help()
         self\open = False
+        self\scroll = 0
+        self\lastContentH = 0
         Return self
     End Method
 
@@ -46,6 +55,7 @@ Type Help
 
     Method openModal()
         self\open = True
+        self\scroll = 0
         FlushKeys
         Loom_ConsumeClick()
         WriteLog(LoomLog, "Help: open")
@@ -86,9 +96,38 @@ Type Help
         LoomText(modalX + HELP_PAD, modalY + 6, "LOOM  |  KEYBINDINGS", LOOM_BRASS_500_R, LOOM_BRASS_500_G, LOOM_BRASS_500_B)
         LoomTheme_UseBody()
 
+        // Scrollable body region. The keybinding table overflows the modal,
+        // so the rows paint under a clipped viewport that scrolls; the header
+        // above and the footer hint below stay pinned. bodyTop/bodyBottom
+        // bound the visible band.
+        Local bodyTop%    = modalY + HELP_HEADER_H + 8
+        Local bodyBottom% = modalY + HELP_MODAL_H - HELP_HINT_H - 10
+        Local bodyH%      = bodyBottom - bodyTop
+
+        // Mouse wheel + arrow keys scroll the body. Loom_MouseWheel is the
+        // per-frame delta; each tick moves HELP_ROW_H * 3 px. Clamp against
+        // last frame's measured content height.
+        Local maxScroll% = self\lastContentH - bodyH
+        If maxScroll < 0 Then maxScroll = 0
+        Local wheelTicks% = Loom_MouseWheel()
+        If wheelTicks <> 0
+            self\scroll = self\scroll - wheelTicks * HELP_ROW_H * 3
+            Loom_ConsumeWheel()
+        EndIf
+        If KeyDown(208) Then self\scroll = self\scroll + 8   // Down arrow
+        If KeyDown(200) Then self\scroll = self\scroll - 8   // Up arrow
+        If self\scroll < 0 Then self\scroll = 0
+        If self\scroll > maxScroll Then self\scroll = maxScroll
+
+        // Clip subsequent 2D drawing to the body band so overflow rows don't
+        // paint over the footer / outside the modal. Reset to full screen
+        // after the table (footer + scrollbar draw unclipped).
+        Viewport modalX + 2, bodyTop, HELP_MODAL_W - 4, bodyH
+
         // Body -- rendered as a two-column table via per-row helpers so
-        // the row layout stays consistent.
-        Local rowY% = modalY + HELP_HEADER_H + 12
+        // the row layout stays consistent. Rows start at bodyTop offset by
+        // the scroll; the clip hides anything above/below the band.
+        Local rowY% = bodyTop - self\scroll
 
         rowY = Help::section(self, modalX, rowY, "Global")
         rowY = Help::row(self, modalX, rowY, "Ctrl+K",       "Command palette (find anywhere)")
@@ -133,10 +172,26 @@ Type Help
         rowY = Help::row(self, modalX, rowY, "Click dirty badge",        "Save that kind")
         rowY = Help::row(self, modalX, rowY, "Click broken-ref count",   "Open the broken-ref finder")
 
+        // Done painting the table -- record the full content height (in
+        // unscrolled coords) so next frame can clamp scroll, then drop the
+        // clip so the footer + scrollbar draw normally.
+        self\lastContentH = (rowY + self\scroll) - bodyTop
+        Viewport 0, 0, GraphicsWidth(), GraphicsHeight()
+
+        // Scrollbar thumb on the right edge of the body when content overflows.
+        If self\lastContentH > bodyH
+            Local trackX% = modalX + HELP_MODAL_W - 6
+            LoomFill(trackX, bodyTop, 3, bodyH, LOOM_STONE_700_R, LOOM_STONE_700_G, LOOM_STONE_700_B)
+            Local thumbH% = (bodyH * bodyH) / self\lastContentH
+            If thumbH < 20 Then thumbH = 20
+            Local thumbY% = bodyTop + (self\scroll * (bodyH - thumbH)) / maxScroll
+            LoomFill(trackX, thumbY, 3, thumbH, LOOM_BRASS_500_R, LOOM_BRASS_500_G, LOOM_BRASS_500_B)
+        EndIf
+
         // Footer hint
         Local hy% = modalY + HELP_MODAL_H - HELP_HINT_H - 4
         LoomHRule(modalX + HELP_PAD, hy - 2, HELP_MODAL_W - HELP_PAD * 2, LOOM_BRASS_700_R, LOOM_BRASS_700_G, LOOM_BRASS_700_B)
-        LoomText(modalX + HELP_PAD, hy + 4, "Esc or F1 to close", LOOM_STONE_300_R, LOOM_STONE_300_G, LOOM_STONE_300_B)
+        LoomText(modalX + HELP_PAD, hy + 4, "Esc or F1 to close  |  wheel / arrows to scroll", LOOM_STONE_300_R, LOOM_STONE_300_G, LOOM_STONE_300_B)
 
         // Click-outside-modal closes
         If clicked = True


### PR DESCRIPTION
## Why

Two usability defects the user hit while exercising the Loom editor:

1. **F1 Help / keybindings modal overflows.** The modal is 520px tall but the keybinding table renders ~850px of content with **no clipping** — the lower sections (Composer / Bulk edit / Ribbon) ran out the bottom of the modal and off the screen.
2. **Issues-modal filter chips are too tall.** The category filter used the verbose internal keys (`missing-texture`, `orphan-script`, …) as chip labels, wrapping the strip to 3–4 rows.

## What

- **Help.bb** — added a body scroll offset; the table now paints under a clipped `Viewport` band (header + footer hint stay pinned). Scrolls via mouse wheel and Up/Down arrows, with a brass scrollbar thumb when content overflows. Content height is measured during render and clamped on the next frame (same measured-then-clamp pattern as the composer body).
- **BrokenRefs.bb** — compact, index-aligned display labels for the filter chips so the strip fits ~2 full-width rows. The header text still spells out the active filter's full category key, so no information is lost.

## Note on the reported "palette select → stack overflow"

That third report was the **already-merged #434 fix not being in the user's built `bin/Loom.exe`** — the exe predated the #434 commit by ~3 minutes. Palette-select renders the same thread web #434 fixed (`focus` and `jump` share the downstream render path), so it was the same negative-array-index bug via a different entry point. A rebuild from current source resolves it; no new code change required.

## Verification

- `compile.bat -t` clean (exit 0). UI-only changes confined to Loom-only modules; no logic-test coverage affected.
- Runtime GUI verification is by user screenshot (agent cannot run Graphics3D).

🤖 Generated with [Claude Code](https://claude.com/claude-code)