### PR TITLE
Loom: fix F1 Help-modal crash (scrollbar integer divide-by-zero)

### DIFF
--- a/src/Modules/Loom/Help.bb
+++ b/src/Modules/Loom/Help.bb
@@ -184,12 +184,22 @@ Type Help
         self\lastContentH = (rowY + self\scroll) - bodyTop
 
         // Scrollbar thumb on the right edge of the body when content overflows.
+        // Derive the scroll denominator from THIS frame's freshly-measured
+        // lastContentH -- NOT the frame-top `maxScroll`, which is computed
+        // from the PREVIOUS frame's lastContentH (0 on the first open). On
+        // that first frame the guard below is true (content overflows) but
+        // frame-top maxScroll is still 0, so dividing by it was an integer
+        // divide-by-zero -> BlitzForge "Stack overflow!" the instant F1 opened.
+        // `denom` is > 0 whenever this branch runs (lastContentH > bodyH).
         If self\lastContentH > bodyH
+            Local denom% = self\lastContentH - bodyH
             Local trackX% = modalX + HELP_MODAL_W - 6
             LoomFill(trackX, bodyTop, 3, bodyH, LOOM_STONE_700_R, LOOM_STONE_700_G, LOOM_STONE_700_B)
             Local thumbH% = (bodyH * bodyH) / self\lastContentH
             If thumbH < 20 Then thumbH = 20
-            Local thumbY% = bodyTop + (self\scroll * (bodyH - thumbH)) / maxScroll
+            Local thumbScroll% = self\scroll
+            If thumbScroll > denom Then thumbScroll = denom
+            Local thumbY% = bodyTop + (thumbScroll * (bodyH - thumbH)) / denom
             LoomFill(trackX, thumbY, 3, thumbH, LOOM_BRASS_500_R, LOOM_BRASS_500_G, LOOM_BRASS_500_B)
         EndIf
 


### PR DESCRIPTION
## Real root cause (PR #436's theory was wrong)

#436 guessed the F1 stack overflow was TrueType text under a 2D `Viewport` clip and removed the clip. It didn't help — the modal still crashed on open. I stopped guessing and added temporary in-render log markers; a user F1 run produced:

```
Help: rA M3 scroll/wheel done scroll=0 maxScroll=0
Help: rA M4 before rows rowY=154 bodyTop=154 bodyBottom=600
Help: rA M5 rows done lastContentH=782      <-- last line; crash here
```

The crash is in the scrollbar block (M5 reached, M6 never), and `maxScroll=0` is the smoking gun:

- `maxScroll` is computed at the **top** of the frame from the **previous** frame's `lastContentH` — which is `0` on the first open.
- The rows then render and set `lastContentH = 782` (> `bodyH = 446`).
- The scrollbar guard `If self\lastContentH > bodyH` is now **true**, so the block runs — but `maxScroll` is still the stale `0`.
- `thumbY = ... / maxScroll` is an **integer divide-by-zero**, which BlitzForge reports as `Stack overflow!`.

This was mine, introduced in #435 and carried through #436.

## Fix

Derive the scrollbar denominator from **this** frame's freshly-measured `lastContentH` (`denom = lastContentH - bodyH`), which is guaranteed `> 0` whenever the overflow branch runs — instead of the stale frame-top `maxScroll`. Also clamp the thumb's scroll input to `denom`.

## Verification

- `compile.bat -t` clean (exit 0).
- Crash line confirmed by instrumented log capture from a user F1 run (markers since removed). The divide-by-zero → `Stack overflow!` mapping matches the known BlitzForge behavior for integer `Div`/`Mod` by zero.

🤖 Generated with [Claude Code](https://claude.com/claude-code)