### PR TITLE
fix: revert orphaned pets to AI_Wait so the AI tick can't deref a Null leader

### DIFF
--- a/src/Modules/Actors.bb
+++ b/src/Modules/Actors.bb
@@ -764,6 +764,14 @@ Function FreeActorInstance(A.ActorInstance)
 		ChildNext = Child\NextSlave
 		Child\Leader = Null
 		Child\NextSlave = Null
+		; A surviving child was a pet of A (AI_Pet / AI_PetChase); its
+		; leader is now gone. Reset to idle so the server AI tick's pet
+		; branches don't deref the now-Null Leader -- a crash in debug
+		; builds, or (per the non-short-circuit / skipped-__bbNullObjEx
+		; behaviour) a silent walk to world origin in release. Mirrors
+		; the AI_Wait reset BVM_SETLEADER performs at its SlaveUnlink site.
+		Child\AIMode = AI_Wait
+		Child\AITarget = Null
 		Child = ChildNext
 	Wend
 	A\FirstSlave = Null

--- a/src/Modules/GameServer.bb
+++ b/src/Modules/GameServer.bb
@@ -948,6 +948,16 @@ Function UpdateActorInstances(Broadcast)
 							EndIf
 						EndIf
 					EndIf
+				; Orphaned pet: its leader was freed without resetting AIMode.
+				; FreeActorInstance's orphan loop and BVM_SETLEADER reset it at
+				; the source; this is the tick-side backstop so a missed future
+				; orphaning path can't deref a Null AI\Leader in the pet branches
+				; below (the AI_Chase branch already follows this Null discipline).
+				; Operands are plain reads/compares -- no deref through Leader --
+				; so the non-short-circuit And/Or is safe here.
+				ElseIf (AI\AIMode = AI_Pet Or AI\AIMode = AI_PetChase) And AI\Leader = Null
+					AI\AIMode = AI_Wait
+					AI\AITarget = Null
 				; Pet AI
 				ElseIf AI\AIMode = AI_Pet
 					; Move towards leader's position
@@ -1390,7 +1400,10 @@ Function CommandPet(AI.ActorInstance, Command$, Params$)
 			AI\AITarget = Null
 		; Pet to attack leader's target
 		Case "ATTACK"
-			If AI\Actor\Aggressiveness < 3
+			; Guard AI\Leader before the deref below -- an orphaned pet (leader
+			; freed) must not crash here. Both operands are plain reads/compares
+			; (no deref through Leader), so the non-short-circuit And is safe.
+			If AI\Actor\Aggressiveness < 3 And AI\Leader <> Null
 				If AI\Leader\AITarget <> Null
 					AI\AITarget = AI\Leader\AITarget
 					AI\AIMode = AI_PetChase

