### PR TITLE
fix: clamp loaded position floats in ReadActorInstance (close persistence NaN gap)

### DIFF
--- a/src/Modules/Actors.bb
+++ b/src/Modules/Actors.bb
@@ -415,9 +415,20 @@ Function ReadActorInstance.ActorInstance(Stream)
 	A\Name$      = ReadBoundedString$(Stream, 256)
 	A\Tag$       = ReadBoundedString$(Stream, 256)
 	A\TeamID     = ReadInt(Stream)
-	A\X# = ReadFloat#(Stream)
-	A\Y# = ReadFloat#(Stream)
-	A\Z# = ReadFloat#(Stream)
+	; Sanitise loaded position floats the same way the wire / BVM entry
+	; points do (ClampWorldCoord in BVM_MOVEACTOR, ServerNet P_InventoryUpdate
+	; "D", etc. -- see RCEnet.bb and the "Float sanitisation" doctrine in
+	; CLAUDE.md). A corrupted or tampered Accounts.dat row could carry a NaN
+	; / Inf / absurd X/Y/Z; loaded raw, that value flows straight into the
+	; broadcast actor state P_StandardUpdate replicates to every client and
+	; poisons spatial code (collision, LOD culling, EntityDistance#) for the
+	; whole zone on every server boot. Every other field in this loader is
+	; already bounded (strings, appearance indices, slave count, HomeFaction)
+	; -- the position floats were the one gap. Clamp-to-0 (world origin) is a
+	; recoverable degraded state; NaN is not.
+	A\X# = ClampWorldCoord#(ReadFloat#(Stream))
+	A\Y# = ClampWorldCoord#(ReadFloat#(Stream))
+	A\Z# = ClampWorldCoord#(ReadFloat#(Stream))
 	A\Gender     = ReadByte(Stream)
 	A\XP         = ReadInt(Stream)
 	A\XPBarLevel = ReadByte(Stream)

--- a/src/Tests/Modules/ActorLoadFloatClampTest.bb
+++ b/src/Tests/Modules/ActorLoadFloatClampTest.bb
@@ -1,0 +1,82 @@
+; Tests for the position-float sanitisation in ReadActorInstance
+; (Modules/Actors.bb). The character load path reads X/Y/Z off disk and,
+; as of the position-float-clamp fix, routes each through ClampWorldCoord#
+; before storing it on the ActorInstance. A corrupted or tampered
+; Accounts.dat row could otherwise carry a NaN / Inf / out-of-range
+; position that, loaded raw, flows into the broadcast actor state
+; P_StandardUpdate replicates to every client and poisons spatial code
+; (collision, LOD culling, EntityDistance#) for the whole zone.
+;
+; What this pins that ClampFloatTest.bb does NOT:
+;   ClampFloatTest exercises ClampWorldCoord# on float *literals*. This
+;   file exercises the *load-path contract*: a poisoned float written to a
+;   Bank and read back (the same 4-byte IEEE round-trip WriteFloat/ReadFloat
+;   perform against the save stream) still arrives poisoned, and the
+;   read-then-clamp pattern at the load site neutralises it -- while a
+;   legitimate saved position survives the round-trip and passes through
+;   unchanged. This is the regression that would re-open if someone dropped
+;   the ClampWorldCoord# wrapper from the ReadFloat# calls in
+;   ReadActorInstance.
+;
+; Actors.bb itself can't be Included into a test build (it pulls in the
+; Items / world graph). Per the established pattern (see ClampFloatTest.bb
+; and RCEWireEncodingTest.bb), replicate the helper verbatim and the
+; load-site pattern (PeekFloat after a PokeFloat = ReadFloat after a
+; WriteFloat). A refactor that changes ClampWorldCoord# must update the
+; production copy and this duplicate -- the trigger to refresh this test.
+;
+; NOT Strict: ClampWorldCoord#'s param is a bare float in production and
+; can't take a Local Strict typing; matches ClampFloatTest.bb.
+
+Const WorldCoordMax# = 100000.0
+Function ClampWorldCoord#(v#)
+	If v# > -WorldCoordMax# And v# < WorldCoordMax# Then Return v#
+	Return 0.0
+End Function
+
+; Round-trip a float through a 4-byte Bank exactly as WriteFloat/ReadFloat
+; do against the save stream, returning the read-back value. NaN and Inf
+; bit patterns survive a PokeFloat/PeekFloat round-trip unchanged, which is
+; precisely why the clamp has to happen AFTER the read, not be assumed away
+; by the serializer.
+Function RoundTripFloat#(v#)
+	Local b = CreateBank(4)
+	PokeFloat(b, 0, v#)
+	Local out# = PeekFloat(b, 0)
+	FreeBank(b)
+	Return out#
+End Function
+
+
+; A NaN saved to disk survives the Bank round-trip (still NaN) and the
+; load-site clamp collapses it to 0. Without the clamp this NaN would reach
+; broadcast actor state. NaN is constructed via runtime vars so the
+; compiler can't constant-fold it.
+Test testLoadedNaNPositionIsClamped()
+	Local zero# = 0.0
+	Local nan# = zero# / zero#
+	; Sanity: a NaN really does survive the serialise/deserialise round-trip.
+	Local loaded# = RoundTripFloat#(nan#)
+	; A surviving NaN fails every ordered comparison, so it is NOT in range.
+	Assert(Not (loaded# > -WorldCoordMax# And loaded# < WorldCoordMax#))
+	; The load-site pattern neutralises it.
+	Assert(ClampWorldCoord#(loaded#) = 0.0)
+End Test
+
+; An out-of-range magnitude (e.g. a corrupted exponent byte) survives the
+; round-trip and is clamped to 0 at the load site.
+Test testLoadedOutOfRangePositionIsClamped()
+	; BlitzForge has no scientific-notation float literal -- use a plain
+	; decimal well outside the +/-WorldCoordMax (100000) window.
+	Local huge# = 1000000.0
+	Assert(ClampWorldCoord#(RoundTripFloat#(huge#)) = 0.0)
+	Assert(ClampWorldCoord#(RoundTripFloat#(-huge#)) = 0.0)
+End Test
+
+; A legitimate saved position survives the round-trip and passes through
+; the clamp unchanged -- the fix is non-destructive for real save data.
+Test testLoadedValidPositionPassesThrough()
+	Assert(ClampWorldCoord#(RoundTripFloat#(4096.5)) = 4096.5)
+	Assert(ClampWorldCoord#(RoundTripFloat#(-2048.25)) = -2048.25)
+	Assert(ClampWorldCoord#(RoundTripFloat#(0.0)) = 0.0)
+End Test


### PR DESCRIPTION
## Non-technical summary

When the server loads a saved character, it reads that character's world position (X/Y/Z) from disk. If a save file is corrupted or tampered with so a position contains a `NaN` ("not a number") or an absurd value, the server previously loaded it **as-is** and then broadcast it to every player in the zone. A single bad number poisons the math that powers collision, level-of-detail culling, and distance checks — degrading the experience for *everyone* in that zone, on every server restart, until someone manually fixes the row.

This fix sanitises those three position values at load time, the same way the engine already sanitises positions arriving over the network and from scripts. Legitimate positions are completely unaffected; only already-broken values are neutralised (snapped to the world origin, a recoverable state).

## Technical summary

`ReadActorInstance` ([Actors.bb:418-420](../blob/develop/src/Modules/Actors.bb#L418)) read the saved `X#`/`Y#`/`Z#` via raw `ReadFloat#` with no NaN/Inf/range guard — while **every** neighbouring field in the same loader is bounded (`ReadBoundedString$` for Area/Name/Tag, the appearance-index clamps at :434-438, the slave-count cap at :463-465, the HomeFaction clamp at :473). The position floats were the single gap in an otherwise-exhaustive persistence-hardening sweep, and they feed directly into the per-tick `P_StandardUpdate` broadcast — the exact value class CLAUDE.md's "Float sanitisation at the BVM / wire boundary" doctrine exists for. The wire and BVM entry points were swept (#237-#239); this disk read was missed.

Change: route the three reads through the existing, proven `ClampWorldCoord#` helper ([RCEnet.bb:118](../blob/develop/src/Modules/RCEnet.bb#L118)), matching the `BVM_MOVEACTOR` shape. `ClampWorldCoord#` is a pass-through for every finite in-range value, so legitimate saves are untouched; NaN/Inf/`|v|≥100000` collapse to `0.0`. **No save-format change** — purely a read-time value guard, so the protocol/BVM doc generators don't need regenerating.

Added `src/Tests/Modules/ActorLoadFloatClampTest.bb` — pins the load-path contract at the **stream boundary**, which `ClampFloatTest.bb` (literals only) doesn't reach: a NaN / out-of-range float survives a `CreateBank`/`PokeFloat`/`PeekFloat` round-trip (the same 4-byte IEEE round-trip `WriteFloat`/`ReadFloat` perform against the save stream) and the read-then-clamp pattern neutralises it, while a legitimate position passes through unchanged. `Actors.bb` can't be `Include`d offline (pulls Items/world graph), so `ClampWorldCoord#` is replicated per the established ClampFloatTest/RCEWireEncodingTest convention.

## Acceptance criteria + results

- [x] `ReadActorInstance` clamps loaded X/Y/Z through `ClampWorldCoord#` — diff above; NaN/Inf/out-of-range can no longer reach broadcast state.
- [x] New test passes under `test.bat`: NaN-via-Bank-round-trip → 0, out-of-range → 0, valid position → unchanged. (`test.bat ActorLoadFloatClamp` → `1 passed, 0 failed`.)
- [x] `compile.bat` (full) clean — all 5 engine targets + 7 tools, **including RC Terrain Editor** which includes both `Actors.bb` and `rcenet.bb` (verified the helper resolves in every Actors.bb compilation unit; Actors.bb already references `RCE_StrFromInt$` so every includer must already pull RCEnet).
- [x] No wire format, packet dispatch, opcode table, or save-file *format* change → generator-staleness gate not triggered.

## Trade-offs & deferred follow-ups

- **Clamp-to-origin**: a corrupted position snaps to `(0,0,0)`. This is a deliberate, recoverable degraded state (an admin can relocate the character) and is strictly better than propagating NaN, which is unrecoverable and zone-wide. Considered and rejected: clamp-to-last-known-good (no such state exists at load time) and rejecting the character outright (too destructive for a single bad field).
- **Test enforcement honesty**: because the network/world modules can't be `Include`d in an offline test build, the test replicates `ClampWorldCoord#` rather than calling the real loader. It pins the *behavioural contract* (and the stream round-trip), not the literal presence of the wrapper in `ReadActorInstance`; that presence is evidenced by the diff + the full compile.
- **Deferred**: `LoadActors` reads `Scale#`/`Radius#` raw at [Actors.bb:903-904](../blob/develop/src/Modules/Actors.bb#L903) — a *different* function loading author-controlled actor templates (lower tamper surface, `ClampSaneFloat#` territory). Out of scope here; a reasonable lower-priority follow-up.
