### PR TITLE
fix: atomic-write the primary save paths in RC Architect / Tree / Caves editors

### DIFF
--- a/src/Tests/Modules/SafeWriteCommitTest.bb
+++ b/src/Tests/Modules/SafeWriteCommitTest.bb
@@ -1,0 +1,110 @@
+; Tests for SafeWriteOpen$ / SafeWriteCommit% in Modules/Logging.bb.
+;
+; These helpers are the engine + tools' atomic-write primitive: write to a
+; .tmp, then promote it to the final path only on success, demoting the
+; previous file to .bak. Every persistent on-disk save is supposed to route
+; through them (CLAUDE.md "Atomic writes"), and as of PR #449/#452-era work
+; the three editor-tool primary save paths (RC Architect / Tree / Caves) now
+; do too. Despite being load-bearing across the whole codebase, the helper
+; had ZERO test coverage -- this pins its contract directly.
+;
+; Unlike most tests in this dir, this is a genuine INTEGRATION test: it
+; Includes the real Logging.bb and exercises the actual helpers against real
+; files in the current directory (Logging.bb has no RakNet/world deps, so it
+; CAN be Included offline -- same precedent as ReadBoundedStringTest.bb).
+;
+; NOT Strict: SafeWriteCommit% takes its file-handle param untyped (Int),
+; which Strict can't auto-convert from the BBStream that WriteFile returns --
+; same reason ReadBoundedStringTest.bb is non-Strict.
+
+; LogMode=0 / MainLog=0 keep Logging.bb's WriteLog calls silent no-ops.
+Global LogMode = 0
+Global MainLog = 0
+
+Include "Modules\Logging.bb"
+
+Global swFinal$ = CurrentDir$() + "safewrite_commit_test.dat"
+Global swTemp$  = swFinal$ + ".tmp"
+Global swBak$   = swFinal$ + ".bak"
+
+Function SWCleanup()
+	If FileType(swFinal$) = 1 Then DeleteFile(swFinal$)
+	If FileType(swTemp$) = 1 Then DeleteFile(swTemp$)
+	If FileType(swBak$) = 1 Then DeleteFile(swBak$)
+End Function
+
+; Write `n` bytes (value 65 = 'A') to a fresh file at `path`.
+Function SeedFile(path$, n)
+	f = WriteFile(path$)
+	For i = 1 To n
+		WriteByte f, 65
+	Next
+	CloseFile f
+End Function
+
+
+; SafeWriteOpen$ derives the temp path by appending ".tmp".
+Test testOpenAppendsTmpSuffix()
+	Assert(SafeWriteOpen$("foo.dat") = "foo.dat.tmp")
+	Assert(SafeWriteOpen$("a\b\c.lgt") = "a\b\c.lgt.tmp")
+End Test
+
+; A non-empty temp is promoted to the final path; the temp is removed and the
+; written content survives the promotion.
+Test testCommitPromotesNonEmptyTemp()
+	SWCleanup()
+	tmp$ = SafeWriteOpen$(swFinal$)
+	f = WriteFile(tmp$)
+	WriteInt f, 12345
+	ok = SafeWriteCommit%(tmp$, swFinal$, f)
+	Assert(ok = True)
+	Assert(FileType(swFinal$) = 1)   ; final exists
+	Assert(FileType(swTemp$) <> 1)   ; temp removed
+	rf = ReadFile(swFinal$)
+	Assert(ReadInt(rf) = 12345)      ; content intact through promote
+	CloseFile rf
+	SWCleanup()
+End Test
+
+; A zero-length temp is REFUSED -- a pre-existing final must survive intact
+; (this is the data-loss protection the tool save paths now rely on).
+Test testCommitRefusesEmptyTempAndKeepsOriginal()
+	SWCleanup()
+	SeedFile(swFinal$, 4)            ; pre-existing 4-byte save
+	tmp$ = SafeWriteOpen$(swFinal$)
+	f = WriteFile(tmp$)              ; open temp, write NOTHING (0 bytes)
+	ok = SafeWriteCommit%(tmp$, swFinal$, f)
+	Assert(ok = False)               ; refused to promote empty
+	Assert(FileType(swFinal$) = 1)   ; original still present
+	Assert(FileSize(swFinal$) = 4)   ; original content untouched
+	Assert(FileType(swTemp$) <> 1)   ; empty temp cleaned up
+	SWCleanup()
+End Test
+
+; A successful commit over an existing file demotes the old version to .bak.
+Test testCommitDemotesExistingToBak()
+	SWCleanup()
+	SeedFile(swFinal$, 7)            ; old final, 7 bytes
+	tmp$ = SafeWriteOpen$(swFinal$)
+	f = WriteFile(tmp$)
+	WriteByte f, 66
+	WriteByte f, 66                 ; new final, 2 bytes
+	ok = SafeWriteCommit%(tmp$, swFinal$, f)
+	Assert(ok = True)
+	Assert(FileSize(swFinal$) = 2)   ; new content promoted
+	Assert(FileType(swBak$) = 1)     ; old demoted to .bak
+	Assert(FileSize(swBak$) = 7)     ; .bak holds the previous content
+	SWCleanup()
+End Test
+
+; If the temp was never created (e.g. WriteFile returned 0), commit refuses
+; and the original file is untouched -- no clobber on a failed open.
+Test testCommitWithMissingTempRefuses()
+	SWCleanup()
+	SeedFile(swFinal$, 5)
+	ok = SafeWriteCommit%(swTemp$, swFinal$, 0)   ; temp never written, handle 0
+	Assert(ok = False)
+	Assert(FileType(swFinal$) = 1)
+	Assert(FileSize(swFinal$) = 5)
+	SWCleanup()
+End Test

