### PR TITLE
fix: decode reputation as signed on the wire (negative reputation corrupted)

### DIFF
--- a/src/Modules/Actors.bb
+++ b/src/Modules/Actors.bb
@@ -1154,7 +1154,7 @@ Function ActorInstanceFromString.ActorInstance(Pa$)
 	A\Tag$ = Mid$(Pa$, Offset + 1, NameLen)
 	Offset = Offset + 1 + NameLen
 	If A\Actor\Genders = 0 Then A\Gender = RCE_IntFromStr(Mid$(Pa$, Offset, 1)) : Offset = Offset + 1
-	A\Reputation = RCE_IntFromStr(Mid$(Pa$, Offset, 2))
+	A\Reputation = RCE_SignedShortFromStr(Mid$(Pa$, Offset, 2))  ; signed: reputation can be negative
 	A\FaceTex = RCE_IntFromStr(Mid$(Pa$, Offset + 2, 2))
 	A\Hair    = RCE_IntFromStr(Mid$(Pa$, Offset + 4, 2))
 	A\BodyTex = RCE_IntFromStr(Mid$(Pa$, Offset + 6, 2))

--- a/src/Modules/ClientNet.bb
+++ b/src/Modules/ClientNet.bb
@@ -1006,7 +1006,7 @@ Function UpdateNetwork()
 							A\Attributes\Maximum[Attribute] = RCE_IntFromStr(Mid$(M\MessageData$, 5, 2))
 						EndIf
 					ElseIf Left$(M\MessageData$, 1) = "R"
-						A\Reputation = RCE_IntFromStr(Mid$(M\MessageData$, 4, 2))
+						A\Reputation = RCE_SignedShortFromStr(Mid$(M\MessageData$, 4, 2))  ; signed: reputation can be negative
 					EndIf
 				EndIf
 

--- a/src/Modules/MainMenu.bb
+++ b/src/Modules/MainMenu.bb
@@ -1881,7 +1881,7 @@ Function CharSelect()
 							; Block 1
 							If Mid$(M\MessageData$, 2, 1) = "1"
 								Me\Gold = RCE_IntFromStr(Mid$(M\MessageData$, 3, 4))
-								Me\Reputation = RCE_IntFromStr(Mid$(M\MessageData$, 7, 2))
+								Me\Reputation = RCE_SignedShortFromStr(Mid$(M\MessageData$, 7, 2))  ; signed: reputation can be negative
 								Me\Level = RCE_IntFromStr(Mid$(M\MessageData$, 9, 2))
 								Me\XP = RCE_IntFromStr(Mid$(M\MessageData$, 11, 4))
 								Me\HomeFaction = RCE_IntFromStr(Mid$(M\MessageData$, 15, 1))

--- a/src/Modules/RCEnet.bb
+++ b/src/Modules/RCEnet.bb
@@ -82,6 +82,20 @@ Function RCE_IntFromStr(Dat$)
   Return PeekInt(RCE_ConvertBank, 0)
 End Function
 
+; Reads a SIGNED 16-bit value from a 2-byte wire field. RCE_IntFromStr zero-
+; fills the 4-byte bank and writes only the bytes present, so a 2-byte field
+; always decodes 0..65535 (unsigned). A field that carries a signed value in
+; a 2-byte slot must sign-extend: a decoded value >= 32768 is negative. Use
+; this (not RCE_IntFromStr) for such fields -- e.g. reputation, which the
+; save path already stores signed via WriteShort/ReadShort, but every wire
+; reader had been decoding unsigned (so a hostile/negative reputation arrived
+; as a large positive on the client).
+Function RCE_SignedShortFromStr(Dat$)
+  Local v = RCE_IntFromStr(Dat$)
+  If v >= 32768 Then v = v - 65536
+  Return v
+End Function
+
 Function RCE_StrFromInt$(Num, Length = 4)
   PokeInt RCE_ConvertBank, 0, Num
   Dat$ = ""

--- a/src/Tests/Modules/RCEWireEncodingTest.bb
+++ b/src/Tests/Modules/RCEWireEncodingTest.bb
@@ -285,3 +285,46 @@ Test testByteOrderTwoBytePreservesHighLowOrder()
 	Assert(Asc(Mid$(encoded$, 1, 1)) = 2)
 	Assert(Asc(Mid$(encoded$, 2, 1)) = 1)
 End Test
