### PR TITLE
fix: free ActionBar on character deletion (P_DeleteCharacter heap leak)

### DIFF
--- a/src/Modules/ServerNet.bb
+++ b/src/Modules/ServerNet.bb
@@ -2951,6 +2951,13 @@ Function UpdateNetwork()
 							If Number > -1 And Number < 10
 								; Delete the character
 								If A\QuestLog[Number] <> Null Then Delete A\QuestLog[Number]
+								; Free the per-character ActionBar too: the shift loop below
+								; overwrites A\ActionBar[Number] without releasing it, leaking one
+								; ActionBarData (+ its 36 slot strings) per character deletion.
+								; DeleteCharacter() only frees the ActorInstance, and the load
+								; cleanup at AccountsServer.bb:366 frees QuestLog AND ActionBar
+								; together -- restore that symmetry here. No double-free.
+								If A\ActionBar[Number] <> Null Then Delete A\ActionBar[Number]
 								If MySQL = True
 									//My_DeleteCharacter(A, Number)
 								Else

--- a/src/Tests/Modules/DeleteCharacterCleanupTest.bb
+++ b/src/Tests/Modules/DeleteCharacterCleanupTest.bb
@@ -1,0 +1,102 @@
+Strict
+EnableGC
+
+; Tests for the P_DeleteCharacter slot-cleanup invariant in ServerNet.bb.
+;
+; An Account holds three parallel per-slot arrays (AccountsServer.bb):
+;   Field Character.ActorInstance[9]
+;   Field QuestLog.QuestLog[9]
+;   Field ActionBar.ActionBarData[9]
+; Deleting character `Number` must RELEASE that slot's resources before the
+; shift loop overwrites them, then shift slots Number+1..9 down and null slot
+; 9. The handler released QuestLog (and the actor, via DeleteCharacter) but
+; NOT ActionBar -- so the shift overwrote A\ActionBar[Number] and leaked one
+; ActionBarData (+ its 36 slot strings) per deletion. The fix adds the
+; matching `Delete A\ActionBar[Number]`, restoring the symmetry the load
+; cleanup (AccountsServer.bb:366) already has.
+;
+; ServerNet.bb can't be Included into a test build (RakNet externs), so the
+; slot-management is replicated here on integer instance-ids with a release
+; log, per the established ClampFloatTest convention. The model mirrors the
+; FIXED handler; a regression that drops the ActionBar release would make
+; the model's freed-log omit it -- which testDeleteReleasesAllThree pins.
+
+Type MockAcct
+	Field ch[9]      ; character (ActorInstance) id; 0 = empty slot
+	Field ql[9]      ; QuestLog instance id
+	Field ab[9]      ; ActionBar instance id
+	Field freed$     ; release log: "C<id>;" / "Q<id>;" / "A<id>;" per release
+End Type
+
+; Replicates the FIXED P_DeleteCharacter cleanup+shift for slot `Number`.
+Function DeleteCharSlot(M.MockAcct, Number)
+	; Release the deleted slot's resources BEFORE the shift overwrites them.
+	; DeleteCharacter() frees the actor; QuestLog and ActionBar are Delete'd.
+	If M\ch[Number] <> 0 Then M\freed$ = M\freed$ + "C" + Str$(M\ch[Number]) + ";"
+	If M\ql[Number] <> 0 Then M\freed$ = M\freed$ + "Q" + Str$(M\ql[Number]) + ";"
+	If M\ab[Number] <> 0 Then M\freed$ = M\freed$ + "A" + Str$(M\ab[Number]) + ";"
+	; Shift remaining slots down.
+	Local i
+	For i = Number To 8
+		M\ch[i] = M\ch[i + 1]
+		M\ql[i] = M\ql[i + 1]
+		M\ab[i] = M\ab[i + 1]
+	Next
+	M\ch[9] = 0
+	M\ql[9] = 0
+	M\ab[9] = 0
+End Function
+
+; Helper: load N sequential characters into slots 0..N-1 with distinct ids.
+Function Populate(M.MockAcct, N)
+	Local i
+	For i = 0 To N - 1
+		M\ch[i] = 100 + i
+		M\ql[i] = 200 + i
+		M\ab[i] = 300 + i
+	Next
+End Function
+
+
+; The deleted slot releases ALL THREE resources -- crucially the ActionBar
+; (id 301 for slot 1), which the pre-fix handler leaked.
+Test testDeleteReleasesAllThree()
+	Local m.MockAcct = New MockAcct()
+	Populate(m, 3)
+	DeleteCharSlot(m, 1)
+	Assert(Instr(m\freed$, "C101;") > 0)  ; actor freed
+	Assert(Instr(m\freed$, "Q201;") > 0)  ; questlog freed
+	Assert(Instr(m\freed$, "A301;") > 0)  ; ACTIONBAR freed (the fix)
+End Test
+
+; The shift pulls slot Number+1.. down into Number.., across all 3 arrays.
+Test testShiftMovesRemainingDown()
+	Local m.MockAcct = New MockAcct()
+	Populate(m, 3)
+	DeleteCharSlot(m, 1)
+	; slot 1 now holds what was slot 2 (ids 102/202/302)
+	Assert(m\ch[1] = 102) : Assert(m\ql[1] = 202) : Assert(m\ab[1] = 302)
+	; slot 0 untouched
+	Assert(m\ch[0] = 100) : Assert(m\ab[0] = 300)
+End Test
+
+; Slot 9 is cleared after a shift (no dangling duplicate of slot 8).
+Test testLastSlotCleared()
+	Local m.MockAcct = New MockAcct()
+	Populate(m, 10)              ; all 10 slots full
+	DeleteCharSlot(m, 0)
+	Assert(m\ch[9] = 0) : Assert(m\ql[9] = 0) : Assert(m\ab[9] = 0)
+	; what was slot 9 (ids 109/...) shifted into slot 8
+	Assert(m\ch[8] = 109) : Assert(m\ab[8] = 309)
+End Test
+
+; Deleting the last populated slot releases its ActionBar and leaves the
+; array consistent (no shift needed beyond clearing).
+Test testDeleteLastPopulatedSlot()
+	Local m.MockAcct = New MockAcct()
+	Populate(m, 3)
+	DeleteCharSlot(m, 2)
+	Assert(Instr(m\freed$, "A302;") > 0)  ; last slot's ActionBar freed
+	Assert(m\ch[2] = 0) : Assert(m\ab[2] = 0)
+	Assert(m\ch[0] = 100) : Assert(m\ch[1] = 101)  ; earlier slots intact
+End Test