--- a/src/Tools/RC Architect.BB
+++ b/src/Tools/RC Architect.BB
@@ -1107,7 +1107,14 @@ End Function
 
 Function savework(SF$="")
 FN$=sf$
-sfile=WriteFile (fn$)
+; Atomic save: write to a .tmp and only promote it on success, so a crash or
+; a failed/partial write can't truncate the user's existing .act map. Matches
+; the .tmp-protected mesh-pad path already in this file (~:1561) and the
+; CLAUDE.md atomic-write convention. SafeWriteCommit closes the handle and
+; performs the atomic promote (and refuses to clobber the original if the
+; temp is missing/empty).
+Local TmpPath$ = SafeWriteOpen$(fn$)
+sfile=WriteFile (TmpPath$)
 ;find out how many dropmodels there are
 dmc=0
 
@@ -1137,7 +1144,7 @@ WriteByte sfile,dm\cg
 WriteByte sfile,dm\cb
 Next
 
-CloseFile sfile
+SafeWriteCommit%(TmpPath$, fn$, sfile)
 
 ChangeDir thispath$
 

--- a/src/Tools/RC Caves Editor.BB
+++ b/src/Tools/RC Caves Editor.BB
@@ -2666,7 +2666,14 @@ savemultimesh (cube,"Data\RCCAVES\"+thisfold$,"Data\RCCAVES\",7)
 lightf$=Left$(thisfold$,Len(thisfold$)-3)
 lightf$=lightf$+"LGT"
 ChangeDir thispath$
-sfl=WriteFile("Data\RCCAVES\"+lightf$)
+; Atomic save of the .LGT light file: write to .tmp, promote on success, so a
+; crash/partial write can't truncate the user's existing light data.
+; (CLAUDE.md atomic writes; matches the .tmp-protected path at ~:2932 here.)
+; No ChangeDir occurs between here and the commit, so the relative temp/final
+; paths resolve consistently from thispath$.
+Local CaveLightPath$ = "Data\RCCAVES\"+lightf$
+Local TmpPath$ = SafeWriteOpen$(CaveLightPath$)
+sfl=WriteFile(TmpPath$)
 
  
  
@@ -2695,7 +2702,7 @@ For dm.dropmodel=Each DropModel
 
 Next
 
-CloseFile sfl
+SafeWriteCommit%(TmpPath$, CaveLightPath$, sfl)
 
 ChangeDir thispath$
 fui_notify("Cave Saved.")

--- a/src/Tools/RC Tree Editor.BB
+++ b/src/Tools/RC Tree Editor.BB
@@ -1111,7 +1111,13 @@ cb=0
  Next
 
  ChangeDir BRANCHPATH$
-sfile=WriteFile (fn$)
+; Atomic save: write to a .tmp under BRANCHPATH$ and only promote on success
+; so a crash/partial write can't truncate the user's existing tree file.
+; (CLAUDE.md atomic writes; matches the .tmp-protected path at ~:2671 here.)
+; No ChangeDir occurs between here and the commit below, so the relative
+; temp/final paths resolve consistently.
+Local TmpPath$ = SafeWriteOpen$(fn$)
+sfile=WriteFile (TmpPath$)
 ;new
  WriteFloat sfile, barkscale#
  WriteInt sfile, maxtrunks
@@ -1168,7 +1174,7 @@ If FileType(newpath$+lt$)<>1 Then Savetexture  t,newpath$+lt$
  Next
 
 
-CloseFile sfile
+SafeWriteCommit%(TmpPath$, fn$, sfile)
 
 End Function
 


### PR DESCRIPTION
## Non-technical summary

Three of the standalone editors (RC Architect, RC Tree Editor, RC Caves Editor) saved the user's work by **overwriting the existing file in place**. If the program crashed or the disk filled mid-save, the old file was already destroyed — the user lost their work with no recovery. This makes those saves **atomic**: write to a temporary file first, and only replace the real file once the write fully succeeds (keeping the previous version as a `.bak`). It also adds the first test for the shared atomic-write helper.

## Technical summary

Each tool's primary save opened the final path directly (`WriteFile(finalPath$)`) and streamed records into it — an in-place overwrite with no recovery on crash/partial write. This is **sibling-asymmetry**: each file *already* uses a `.tmp`-then-promote pattern on its **other** save/export path (RC Architect ~:1561, Tree ~:2671, Caves ~:2932) — only the primary save was missed. It also violates CLAUDE.md's atomic-write convention.

Routed each primary save through Logging.bb's `SafeWriteOpen$` / `SafeWriteCommit%`:
- [RC Architect.BB](../blob/develop/src/Tools/RC%20Architect.BB) `savework()` — the `.act` map save.
- [RC Tree Editor.BB](../blob/develop/src/Tools/RC%20Tree%20Editor.BB) tree save — writes under `BRANCHPATH$` (relative).
- [RC Caves Editor.BB](../blob/develop/src/Tools/RC%20Caves%20Editor.BB) `SAVEWORK()` — the `.LGT` light file.

`SafeWriteCommit` closes the handle and atomically promotes the temp (demoting the previous file to `.bak`), **refusing to clobber the original if the temp is missing or zero-length**. Each site was verified to do **no `ChangeDir` between the temp write and the commit**, so the relative temp/final paths resolve consistently for `SafeWriteCommit`'s `CopyFile`/`DeleteFile`. The on-disk record stream is byte-for-byte identical; only the write target + promote change.

**Plus the first test for `SafeWriteCommit`** — a load-bearing helper used across the engine and now these tools, with **zero prior coverage**. A genuine *integration* test (Includes the real Logging.bb, exercises real files in `CurrentDir$()`, per the `ReadBoundedStringTest` precedent — not replicated-logic).

## Acceptance criteria + results

- [x] All three primary saves write to a `.tmp` and promote via `SafeWriteCommit%`; no remaining bare `WriteFile(finalPath$)` on a primary save path in these files.
- [x] A failed/partial/empty temp leaves the pre-existing saved file intact (guaranteed by `SafeWriteCommit` refusing to promote a missing/zero-length temp — pinned by the new test).
- [x] No `ChangeDir` between temp-write and commit in any of the three (verified) → relative paths resolve correctly.
- [x] All three tools **compile and link clean** (no `:line:col:` errors; built directly via `blitzcc`).
- [x] `test.bat SafeWriteCommit` passes (5 tests): non-empty temp promoted (content survives) · zero-length temp refused, original intact · successful commit demotes old → `.bak` · missing temp/handle-0 refuses without clobber · `SafeWriteOpen$` appends `.tmp`.
- [x] On-disk save format unchanged (identical record stream). No engine target, no `docs/protocol/index.md`.

## Trade-offs & deferred follow-ups

- **Minimal migration** — only the path/promote changed; no new `If handle=0` guard was added, because routing through the temp + `SafeWriteCommit`'s refuse-on-missing/empty already makes a failed open safe (the original is never touched until a successful promote), which is strictly better than the prior behavior.
- The already-`.tmp`-protected sibling paths in each file were left as-is (some use a manual `.tmp`+`CopyFile` rather than the canonical helpers) — a separate cosmetic consolidation, out of scope here.
- These three were the stragglers of an otherwise-complete atomic-write sweep (engine + Terrain/Rock editors already migrated).
