### PR TITLE
test: pin the P_StatUpdate wire byte-layout contract (9 builders, 1 reader)

### DIFF
--- a/src/Tests/Modules/StatUpdateWireLayoutTest.bb
+++ b/src/Tests/Modules/StatUpdateWireLayoutTest.bb
@@ -1,0 +1,122 @@
+; Tests for the P_StatUpdate (packet const 22) wire byte-layout contract.
+;
+; P_StatUpdate is BUILT in nine server-side places across four modules and
+; READ in exactly one client handler -- the offsets are coupled only by
+; convention, nothing pins them. The layout has two shapes:
+;
+;   "A" (attribute value) / "M" (attribute maximum):
+;       subcode(1) + RuntimeID(2) + Attribute(1) + Value(2)   = 6 bytes
+;       reader: ClientNet.bb -- RID @ Mid$(,2,2), Att @ Mid$(,4,1), Val @ Mid$(,5,2)
+;   "R" (reputation):
+;       subcode(1) + RuntimeID(2) + Reputation(2)             = 5 bytes
+;       reader: ClientNet.bb -- RID @ Mid$(,2,2), Rep @ Mid$(,4,2)   (NO Attribute byte)
+;
+; The "R" form is asymmetric: its value sits at offset 4, while "A"/"M" put
+; Attribute at 4 and the value at 5. A refactor that (a) widens any field,
+; (b) "unifies" "R" by inserting an Attribute byte, (c) reorders
+; RuntimeID/Attribute, or (d) drifts one of the nine builders out of step,
+; silently shifts every downstream Mid$ slice -> wrong HP/mana/reputation
+; displayed, or an out-of-band Attribute that the reader's `0..39` guard
+; drops (stat update silently vanishes). No crash, no compile error.
+;
+; Builders (verified): ServerNet.bb:360/374 (A/M), GameServer.bb:769/804 (A),
+; ScriptingCommands.bb:2350/2387/2433/2466 (A/M), Server.bb:1010 (R via
+; UpdateReputation). Reader: ClientNet.bb:990-1010.
+;
+; ClientNet.bb / ServerNet.bb can't be Included offline (RakNet externs), so
+; the wire primitive and both layouts are replicated here per the established
+; RCEWireEncodingTest.bb / ClampFloatTest.bb convention. The test reconstructs
+; each field via the EXACT reader Mid$ offsets, independently of the builder's
+; concatenation order, so it is not tautological: a builder/reader offset
+; disagreement fails an assert. NOT Strict (bare-int + Bank primitive).
+
+Global StatBank = CreateBank(4)
+
+Function StatStrFromInt$(Num, Length = 4)
+	PokeInt StatBank, 0, Num
+	Dat$ = ""
+	For i = Length - 1 To 0 Step -1
+		Dat$ = Chr$(PeekByte(StatBank, i)) + Dat$
+	Next
+	Return Dat$
+End Function
+
+Function StatIntFromStr(Dat$)
+	PokeInt StatBank, 0, 0
+	For i = 1 To Len(Dat$)
+		PokeByte StatBank, i - 1, Asc(Mid$(Dat$, i, 1))
+	Next
+	Return PeekInt(StatBank, 0)
+End Function
+
+; --- Builders: byte-for-byte mirrors of the production senders ---------
+Function BuildStatA$(rid, att, val)
+	Return "A" + StatStrFromInt$(rid, 2) + StatStrFromInt$(att, 1) + StatStrFromInt$(val, 2)
+End Function
+Function BuildStatM$(rid, att, mx)
+	Return "M" + StatStrFromInt$(rid, 2) + StatStrFromInt$(att, 1) + StatStrFromInt$(mx, 2)
+End Function
+Function BuildStatR$(rid, rep)
+	Return "R" + StatStrFromInt$(rid, 2) + StatStrFromInt$(rep, 2)
+End Function
+
+
+; "A" round-trips through the reader's offsets, and is exactly 6 bytes.
+Test testAttributeUpdateRoundTrip()
+	Local p$ = BuildStatA$(1234, 7, 500)
+	Assert(Len(p$) = 6)
+	Assert(Left$(p$, 1) = "A")
+	Assert(StatIntFromStr(Mid$(p$, 2, 2)) = 1234)   ; RuntimeID
+	Assert(StatIntFromStr(Mid$(p$, 4, 1)) = 7)      ; Attribute
+	Assert(StatIntFromStr(Mid$(p$, 5, 2)) = 500)    ; Value
+End Test
+
+; "M" uses the identical offsets as "A"; boundary RuntimeID + boundary
+; Attribute (39, the highest the reader's `< 40` guard accepts).
+Test testMaximumUpdateRoundTrip()
+	Local p$ = BuildStatM$(65535, 39, 30000)
+	Assert(Len(p$) = 6)
+	Assert(Left$(p$, 1) = "M")
+	Assert(StatIntFromStr(Mid$(p$, 2, 2)) = 65535)
+	Assert(StatIntFromStr(Mid$(p$, 4, 1)) = 39)
+	Assert(StatIntFromStr(Mid$(p$, 5, 2)) = 30000)
+End Test
+
+; "R" round-trips: reputation lives at offset 4 (width 2), and the packet is
+; 5 bytes -- there is NO Attribute byte.
+Test testReputationRoundTrip()
+	Local p$ = BuildStatR$(42, 12345)
+	Assert(Len(p$) = 5)
+	Assert(Left$(p$, 1) = "R")
+	Assert(StatIntFromStr(Mid$(p$, 2, 2)) = 42)     ; RuntimeID
+	Assert(StatIntFromStr(Mid$(p$, 4, 2)) = 12345)  ; Reputation @ offset 4
+End Test
+
+; The asymmetry guard: "R" value is at offset 4 and the packet is 5 bytes,
+; whereas "A"/"M" value is at offset 5 and 6 bytes. A future "uniformity"
+; refactor that inserts an Attribute byte into "R" (making it 6 bytes and
+; moving reputation to offset 5) breaks these asserts -- which is the point.
+Test testRvsAMOffsetAsymmetryPinned()
+	Local r$ = BuildStatR$(1, 1000)
+	Local a$ = BuildStatA$(1, 9, 1000)
+	Assert(Len(r$) = 5)
+	Assert(Len(a$) = 6)
+	; same value, different offset per subcode:
+	Assert(StatIntFromStr(Mid$(r$, 4, 2)) = 1000)   ; R: value at 4
+	Assert(StatIntFromStr(Mid$(a$, 5, 2)) = 1000)   ; A: value at 5
+End Test
+
+; RuntimeID is at the same offset (2, width 2) for ALL subcodes -- the reader
+; decodes it before branching on subcode.
+Test testRuntimeIDOffsetSharedAcrossSubcodes()
+	Assert(StatIntFromStr(Mid$(BuildStatA$(777, 0, 0), 2, 2)) = 777)
+	Assert(StatIntFromStr(Mid$(BuildStatM$(777, 0, 0), 2, 2)) = 777)
+	Assert(StatIntFromStr(Mid$(BuildStatR$(777, 0), 2, 2)) = 777)
+End Test
+
+; Boundary values survive the 2-byte fields (0 and 65535).
+Test testTwoByteFieldBoundaries()
+	Assert(StatIntFromStr(Mid$(BuildStatA$(0, 0, 0), 5, 2)) = 0)
+	Assert(StatIntFromStr(Mid$(BuildStatA$(0, 0, 65535), 5, 2)) = 65535)
+	Assert(StatIntFromStr(Mid$(BuildStatR$(0, 65535), 4, 2)) = 65535)
+End Test


### PR DESCRIPTION
## Non-technical summary

`P_StatUpdate` is the packet that tells the client about a character's HP/mana/attribute and reputation changes. It's *built* in nine different places on the server and *read* in one place on the client, and the exact byte positions are matched only by convention — nothing checks they still agree. If a future change shifts a field, the client would silently show the wrong HP/mana/reputation (or drop the update entirely) with no crash and no compile error. This adds a test that pins the byte layout so any such drift is caught immediately.

## Technical summary

`P_StatUpdate` (const 22) has two layouts:

| Subcode | Layout | Reader offsets (ClientNet.bb:990-1010) |
|---|---|---|
| `A` (attr value) / `M` (attr max) | `subcode(1) + RuntimeID(2) + Attribute(1) + Value(2)` = **6 bytes** | RID `Mid$(,2,2)`, Att `Mid$(,4,1)`, Val `Mid$(,5,2)` |
| `R` (reputation) | `subcode(1) + RuntimeID(2) + Reputation(2)` = **5 bytes** | RID `Mid$(,2,2)`, Rep `Mid$(,4,2)` — **no Attribute byte** |

The `R` form is **asymmetric** — its value is at offset 4, while `A`/`M` put the value at offset 5. Nine builders must stay in lockstep with one reader: ServerNet.bb (A/M), GameServer.bb (A×2), ScriptingCommands.bb (A/M ×2), Server.bb (`UpdateReputation` → R). A widening, a reorder, "unifying" `R` with an Attribute byte, or one builder drifting would silently shift every downstream `Mid$` slice → wrong stat/reputation displayed, or an Attribute read from the wrong byte that the reader's `0..39` guard drops (update vanishes). No crash, no compile error.

Adds `src/Tests/Modules/StatUpdateWireLayoutTest.bb` (non-Strict; replicates `RCE_StrFromInt$`/`RCE_IntFromStr` per the `RCEWireEncodingTest.bb` convention — the network modules pull RakNet externs and can't be `Include`d offline). The test builds each payload exactly as the production senders do, then reconstructs each field via the **exact reader `Mid$` offsets** — independently of the builders' concatenation order, so it's **non-tautological**: a builder/reader offset disagreement fails an assert.

## Acceptance criteria + results

- [x] `test.bat StatUpdateWireLayout` → `1 passed, 0 failed` (6 Test blocks).
- [x] `A`/`M`/`R` round-trip RuntimeID/Attribute/Value(or Reputation) via the reader's offsets.
- [x] Lengths pinned: `A`/`M` = 6 bytes, `R` = 5 bytes.
- [x] Asymmetry pinned: `R` value at offset 4, `A` value at offset 5 — a future "unify R with an Attribute byte" change breaks `testRvsAMOffsetAsymmetryPinned`.
- [x] RuntimeID shared at offset 2 (width 2) across all three subcodes (the reader decodes it before branching).
- [x] 2-byte field boundaries (0 / 65535) survive.
- [x] Test-only; no production `.bb` touched; no packet-index/doc change.

## Trade-offs & deferred follow-ups

- **Replicated-logic test** (network modules can't be `Include`d offline): it pins the *modeled* layout against the reader offsets I transcribed from `ClientNet.bb`, not the live handler. The replicated-gate convention (matching `RCEWireEncodingTest`) is: a production layout change must update this file. Mitigation against transcription error: every offset/width was read directly from source and cross-checked against three builders (ServerNet `A`/`M`, Server.bb `R`).
- **Deferred (separate latent bug, flagged not fixed):** reputation is sent as a 2-byte field and read back unsigned, so a **negative** reputation (`UpdateReputation` with `Value < 0`) does not round-trip — it returns as a large positive. Out of scope for this layout test; worth a follow-up to decide whether reputation should be signed on the wire.
- Did not extend to `P_StandardUpdate` (its trailing field is a conditional 2-byte-energy vs 4-byte-fly-Y — a poorer fit; separate increment).
