### PR TITLE
fix: guard Phase_Length > 0 in the sun phase calc (Mod/divide-by-zero client crash)

### DIFF
--- a/src/Modules/Environment3D.bb
+++ b/src/Modules/Environment3D.bb
@@ -466,9 +466,18 @@ Next
 		
 			;	Updates phase texture
 
-			If (S\ShowPhases = True) And (TimeH = S\StartH[CurrentSeason]) And (TimeM = S\StartM[CurrentSeason])
+			; Guard Phase_Length > 0: the phase-index calc below does an integer
+			; `Day Mod (8 * S\Phase_Length)` and `/ S\Phase_Length`, and
+			; Phase_Length is read unclamped from the area .dat (Environment.bb)
+			; independently of ShowPhases. A sun with ShowPhases=1 and
+			; Phase_Length=0 (hand-edited / placeholder content) would hit
+			; Mod-by-zero / divide-by-zero, which BlitzForge surfaces as a
+			; "Stack overflow!" crash on the render tick -- the same class the
+			; adjacent PathLength block below already guards. Zero-length phases
+			; simply don't advance.
+			If (S\ShowPhases = True) And (S\Phase_Length > 0) And (TimeH = S\StartH[CurrentSeason]) And (TimeM = S\StartM[CurrentSeason])
 				; Convert day to phase index
-				S\CurrentPhase = Int((Day Mod (8 * S\Phase_Length)) / S\Phase_Length - 0.05) ;8 = number of phases			
+				S\CurrentPhase = Int((Day Mod (8 * S\Phase_Length)) / S\Phase_Length - 0.05) ;8 = number of phases
 
 				Tex = GetTexture(S\TexID[S\CurrentPhase])			
 				If Tex <> 0 Then EntityTexture(S\EN, Tex)

--- a/src/Tests/Modules/SunPhaseLengthGuardTest.bb
+++ b/src/Tests/Modules/SunPhaseLengthGuardTest.bb
@@ -1,0 +1,73 @@
+Strict
+EnableGC
+
+; Tests for the sun phase-update guard in Environment3D.bb (~:469).
+;
+; The phase-index calc at Environment3D.bb:471 is:
+;     S\CurrentPhase = Int((Day Mod (8 * S\Phase_Length)) / S\Phase_Length - 0.05)
+; an INTEGER `Mod (8 * Phase_Length)` and INTEGER `/ Phase_Length`. Phase_Length
+; is read UNCLAMPED as a byte from the area .dat (Environment.bb:253),
+; independently of ShowPhases. A sun with ShowPhases=1 and Phase_Length=0
+; (hand-edited / placeholder content) would hit `Mod 0` and `/0`, which
+; BlitzForge surfaces as a "Stack overflow!" crash on the sun-render tick
+; (see feedback_blitz_intdiv_zero_stackoverflow). The fix adds `Phase_Length
+; > 0` to the guard so the calc is never reached with a zero length -- the
+; same class the adjacent PathLength block already guards.
+;
+; Environment3D.bb can't be Included into a test build (Graphics3D / world
+; surface), so the guard predicate and the (positive-length) calc are
+; replicated here per the established convention. The guard is what this
+; iteration changed; the calc is replicated only to confirm valid data
+; computes without a zero divisor. We never call the calc with Phase_Length
+; = 0 -- that is precisely the crash the guard prevents (and would crash the
+; test runner if invoked).
+
+Const PHASES = 8
+
+; Replicates the FIXED guard at Environment3D.bb:469: the phase-index calc
+; runs only when ShowPhases AND Phase_Length > 0 AND the time matches.
+Function ShouldUpdatePhase(ShowPhases, PhaseLength, TimeMatches)
+	If ShowPhases = True And PhaseLength > 0 And TimeMatches = True Then Return True
+	Return False
+End Function
+
+; Replicates Environment3D.bb:471 -- only valid (>0) lengths are ever passed,
+; mirroring the guard. Integer Mod + integer divide, as in production.
+Function PhaseIndex(Day, PhaseLength)
+	Return Int((Day Mod (PHASES * PhaseLength)) / PhaseLength - 0.05)
+End Function
+
+
+; THE fix: a zero Phase_Length never triggers the (crash-prone) calc, no
+; matter the other conditions.
+Test testGuardBlocksZeroPhaseLength()
+	Assert(ShouldUpdatePhase(True, 0, True)  = False)
+	Assert(ShouldUpdatePhase(True, 0, False) = False)
+	Assert(ShouldUpdatePhase(False, 0, True) = False)
+End Test
+
+; A valid phased sun at its start time still updates.
+Test testGuardAllowsValidPhasedSun()
+	Assert(ShouldUpdatePhase(True, 1, True) = True)
+	Assert(ShouldUpdatePhase(True, 5, True) = True)
+End Test
+
+; All three conditions are required (no spurious update).
+Test testGuardRequiresAllConditions()
+	Assert(ShouldUpdatePhase(False, 5, True) = False)  ; phases disabled
+	Assert(ShouldUpdatePhase(True, 5, False) = False)  ; wrong time
+End Test
+
+; For any positive Phase_Length the calc has a non-zero divisor (8*PL and PL)
+; and yields an in-range phase index -- i.e. valid data computes safely. We
+; deliberately never pass 0 here.
+Test testPhaseIndexSafeForPositiveLength()
+	Assert(PHASES * 1 > 0)
+	Assert(PHASES * 5 > 0)
+	; Index stays within 0..PHASES-1 across a spread of days/lengths.
+	Local idx
+	idx = PhaseIndex(0, 1)   : Assert(idx >= 0 And idx < PHASES)
+	idx = PhaseIndex(100, 3) : Assert(idx >= 0 And idx < PHASES)
+	idx = PhaseIndex(55, 8)  : Assert(idx >= 0 And idx < PHASES)
+	idx = PhaseIndex(7, 1)   : Assert(idx >= 0 And idx < PHASES)
+End Test


