### PR TITLE
fix: bound script-supplied slot in BVM_ACTORBACKPACK/RING/AMULET (OOB Field read)

### DIFF
--- a/src/Modules/ScriptingCommands.bb
+++ b/src/Modules/ScriptingCommands.bb
@@ -1267,7 +1267,14 @@ Function BVM_ACTORBACKPACK%(Param1%, Param2%)
 	Actor.ActorInstance = Object.ActorInstance(Param1)
 	If Actor <> Null
 		Num = Param2 - 1
-		Result% = Handle(Actor\Inventory\Items[SlotI_Backpack + Num])
+		; Param2 is a raw script-supplied int. Items is Field [Slots_Inventory];
+		; bound the computed slot before indexing, mirroring BVM_BACKPACKCOUNT.
+		; Without it an out-of-range slot is an OOB Field read whose garbage flows
+		; into Handle() -> server crash / type-confused handle. Out of range => 0
+		; ("no item"), the sentinel callers already expect.
+		If SlotI_Backpack + Num >= SlotI_Backpack And SlotI_Backpack + Num <= Slots_Inventory
+			Result% = Handle(Actor\Inventory\Items[SlotI_Backpack + Num])
+		EndIf
 	EndIf
 Return Result
 End Function
@@ -1342,7 +1349,10 @@ Function BVM_ACTORRING%(Param1%, Param2%)
 	Actor.ActorInstance = Object.ActorInstance(Param1%)
 	If Actor <> Null
 		Num = Param2% - 1
-		Result% = Handle(Actor\Inventory\Items[SlotI_Ring1 + Num])
+		; Bound the script-supplied ring slot (8..11) before indexing Items[].
+		If SlotI_Ring1 + Num >= SlotI_Ring1 And SlotI_Ring1 + Num <= SlotI_Ring4
+			Result% = Handle(Actor\Inventory\Items[SlotI_Ring1 + Num])
+		EndIf
 	EndIf
 Return Result%
 End Function
@@ -1351,7 +1361,10 @@ Function BVM_ACTORAMULET%(Param1%, Param2%)
 	Actor.ActorInstance = Object.ActorInstance(Param1%)
 	If Actor <> Null
 		Num = Param2% - 1
-		Result% = Handle(Actor\Inventory\Items[SlotI_Amulet1 + Num])
+		; Bound the script-supplied amulet slot (12..13) before indexing Items[].
+		If SlotI_Amulet1 + Num >= SlotI_Amulet1 And SlotI_Amulet1 + Num <= SlotI_Amulet2
+			Result% = Handle(Actor\Inventory\Items[SlotI_Amulet1 + Num])
+		EndIf
 	EndIf
 Return Result%
 End Function

--- a/src/Tests/Modules/BvmInventoryAccessorBoundsTest.bb
+++ b/src/Tests/Modules/BvmInventoryAccessorBoundsTest.bb
@@ -1,0 +1,97 @@
+Strict
+EnableGC
+
+; Pins the slot-bounds contract for the BVM inventory accessors
+; BVM_ACTORBACKPACK / BVM_ACTORRING / BVM_ACTORAMULET (ScriptingCommands.bb).
+;
+; Each takes a raw script-supplied Param2 and computes a slot index into
+; Actor\Inventory\Items[] -- a Field [Slots_Inventory] (46 slots, 0..45). The
+; accessors used to index with NO bound check, while the sibling
+; BVM_BACKPACKCOUNT bounds the identical expression. An out-of-range Param2
+; (e.g. ActorRing(clicker, 9999) or a negative) was an out-of-bounds Field read
+; whose garbage flowed into Handle() -> server crash / type-confused handle, one
+; click from any hostile NPC script. The fix bounds each computed slot and
+; returns 0 ("no item") when out of range.
+;
+; ScriptingCommands.bb can't be Included into a test build (RakNet/world deps),
+; so the slot-resolution is replicated here on the real constants, per the
+; established ClampFloatTest / *CleanupTest convention. -1 models "rejected"
+; (the handler leaves Result = 0 and never indexes Items[]).
+
+; Mirror of Inventories.bb:15-31.
+Const SlotI_Ring1     = 8
+Const SlotI_Ring4     = 11
+Const SlotI_Amulet1   = 12
+Const SlotI_Amulet2   = 13
+Const SlotI_Backpack  = 14
+Const Slots_Inventory = 45
+
+; Mirrors the FIXED BVM_ACTORBACKPACK index resolution.
+Function BackpackIndex%(Param2)
+	Local Num = Param2 - 1
+	If SlotI_Backpack + Num >= SlotI_Backpack And SlotI_Backpack + Num <= Slots_Inventory
+		Return SlotI_Backpack + Num
+	EndIf
+	Return -1
+End Function
+
+; Mirrors the FIXED BVM_ACTORRING index resolution.
+Function RingIndex%(Param2)
+	Local Num = Param2 - 1
+	If SlotI_Ring1 + Num >= SlotI_Ring1 And SlotI_Ring1 + Num <= SlotI_Ring4
+		Return SlotI_Ring1 + Num
+	EndIf
+	Return -1
+End Function
+
+; Mirrors the FIXED BVM_ACTORAMULET index resolution.
+Function AmuletIndex%(Param2)
+	Local Num = Param2 - 1
+	If SlotI_Amulet1 + Num >= SlotI_Amulet1 And SlotI_Amulet1 + Num <= SlotI_Amulet2
+		Return SlotI_Amulet1 + Num
+	EndIf
+	Return -1
+End Function
+
+
+; Legit backpack slots resolve to in-bounds Items[] indices (14..45).
+Test testBackpackInRangeResolves()
+	Assert(BackpackIndex%(1) = 14)    ; first backpack slot
+	Assert(BackpackIndex%(32) = 45)   ; last valid index (Slots_Inventory)
+End Test
+
+; Out-of-range backpack Param2 is rejected (no Items[] index) -- this is the
+; crash/UAF guard. 33 -> 46 (past array), 0 -> 13 (before backpack), and the
+; hostile huge/negative values.
+Test testBackpackOutOfRangeRejected()
+	Assert(BackpackIndex%(33) = -1)     ; 46, one past the array
+	Assert(BackpackIndex%(0) = -1)      ; 13, below SlotI_Backpack
+	Assert(BackpackIndex%(9999) = -1)   ; the DoS value
+	Assert(BackpackIndex%(-100) = -1)   ; negative index
+End Test
+
+; Rings resolve for 1..4 (slots 8..11).
+Test testRingInRangeResolves()
+	Assert(RingIndex%(1) = 8)
+	Assert(RingIndex%(4) = 11)
+End Test
+
+Test testRingOutOfRangeRejected()
+	Assert(RingIndex%(0) = -1)      ; 7, below Ring1
+	Assert(RingIndex%(5) = -1)      ; 12, above Ring4 (would hit amulet/other)
+	Assert(RingIndex%(9999) = -1)
+	Assert(RingIndex%(-50) = -1)
+End Test
+
+; Amulets resolve for 1..2 (slots 12..13).
+Test testAmuletInRangeResolves()
+	Assert(AmuletIndex%(1) = 12)
+	Assert(AmuletIndex%(2) = 13)
+End Test
+
+Test testAmuletOutOfRangeRejected()
+	Assert(AmuletIndex%(0) = -1)      ; 11, below Amulet1
+	Assert(AmuletIndex%(3) = -1)      ; 14, above Amulet2
+	Assert(AmuletIndex%(9999) = -1)
+	Assert(AmuletIndex%(-1) = -1)
+End Test


