### PR TITLE
fix: clamp Area\SpawnWaypoint at load to prevent server-crash Field-OOB

### DIFF
--- a/src/Modules/ServerAreas.bb
+++ b/src/Modules/ServerAreas.bb
@@ -328,6 +328,18 @@ Function ServerLoadArea.Area(Name$)
 		For i = 0 To 999
 			A\SpawnActor[i]        = ReadShort(F)
 			A\SpawnWaypoint[i]     = ReadShort(F)
+			; WaypointX/Y/Z are Field[1999]. SpawnWaypoint is read signed
+			; (-32768..32767) and later copied verbatim into AI\CurrentWaypoint
+			; at spawn (Server.bb:565 / :775), bypassing SetArea's own range
+			; clamp, then used to index WaypointX#[AI\CurrentWaypoint] on the AI
+			; patrol tick (GameServer.bb:864/869/930 -- unguarded, unlike the
+			; NextWaypoint siblings at :880-892). A corrupt or hand-edited area
+			; file with an out-of-range slot would Field-OOB and crash the shared
+			; server (every connected player disconnected). Clamp at the load
+			; boundary -- same pattern as the DamageType clamp below and the
+			; SpawnActor range guard in PreLoadSpawns (Server.bb:758). Slot 0 is a
+			; valid origin fallback, matching SetArea's own out-of-range behaviour.
+			If A\SpawnWaypoint[i] < 0 Or A\SpawnWaypoint[i] > 1999 Then A\SpawnWaypoint[i] = 0
 			A\SpawnSize#[i]        = ReadFloat#(F)
 			A\SpawnScript$[i]      = ReadBoundedString$(F, 1024)
 			A\SpawnActorScript$[i] = ReadBoundedString$(F, 1024)

--- a/src/Tests/Modules/SpawnWaypointClampTest.bb
+++ b/src/Tests/Modules/SpawnWaypointClampTest.bb
@@ -1,0 +1,59 @@
+Strict
+EnableGC
+
+; Pins the waypoint-slot bounds-clamp contract applied to Area\SpawnWaypoint
+; at load (src/Modules/ServerAreas.bb, in LoadArea right after the ReadShort).
+;
+; WHY THIS MATTERS: SpawnWaypoint is read signed via ReadShort (-32768..32767)
+; from the area .dat, then copied verbatim into AI\CurrentWaypoint at spawn
+; (Server.bb:565 / :775) -- which BYPASSES SetArea's own range clamp -- and is
+; finally used to index WaypointX#[AI\CurrentWaypoint] (a Field[1999]) on the
+; AI patrol tick (GameServer.bb:864/869/930). Those consumer sites are
+; UNGUARDED, unlike the NextWaypoint siblings at GameServer.bb:880-892. A
+; corrupt or hand-edited area file with an out-of-range slot therefore
+; Field-OOBs and crashes the shared server, disconnecting every player.
+;
+; The fix clamps at the load boundary: `If v < 0 Or v > 1999 Then v = 0`.
+; This is a REPLICATED-LOGIC test (the real clamp is inline in LoadArea, which
+; cannot be unit-loaded without the full area-file format + ServerAreas dep
+; graph). clampWaypointSlot% below mirrors the source expression exactly; the
+; source fix is additionally verified by clean compile + the traced consumer
+; chain. The assertions that carry the contract are the NEGATIVE and >1999
+; cases -- a `> 1999`-only guard (dropping the `< 0` half) is precisely the
+; original NextWaypoint bug recorded in the GameServer.bb:871-879 comment, and
+; this test fails if that regression is reintroduced here.
+
+; Exact mirror of the clamp applied at ServerAreas.bb LoadArea.
+Function clampWaypointSlot%(v%)
+	If v < 0 Or v > 1999 Then Return 0
+	Return v
+End Function
+
+; In-range values pass through untouched (lower edge, interior, upper edge).
+Test testInRangeSlotsUnchangedAtBothEdges()
+	Assert(clampWaypointSlot%(0) = 0)
+	Assert(clampWaypointSlot%(1) = 1)
+	Assert(clampWaypointSlot%(1000) = 1000)
+	Assert(clampWaypointSlot%(1999) = 1999)
+End Test
+
+; Just past the upper bound clamps to the origin slot (0). 2000 is the first
+; out-of-bounds index for a Field[1999] (slots 0..1999 inclusive).
+Test testJustAboveUpperBoundClampsToZero()
+	Assert(clampWaypointSlot%(2000) = 0)
+End Test
+
+; The full positive reach of a signed ReadShort clamps. This is the value a
+; corrupt .dat can carry in the high byte.
+Test testMaxSignedShortClampsToZero()
+	Assert(clampWaypointSlot%(32767) = 0)
+End Test
+
+; The NEGATIVE half -- the historically-missed case. ReadShort yields negatives
+; for any slot with the sign bit set; a `> 1999`-only guard would let these
+; through and Field-OOB with a negative index.
+Test testNegativeSlotsClampToZero()
+	Assert(clampWaypointSlot%(-1) = 0)
+	Assert(clampWaypointSlot%(-1000) = 0)
+	Assert(clampWaypointSlot%(-32768) = 0)
+End Test