### PR DESCRIPTION
## Non-technical summary

A sky/sun configured with day/night "phases" enabled but a phase length of **0** (easy to produce by hand-editing a zone or via a tool default) would **crash the game client** the moment in-game time reached the sun's start time — and keep crashing every frame. The crash came from dividing by that zero phase length. This adds a one-line guard so a zero-length phase simply doesn't animate instead of crashing.

## Technical summary

The sun phase-index calc at [Environment3D.bb:471](../blob/develop/src/Modules/Environment3D.bb#L471) is integer arithmetic:

```blitz
S\CurrentPhase = Int((Day Mod (8 * S\Phase_Length)) / S\Phase_Length - 0.05)
```

`S\Phase_Length` is read **unclamped** as a byte from the area `.dat` ([Environment.bb:253](../blob/develop/src/Modules/Environment.bb#L253)), independently of `ShowPhases` ([:252](../blob/develop/src/Modules/Environment.bb#L252)). With `ShowPhases=1` and `Phase_Length=0`, both `Mod (8*0)` and `/ 0` are zero-divisor operations — and BlitzForge surfaces integer `Mod 0` / `/0` as a **"Stack overflow!"** crash (not a divide error). It fires the instant time hits the sun's `StartH`/`StartM`, then every render tick: a hard client crash from content data.

The guard at [:469](../blob/develop/src/Modules/Environment3D.bb#L469) checked only `ShowPhases` + the time match. The **adjacent** sun-position block (`PathLength`, :479-494) was already explicitly hardened against this exact zero-duration divide-by-zero class with a comment — the `Phase_Length` divide two lines up was missed in that pass.

**Fix:** add `(S\Phase_Length > 0)` to the guard. All conjuncts are plain field reads/compares (safe under BlitzForge's non-short-circuit `And`), and the divide stays inside the gated body — so valid data (`Phase_Length >= 1`) is bit-identical to before; `Phase_Length=0` simply doesn't advance the phase.

**Note — not a UAF:** the adjacent `GetTexture → EntityTexture → UnloadTexture` idiom (:473-476) was investigated and is **correct** — BlitzForge `Texture` is ref-counted and `EntityTexture` retains it on the brush by value, so `UnloadTexture` only releases the cache's reference. Left unchanged.

## Acceptance criteria + results

- [x] Guard adds `S\Phase_Length > 0`; a zero-length phased sun never reaches the `Mod`/`/` at :471.
- [x] No behavior change for valid data — the new conjunct is always true when `Phase_Length >= 1` (the divide stays in the gated body).
- [x] Client.exe compiles clean (Environment3D.bb is client-only; no `:line:col:` errors).
- [x] `test.bat SunPhaseLengthGuard` passes — `SunPhaseLengthGuardTest.bb` pins: zero length never triggers the calc (regardless of the other conditions), a valid phased sun at its start time still updates, all three conditions required, and positive lengths compute an in-range index with a non-zero divisor. The test never calls the calc with length 0 (that's the crash it guards).
- [x] No `docs/protocol/index.md` change (Environment3D.bb is not a packet-index source).

## Trade-offs & deferred follow-ups

- **Render-path guard only** (the surgical fix). An optional defense-in-depth clamp at load (`Environment.bb:253`: force `ShowPhases=False` if `Phase_Length < 1`) would also close it, but the use-site guard alone fully prevents the crash and matches the adjacent PathLength precedent. Deferred as optional.
- **Replicated-logic test** (Environment3D.bb can't be `Include`d offline — Graphics3D/world surface): pins the guard predicate, not the live render path, per the established convention. The crash itself can't be unit-tested (it would crash the runner) — the test deliberately never passes length 0 to the calc.