### PR DESCRIPTION
## Defect (server-crash DoS + type-confusion)

`BVM_ACTORBACKPACK` / `BVM_ACTORRING` / `BVM_ACTORAMULET` ([ScriptingCommands.bb:1266](src/Modules/ScriptingCommands.bb#L1266), [:1341](src/Modules/ScriptingCommands.bb#L1341), [:1350](src/Modules/ScriptingCommands.bb#L1350)) take a raw script-supplied `Param2` and index `Actor\Inventory\Items[]` — a `Field [Slots_Inventory]` (46 slots, 0..45) — at `SlotI_X + (Param2 - 1)` with **no bound check**:

```basic
Function BVM_ACTORRING%(Param1%, Param2%)
	Actor.ActorInstance = Object.ActorInstance(Param1%)
	If Actor <> Null
		Num = Param2% - 1
		Result% = Handle(Actor\Inventory\Items[SlotI_Ring1 + Num])   ; <- unchecked
	EndIf
Return Result%
End Function
```

A non-privileged clicker script (any NPC Examine / Trade / RightClick / ItemScript) calling `ActorRing(clicker, 9999)` → index `10006`, or a negative `Param2` → index before the array, is an out-of-bounds `Field` read. The garbage value flows into `Handle()` → `_bbObjToHandle` dereferences it as a `BBObj*` → either an access violation that **crashes the whole server (every player disconnected)**, or — if it aliases a live object — a **type-confused handle** returned to the non-priv script. One click from any hostile NPC script. Field-array bounds guards are emitted only in debug builds; the shipped server (`compile.bat`, no `-d`) has none.

**Sibling-asymmetry miss:** the sibling `BVM_BACKPACKCOUNT` ([:1275](src/Modules/ScriptingCommands.bb#L1275)) bounds the *identical* `SlotI_Backpack + Num` expression. The handle-fetch accessors were never given the same guard — they read like harmless getters.

## Fix

Bound each computed slot before indexing, mirroring `BVM_BACKPACKCOUNT`:

| Accessor | Valid slot range |
|---|---|
| Backpack | `SlotI_Backpack` (14) .. `Slots_Inventory` (45) |
| Ring | `SlotI_Ring1` (8) .. `SlotI_Ring4` (11) |
| Amulet | `SlotI_Amulet1` (12) .. `SlotI_Amulet2` (13) |

Out of range falls through returning `0` — the "no item" sentinel callers already expect. **No shipped content script calls any of the three** (grep of `data/`), so legitimate behavior is unchanged; only the previously-crashing out-of-range calls now return `0`.

## Verification

- **Compile:** Server target builds clean to an unlocked path — `EXIT=0`, full 4.69 MB artifact, no `:line:col:` errors.
- **Test:** new `BvmInventoryAccessorBoundsTest.bb` → `[PASS]`, 6 tests (exit 0). Pins in-range resolution (backpack 1→14, 32→45; ring 1..4→8..11; amulet 1..2→12..13) and rejection of past-end / before-start / huge (`9999`) / negative `Param2`. Replicated slot-resolution on the real constants (ScriptingCommands.bb can't be Included — RakNet/world deps), same convention as the `*CleanupTest` files.
- Body-only edit: no opcode/signature/gate change, not a packet file → no `gen_bvm_reference`/`gen_packet_index` impact.

## Note

The single-slot accessors (`ACTORHAT`/`ACTORWEAPON`/`ACTORSHIELD`/…) use fixed constant indices (no `Param2`) and are safe. Recon also flagged `BVM_PARTYMEMBER` and the ability getters as sharing the "index-getter" shape — left for a separate audit (string-keyed or differently-bounded; not confirmed defects).