+
+; ====================================================================
+; RCE_SignedShortFromStr: decode a 2-byte field as SIGNED 16-bit.
+; RCE_IntFromStr alone decodes 0..65535 (unsigned) because it zero-fills
+; the 4-byte bank and writes only the bytes present. A field carrying a
+; signed value in a 2-byte slot (reputation -- stored signed by the save
+; path via WriteShort/ReadShort, but historically read UNSIGNED by every
+; wire reader) must sign-extend: decoded >= 32768 is negative. Replicated
+; here per the same offline-Include constraint; mirrors RCEnet.bb.
+; ====================================================================
+
+Function TestSignedShortFromStr(Dat$)
+	Local v = TestIntFromStr(Dat$)
+	If v >= 32768 Then v = v - 65536
+	Return v
+End Function
+
+Test testSignedShortNonNegativeUnchanged()
+	; 0..32767 decode identically to the unsigned read.
+	Assert(TestSignedShortFromStr(TestStrFromInt$(0, 2))     = 0)
+	Assert(TestSignedShortFromStr(TestStrFromInt$(1, 2))     = 1)
+	Assert(TestSignedShortFromStr(TestStrFromInt$(12345, 2)) = 12345)
+	Assert(TestSignedShortFromStr(TestStrFromInt$(32767, 2)) = 32767)
+End Test
+
+Test testSignedShortNegativeRoundTrip()
+	; A negative value sent through the 2-byte field (its low 2 bytes) is
+	; recovered exactly by the sign-extend -- the reputation fix. Plain
+	; RCE_IntFromStr would return these as large positives.
+	Assert(TestSignedShortFromStr(TestStrFromInt$(-1, 2))     = -1)
+	Assert(TestSignedShortFromStr(TestStrFromInt$(-100, 2))   = -100)
+	Assert(TestSignedShortFromStr(TestStrFromInt$(-10000, 2)) = -10000)
+	Assert(TestSignedShortFromStr(TestStrFromInt$(-32768, 2)) = -32768)
+End Test
+
+Test testSignedShortContrastWithUnsigned()
+	; Wire bytes for -1 are 0xFFFF. Unsigned read = 65535; signed = -1.
+	; Pins the exact behavioural difference the fix makes at the reputation
+	; reader sites (ClientNet.bb, Actors.bb, MainMenu.bb).
+	Local wire$ = TestStrFromInt$(-1, 2)
+	Assert(TestIntFromStr(wire$)         = 65535)
+	Assert(TestSignedShortFromStr(wire$) = -1)
+End Test


### PR DESCRIPTION
## Non-technical summary

A character's **reputation** can be negative (hostile factions). The game stores it correctly as a signed value on disk, but when the server sent reputation to the client over the network, the client decoded it as an **unsigned** number — so a reputation of, say, `-10000` showed up on the client as `55536`. This fixes the client to read reputation as signed, matching how it's saved, so negative reputation now displays and behaves correctly.

## Technical summary

Reputation is signed: the save path uses `WriteShort`/`ReadShort` (signed 16-bit, [Actors.bb:328/463](../blob/develop/src/Modules/Actors.bb#L328)), `BVM_SETREPUTATION(clicker, -10000)` is a documented value, and the server's `A\Reputation` is a 32-bit Int holding the real signed value. But every **wire reader** decoded reputation with `RCE_IntFromStr`, which zero-fills the 4-byte bank and writes only the 2 bytes present → a 2-byte field always reads `0..65535` (unsigned). A negative reputation therefore arrived on the client as a large positive (e.g. `-10000 → 55536`), corrupting the client's reputation **display** and any **client-side** faction-interaction gating. (Server-side gating is unaffected — it uses the server's own signed field; this is a client-read bug.)

Three readers were affected, all decoding the same 2-byte reputation field unsigned:
- `ClientNet.bb` — P_StatUpdate `"R"` handler
- `Actors.bb` — actor-state broadcast decode
- `MainMenu.bb` — character-list decode

**Fix:** add `RCE_SignedShortFromStr(Dat$)` to [RCEnet.bb](../blob/develop/src/Modules/RCEnet.bb) — reads the 2-byte field via `RCE_IntFromStr` then sign-extends (`>= 32768` ⇒ negative) — and use it at the three reputation reader sites.

Why sign-extend rather than widen to 4 bytes: it keeps the wire width at 2 bytes, so there's **no packet-layout change, no `index.md` regen, no save-format change** — and it makes the wire consistent with the already-signed save path. Reputation fits signed 16-bit (the save's `WriteShort` already bounds it there). Only reputation changes; attribute Value/Maximum stay unsigned (non-negative). The three reader edits are same-line swaps (net-zero), so no packet-handler line numbers shift.

## Acceptance criteria + results

- [x] All three reputation wire readers sign-extend (ClientNet/Actors/MainMenu) via the shared helper.
- [x] Negative reputation round-trips: a value sent through the 2-byte field is recovered exactly (`-1/-100/-10000/-32768`), where the old unsigned read returned a large positive.
- [x] Non-negative reputation (`0..32767`) is unchanged.
- [x] Wire width / packet layout unchanged → `docs/protocol/index.md` not touched (verified); save format unchanged.
- [x] Compiles clean across targets: Server parse/gen clean, **Client.exe** (all four changed files) and **RC Terrain Editor.exe** (tool incl. Actors+RCEnet) link clean — no `:line:col:` errors.
- [x] `test.bat RCEWireEncoding` passes — `RCEWireEncodingTest.bb` extended with a replicated `RCE_SignedShortFromStr` and tests pinning the negative round-trip and the unsigned-vs-signed contrast (`0xFFFF` → `65535` unsigned, `-1` signed).

## Trade-offs & deferred follow-ups

- **Reader-side sign-extend** (not a wire widen): chosen because the wire was already 2-byte everywhere and the save format is 16-bit signed — widening would have diverged the wire from the save and required changing 3 senders + the `WriteShort` save. Sign-extending the readers is the minimal, consistent fix.
- **Deferred:** reputation isn't clamped to ±32767 at the setter (`UpdateReputation` / `BVM_SETREPUTATION`), so a value beyond signed-16-bit range would still corrupt on **both** the save (`WriteShort`) and wire paths — a separate clamp-at-source follow-up (same shape as the inventory stack cap).
- Server-authoritative faction gating already used the correct signed value; this fixes the client's view (display + any client-side faction logic).
