### PR TITLE
fix: free homing projectiles targeting an NPC before it fades out (dangling-Target crash)

### DIFF
--- a/src/Client.bb
+++ b/src/Client.bb
@@ -791,7 +791,8 @@ Function UpdateActorInstances()
 					If AI\ShieldEN <> 0 Then EntityAlpha AI\ShieldEN, Alpha#
 					If AI\HatEN <> 0 Then EntityAlpha AI\HatEN, Alpha#
 					Else
-						SafeFreeActorInstance(AI)
+						FreeProjectilesTargeting(AI) ; clear homing projectiles before the actor is freed (death/fade-out path; see Projectiles3D.bb)
+							SafeFreeActorInstance(AI)
 					EndIf 
 				EndIf
 			EndIf

--- a/src/Modules/Projectiles3D.bb
+++ b/src/Modules/Projectiles3D.bb
@@ -106,3 +106,26 @@ Function FreeProjectileInstance(P.ProjectileInstance)
 	Delete(P)
 
 End Function
+
+; Frees every in-flight homing projectile whose Target is actor A. MUST be
+; called before A is freed (SafeFreeActorInstance / FreeActorInstance) on any
+; client path, otherwise UpdateProjectiles derefs P\Target\CollisionEN on the
+; next frame against a freed actor. The `If P\Target <> Null` guard there does
+; NOT protect this: Blitz3D Delete does not null other references, so P\Target
+; stays a DANGLING (non-Null) handle, and FreeActorInstance3D has already freed
+; CollisionEN regardless -- a hard crash either way. The P_ActorGone and
+; zone-change handlers in ClientNet.bb already inline this sweep on their paths;
+; the NPC death/fade-out path (Client.bb, the common combat case) did not.
+; After-cursor walk: FreeProjectileInstance Deletes the current element, same
+; idiom as UpdateProjectiles above.
+Function FreeProjectilesTargeting(A.ActorInstance)
+
+	Local P.ProjectileInstance = First ProjectileInstance
+	Local PNext.ProjectileInstance = Null
+	While P <> Null
+		PNext = After P
+		If P\Target = A Then FreeProjectileInstance(P)
+		P = PNext
+	Wend
+
+End Function


### PR DESCRIPTION
## Defect (client crash)

A homing projectile keeps a live reference to its target — `ProjectileInstance\Target` ([Projectiles3D.bb:3](src/Modules/Projectiles3D.bb#L3), set at [:19](src/Modules/Projectiles3D.bb#L19)) — and `UpdateProjectiles` re-homes **every frame**:

```basic
If P\Target <> Null
    P\TargetX# = EntityX#(P\Target\CollisionEN)   ; :75
    ...
```

When the targeted NPC dies → fade-out (`AIMode` counts down) → once faded, [`Client.bb:794`](src/Client.bb#L794) calls `SafeFreeActorInstance(AI)`, which frees the actor's 3D entities (`CollisionEN`) and `Delete`s the `ActorInstance`. **Blitz3D `Delete` does not null other references** — so `P\Target` is left *dangling* (non-`Null`), and `CollisionEN` is freed regardless. The `<> Null` guard can't catch a dangling handle, so the next frame derefs a freed entity/instance → crash.

A slow homing projectile that outlives a low-HP target (ordinary combat) hits this every time; a malicious/buggy server can drive it deliberately.

The `P_ActorGone` and zone-change handlers ([ClientNet.bb:1556](src/Modules/ClientNet.bb#L1556), [:1677](src/Modules/ClientNet.bb#L1677)) **already** sweep `ProjectileInstance\Target` before freeing an actor — but the **death/fade-out path**, the dominant way a combat target disappears, did not.

## Fix

Add `FreeProjectilesTargeting(A.ActorInstance)` to [Projectiles3D.bb](src/Modules/Projectiles3D.bb) and call it at the fade-out free site in `Client.bb`.

**Why not centralize inside `SafeFreeActorInstance`** (which would cover all paths)? It lives in `Actors3D.bb`, which `GUE.bb` and `Gubbin Tool.bb` include **without** `Projectiles3D.bb` (only `Client.bb` includes the latter). Referencing `ProjectileInstance` there would break the GUE + Gubbin Tool compile. `Projectiles3D.bb` is the only module where the type is in scope across every consuming target — verified the include graph before placing it. The helper uses the same After-cursor walk as `UpdateProjectiles` (the destroy branch `Delete`s the current element).

## Verification

- **Compile:** Client target builds clean to an unlocked path — `EXIT=0`, full 3.93 MB artifact, no `:line:col:` errors. GUE/Gubbin Tool unaffected (`Actors3D.bb` untouched; they never see the new helper) — CI confirms across all targets.
- **No packet-handler edits** (Projectiles3D.bb + Client.bb only) → no generator-doc regen.
- **No unit test:** this client-3D crash path requires Graphics3D + heavy 3D deps and can't be headless-tested — same as the soft-fail crash-fix series (#128–#309). Verified by the traced consumer chain above and parity with the two existing, shipped sweep sites it mirrors.

## Deferred follow-up

Convert the two inline `ClientNet.bb` sweeps to call the new helper for a single source of truth (touches `ClientNet.bb` → needs the packet-index `--check` regen step).
