### PR TITLE
fix: key client spell cooldowns by spell ID to match the server (SpellCharge desync)

### DIFF
--- a/src/Modules/Interface3D.bb
+++ b/src/Modules/Interface3D.bb
@@ -364,6 +364,37 @@ Function GetTarget$(EN)
 End Function
 
 ; Updates the standard components and handles player input
+; --- Spell cooldown helpers ------------------------------------------
+; SpellCharge[] is keyed by spell ID (0..999) -- see the field comment in
+; Actors.bb and the authoritative server (ServerNet.bb P_SpellUpdate "F"
+; gates on AI\SpellCharge[SpellID]; GameServer.bb decrements 0..999 by
+; spell ID). The client action bar and spellbook previously keyed
+; SpellCharge by a KnownSpells index (action bar non-memorise / spellbook)
+; or a memorise slot (action bar memorise), so the client's predictive
+; cooldown lived in a different slot than the server's authority and than
+; the other client surface -- casting from one surface left the other
+; reading "ready" (spurious LS_AbilityNotRecharged, or a click the server
+; silently drops). Centralise the spell-ID-keyed, bound-checked access so
+; every client cast site matches the server.
+;
+; A spell ID outside 0..999 is not castable server-side (the server wraps
+; its cast path in the same 0..999 guard), so treat it as "ready" here --
+; the cast packet is still sent and the authoritative server is the final
+; arbiter. The bound check lives in a nested If inside the helper because
+; BlitzForge `And` is non-short-circuit: `If id <= 999 And arr[id] ...`
+; would still evaluate arr[id] for an out-of-range id.
+Function SpellChargeReady(M.ActorInstance, SpellID)
+	If SpellID < 0 Or SpellID > 999 Then Return True
+	If M\SpellCharge[SpellID] <= 0 Then Return True
+	Return False
+End Function
+
+Function SetSpellCharge(M.ActorInstance, SpellID, Charge)
+	If SpellID < 0 Or SpellID > 999 Then Return
+	M\SpellCharge[SpellID] = Charge
+End Function
+; ---------------------------------------------------------------------
+
 Function UpdateInterface()
 
 	; Gooey system
@@ -1089,14 +1120,14 @@ Function UpdateInterface()
 					RechargeTime = SpClick\RechargeTime
 					Pa$ = RCE_StrFromInt$(SpId, 2)
 					; Recharged
-					If Me\SpellCharge[Num] <= 0
+					If SpellChargeReady(Me, SpId)
 						If PlayerTarget > 0
 							AI.ActorInstance = Object.ActorInstance(PlayerTarget)
-							Pa$ = Pa$ + RCE_StrFromInt$(AI\RuntimeID, 2)
+							If AI <> Null Then Pa$ = Pa$ + RCE_StrFromInt$(AI\RuntimeID, 2)
 						EndIf
 						RCE_Send(Connection, PeerToHost, P_SpellUpdate, "F" + Pa$, True)
-						Me\SpellCharge[Num] = RechargeTime
-						
+						SetSpellCharge(Me, SpId, RechargeTime)
+
 						;[654]
 						RechargeTime = RechargeTime - 1000
 						;Output ("RechargeTime = "+RechargeTime/1000)
@@ -1215,7 +1246,7 @@ Function UpdateInterface()
 				RechargeTime = SpKey\RechargeTime
 				Pa$ = RCE_StrFromInt$(SpId2, 2)
 				; Recharged
-				If Me\SpellCharge[Num] <= 0
+				If SpellChargeReady(Me, SpId2)
 					If PlayerTarget > 0
 						AI.ActorInstance = Object.ActorInstance(PlayerTarget)
 						; Stale target handle: send the cast untargeted
@@ -1225,8 +1256,8 @@ Function UpdateInterface()
 						If AI <> Null Then Pa$ = Pa$ + RCE_StrFromInt$(AI\RuntimeID, 2)
 					EndIf
 					RCE_Send(Connection, PeerToHost, P_SpellUpdate, "F" + Pa$, True)
-					Me\SpellCharge[Num] = RechargeTime
-					
+					SetSpellCharge(Me, SpId2, RechargeTime)
+
 				;[654] fixing cooldown reset bug in action bar
 						RechargeTime = RechargeTime - 1000
 					;	Output ("RechargeTime = "+RechargeTime/1000)
