### PR TITLE
fix: eliminate SIGPIPE race in gen_packet_index.sh that truncated index.md

### DIFF
--- a/scripts/gen_packet_index.sh
+++ b/scripts/gen_packet_index.sh
@@ -142,9 +142,20 @@ pages is a per-iteration documentation task — see CONTRIBUTING.md.
 HEADER
 
 # Build the table.
+#
+# The per-row lookups MUST NOT use `awk ... exit` to stop at the first
+# match. Under `set -euo pipefail`, `exit` closes awk's stdin pipe while the
+# upstream `echo` may still be writing, so `echo` takes SIGPIPE (status 141);
+# pipefail propagates that to the command substitution and `set -e` then
+# aborts this `while` subshell mid-iteration, truncating "$OUTPUT.new". The
+# failure is intermittent (the race only fires when `echo` hasn't finished
+# writing, i.e. under load) and silently produced a truncated docs/protocol/
+# index.md plus a flaky `--check`. Instead, let awk drain all input and keep
+# only the first match via a guard flag -- mirrors gen_bvm_reference.sh,
+# whose awk has no `exit` and never raced.
 echo "$packets" | while IFS='|' read -r id name; do
-    server_line=$(echo "$server_handlers" | awk -F'|' -v n="$name" '$1 == n { print $2; exit }')
-    client_line=$(echo "$client_handlers" | awk -F'|' -v n="$name" '$1 == n { print $2; exit }')
+    server_line=$(echo "$server_handlers" | awk -F'|' -v n="$name" '$1 == n && !seen { print $2; seen = 1 }')
+    client_line=$(echo "$client_handlers" | awk -F'|' -v n="$name" '$1 == n && !seen { print $2; seen = 1 }')
 
     # Direction
     if [ -n "$server_line" ] && [ -n "$client_line" ]; then


### PR DESCRIPTION
## Non-technical summary

The script that regenerates the wire-protocol reference doc (`docs/protocol/index.md`) had an intermittent bug: under system load it would sometimes write a **truncated** doc (dropping packets off the end), and its CI "is this doc up to date?" check would **false-fail**. This made the generator-staleness CI gate unreliable for any change touching the packet code — a PR could be blocked by a doc-check failure that had nothing to do with the PR. This fixes the root cause so regeneration and the check are now deterministic.

## Technical summary

The table loop in [`gen_packet_index.sh`](../blob/develop/scripts/gen_packet_index.sh) looked up each handler's line number with:

```sh
server_line=$(echo "$server_handlers" | awk -F'|' -v n="$name" '$1 == n { print $2; exit }')
```

Under `set -euo pipefail`, `awk … exit` closes its stdin pipe on the first match while the upstream `echo` may still be writing → `echo` takes **SIGPIPE** (status 141) → `pipefail` propagates it to the command substitution → `set -e` aborts the enclosing `while` subshell mid-iteration. Because the loop runs inside `{ … } > "$OUTPUT.new"`, the abort leaves a **truncated** `index.md`.

It's intermittent: SIGPIPE only fires when `echo` hasn't finished writing by the time `awk` exits — i.e. **under load**. On a quiet tree it passes (which is why earlier investigation wrongly marked it "not reproducible"). A prior iteration reproduced it hard: regenerations produced 106 → 81 / 39-line truncated docs, and `--check` false-failed ~80% of the time under load. Especially nasty: two consecutive regens can truncate to the *same* length, so a `diff -q regenA regenB` stability check is fooled into committing a truncated doc.

**Fix:** drop the `exit` and keep first-match via a guard flag —

```sh
awk -F'|' -v n="$name" '$1 == n && !seen { print $2; seen = 1 }'
```

awk now drains **all** of its stdin, so `echo` can never receive SIGPIPE — the race is removed *by construction*, not merely narrowed. This mirrors `gen_bvm_reference.sh`, whose analogous awk has no `exit` and never raced. Output is byte-identical (one `Case` per packet per file → first-match unchanged).

## Acceptance criteria + results

No shell-test harness exists in-repo, so the acceptance evidence is a deterministic stress run under 4× `yes` CPU load (the condition that triggered the ~80% failure):

- [x] Single regen byte-identical to the committed develop `index.md` (106 lines).
- [x] **25 regens under CPU load → 0/25 truncated** (min line count 106). *(Before: ~80% truncated under the same load.)*
- [x] **`gen_packet_index.sh --check` 25× under CPU load → 0 failures.**
- [x] Stale-detection regression guard intact: a hand-edited (stale) doc still makes `--check` exit 1; a restored doc exits 0.
- [x] Output unchanged: this PR modifies only the script; `docs/protocol/index.md` is not touched (the generator produces the identical doc).

## Trade-offs & deferred follow-ups

- First-match-via-guard vs `exit`: keeps the original "first handler wins" semantics while draining the pipe. Marginally more awk work per lookup (it reads to EOF), but the handler lists are tiny — negligible vs. the per-row `echo`/subprocess cost already present.
- This corrects an earlier loop-memory conclusion that the race was "disconfirmed" — it was real, just load-dependent.
- The sibling `gen_bvm_reference.sh` already lacks `exit` and is unaffected; no change needed there.
