### PR TITLE
fix: party-XP split conserves XP across zones (remainder used wrong divisor)

### DIFF
--- a/src/Modules/GameServer.bb
+++ b/src/Modules/GameServer.bb
@@ -83,7 +83,16 @@ Function GiveXP(A.ActorInstance, XP, IgnoreParty = 0)
 						If Party\Player[i]\ServerArea = A\ServerArea Then GiveXP(Party\Player[i], PartyXP, True)
 					EndIf
 				Next
-				XP = PartyXP + (XP Mod Party\Members)
+				; The recipient (A) keeps its share plus the division remainder.
+				; The remainder MUST use the SAME divisor as the split above --
+				; the in-area `Members`, not the total-party `Party\Members`.
+				; Each of the (Members-1) other in-area members received
+				; PartyXP = XP / Members, so for the distributed total to equal
+				; XP exactly, A must keep PartyXP + (XP Mod Members). Using
+				; Party\Members here fabricated or dropped XP whenever the party
+				; spanned zones (Members <> Party\Members): e.g. XP=10, Members=2,
+				; Party\Members=3 gave 5 + (10 Mod 3)=6, total 11 from a 10 award.
+				XP = PartyXP + (XP Mod Members)
 			EndIf
 		EndIf
 	EndIf

--- a/src/Tests/Modules/PartyXPSplitTest.bb
+++ b/src/Tests/Modules/PartyXPSplitTest.bb
@@ -1,0 +1,88 @@
+Strict
+EnableGC
+
+; Tests for the party-XP split conservation invariant in GameServer.bb's
+; GiveXP (the IgnoreParty = 0 share block).
+;
+; A kill that awards XP to a partied player splits it among party members
+; IN THE SAME AREA. The per-member share uses the in-area count:
+;     PartyXP = XP / Members          ; Members = party members in A's area
+; each of the (Members-1) OTHER in-area members receives PartyXP, and the
+; recipient A keeps the remainder. The bug: the remainder used the TOTAL
+; party count (Party\Members) instead of the in-area Members:
+;     XP = PartyXP + (XP Mod Party\Members)   ; WRONG divisor
+; so the distributed total only equalled the award when the whole party was
+; in one zone (Members == Party\Members). Split across zones, it fabricated
+; or dropped XP on every shared kill. Fix: remainder over `Members`.
+;
+; GameServer.bb can't be Included into a test build (pulls the world/network
+; surface), so the split arithmetic is replicated here per the established
+; ClampFloatTest convention. The test computes the FULL distribution and
+; asserts conservation against the award; it independently models the buggy
+; formula to demonstrate the non-conservation the fix removes. `Members >= 1`
+; always (the production guard requires Members > 0 before this code runs),
+; so there is no divide-by-zero.
+
+; Recipient A's keep-share under the FIXED formula (remainder over Members).
+Function RecipientShareFixed(XP, Members)
+	Return (XP / Members) + (XP Mod Members)
+End Function
+
+; Total XP actually distributed under the FIX: (Members-1) other in-area
+; members each get XP/Members, plus the recipient's keep-share.
+Function TotalDistributedFixed(XP, Members)
+	Return (Members - 1) * (XP / Members) + RecipientShareFixed(XP, Members)
+End Function
+
+; Total distributed under the BUG: remainder taken over the total party
+; count (PartyMembers) rather than the in-area count (Members).
+Function TotalDistributedBuggy(XP, Members, PartyMembers)
+	Local per = XP / Members
+	Local recipient = per + (XP Mod PartyMembers)
+	Return (Members - 1) * per + recipient
+End Function
+
+
+; THE invariant: the fix conserves XP exactly for any in-area member count
+; and any award (including ones not divisible by the member count).
+Test testFixedConservesXP()
+	Assert(TotalDistributedFixed(1, 1) = 1)
+	Assert(TotalDistributedFixed(7, 2) = 7)
+	Assert(TotalDistributedFixed(10, 2) = 10)
+	Assert(TotalDistributedFixed(10, 3) = 10)
+	Assert(TotalDistributedFixed(100, 3) = 100)
+	Assert(TotalDistributedFixed(999, 5) = 999)
+	Assert(TotalDistributedFixed(13, 7) = 13)
+	Assert(TotalDistributedFixed(100, 5) = 100)
+End Test
+
+; Solo-in-zone member of a multi-zone party keeps the entire award.
+Test testSoloInZoneKeepsAllXP()
+	Assert(TotalDistributedFixed(10, 1) = 10)
+	Assert(RecipientShareFixed(10, 1) = 10)
+	Assert(RecipientShareFixed(999, 1) = 999)
+End Test
+
+; The bug: party split across zones (Members < PartyMembers) fabricates XP.
+; XP=10, in-area Members=2, total Party\Members=3 -> 5 + (10 Mod 3)=6, total 11.
+Test testBuggyFabricatesXPWhenPartySpansZones()
+	Assert(TotalDistributedBuggy(10, 2, 3) = 11)   ; conjures 1 XP
+	Assert(TotalDistributedBuggy(10, 2, 3) <> 10)
+End Test
+
+; The bug can also DROP XP for other divisor relationships.
+; XP=10, Members=3, PartyMembers=2 -> per=3, recipient=3+(10 Mod 2)=3, others=6, total 9.
+Test testBuggyDropsXPForOtherSplits()
+	Assert(TotalDistributedBuggy(10, 3, 2) = 9)
+	Assert(TotalDistributedBuggy(10, 3, 2) <> 10)
+End Test
+
+; The fix is a no-op in the common case: whole party in one zone
+; (Members == Party\Members) -> buggy and fixed agree, both conserve.
+Test testBuggyEqualsFixedWhenWholePartyInZone()
+	Assert(TotalDistributedBuggy(7, 2, 2)   = 7)
+	Assert(TotalDistributedBuggy(10, 3, 3)  = 10)
+	Assert(TotalDistributedBuggy(100, 5, 5) = 100)
+	Assert(TotalDistributedBuggy(10, 3, 3)  = TotalDistributedFixed(10, 3))
+	Assert(TotalDistributedBuggy(100, 5, 5) = TotalDistributedFixed(100, 5))
+End Test