--- a/src/Tests/Modules/PetOrphanAIModeTest.bb
+++ b/src/Tests/Modules/PetOrphanAIModeTest.bb
@@ -1,0 +1,116 @@
+Strict
+EnableGC
+
+; Tests for the pet-orphaning invariant enforced in Actors.bb
+; (FreeActorInstance's slave-orphan loop) and GameServer.bb (the AI tick's
+; orphaned-pet backstop branch).
+;
+; Contract: a pet NPC has AIMode AI_Pet (5) or AI_PetChase (6) and a non-Null
+; \Leader. The server AI tick's pet branches deref AI\Leader\X# / \AITarget /
+; \Actor\Radius# with no Null guard. If a leader is freed while a pet still
+; references it, the pet must be reverted to AI_Wait (0) with a cleared
+; \Leader, or the next tick derefs a Null Leader -- a crash in debug builds,
+; or a silent walk to world origin in release (skipped __bbNullObjEx). The
+; fix resets AIMode at the source (FreeActorInstance orphan loop; BVM_SETLEADER
+; already did) and adds a tick-side backstop that demotes any pet whose
+; Leader has gone Null.
+;
+; Actors.bb / GameServer.bb can't be Included into a test build (they pull the
+; Items / world graph / network externs), so the orphan loop and the tick
+; demotion predicate are replicated verbatim here, per the established
+; ClampFloatTest / SpellCooldownIndexTest convention. A change to either
+; production copy must update this duplicate.
+
+Const AI_Wait     = 0
+Const AI_Pet      = 5
+Const AI_PetChase = 6
+
+Type MockActor
+	Field Leader.MockActor
+	Field FirstSlave.MockActor
+	Field NextSlave.MockActor
+	Field AITarget.MockActor
+	Field AIMode
+End Type
+
+; Mirror of Actors.bb FreeActorInstance's orphan loop: walk the freed
+; leader's slave chain, detach each surviving child and revert it to idle.
+Function OrphanLeaderChildren(L.MockActor)
+	Local Child.MockActor = L\FirstSlave
+	Local ChildNext.MockActor = Null
+	While Child <> Null
+		ChildNext = Child\NextSlave
+		Child\Leader = Null
+		Child\NextSlave = Null
+		Child\AIMode = AI_Wait
+		Child\AITarget = Null
+		Child = ChildNext
+	Wend
+	L\FirstSlave = Null
+End Function
+
+; Mirror of the GameServer.bb AI tick orphaned-pet backstop branch:
+; (AIMode = AI_Pet Or AIMode = AI_PetChase) And Leader = Null -> demote.
+Function TickDemoteIfOrphaned(M.MockActor)
+	If (M\AIMode = AI_Pet Or M\AIMode = AI_PetChase) And M\Leader = Null
+		M\AIMode = AI_Wait
+		M\AITarget = Null
+	EndIf
+End Function
+
+
+; Freeing a leader reverts every surviving pet child to AI_Wait with a
+; cleared Leader -- the root-cause fix for the orphan-on-leader-free path.
+Test testOrphanLoopResetsChildrenToWait()
+	Local lead.MockActor = New MockActor()
+	Local foe.MockActor = New MockActor()
+	Local c1.MockActor = New MockActor()
+	Local c2.MockActor = New MockActor()
+	c1\AIMode = AI_Pet      : c1\Leader = lead : c1\AITarget = foe
+	c2\AIMode = AI_PetChase : c2\Leader = lead : c2\AITarget = foe
+	; Head-insert chain as SlaveLink builds it: FirstSlave -> c2 -> c1.
+	lead\FirstSlave = c2 : c2\NextSlave = c1
+
+	OrphanLeaderChildren(lead)
+
+	Assert(lead\FirstSlave = Null)
+	Assert(c1\Leader = Null) : Assert(c1\AIMode = AI_Wait) : Assert(c1\AITarget = Null)
+	Assert(c2\Leader = Null) : Assert(c2\AIMode = AI_Wait) : Assert(c2\AITarget = Null)
+End Test
+
+; Tick backstop: an AI_Pet whose leader is gone is demoted to idle.
+Test testTickDemotesOrphanedPet()
+	Local p.MockActor = New MockActor()
+	p\AIMode = AI_Pet : p\Leader = Null
+	TickDemoteIfOrphaned(p)
+	Assert(p\AIMode = AI_Wait)
+End Test
+
+; Tick backstop covers AI_PetChase too, and clears the stale target.
+Test testTickDemotesOrphanedPetChase()
+	Local p.MockActor = New MockActor()
+	Local foe.MockActor = New MockActor()
+	p\AIMode = AI_PetChase : p\Leader = Null : p\AITarget = foe
+	TickDemoteIfOrphaned(p)
+	Assert(p\AIMode = AI_Wait)
+	Assert(p\AITarget = Null)
+End Test
+
+; A pet WITH a live leader is left untouched (no spurious demotion).
+Test testTickLeavesAttendedPet()
+	Local lead.MockActor = New MockActor()
+	Local p.MockActor = New MockActor()
+	p\AIMode = AI_Pet : p\Leader = lead
+	TickDemoteIfOrphaned(p)
+	Assert(p\AIMode = AI_Pet)
+	Assert(p\Leader = lead)
+End Test
+
+; A non-pet actor with a Null leader is NOT touched -- the backstop only
+; fires for pet modes, so leaderless plain NPCs keep their AIMode.
+Test testTickLeavesNonPetWithNullLeader()
+	Local n.MockActor = New MockActor()
+	n\AIMode = AI_Wait : n\Leader = Null
+	TickDemoteIfOrphaned(n)
+	Assert(n\AIMode = AI_Wait)
+End Test


### PR DESCRIPTION
## Non-technical summary

When a pet's owner (its "leader") is removed from the world — for example when a scripted zone instance is torn down — the pet could be left pointing at an owner that no longer exists. On the next server tick the pet's AI tried to read that dead owner's position, which either crashes the whole server (debug builds) or, in release builds, silently sends the pet walking to the world origin (0,0) forever. This change makes an orphaned pet quietly revert to "idle" instead, and adds a safety net so no future code path can reintroduce the crash.

## Technical summary