### PR DESCRIPTION
## Defect

A corrupt or hand-edited area `.dat` can crash the **shared server process** — disconnecting every connected player, repeatedly on every respawn — via an unguarded `Field` out-of-bounds read on the AI patrol tick.

### Chain (verified end-to-end)

1. **Load (unclamped):** [`ServerAreas.bb:330`](src/Modules/ServerAreas.bb#L330) — `A\SpawnWaypoint[i] = ReadShort(F)`. `ReadShort` is signed (−32768..32767); the value is not range-checked. The sibling `DamageType` (:354) and `SpawnActor` (guarded at both consumers) *are* checked — `SpawnWaypoint` was the lone gap.
2. **Spawn (clamp bypassed):** [`Server.bb:565`](src/Server.bb#L565) and [`:775`](src/Server.bb#L775) — `AI\CurrentWaypoint = ...SpawnWaypoint[i]`. This overwrites the value `SetArea` just clamped ([`GameServer.bb:1270-1283`](src/Modules/GameServer.bb#L1270)) with the **raw** one, then sets `AIMode = AI_Patrol`.
3. **Consume (unguarded OOB):** [`GameServer.bb:864`](src/Modules/GameServer.bb#L864) / `:869` / `:930` — `WaypointX#[AI\CurrentWaypoint]`, where `WaypointX#/Y#/Z#` are `Field[1999]`. The `NextWaypoint` siblings at :880-892 were hardened in a prior sweep; `CurrentWaypoint` from the spawner was not. An index `< 0` or `> 1999` is a hard `Field` OOB → "Stack overflow!" → server down.

Server-triggerable independent of shipped content: any area file an admin edits (NPC spawn config is routinely hand-tuned) can carry an out-of-range slot.

## Fix

One-line clamp at the load boundary, matching the `DamageType` clamp three lines below and the `SpawnActor` guard in `PreLoadSpawns` ([`Server.bb:758`](src/Server.bb#L758)):

```basic
If A\SpawnWaypoint[i] < 0 Or A\SpawnWaypoint[i] > 1999 Then A\SpawnWaypoint[i] = 0
```

After this, **every** writer of `AI\CurrentWaypoint` yields an in-range slot — `SetArea` clamps, `NextWP` is guarded before assignment (:888), and the `ScriptingCommands` setter uses a 0..249 loop index — so the unguarded reads are safe. Slot 0 is a valid origin fallback, identical to `SetArea`'s own out-of-range behaviour. Single-point boundary fix protects all consumers (spawner, GUE, Loom).

## Why clamp-at-load (not at-use)

`SpawnWaypoint` is consumed at 3+ unguarded sites plus the raw `CurrentWaypoint` copy; one load clamp closes all of them, versus guarding each read. It also mirrors the immediately-adjacent `DamageType` pattern.

## Verification

- **Compile:** Server target builds clean to an unlocked path — `EXIT=0`, full 4.69 MB artifact, no `:line:col:` errors. (A `bin/Server.exe`-locked run shows only `Error creating executable` at the link step, which is the running-server lock, not a code error.)
- **Test:** new `src/Tests/Modules/SpawnWaypointClampTest.bb` → `[PASS]`, `Ran 1 files: 1 passed, 0 failed.` (exit 0). Pins in-range pass-through at both edges, `>1999` + full-positive-`ReadShort` clamp, and the **negative-slot half** — the case a `> 1999`-only guard would miss (exactly the original `NextWaypoint` bug recorded in the GameServer.bb:871-879 comment). Replicated-logic test: `LoadArea` can't be unit-loaded without the full area-file format + ServerAreas dep graph, so the test mirrors the clamp expression and the source is additionally verified by the compile + traced chain above.

Not a packet-handler edit (no `Case P_` in ServerNet/ClientNet) → no generator-doc regen needed.