@@ -1303,17 +1334,15 @@ Function UpdateInterface()
 	; Update compass direction
 	UpdateCompass()
 
-	; Recharge spells
+	; Recharge spells -- cooldowns are keyed by spell ID (0..999), matching
+	; the server's GameServer.bb decrement. The old code split on
+	; RequireMemorise and walked the wrong index spaces (0..9 memorise slots
+	; / 0..999 KnownSpells indices), desyncing from SpellCharge's spell-ID
+	; contract; a single uniform 0..999 pass is correct for both modes.
 	If MilliSecs() - LastSpellRecharge > 100
-		If RequireMemorise
-			For i = 0 To 9
-				If Me\SpellCharge[i] > 0 Then Me\SpellCharge[i] = Me\SpellCharge[i] - 100
-			Next
-		Else
-			For i = 0 To 999
-				If Me\SpellCharge[i] > 0 Then Me\SpellCharge[i] = Me\SpellCharge[i] - 100
-			Next
-		EndIf
+		For i = 0 To 999
+			If Me\SpellCharge[i] > 0 Then Me\SpellCharge[i] = Me\SpellCharge[i] - 100
+		Next
 		LastSpellRecharge = MilliSecs()
 	EndIf
 
@@ -1495,7 +1524,7 @@ Function UpdateInterface()
 					; us an OOB Num (corrupt sort table or 0-known-spells).
 					If Num < 0 Or Num > 999
 						; nothing to cast
-					ElseIf Me\SpellCharge[Num] <= 0
+					ElseIf SpellChargeReady(Me, Me\KnownSpells[Num])
 						; Spell may have been deleted between sessions while
 						; still in KnownSpells; SpellsList(...) returns Null
 						; and the bare \RechargeTime deref crashes. Resolve
@@ -1512,7 +1541,7 @@ Function UpdateInterface()
 							If AI <> Null Then Pa$ = Pa$ + RCE_StrFromInt$(AI\RuntimeID, 2)
 						EndIf
 						RCE_Send(Connection, PeerToHost, P_SpellUpdate, "F" + Pa$, True)
-						Me\SpellCharge[Num] = SpBk\RechargeTime
+						SetSpellCharge(Me, SIDBk, SpBk\RechargeTime)
 						EndIf  ; SpBk <> Null
 					; Not recharged
 					Else

