### PR TITLE
fix: Caves editor persists a zero-light save (clear .LGT instead of keeping stale)

### DIFF
--- a/src/Tools/RC Caves Editor.BB
+++ b/src/Tools/RC Caves Editor.BB
@@ -2677,7 +2677,15 @@ sfl=WriteFile(TmpPath$)
 
  
  
+; Count lights as written. Zero lights is a legitimate state, but the .LGT
+; save writes nothing outside this loop, so zero lights => a 0-byte temp that
+; SafeWriteCommit refuses to promote -- which would leave the stale old .LGT
+; and resurrect deleted lights on reload. Track the count and, when empty,
+; clear the .LGT directly at the commit site below. (The loader at ~:2750
+; treats a missing .LGT as "no lights".)
+Local lightCount = 0
 For dm.dropmodel=Each DropModel
+   lightCount = lightCount + 1
 
    WriteInt sfl,dm\islight
    WriteInt sfl,dm\meshid
@@ -2702,7 +2710,17 @@ For dm.dropmodel=Each DropModel
 
 Next
 
-SafeWriteCommit%(TmpPath$, CaveLightPath$, sfl)
+If lightCount = 0
+	; No lights to save. SafeWriteCommit refuses a 0-byte temp (its
+	; write-failure guard), which would keep the previous .LGT and bring
+	; deleted lights back on reload. Persist the cleared state by removing
+	; the .LGT directly -- the loader treats a missing .LGT as "no lights".
+	CloseFile sfl
+	SafeWriteAbort(TmpPath$)
+	If FileType(CaveLightPath$) = 1 Then DeleteFile(CaveLightPath$)
+Else
+	SafeWriteCommit%(TmpPath$, CaveLightPath$, sfl)
+EndIf
 
 ChangeDir thispath$
 fui_notify("Cave Saved.")


### PR DESCRIPTION
Follow-up to #453, addressing the reviewer-required change.

## Problem
The SafeWrite migration of the RC Caves Editor `.LGT` save (#453) regressed the **zero-light** case. `SAVEWORK` writes nothing outside the `For dm = Each DropModel` loop, so a cave with no light dropmodels produces a **0-byte temp**. `SafeWriteCommit`s write-failure guard refuses to promote a 0-byte temp, so the previous `.LGT` survived. Since the loader (`If FileType(.LGT)<>1 Then Return` then `While Not Eof`) treats a **missing or empty** `.LGT` as no lights, the users deleted lights silently reappeared on reload.

(Architect and Tree are unaffected — they always write a leading count/header, so their streams are never empty; the refuse-empty guard is purely protective there.)

## Fix
Count lights as written; when **zero**, abort the temp and **delete** the existing `.LGT` directly (the loader reads a missing `.LGT` as no lights), instead of `SafeWriteCommit`. Non-empty saves stay atomic via `SafeWriteCommit`. No double-close. On-disk format unchanged.

## Verified
- RC Caves Editor compiles + links clean (no `:line:col:`; built directly via blitzcc).
- Loader missing/empty-=-no-lights behavior confirmed at the `.LGT` load site.
- The carve-out is Caves-specific and documented in-code.