### PR TITLE
fix: cap inventory stack amounts to the 16-bit save/wire ceiling

### DIFF
--- a/src/Modules/Inventories.bb
+++ b/src/Modules/Inventories.bb
@@ -30,6 +30,22 @@ Const SlotI_Backpack = 14
 
 Const Slots_Inventory = 45
 
+; Maximum stack count a single inventory slot may hold. The save format
+; (Actors.bb WriteShort/ReadShort) is SIGNED 16-bit and the wire field
+; (RCE_StrFromInt$(x, 2)) is 2 bytes, so a count past 32767 corrupts on
+; save->load: WriteShort 40000 -> ReadShort -25536, which the `<= 0` slot
+; cleanup treats as empty and DELETES the whole stack. Clamp every
+; accumulation to this ceiling so the authoritative 32-bit Amounts[] field
+; never outgrows what it can be serialised as.
+Const MaxStackAmount = 32767
+
+; Clamp a stack total to the 16-bit serialisation ceiling. Pure (no logging)
+; so it is unit-testable in isolation.
+Function ClampStackAmount(Total)
+	If Total > MaxStackAmount Then Return MaxStackAmount
+	Return Total
+End Function
+
 ; Inventory object
 Type Inventory
 	Field Items.ItemInstance[Slots_Inventory]