A pet NPC has `AIMode` `AI_Pet` (5) or `AI_PetChase` (6) and a `\Leader` handle. The server AI tick's pet branches in `UpdateActorInstances` deref `AI\Leader\X#` / `\Y#` / `\Z#` / `\IsRunning` / `\Actor\Radius#` / `\AITarget` **with no Null guard** — unlike the `AI_Chase` branch, which guards `AI\AITarget <> Null` per CLAUDE.md's handle-lookup discipline. `CommandPet "ATTACK"` likewise derefs `AI\Leader\AITarget`.

`FreeActorInstance`'s slave-orphan loop detached surviving children (`Child\Leader = Null`) but **never reset `Child\AIMode`**. So a pet whose leader is freed — e.g. `BVM_REMOVEZONEINSTANCE` freeing each NPC in a zone instance individually, or any `FreeActorInstance` that didn't cascade through `FreeActorInstanceSlaves` — kept its pet AIMode with a now-Null `\Leader`. The next tick deref of a Null `Leader` is a crash in debug builds, or (release skips `__bbNullObjEx`) a silent read-as-0 that snaps the pet's destination to world origin. The correct reset already existed three lines from the gap, in `BVM_SETLEADER` (`SlaveUnlink` then `AIMode = AI_Wait`); only the non-BVM orphan path omitted it.

**Fix (defense-in-depth, source first):**
- [`Actors.bb`](../blob/develop/src/Modules/Actors.bb) `FreeActorInstance` orphan loop: reset each surviving child to `AIMode = AI_Wait` and clear `AITarget` alongside `Leader = Null`. **Root cause.**
- [`GameServer.bb`](../blob/develop/src/Modules/GameServer.bb) AI tick: a backstop `ElseIf (AI\AIMode = AI_Pet Or AI\AIMode = AI_PetChase) And AI\Leader = Null` **before** the pet branches, demoting orphaned pets to `AI_Wait` so a future orphaning path can't reintroduce the Null deref.
- `GameServer.bb` `CommandPet "ATTACK"`: guard `AI\Leader <> Null` before the leader deref.

**Deliberately did NOT** add the reset inside `SlaveUnlink`: `SlaveLink` calls `SlaveUnlink` to detach before re-attaching and does not re-set `AIMode`, so resetting there would idle a pet being **transferred** to a new leader. The backstop's `And`/`Or` operands are plain reads/compares (no deref through `Leader`), so BlitzForge's **non-short-circuit** `And`/`Or` is safe.

No wire/packet/save-format change — server-only logic plus the shared `Actors.bb` orphan loop.

## Acceptance criteria + results

- [x] After freeing a leader, each surviving slave has `\Leader = Null` **and** `\AIMode = AI_Wait` **and** `\AITarget = Null` (root-cause reset; pinned by `testOrphanLoopResetsChildrenToWait`).
- [x] The AI tick performs no Null-leader deref: an `AI_Pet`/`AI_PetChase` actor with `Leader = Null` is demoted to `AI_Wait` before the pet branches run (`testTickDemotesOrphanedPet` / `…PetChase`).
- [x] No spurious demotion: a pet with a live leader, and a non-pet leaderless NPC, are left untouched (`testTickLeavesAttendedPet` / `…LeavesNonPetWithNullLeader`).
- [x] `CommandPet "ATTACK"` guards `AI\Leader <> Null`.
- [x] Compiles clean: Server.bb (GameServer.bb + Actors.bb) and Client.bb (Actors.bb), no `:line:col:` errors. (GameServer.bb is server-only; Actors.bb is shared — CI builds GUE/Loom/tools.)
- [x] `test.bat PetOrphanAIMode` → `1 passed, 0 failed`.
- [x] No wire/opcode/save-format change → generator-staleness gate not triggered.

## Trade-offs & deferred follow-ups

- **SlaveUnlink left unchanged** (see above) — resetting AIMode there would regress `SlaveLink` pet re-parenting. The reset lives in the orphan loop (where the child is genuinely losing its leader) and the tick backstop.
- **Verification ceiling**: the server can't be stood up headlessly by an agent, so real-path verification is compile + static trace per repo norms; the test pins the *replicated* orphan-loop + demotion logic, not the live `Actors.bb`/`GameServer.bb` code (same constraint as `ClampFloatTest`/`SpellCooldownIndexTest`).
- **`AI_PetWait`** (mode 7) is intentionally not part of this — its tick path doesn't deref `\Leader`.