--- a/src/Tests/Modules/SpellCooldownIndexTest.bb
+++ b/src/Tests/Modules/SpellCooldownIndexTest.bb
@@ -1,0 +1,100 @@
+Strict
+EnableGC
+
+; Tests for the client spell-cooldown indexing contract enforced by the
+; SpellChargeReady / SetSpellCharge helpers in Modules/Interface3D.bb.
+;
+; SpellCharge[] is keyed by spell ID (0..999) -- see the field comment in
+; Actors.bb and the authoritative server: ServerNet.bb's P_SpellUpdate "F"
+; gates on AI\SpellCharge[SpellID] and GameServer.bb decrements 0..999 by
+; spell ID. Before the fix, the client action bar keyed SpellCharge by a
+; KnownSpells index (or a memorise slot in memorise mode) and the spellbook
+; keyed it by a different KnownSpells index, so the same physical spell had
+; up to three independent client cooldown slots -- none matching the
+; server. Casting from the action bar then reading the spellbook (or vice
+; versa) showed an incoherent cooldown.
+;
+; The regression this pins: BOTH client surfaces now resolve the spell ID
+; and key SpellCharge by it, so the same spell ID always maps to the same
+; slot. The helpers also bound-check (SpellCharge is Field[999]); a spell
+; ID outside 0..999 is uncastable server-side and is treated as "ready"
+; without an out-of-bounds access. The bound lives in a nested If because
+; BlitzForge `And` is non-short-circuit.
+;
+; Interface3D.bb can't be Included into a test build (it pulls F-UI / Gooey
+; / world graph / RakNet externs unavailable offline), so the two helpers
+; are replicated verbatim here, per the established ClampFloatTest /
+; RCEWireEncodingTest convention. A refactor that changes either helper has
+; to update the production copy and this duplicate.
+
+Type MockActor
+	Field SpellCharge[999]   ; mirrors ActorInstance\SpellCharge[999]
+End Type
+
+Function SpellChargeReady(M.MockActor, SpellID)
+	If SpellID < 0 Or SpellID > 999 Then Return True
+	If M\SpellCharge[SpellID] <= 0 Then Return True
+	Return False
+End Function
+
+Function SetSpellCharge(M.MockActor, SpellID, Charge)
+	If SpellID < 0 Or SpellID > 999 Then Return
+	M\SpellCharge[SpellID] = Charge
+End Function
+
+
+; A freshly-loaded actor (all slots 0) reports every trackable spell ready.
+Test testFreshActorAllReady()
+	Local m.MockActor = New MockActor()
+	Assert(SpellChargeReady(m, 0) = True)
+	Assert(SpellChargeReady(m, 42) = True)
+	Assert(SpellChargeReady(m, 999) = True)
+End Test
+
+; Setting a cooldown by spell ID makes exactly that spell not-ready, and
+; leaves other spell IDs untouched (no cross-slot bleed).
+Test testSetMakesOnlyThatSpellNotReady()
+	Local m.MockActor = New MockActor()
+	SetSpellCharge(m, 42, 5000)
+	Assert(SpellChargeReady(m, 42) = False)
+	Assert(SpellChargeReady(m, 41) = True)
+	Assert(SpellChargeReady(m, 43) = True)
+End Test
+
+; THE core regression: store and gate use the SAME slot for the SAME spell
+; ID. The pre-fix bug stored at one index space (action bar) and read at
+; another (spellbook); here the round-trip on a single spell ID is coherent.
+Test testSameSpellIdSameSlot()
+	Local m.MockActor = New MockActor()
+	; "Action bar" cast stores by spell ID...
+	SetSpellCharge(m, 314, 4000)
+	; ..."spellbook" gate reads by the same spell ID and sees not-ready.
+	Assert(SpellChargeReady(m, 314) = False)
+End Test
+
+; Out-of-range spell IDs are treated as ready and never index the array
+; out of bounds (read or write).
+Test testOutOfRangeIdsAreSafeAndReady()
+	Local m.MockActor = New MockActor()
+	Assert(SpellChargeReady(m, -1) = True)
+	Assert(SpellChargeReady(m, 1000) = True)
+	Assert(SpellChargeReady(m, 65534) = True)
+	; A write past the trackable range is a silent no-op (no OOB, no crash).
+	SetSpellCharge(m, 1500, 9999)
+	SetSpellCharge(m, -5, 9999)
+	Assert(SpellChargeReady(m, 1500) = True)
+End Test
+
+; The uniform 0..999 decrement (Interface3D recharge loop) eventually
+; returns a charged spell to ready, keyed by spell ID.
+Test testDecrementReturnsToReady()
+	Local m.MockActor = New MockActor()
+	SetSpellCharge(m, 7, 200)
+	Assert(SpellChargeReady(m, 7) = False)
+	; Two 100ms recharge ticks over the spell-ID slot.
+	Local tick
+	For tick = 1 To 2
+		If m\SpellCharge[7] > 0 Then m\SpellCharge[7] = m\SpellCharge[7] - 100
+	Next
+	Assert(SpellChargeReady(m, 7) = True)
+End Test


### PR DESCRIPTION
## Non-technical summary

In the game client, a spell's cooldown is shown in two places: the action bar and the spellbook. Because of an indexing bug, those two surfaces tracked the same spell's cooldown in **different internal slots**, and neither matched what the authoritative server uses. The visible result: cast a spell from the action bar, then look at it in the spellbook (or vice versa), and the cooldown was incoherent — you'd either get a spurious "ability not recharged" message on a spell that was actually ready, or click a spell that *looked* ready only to have the server silently ignore it.

This change makes the client track every spell's cooldown by its **spell ID**, exactly like the server already does, so both UI surfaces agree with each other and with the server.

## Technical summary

