### PR TITLE
Loom: fix Help-modal wheel + composer sticky scroll across entities

### DIFF
--- a/src/Modules/Loom/Browser.bb
+++ b/src/Modules/Loom/Browser.bb
@@ -288,7 +288,7 @@ Type Browser
         If self\threads <> Null And self\threads\focusKind <> ""
             Return False
         EndIf
-        Browser::drawCardGrid(self, sw - composerWidth, sh, mx, my, clicked)
+        Browser::drawCardGrid(self, sw - composerWidth, sh, mx, my, clicked, inputEnabled)
         Return self\cardClickLatch
     End Method
 
@@ -686,7 +686,7 @@ Type Browser
     // pathology, and is cleaner OO design anyway. Returns True via
     // self\cardClickLatch (which the per-kind methods set as a side effect).
     // -------------------------------------------------------------------------
-    Method drawCardGrid%(sw%, sh%, mx%, my%, clicked%)
+    Method drawCardGrid%(sw%, sh%, mx%, my%, clicked%, inputEnabled%)
         Local gridX% = BR_SECTION_PAD
         Local gridY% = BR_TOP_RIBBON + BR_TAB_BAR_H + BR_FILTER_BAR_H + BR_SECTION_PAD
         Local gridW% = sw - (BR_SECTION_PAD * 2)
@@ -725,8 +725,14 @@ Type Browser
         Local rowPitch% = BR_CARD_H + BR_CARD_GAP
         Local gridViewTop% = BR_FILTER_BAR_Y + BR_FILTER_BAR_H + 2
         Local gridViewBottom% = sh - BR_BOT_RIBBON
+        // Gate wheel consumption on inputEnabled: when a modal (Help, Issues,
+        // palette, etc.) is open, Loom sets browserInput=False, and the modal
+        // -- which renders AFTER the browser in the frame -- needs the wheel
+        // tick for its own scroll. Without this gate the card grid (sitting
+        // behind the modal overlay) ate the tick first and the modal's wheel
+        // appeared dead. (Reported: Help modal wheel not scrolling.)
         Local wheel% = Loom_MouseWheel()
-        If wheel <> 0 And atlasActive = False And mx < sw And my >= gridViewTop And my < gridViewBottom
+        If wheel <> 0 And inputEnabled = True And atlasActive = False And mx < sw And my >= gridViewTop And my < gridViewBottom
             self\cardScroll = self\cardScroll - wheel * rowPitch
             If self\cardScroll < 0 Then self\cardScroll = 0
             Local contentH% = self\lastGridRows * rowPitch

--- a/src/Modules/Loom/Composer.bb
+++ b/src/Modules/Loom/Composer.bb
@@ -119,6 +119,13 @@ Type Composer
     Field lastContentBottom%
     Field bodyTop%
     Field bodyBottom%
+    // Last (kind, refID) the body was laid out for. When focus changes we
+    // reset scrollOffset to 0 so a new entity always opens at the top --
+    // otherwise the previous entity's scroll position "sticks" onto the new
+    // one (and can sit past its shorter content). Tracks ALL focus changes,
+    // not just edit-active ones (the edit-only reset missed plain navigation).
+    Field scrollFocusKind$
+    Field scrollFocusRefID%
 
     // Collapse state -- when True, the composer renders only as a thin
     // brass sliver on the right edge with a chevron to expand. Lets the
@@ -312,13 +319,22 @@ Type Composer
         Local kind$ = self\threads\focusKind
         Local refID% = self\threads\focusID
 
+        // Reset scroll to the top on ANY focus change (new entity / new kind),
+        // regardless of edit state. Without this the prior entity's
+        // scrollOffset sticks onto the newly-focused one -- and since it's only
+        // clamped to the new entity's measured height a frame LATER, it can
+        // briefly sit further down than the new (often shorter) entity allows.
+        If self\scrollFocusKind <> kind Or self\scrollFocusRefID <> refID
+            self\scrollOffset = 0
+            self\scrollFocusKind = kind
+            self\scrollFocusRefID = refID
+        EndIf
+
         // If focus changed while editing, cancel the pending edit (don't
         // mutate a stale target). Same kind+id keeps the edit active.
-        // Reset scroll on focus change so the new entity opens at the top.
         If self\editKind <> ""
             If self\editKind <> kind Or self\editRefID <> refID
                 Composer::cancelEdit(self)
-                self\scrollOffset = 0
             EndIf
         EndIf
 


### PR DESCRIPTION
Two scroll defects reported after the F1 fix landed.

## 1. Help modal wheel did nothing (arrow keys worked)

The browser's card-grid wheel handler consumes the wheel tick whenever the cursor is over the grid, with **no check for an open modal**. The browser renders *before* the modals in the frame, so the grid (behind the modal overlay) ate the tick before Help could read it. Arrow keys worked because Help reads those directly.

**Fix:** gate the card-grid wheel consumption on `inputEnabled` — Loom already sets `browserInput=False` whenever any modal is open — so the later-rendering modal receives the tick. The card grid only runs when nothing is focused, which is exactly the case where a modal overlays it.

## 2. Composer scroll stuck across entities

Opening a new entity kept the previous one's `scrollOffset`, sometimes scrolled further down than the new (shorter) entity allows. The reset-to-top only ran inside the `editKind <> ""` branch, so plain navigation (the common case) never reset.

**Fix:** track the last laid-out `(kind, refID)` and reset `scrollOffset = 0` on **any** focus change. The "further than allowed" symptom was the measure-this-frame / clamp-next-frame window — the stale offset wasn't clamped to the new entity's height until a frame later; resetting on focus change removes the window.

## Verification

- `compile.bat -t` clean (exit 0).
- Runtime confirmation by user (agent can't run Graphics3D).

🤖 Generated with [Claude Code](https://claude.com/claude-code)