### PR TITLE
docs: mark dead BVM commands (SETOWNER, SCENERYOWNER) as non-callable in reference

### DIFF
--- a/docs/bvm-reference.md
+++ b/docs/bvm-reference.md
@@ -20,6 +20,7 @@ clicker, or only from a script the server itself spawned (or from a DM / GM):
 | `None` | Callable from any script. Pure-read or otherwise safe. |
 | `SelfOrPrivileged` | Callable if the target actor is the script's spawning actor (`SI\AI`) OR the script was spawned privileged. **WRONG choice** for any function that must block clicker exploits in Examine / Trade / RightClick / ItemScript spawns (where `SI\AI = Handle(clicker)`) — use `Privileged` instead. |
 | `Privileged` | Callable only from privileged scripts (server-spawned or DM-initiated). Mutates global state, opens host resources, or invokes terminal failures. |
+| `Dead` | **Not callable — does nothing.** The opcode survives in the dispatch table for opcode-number stability, but the implementation is permanently disabled (commented out in `ScriptingCommands.bb`, marked `DEAD-API`) and the dispatch case is a silent no-op. A script that calls it compiles and runs without error but has no effect; do not write new scripts against it. |
 
 See `CLAUDE.md`'s "Privilege gating in BVM commands" section for the full threat model.
 
@@ -307,7 +308,7 @@ none = void/Bool. Parameter sigils inside the argument list use the same.
 | `REPUTATION` | `REPUTATION(PARAM1%)` : Int | None |
 | `RESISTANCE` | `RESISTANCE(PARAM1%, PARAM2$)` : Int | None |
 | `SAVESTATE` | `SAVESTATE()` | Privileged |
-| `SCENERYOWNER` | `SCENERYOWNER(PARAM1$, PARAM2%, PARAM3%=0)` : Int | None |
+| `SCENERYOWNER` | `SCENERYOWNER(PARAM1$, PARAM2%, PARAM3%=0)` : Int | Dead |
 | `SCREENFLASH` | `SCREENFLASH(PARAM1%, PARAM2%, PARAM3%, PARAM4%, PARAM5%, PARAM6%, PARAM7%=0)` | None |
 | `SCRIPTLOG` | `SCRIPTLOG(PARAM1$="")` | None |
 | `SEASON` | `SEASON()` : String | None |
@@ -317,7 +318,7 @@ none = void/Bool. Parameter sigils inside the argument list use the same.
 | `SETLEADER` | `SETLEADER(PARAM1%, PARAM2%)` | Privileged |
 | `SETMAXATTRIBUTE` | `SETMAXATTRIBUTE(PARAM1%, PARAM2$, PARAM3%)` | Privileged |
 | `SETNAME` | `SETNAME(PARAM1%, PARAM2$)` | Privileged |
-| `SETOWNER` | `SETOWNER(PARAM1%, PARAM2$, PARAM3%, PARAM4% = 0)` | None |
+| `SETOWNER` | `SETOWNER(PARAM1%, PARAM2$, PARAM3%, PARAM4% = 0)` | Dead |
 | `SETREPUTATION` | `SETREPUTATION(PARAM1%, PARAM2%)` | Privileged |
 | `SETRESISTANCE` | `SETRESISTANCE(PARAM1%, PARAM2$, PARAM3%)` | Privileged |
 | `SETSUPERGLOBAL` | `SETSUPERGLOBAL(PARAM1%, PARAM2$)` | None |

