### PR TITLE
fix: reset hSI after the script invoke loop so the privileged-script allowlist actually elevates

### DIFF
--- a/src/Modules/Scripting.bb
+++ b/src/Modules/Scripting.bb
@@ -417,6 +417,20 @@ Function UpdateScripts()
 		EndIf
 		S = SNext
 	Wend
+	; No script is executing once the invoke loop exits, so restore the
+	; "engine, not script" invariant: hSI = 0. hSI was set to each invoked
+	; script's handle at the BVM_Invoke call above and, without this reset,
+	; lingered as a stale (often freed) handle between ticks. The main loop
+	; runs RCE_Update() (packet dispatch -> engine-initiated ThreadScript for
+	; chat / spell / right-click / NPC-init) BEFORE the next UpdateScripts(),
+	; so every engine-initiated spawn after the first script ran saw hSI <> 0
+	; and looked script-initiated -- silently defeating ThreadScript's
+	; privileged-script allowlist elevation (the `hSI = 0` gate, #329) for
+	; exactly the shipped content scripts the carve-out exists for. The gate's
+	; own comment documents the assumed invariant ("hSI is 0 at the call
+	; site"); this establishes it. Elevation only denies on stale hSI (never
+	; grants), so the regression was inert allowlist, not privilege escalation.
+	hSI = 0
 	If Pass <> 0 Then Pass = Pass - 1 Else Pass = Threads
 
 End Function

--- a/src/Tests/Modules/PrivilegedScriptAllowlistTest.bb
+++ b/src/Tests/Modules/PrivilegedScriptAllowlistTest.bb
@@ -258,3 +258,65 @@ Test testScriptInitiatedNonAllowlistedStaysNonPriv()
 	MockAdd("marriage")
 	Assert(MockEffectivePriv%("user_script", 0, 12345) = 0)
 End Test
+
+; ====================================================================
+; hSI lifecycle (PR fixing the stale-hSI elevation regression).
+;
+; The elevation gate above keys "engine-initiated" off hSI = 0. Its
+; correctness depends on hSI ACTUALLY being 0 when no script is running.
+; UpdateScripts sets hSI = Handle(S) for each invoked script (BVM_Invoke)
+; but, before the fix, never reset it after the invoke loop -- so hSI
+; lingered as the last (often freed) script's handle between ticks. The
+; main loop runs RCE_Update() (engine-initiated ThreadScript for chat /
+; spell / right-click / NPC-init) BEFORE the next UpdateScripts(), so
+; after the first script ever ran, every engine-initiated allowlisted
+; spawn saw hSI <> 0, was misclassified as script-initiated, and did NOT
+; elevate -- the #329 allowlist was silently inert. The fix resets hSI = 0
+; at the end of UpdateScripts's invoke loop. These tests model the tick
+; lifecycle to pin both the bug and the fix.
+; ====================================================================
+
+Global LifecycleHSI% = 0
+
+; Models UpdateScripts's invoke loop WITH the fix: hSI is set per invoked
+; script, then reset to 0 once the loop exits (no script running after).
+Function TickInvokeLoopFixed(ScriptHandle%)
+	LifecycleHSI = ScriptHandle   ; hSI = Handle(S) at the BVM_Invoke call
+	LifecycleHSI = 0              ; the fix: reset after the invoke loop
+End Function
+
+; Models the pre-fix loop: hSI set, never reset -> lingers stale.
+Function TickInvokeLoopBuggy(ScriptHandle%)
+	LifecycleHSI = ScriptHandle
+End Function
+
+Test testEngineSpawnAfterScriptRanStillElevatesWithReset()
+	; A script ran this tick (hSI got set); the fix resets it. The next
+	; engine-initiated allowlisted spawn reads hSI = 0 and elevates.
+	MockReset()
+	MockAdd("marriage")
+	TickInvokeLoopFixed(98765)
+	Assert(LifecycleHSI = 0)
+	Assert(MockEffectivePriv%("marriage", 0, LifecycleHSI) = 1)
+End Test
+
+Test testWithoutResetStaleHSIDefeatsElevation()
+	; Demonstrates the regression the reset closes: without the reset, hSI
+	; lingers nonzero, so the engine-initiated allowlisted spawn is
+	; misclassified as script-initiated and silently does NOT elevate.
+	MockReset()
+	MockAdd("marriage")
+	TickInvokeLoopBuggy(98765)
+	Assert(LifecycleHSI = 98765)
+	Assert(MockEffectivePriv%("marriage", 0, LifecycleHSI) = 0)
+End Test
+
+Test testStaleHSIStillBlocksGenuineScriptInitiatedBypass()
+	; The reset must not weaken the BVM_THREADEXECUTE protection: a spawn
+	; genuinely initiated from inside a running script (hSI set to the live
+	; script's handle during the invoke loop) must still NOT elevate.
+	MockReset()
+	MockAdd("In-game Commands")
+	LifecycleHSI = 55555   ; a live script is mid-invoke
+	Assert(MockEffectivePriv%("In-game Commands", 0, LifecycleHSI) = 0)
+End Test


### PR DESCRIPTION
## Non-technical summary

Certain shipped content scripts (marriage, the in-game GM commands, the AOE damage spell template, etc.) need elevated permission to call privileged engine commands even when triggered by an ordinary player click. A previous change (#329) added an "allowlist" to grant exactly those scripts that permission **when the engine triggers them** (vs. when another script triggers them). This change fixes a latent bug that made that allowlist **silently stop working after the first script of the session ran** — so those content scripts have been quietly failing their privileged steps in practice. The fix is one line and restores the intended behavior; it cannot grant any *extra* privilege (the bug only ever denied).

## Technical summary

`ThreadScript`'s elevation gate ([Scripting.bb:275](../blob/develop/src/Modules/Scripting.bb#L275)) distinguishes engine-initiated spawns from script-initiated ones via `hSI = 0`:

```blitz
If EffectivePriv = 0 And hSI = 0
    If IsPrivilegedScript(Name$) Then EffectivePriv = 1
```

Its own comment documents the assumed invariant: *"…invoked from engine code outside any running script, so **hSI is 0 at the call site**."* **Nothing established that invariant.** `UpdateScripts` sets `hSI = Handle(S)` for each invoked script ([:386](../blob/develop/src/Modules/Scripting.bb#L386), at `BVM_Invoke`) and **never reset it** after the invoke loop — the only zero-assignment was the one-time `Global hSI% = 0`. So after the first script runs, `hSI` permanently holds the last (often already-`Delete`d) script's handle between ticks. The main loop runs `RCE_Update()` (packet dispatch → `ThreadScript` for chat/spell/right-click/NPC-init) at [Server.bb:529](../blob/develop/src/Server.bb#L529) **before** the next `UpdateScripts()` at [:735](../blob/develop/src/Server.bb#L735), with no reset between — so every engine-initiated allowlisted spawn after the first tick saw `hSI <> 0`, was misclassified as script-initiated, and **did not elevate**. The #329 allowlist was silently inert for its five shipped scripts. The existing unit test passed only because its mock hard-codes `HSI=0` — contract-vs-impl drift.

**This is a reliability regression, not a privilege escalation:** stale-nonzero `hSI` makes the gate *deny* elevation (safe direction), never grant.

**Fix:** reset `hSI = 0` at the end of `UpdateScripts`'s invoke loop (no script is running once it exits). One line, establishing the documented invariant.

The `BVM_THREADEXECUTE` bypass protection is unaffected: inside a live script, `hSI` is set at :386 during the invoke, so script-initiated spawns still see `hSI <> 0` and still don't elevate. No between-tick reader relies on the stale handle — the `Object.ScriptInstance(hSI)` readers in ScriptingCommands all run *inside* `BVM_Invoke` (hSI freshly set) and already Null-guard a dead handle.

## Acceptance criteria + results

- [x] `hSI` is reset to 0 at the end of the invoke loop → engine-initiated spawns on the next tick are recognised (`hSI = 0`) and allowlisted scripts elevate.
- [x] No weakening of the bypass guard: a genuinely script-initiated spawn (live `hSI`) still does not elevate.
- [x] Server compiles clean — `Server.bb` parse/gen with no `:line:col:` errors (link "error" was only the running-`Server.exe` lock; Scripting.bb is server-only).
- [x] `test.bat PrivilegedScriptAllowlist` passes — extended with a tick-lifecycle model pinning **the bug** (`TickInvokeLoopBuggy` → stale hSI → `MockEffectivePriv(...) = 0`) and **the fix** (`TickInvokeLoopFixed` → reset → `= 1`), plus `testStaleHSIStillBlocksGenuineScriptInitiatedBypass`.
- [x] No `docs/protocol/index.md` change (Scripting.bb is not a packet-index source).

## Trade-offs & deferred follow-ups

- **Replicated-logic test** (Scripting.bb can't be `Include`d offline — pulls the full BVM surface), so it models the gate + lifecycle, not the live `UpdateScripts`. The fix's correctness rests on the static control-flow trace (set at :386, never reset; `RCE_Update` before `UpdateScripts`) + the gate's own documented invariant. The test is the regression pin per the established replicated-gate convention.
- **Defensive alternative considered:** also reset `hSI` immediately after each `BVM_Invoke` returns, or have the gate resolve `Object.ScriptInstance(hSI)` and treat a dead handle as engine-initiated. The single end-of-loop reset is the minimal change that establishes the exact invariant the gate documents; the per-invoke reset is unnecessary (no engine-initiated `ThreadScript` runs mid-invoke-loop).