@@ -109,6 +125,15 @@ Function InventoryAdd(A.ActorInstance, SlotFrom, SlotTo, Amount, TellServer = Tr
 	; SlotTo into negative — an unbounded item-duplication path.
 	; Mirrors the partial-amount guard in InventorySwap (~line 152).
 	If Amount < 1 Or Amount > A\Inventory\Amounts[SlotFrom] Then Return False
+
+	; Cap the moved amount so SlotTo never exceeds the stack ceiling
+	; (MaxStackAmount); the remainder stays in SlotFrom rather than being
+	; lost or overflowing into a value the save format can't represent.
+	; Non-lossy merge -- only as much as fits is moved.
+	Local Movable = MaxStackAmount - A\Inventory\Amounts[SlotTo]
+	If Movable < 0 Then Movable = 0
+	If Amount > Movable Then Amount = Movable
+	If Amount < 1 Then Return False
 
 	; Do it
 	A\Inventory\Amounts[SlotTo] = A\Inventory\Amounts[SlotTo] + Amount

--- a/src/Modules/ScriptingCommands.bb
+++ b/src/Modules/ScriptingCommands.bb
@@ -2854,7 +2854,12 @@ Function BVM_GIVEITEM(Param1%, Param2$, Param3%=1)
 											Actor\Inventory\Amounts[i] = 0
 										EndIf
 										Actor\Inventory\Items[i] = II
-										Actor\Inventory\Amounts[i] = Actor\Inventory\Amounts[i] + ThisAmount
+										; Clamp to the 16-bit save/wire ceiling (see ClampStackAmount
+										; in Inventories.bb) so a BVM GiveItem can't push the slot past
+										; what the save format represents (which would lose the whole
+										; stack on save->load). Excess above the cap is dropped here;
+										; non-lossy residual is a deferred follow-up.
+										Actor\Inventory\Amounts[i] = ClampStackAmount(Actor\Inventory\Amounts[i] + ThisAmount)
 
 										; Visual stuff
 										If i = SlotI_Weapon Or i = SlotI_Shield Or i = SlotI_Hat Or i = SlotI_Chest

--- a/src/Modules/ServerNet.bb
+++ b/src/Modules/ServerNet.bb
@@ -1642,7 +1642,7 @@ Function UpdateNetwork()
 											AI\Inventory\Amounts[SlotI] = 0
 										EndIf
 										AI\Inventory\Items[SlotI] = D\Item
-										AI\Inventory\Amounts[SlotI] = AI\Inventory\Amounts[SlotI] + D\Amount
+										AI\Inventory\Amounts[SlotI] = ClampStackAmount(AI\Inventory\Amounts[SlotI] + D\Amount)  ; cap to 16-bit save/wire ceiling
 										If SlotI < SlotI_Backpack Then SendEquippedUpdate(AI)
 
 										; Tell this player he got it
@@ -1727,7 +1727,7 @@ Function UpdateNetwork()
 												AI\Inventory\Amounts[SlotI] = 0
 											EndIf
 											AI\Inventory\Items[SlotI] = II
-											AI\Inventory\Amounts[SlotI] = AI\Inventory\Amounts[SlotI] + II\Assignment
+											AI\Inventory\Amounts[SlotI] = ClampStackAmount(AI\Inventory\Amounts[SlotI] + II\Assignment)  ; cap to 16-bit save/wire ceiling
 											II\Assignment = 0
 											If SlotI < SlotI_Backpack Then SendEquippedUpdate(AI)
 										EndIf

--- a/src/Tests/Modules/InventoryStackClampTest.bb
+++ b/src/Tests/Modules/InventoryStackClampTest.bb
@@ -1,0 +1,97 @@
+Strict
+EnableGC
+
+; Tests for the inventory stack-amount ceiling enforced in Inventories.bb
+; (ClampStackAmount + the non-lossy cap in InventoryAdd) and applied at the
+; server accumulation sites (ServerNet.bb pickup / give-to-slot,
+; ScriptingCommands.bb BVM give).
+;
+; Why a ceiling exists: a slot's Amounts[] is an authoritative 32-bit Int on
+; the server, but it is serialised as SIGNED 16-bit in the save file
+; (Actors.bb WriteShort/ReadShort) and as a 2-byte field on the wire. A stack
+; pushed past 32767 corrupts on save->load -- WriteShort 40000 round-trips
+; through ReadShort to -25536, which the `<= 0` slot cleanup treats as empty
+; and DELETES the whole stack. The dupe-guards added earlier cap the move
+; against the SOURCE amount but never the DESTINATION ceiling; this closes
+; that gap.
+;
+; Inventories.bb can't be Included into a test build (it pulls ItemInstance /
+; the world graph), so ClampStackAmount and the InventoryAdd capped-move are
+; replicated verbatim here, per the established ClampFloatTest convention. A
+; change to either production copy must update this duplicate.
+
+Const MaxStackAmount = 32767
+
+Function ClampStackAmount(Total)
+	If Total > MaxStackAmount Then Return MaxStackAmount
+	Return Total
+End Function
+
+; Two-slot stand-in for an Inventory: aTo = destination, aFrom = source.
+Type MockInv
+	Field aTo
+	Field aFrom
+End Type
+
+; Mirror of InventoryAdd's capped, non-lossy move. The production code has
+; already guaranteed `requested >= 1 And requested <= aFrom` before this
+; point (the negative/oversize dupe guard). Returns True if anything moved.
+Function MergeCapped(M.MockInv, requested)
+	Local Movable = MaxStackAmount - M\aTo
+	If Movable < 0 Then Movable = 0
+	Local amt = requested
+	If amt > Movable Then amt = Movable
+	If amt < 1 Then Return False
+	M\aTo = M\aTo + amt
+	M\aFrom = M\aFrom - amt
+	Return True
+End Function
+
+
+; The clamp caps at the 16-bit ceiling and is a pass-through below it.
+Test testClampCapsAtCeiling()
+	Assert(ClampStackAmount(40000) = MaxStackAmount)
+	Assert(ClampStackAmount(65535) = MaxStackAmount)
+	Assert(ClampStackAmount(32768) = MaxStackAmount)
+	Assert(ClampStackAmount(MaxStackAmount) = MaxStackAmount)
+	Assert(ClampStackAmount(1000) = 1000)
+	Assert(ClampStackAmount(0) = 0)
+End Test
+
+; The accumulation sites never store a value the save format can't hold.
+Test testClampedAddNeverExceedsCeiling()
+	; Simulates ServerNet pickup: existing 32000 + picked-up 5000.
+	Assert(ClampStackAmount(32000 + 5000) <= MaxStackAmount)
+	Assert(ClampStackAmount(32000 + 5000) = MaxStackAmount)
+End Test
+
+; Merging into a near-full destination moves only what fits; the remainder
+; stays in the source -- nothing is lost, and the destination stays <= cap.
+Test testMergeIsNonLossyAtCeiling()
+	Local m.MockInv = New MockInv()
+	m\aTo = 32000 : m\aFrom = 5000
+	Local startTotal = m\aTo + m\aFrom
+	Assert(MergeCapped(m, 5000) = True)
+	Assert(m\aTo = MaxStackAmount)        ; 32000 + 767
+	Assert(m\aFrom = 4233)                ; 5000 - 767 remainder retained
+	Assert(m\aTo + m\aFrom = startTotal)  ; total conserved (non-lossy)
+	Assert(m\aTo <= MaxStackAmount)
+End Test
+
+; A full destination accepts nothing and leaves both slots untouched.
+Test testMergeFullDestMovesNothing()
+	Local m.MockInv = New MockInv()
+	m\aTo = MaxStackAmount : m\aFrom = 100
+	Assert(MergeCapped(m, 100) = False)
+	Assert(m\aTo = MaxStackAmount)
+	Assert(m\aFrom = 100)
+End Test
+
+; A normal sub-ceiling merge is unaffected by the cap.
+Test testMergeNormalUnaffected()
+	Local m.MockInv = New MockInv()
+	m\aTo = 10 : m\aFrom = 5
+	Assert(MergeCapped(m, 5) = True)
+	Assert(m\aTo = 15)
+	Assert(m\aFrom = 0)
+End Test