--- a/scripts/gen_bvm_reference.sh
+++ b/scripts/gen_bvm_reference.sh
@@ -159,10 +159,18 @@ declarations=$(awk -v gates="$gate_index" '
         else if (name ~ /^RAND/ || name ~ /^INT$/ || name ~ /^FLOAT$/ || name ~ /^SQR/ || name ~ /^SIN/ || name ~ /^COS/ || name ~ /^TAN/ || name ~ /^ABS/ || name ~ /^STR/ || name ~ /^CHR/ || name ~ /^ASC/ || name ~ /^LEN/ || name ~ /^LEFT/ || name ~ /^RIGHT/ || name ~ /^MID/ || name ~ /^UPPER/ || name ~ /^LOWER/ || name ~ /^TRIM/ || name ~ /^INSTR/) category = "String & Math"
 
         # Resolve gate (case-insensitive lookup; gate index is upper).
+        # A name present in the opcode table but absent from the live
+        # `Function BVM_*` index is DEAD API: the opcode survives in
+        # RC_Standard_Invoker.bb for opcode-number stability, but the
+        # implementation in ScriptingCommands.bb is commented out and the
+        # dispatch case is a silent no-op (grep "DEAD-API" there). Classify
+        # it as "Dead" rather than silently laundering it into "None" --
+        # an ungated-callable row is an active footgun for scripters, who
+        # would write the call, hit no error, and silently get nothing.
         g = gate[toupper(impl)]
         if (g == "") {
-            g = "None"
-            print "WARN: no BVM impl found for " impl > "/dev/stderr"
+            g = "Dead"
+            print "WARN: no live BVM impl for " impl " -- marking Dead (no-op) in reference" > "/dev/stderr"
         }
 
         print category "|" name "|" impl "|" sigil "|" args "|" g
@@ -194,6 +202,7 @@ clicker, or only from a script the server itself spawned (or from a DM / GM):
 | `None` | Callable from any script. Pure-read or otherwise safe. |
 | `SelfOrPrivileged` | Callable if the target actor is the script's spawning actor (`SI\AI`) OR the script was spawned privileged. **WRONG choice** for any function that must block clicker exploits in Examine / Trade / RightClick / ItemScript spawns (where `SI\AI = Handle(clicker)`) — use `Privileged` instead. |
 | `Privileged` | Callable only from privileged scripts (server-spawned or DM-initiated). Mutates global state, opens host resources, or invokes terminal failures. |
+| `Dead` | **Not callable — does nothing.** The opcode survives in the dispatch table for opcode-number stability, but the implementation is permanently disabled (commented out in `ScriptingCommands.bb`, marked `DEAD-API`) and the dispatch case is a silent no-op. A script that calls it compiles and runs without error but has no effect; do not write new scripts against it. |
 
 See `CLAUDE.md`'s "Privilege gating in BVM commands" section for the full threat model.
 


### PR DESCRIPTION
## Non-technical summary

The BVM scripting reference (`docs/bvm-reference.md`) — the canonical catalog of functions a content scripter can call from `.rsl` / `.rcscript` files — listed two commands, **`SETOWNER`** and **`SCENERYOWNER`**, as live, ungated, callable API. In reality both are **permanently disabled** in the engine: their implementations are commented out and their dispatch cases are silent no-ops, kept in the table only so opcode numbers don't shift. A scripter trusting the reference would write the call, get no compile error and no runtime error, and silently get nothing back — the most confusing kind of doc/code divergence because nothing visibly fails.

This PR makes the reference tell the truth: both rows now show a `Dead` gate with a legend entry explaining the command is not callable and does nothing. It also fixes the *generator* so this can't recur — any BVM that gets disabled-but-left-in-the-table in future is now marked automatically.

## Technical summary

`gen_bvm_reference.sh` builds its gate column by indexing live `^Function BVM_*` definitions in `ScriptingCommands.bb`. A commented-out `;Function BVM_SETOWNER` doesn't match that pattern, so the lookup missed it and the code **defaulted the gate to `None`** while emitting a `WARN: no BVM impl found` to stderr — then printed the row anyway. CI compares only stdout, so the WARN was invisible and an unresolved command was laundered into an authoritative-looking "callable, ungated" row.

Changes:
- **`scripts/gen_bvm_reference.sh`** — when a name from the opcode table has no live `Function BVM_*`, classify the gate as **`Dead`** instead of `None` (with an inline rationale comment), and reword the stderr WARN. Added a `Dead` row to the privilege-legend heredoc.
- **`docs/bvm-reference.md`** — regenerated. `SCENERYOWNER` and `SETOWNER` now render `Dead`; the privilege legend documents the marker.

The `g == ""` → `Dead` mapping is **precise**: the generator emits exactly two WARNs (`BVM_SETOWNER`, `BVM_SCENERYOWNER`), and both are byte-confirmed `DEAD-API` in [`ScriptingCommands.bb:1112-1152`](../blob/develop/src/Modules/ScriptingCommands.bb#L1112) — zero false positives.

No `.bb` source changed; no opcode renumbering; the dead feature is **not** re-enabled (its removal is intentional and tied to opcode stability). No runtime/wire/persistence surface touched.

## Acceptance criteria

- [x] `docs/bvm-reference.md` no longer shows `SETOWNER` or `SCENERYOWNER` with gate `None` — both render `Dead` (lines 311, 321).
- [x] The privilege legend documents the `Dead` marker (line 23).
- [x] `bash scripts/gen_bvm_reference.sh --check` exits 0 against the committed doc (gate stays green).
- [x] Classification is deterministic: a command in the opcode table but absent as a live `Function BVM_*` is classified `Dead`, not `None`; the stderr WARN is retained (reworded).
- [x] Genuine-stale detection still works: tampering with the committed doc makes `--check` exit 1; restoring it returns exit 0 (verified manually — no bash test harness exists in-repo, so this is verified by direct repro).
- [x] No `.bb` source change (staged diff touches only the two files); doc stays LF-only per `.gitattributes`.

## Trade-offs & deferred follow-ups

- **Marker rendering**: chose a `Dead` token in the existing Gate column + legend entry over striking through the function name, to keep the generator's row-emission uniform and the change mechanical. The legend carries the "does nothing" explanation.
- **Deferred**: the sibling generator `gen_packet_index.sh` shares the same `set -euo pipefail` + `$OUTPUT.new` temp-file shape that a separate recon flagged as a potential intermittent `--check` false-failure. That's a distinct DevEx concern (robustness, not correctness) and is intentionally **out of scope** here; left for a future iteration. This PR's `gen_bvm_reference.sh` change does not touch that path.