### PR DESCRIPTION
## Non-technical summary

When a party kills something and the XP is shared, the game splits it among party members **in the same zone**. Due to a divisor mismatch, the math only added up correctly when the *whole* party was in one zone. If the party was spread across zones, every shared kill quietly **created or destroyed a little XP**. This one-token fix makes the shared XP always add up exactly to the amount awarded.

## Technical summary

`GiveXP` ([GameServer.bb:57](../blob/develop/src/Modules/GameServer.bb#L57)) shares a kill's XP among in-area party members:

```blitz
PartyXP = XP / Members                    ; share over the IN-AREA count
... each of (Members-1) other in-area members gets PartyXP ...
XP = PartyXP + (XP Mod Party\Members)     ; BUG: remainder over the TOTAL count
```

`Members` is the count of party members in the recipient's area; `Party\Members` is the total party size. The recipient keeps `PartyXP + remainder`, but the remainder used `Party\Members` instead of `Members`. So:

```
total distributed = Members*(XP/Members) + (XP Mod Party\Members)
                  = XP − (XP Mod Members) + (XP Mod Party\Members)
```

which equals `XP` only when `Members == Party\Members` (whole party in one zone). Split across zones it **fabricates or drops** XP every shared kill:
- `XP=10, Members=2, Party\Members=3` → `5 + (10 Mod 3)=6`, total **11** (conjured 1)
- `XP=10, Members=3, Party\Members=2` → total **9** (lost 1)

**Fix:** take the remainder over `Members` (the same divisor used for the split):

```blitz
XP = PartyXP + (XP Mod Members)
```

Now `total = XP − (XP Mod Members) + (XP Mod Members) = XP` exactly, for any in-area subset. `Members > 0` is guaranteed by the guard one line above, so no divide-by-zero, and the result is **identical in the common all-same-zone case** (the fix is a no-op there). A prior commit added that divide-by-zero guard but left the divisor mismatch; this closes the arithmetic bug.

## Acceptance criteria + results

- [x] Remainder uses `Members` (the split divisor), conserving XP for any in-area count.
- [x] No divide-by-zero (guard `Members > 0` precedes the block).
- [x] No behavior change in the all-same-zone case (fix is a no-op when `Members == Party\Members`).
- [x] Server compiles clean — `Server.bb` parse/gen, no `:line:col:` errors (link "error" is the running-`Server.exe` lock; GameServer.bb is server-only).
- [x] `test.bat PartyXPSplit` passes — `PartyXPSplitTest.bb` pins exact conservation under the fix (XP/Members matrix incl. non-divisible awards and solo-in-zone), demonstrates the bug (`10/2/3`→11 fabricated, `10/3/2`→9 dropped), and confirms the no-op equivalence when the whole party is in one zone.
- [x] No `docs/protocol/index.md` change (GameServer.bb is not a packet-index source).

## Trade-offs & deferred follow-ups

- **Replicated-logic test** (GameServer.bb can't be `Include`d offline — pulls the world/network surface): it models the split arithmetic and asserts conservation against the award, plus independently models the buggy formula to demonstrate the non-conservation — non-tautological. Per the established replicated-gate convention; the fix's correctness also follows from the conservation algebra above.
- Magnitude per kill is small (`< Members` XP), but it's an unambiguous correctness bug (violates XP conservation), not a balance choice. `P_XPUpdate` payload value shifts by at most `Members−1` per shared cross-zone kill; no wire-format change (still a 4-byte int).