`ActorInstance\SpellCharge[999]` is documented as *"indexed by spell ID (matches SpellsList)"* ([Actors.bb:178](../blob/develop/src/Modules/Actors.bb#L178)), and the **server honors that contract**: [ServerNet.bb:1202-1277](../blob/develop/src/Modules/ServerNet.bb#L1202) resolves `SpellID = KnownSpells[Num]`, guards `If SpellID >= 0 And SpellID <= 999`, and gates/stores `SpellCharge[SpellID]`; [GameServer.bb:688](../blob/develop/src/Modules/GameServer.bb#L688) decrements `0..999` by spell ID.

The **client violated the contract at all three cast sites** in `Interface3D.bb`, each using a different index space — none of them the spell ID:
- action bar, memorise mode → the memorise slot (`0..9`)
- action bar, non-memorise → the raw `KnownSpells` index
- spellbook → a `KnownSpells` index reached via the sort table

…and the recharge loop decremented those wrong spaces. So the action bar and spellbook wrote/read different `SpellCharge` slots for the same spell, desyncing the client's predictive cooldown both internally and from the server.

**Fix:** centralise the access in two helpers and route all three cast sites + the recharge loop through spell-ID indexing:

```blitz
Function SpellChargeReady(M.ActorInstance, SpellID)
	If SpellID < 0 Or SpellID > 999 Then Return True
	If M\SpellCharge[SpellID] <= 0 Then Return True
	Return False
End Function

Function SetSpellCharge(M.ActorInstance, SpellID, Charge)
	If SpellID < 0 Or SpellID > 999 Then Return
	M\SpellCharge[SpellID] = Charge
End Function
```

The bound check is a **nested** `If` inside the helper because BlitzForge `And` is non-short-circuit — a combined `If id <= 999 And arr[id] ...` would still read `arr[id]` for an out-of-range id. A spell ID `> 999` is uncastable server-side (the server wraps its cast path in the same `0..999` guard), so the client treats it as ready and lets the authoritative server arbitrate — no client-side OOB. The recharge loop collapses from a `RequireMemorise` fork (`0..9` / `0..999` wrong spaces) to a single uniform `0..999` pass, matching the server.

**Incidental hardening:** the first action-bar cast site dereferenced `AI\RuntimeID` without the `If AI <> Null Then` guard the other two sites already have — a stale-`PlayerTarget` crash vector (CLAUDE.md handle-lookup discipline). Added the guard to match the siblings while rewriting the block.

No server, wire-format, or save-format change. The server remains authoritative, so a client mistake degrades to a dropped click — never a dupe or crash.

## Acceptance criteria + results

- [x] All client `SpellCharge` reads/writes key by **spell ID** (`SpId`/`SpId2`/`SIDBk` → helpers); zero remaining `SpellCharge[Num]` uses (verified by grep).
- [x] Action bar and spellbook gate on the **same** slot for the same spell (the `testSameSpellIdSameSlot` invariant).
- [x] Recharge loop is a single `0..999` pass, no `RequireMemorise` fork.
- [x] `Client.exe` compiles clean (Interface3D.bb is client-only; the local `Server.exe` link error was only a running-server file lock, and Server doesn't include this module — CI builds all targets in a clean env).
- [x] New `SpellCooldownIndexTest.bb` passes (`test.bat SpellCooldownIndex` → `1 passed`): bounds safety / no-OOB, ready-semantics, same-spell-ID-same-slot, out-of-range no-op, and the `0..999` decrement returning a spell to ready.
- [x] No wire/opcode/save-format change → generator-staleness gate not triggered.

## Trade-offs & deferred follow-ups

- **Helper indirection** over inlining the guard at each site: chosen because BlitzForge's non-short-circuit `And` forces a nested guard anyway, and one bound-checked accessor (DRY) mirrors the server's single guarded access and is unit-testable in isolation.
- **Verification ceiling**: the client can't be launched headlessly by an agent (Graphics3D), so real-path verification is compile + static trace per the repo's accepted practice for client changes; the test pins the *contract* via replicated helpers, not the live `Interface3D` code.
- **Deferred (cosmetic)**: two vestigial `[654]` scaffolding blocks remain in the two action-bar branches (a dead `RechargeTime = RechargeTime - 1000` + an empty `If GY_ButtonHit ... If RechargeTime = 0` pair). Harmless, no correctness impact; left in to keep this change a minimal, reviewable correctness fix. Worth a follow-up cleanup.
- **Edge note**: spell IDs `> 999` are treated as "ready" client-side and the cast packet is sent; the server (same `0..999` guard) drops them. Consistent across all three surfaces; only relevant to projects defining spell IDs above 999, which are already uncastable.