### PR DESCRIPTION
## Non-technical summary

A single inventory slot's stack count is stored as a full 32-bit number while the game is running, but it is saved to disk and sent over the network as a **16-bit** value. Nothing stopped a stack from growing past what 16 bits can hold (32767). When that happened, the count corrupted on the next save/reload — a stack of 40000 came back as a negative number, which the "empty slot" cleanup then **deleted entirely**. So a large enough stack would silently vanish when the player logged back in. This change caps stacks at the safe ceiling so the saved value always round-trips correctly.

## Technical summary

`Inventory\Amounts[]` is a 32-bit Int on the server, but serialised SIGNED 16-bit in the save file ([Actors.bb:324/459](../blob/develop/src/Modules/Actors.bb#L324) `WriteShort`/`ReadShort`) and as a 2-byte wire field (`RCE_StrFromInt$(x, 2)`). No accumulation site capped the total, so a slot past 32767 corrupts on save→load (`WriteShort 40000` → `ReadShort -25536` → the `<= 0` slot cleanup deletes the whole stack); the 32768–65535 band desyncs the client. The earlier dupe-guards capped the move against the **source** amount but never the **destination** ceiling.

**Fix:** `Const MaxStackAmount = 32767` + a pure `ClampStackAmount` helper in [`Inventories.bb`](../blob/develop/src/Modules/Inventories.bb), enforced at every accumulation site:
- **`InventoryAdd` (slot-to-slot merge): non-lossy** — move only what fits into SlotTo; the remainder stays in SlotFrom, and the packet it emits carries the actually-moved amount so client and server stay consistent.
- **ServerNet pickup / give-to-slot, and ScriptingCommands BVM give:** clamp the post-add total via `ClampStackAmount`. Excess above the cap is dropped (still strictly better than the whole-stack loss the uncapped path caused on relog); non-lossy residual-on-source for these three is a deferred follow-up.

No save/wire **format** change (stays 16-bit) — the fix makes the engine respect that width, so existing saves load unchanged. The server clamp sites are written as **in-place single-line** changes so packet-index handler line numbers don't shift — `docs/protocol/index.md` is unaffected and needs no regeneration.

## Acceptance criteria + results

- [x] `MaxStackAmount` (= 32767) is used at every clamp site; no magic number.
- [x] Pickup, give-to-slot, and BVM give clamp the post-add total ≤ ceiling.
- [x] `InventoryAdd` merge is non-lossy: only what fits is moved, remainder retained, destination ≤ ceiling.
- [x] Full `compile.bat` clean — all 5 engine targets + 7 tools, no `:line:col:` errors.
- [x] `test.bat InventoryStackClamp` → `1 passed`: pins the cap, that no accumulation stores an un-serialisable value, the non-lossy merge (total conserved + remainder + ≤ ceiling), the full-destination no-op, and that normal sub-ceiling merges are unaffected.
- [x] No wire/opcode/save-format change → packet index unchanged (verified ServerNet.bb line count identical to develop).

## Trade-offs & deferred follow-ups

- **Non-lossy only at the merge site**; pickup/give/BVM drop the excess above the cap (logged-rationale lives in the const comment). Non-lossy residual-on-source for those three is a follow-up — the corruption fix is the priority and over-cap external adds are an edge case.
- **Verification ceiling**: server can't be launched headlessly by an agent, so verification is compile + static reasoning + a replicated-logic unit test (`Inventories.bb` can't be `Include`d offline), per repo convention.
- **Separate confirmed bug surfaced during this work:** `scripts/gen_packet_index.sh` has a real, intermittent SIGPIPE-under-`pipefail` race that can write a **truncated** `index.md` on regen (and false-fail `--check`). It did not affect this PR (no regen needed), but it's now reproduced and warrants its own fix. (Earlier loop iterations had marked it "disconfirmed" because it didn't reproduce on a quiet tree.)
