### PR TITLE
fix: guard Null animset in the CE-model load path (client crash on actor spawn)

### DIFF
--- a/src/Modules/Actors3D.bb
+++ b/src/Modules/Actors3D.bb
@@ -211,7 +211,18 @@ Function LoadActorInstance3D(A.ActorInstance, Scale# = 1.0, SkipAttachments = Fa
 		Name$ = GetMeshName$(A\Actor\MeshIDs[0])
 		; CE model
 		If Upper$(Left$(Name$, 10)) = "CE\CESAVES"
-			A\EN = LoadCEMesh(A\Actor\MeshIDs[0], ActorAnimSet\AnimStart[Anim_Idle], ActorAnimSet\AnimStart[Anim_Idle])
+			; ActorAnimSet (the AnimList slot for MAnimationSet) is sparse and can
+			; be Null when the referenced set was deleted from Animations.dat. The
+			; later sequence loop (~line 432) and PlayAnimation (Animations.bb:53)
+			; both guard this, but the CE branch derefs AnimStart[] first -- an
+			; every-frame client crash at actor spawn for any CE-mesh actor whose
+			; animset slot is empty. Guard the idle-frame read; frame 0 is the
+			; consistent degraded state (a Null set extracts no sequences anyway).
+			If ActorAnimSet <> Null
+				A\EN = LoadCEMesh(A\Actor\MeshIDs[0], ActorAnimSet\AnimStart[Anim_Idle], ActorAnimSet\AnimStart[Anim_Idle])
+			Else
+				A\EN = LoadCEMesh(A\Actor\MeshIDs[0], 0, 0)
+			EndIf
 		; Normal model
 		Else
 			A\EN = GetMesh(A\Actor\MeshIDs[0], ActorHasMultipleTextures(A\Actor, 0))
@@ -341,7 +352,12 @@ Function LoadActorInstance3D(A.ActorInstance, Scale# = 1.0, SkipAttachments = Fa
 		Name$ = GetMeshName$(A\Actor\MeshIDs[1])
 		; CE model
 		If Upper$(Left$(Name$, 10)) = "CE\CESAVES"
-			A\EN = LoadCEMesh(A\Actor\MeshIDs[1], ActorAnimSet\AnimStart[Anim_Idle], ActorAnimSet\AnimStart[Anim_Idle])
+			; Null-animset guard -- see the male branch above (AnimList is sparse).
+			If ActorAnimSet <> Null
+				A\EN = LoadCEMesh(A\Actor\MeshIDs[1], ActorAnimSet\AnimStart[Anim_Idle], ActorAnimSet\AnimStart[Anim_Idle])
+			Else
+				A\EN = LoadCEMesh(A\Actor\MeshIDs[1], 0, 0)
+			EndIf
 		; Normal model
 		Else
 			A\EN = GetMesh(A\Actor\MeshIDs[1], ActorHasMultipleTextures(A\Actor, 1))


### PR DESCRIPTION
## Defect (client crash on actor spawn)

`LoadActorInstance3D` ([Actors3D.bb:210](src/Modules/Actors3D.bb#L210)) resolves `ActorAnimSet = AnimList(A\Actor\MAnimationSet)`, then for a `CE\CESAVES` mesh immediately derefs `ActorAnimSet\AnimStart[Anim_Idle]` to seed `LoadCEMesh` — at both the male ([:214](src/Modules/Actors3D.bb#L214)) and female ([:344](src/Modules/Actors3D.bb#L344)) branches, **with no Null check**.

`AnimList` is a sparse `Dim AnimList.AnimSet(999)`: a slot is `Null` when the referenced animation set was deleted from `Animations.dat` (ordinary content-editing drift — an admin deletes an animset while existing actors still reference it). `MAnimationSet`/`FAnimationSet` are `ReadShort` from `Actors.dat`, clamped to 0..999 ([Actors.bb:920](src/Modules/Actors.bb#L920)), so the **index** is in range — but in-range ≠ populated.

The codebase already knows this:
- The later sequence-extraction loop guards `If ActorAnimSet <> Null` ([:432](src/Modules/Actors3D.bb#L432)).
- `PlayAnimation` guards `If A = Null Then Return` ([Animations.bb:53](src/Modules/Animations.bb#L53)), with a comment calling the unguarded deref *"an every-frame crash."*

The two CE branches run **before** the line-432 guard and deref unconditionally. A remote actor/NPC with a `CE\CESAVES` mesh and a missing/deleted animset crashes the local client every time it enters view (`LoadActorInstance3D` is on the wire-driven actor-spawn path, [ClientNet.bb](src/Modules/ClientNet.bb)). Content-driven, stock server.

## Fix

Guard the CE idle-frame read at both branches, falling back to frame 0 — the consistent degraded state, since a Null animset extracts no sequences at the line-432 loop anyway:

```basic
If ActorAnimSet <> Null
	A\EN = LoadCEMesh(A\Actor\MeshIDs[0], ActorAnimSet\AnimStart[Anim_Idle], ActorAnimSet\AnimStart[Anim_Idle])
Else
	A\EN = LoadCEMesh(A\Actor\MeshIDs[0], 0, 0)
EndIf
```

Uses `If/Else` (no new `Local`) to avoid the duplicate-`Local` trap across the two branches. Extends the same Null-discipline the rest of the function (and `PlayAnimation`) already enforces.

## Verification

- **Compile:** Client **and** GUE both build clean to unlocked paths — `EXIT=0`, full artifacts (Client 3.94 MB, GUE 5.30 MB). `Actors3D.bb` is shared by Client/GUE/Gubbin Tool; the fix adds only a Null guard (no new type), so all targets still build. CI confirms across all five.
- **No packet/BVM edit** → no generator-doc regen.
- **No headless test:** this client-3D path needs Graphics3D and can't be headless-tested (same as the #457 dangling-Target fix). Verified by compile + the traced sparse-`AnimList` chain + parity with the line-432 / `PlayAnimation` sibling guards. A replicated-logic test of `If x <> Null` would be tautological.
