### PR TITLE
fix: resolve pointer-valued RNID in FindActorInstanceFromRNID (all client movement dropped)

### DIFF
--- a/src/Modules/Actors.bb
+++ b/src/Modules/Actors.bb
@@ -262,8 +262,20 @@ Dim FactionDefaultRatings(99, 99)
 ; that want those use FindActorInstanceFromName instead).
 Function FindActorInstanceFromRNID.ActorInstance(RNID)
 
-	If RNID < 1 Or RNID > MaxRNID Then Return Null
-	Return ActorByRNID(RNID)
+	If RNID < 1 Then Return Null
+	; Small connection ids resolve through the O(1) ActorByRNID index.
+	If RNID <= MaxRNID Then Return ActorByRNID(RNID)
+	; RCEnet's RCE_GetMessageConnection returns iSender = (int)Event.peer — a
+	; heap POINTER (> MaxRNID) — so M\FromID (and the \RNID set from it at
+	; StartGame) overflows the O(1) index and the <=MaxRNID guard skips the
+	; ActorByRNID population. The pointer is stable per connection, so fall
+	; back to an O(n) scan of the unconditionally-set \RNID field. Without
+	; this every client P_StandardUpdate / gameplay packet that resolves the
+	; sender via FindActorInstanceFromRNID is silently dropped.
+	For A.ActorInstance = Each ActorInstance
+		If A\RNID = RNID Then Return A
+	Next
+	Return Null
 
 End Function
 


### PR DESCRIPTION
## Problem

Every client's gameplay packets that resolve the sender via `FindActorInstanceFromRNID` — most visibly **player movement** (`P_StandardUpdate`) — are silently dropped. The actor never moves and the move is never broadcast. NPCs still move (they're server-driven), which masks the bug.

## Root cause

The sender id is `M\FromID = RCE_GetMessageConnection() = iSender = (int)Event.peer` (RCEnet `main.cpp:426`) — a heap **pointer**, well above `MaxRNID` (5000), and stable per connection.

The O(1) `ActorByRNID` index assumed a small connection id:
- `FindActorInstanceFromRNID` (`Actors.bb`) returns `Null` for `RNID > MaxRNID`.
- `P_StartGame`'s `If M\FromID > 0 And M\FromID <= MaxRNID` guard (`ServerNet.bb:2156`) skips populating `ActorByRNID` for a pointer-valued id.

So the index is never set and the lookup always misses → no client can move. (`\RNID` is still set unconditionally to the pointer at `ServerNet.bb:2150`.)

## Fix

Keep the O(1) fast path for ids in `[1, MaxRNID]`; for larger (pointer) ids fall back to an O(n) scan of the unconditionally-set `\RNID` field. Minimal, no protocol or DLL change.

## Verification

Against `bin/Server.exe -UNLOCK`: a client sending `P_StandardUpdate` now moves and the move broadcasts to other clients (before: position frozen for self and observers). Proven by logging `M\FromID` at StartGame vs StandardUpdate (identical pointer per connection, `>5000`) and a two-client walk test that now passes.

## Alternative (not taken — larger surface)

Change RCEnet so `iSender` returns `peer->incomingPeerID` (0..4999) and keep the pure-O(1) index. That's a DLL change; this PR is a self-contained engine fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