### PR DESCRIPTION
## Non-technical summary

When a player deletes a character, the server frees most of that character's data — but it forgot to free the character's **action bar**. Each deletion permanently leaked one action-bar object (plus its 36 slot strings), so a long-running server slowly accumulated wasted memory from every character anyone ever deleted. This adds the one missing release, matching how the rest of the codebase already cleans these up together.

## Technical summary

An `Account` holds three parallel per-slot arrays ([AccountsServer.bb:33-35](../blob/develop/src/Modules/AccountsServer.bb#L33)):

```blitz
Field Character.ActorInstance[9]
Field QuestLog.QuestLog[9]
Field ActionBar.ActionBarData[9]
```

`P_DeleteCharacter` ([ServerNet.bb](../blob/develop/src/Modules/ServerNet.bb)) deleted the slot's `QuestLog`, freed its `ActorInstance` (via `DeleteCharacter`), then shifted slots `Number+1..9` down — but **never released `A\ActionBar[Number]`**. The shift loop then overwrote that slot with `A\ActionBar[Number+1]`, orphaning the original `ActionBarData` instance (+ its 36 slot strings). One leak per character deletion → unbounded heap growth over server uptime.

Verified it's a genuine leak, not a double-free:
- `DeleteCharacter()` does **only** `FreeActorInstance(A\Character[Number])` — it never touches `ActionBar`/`QuestLog`.
- The load-cleanup path at [AccountsServer.bb:366](../blob/develop/src/Modules/AccountsServer.bb#L366) already frees **both** together (`Delete A\QuestLog[i-1] : Delete A\ActionBar[i-1]`), and `MySQL.bb:313` frees `ActionBar` on its unload path. The delete handler was the asymmetric outlier — freeing only `QuestLog`.

**Fix:** one line, immediately after the existing `QuestLog` delete, restoring the symmetry:

```blitz
If A\ActionBar[Number] <> Null Then Delete A\ActionBar[Number]
```

The edit sits **below all packet-handler `Case` dispatch lines**, so no `docs/protocol/index.md` handler line reference shifts — regeneration is byte-identical (106 lines), no doc change.

## Acceptance criteria + results

- [x] `P_DeleteCharacter` releases the deleted slot's `ActionBar` before the shift overwrites it (matches the `QuestLog` release one line above and the `AccountsServer.bb:366` pattern).
- [x] No double-free: `DeleteCharacter` doesn't touch `ActionBar` (verified by reading its body).
- [x] Server compiles clean — `Server.bb` parses/generates with no `:line:col:` errors (the link step's "Error creating executable" was only a running-`Server.exe` file lock; CI links in a clean env).
- [x] `docs/protocol/index.md` unchanged (regen byte-identical, 106 lines) — confirmed no `Case P_` line exists below the edit.
- [x] New `DeleteCharacterCleanupTest.bb` passes (`test.bat DeleteCharacterCleanup` → `1 passed`): deleting a slot releases all three resources (actor + QuestLog + **ActionBar**), shifts `Number+1..9` down across all three arrays, and clears slot 9; covers delete-middle, delete-first (full account), and delete-last cases.

## Trade-offs & deferred follow-ups

- **Test is replicated-logic** (ServerNet.bb can't be `Include`d offline due to RakNet externs), so it pins the modeled delete-shift-cleanup invariant rather than the live handler — the same accepted convention as the other tests in `src/Tests/Modules/`. The fix's correctness rests primarily on the sibling-asymmetry evidence + the verified `DeleteCharacter` body + the byte-identical regen.
- Leak magnitude can't be measured in an offline unit test; evidence is the code asymmetry + the released-resource assertion in the test.
