### PR TITLE
Build and run the Rust client (ClientRS) on macOS and Linux

### DIFF
--- a/client-rs/crates/enet-sys/build.rs
+++ b/client-rs/crates/enet-sys/build.rs
@@ -24,6 +24,16 @@ fn main() {
         // ENet's platform code keys off WIN32 (no underscore); MSVC only
         // guarantees _WIN32, so define WIN32 explicitly.
         b.define("WIN32", None);
+    } else {
+        // macOS and modern Linux/glibc provide socklen_t in <sys/socket.h>.
+        // vendor/unix.c only falls back to its own `typedef int socklen_t;`
+        // when HAS_SOCKLEN_T is undefined — and that fallback collides with
+        // the system typedef, a hard error under clang. Signal that the
+        // platform has it so ENet skips the conflicting definition. Every
+        // other HAS_* guard safely takes its portable fallback branch (which
+        // uses BSD socket APIs present on both macOS and Linux), so this is
+        // the only flag the cc build needs on unix.
+        b.define("HAS_SOCKLEN_T", None);
     }
     b.compile("rcenet_c");
 

--- a/client-rs/crates/enet-sys/vendor/protocol.c
+++ b/client-rs/crates/enet-sys/vendor/protocol.c
@@ -1108,8 +1108,6 @@ enet_protocol_check_timeouts (ENetHost * host, ENetPeer * peer, ENetEvent * even
                (outgoingCommand -> roundTripTimeout >= outgoingCommand -> roundTripTimeoutLimit &&
                  ENET_TIME_DIFFERENCE(timeCurrent, peer -> earliestTimeout) >= ENET_PEER_TIMEOUT_MINIMUM)))
        {
-		   FILE *file; fopen_s(&file, "c:\\enet_protocol_check_timeouts.txt","w");
-		   fclose(file);
            enet_protocol_notify_disconnect (host, peer, event);
 
           return 1;

--- a/client-rs/crates/rcce-client/src/bin/client_window.rs
+++ b/client-rs/crates/rcce-client/src/bin/client_window.rs
@@ -83,6 +83,14 @@ struct Gfx {
     device: wgpu::Device,
     queue: wgpu::Queue,
     config: wgpu::SurfaceConfiguration,
+    /// Physical-to-logical UI divisor. On a HiDPI/Retina display the window's
+    /// backing store is `scale`× the logical size; we render the surface at the
+    /// logical size (so the bitmap-font UI and 3D are sized as on a 1× display)
+    /// and let the compositor scale the drawable up to the panel. `config`
+    /// dimensions are therefore LOGICAL, and every UI/overlay/pick path that
+    /// reads them is automatically in logical space — the only other physical
+    /// input is the raw cursor position, which `CursorMoved` divides by this.
+    ui_scale: f32,
 }
 
 impl Gfx {
@@ -130,13 +138,29 @@ impl Gfx {
         // captures (the offscreen RCCE_SHOT renders at config.width/height and the
         // overlay lays out against them, so this gives a full-res HUD screenshot
         // even when the headless window's physical size is tiny).
-        let (cfg_w, cfg_h) = std::env::var("RCCE_RES")
-            .ok()
-            .and_then(|s| {
-                let p: Vec<u32> = s.split(['x', 'X']).filter_map(|t| t.trim().parse().ok()).collect();
-                (p.len() == 2 && p[0] > 0 && p[1] > 0).then(|| (p[0], p[1]))
-            })
-            .unwrap_or((size.width.max(1), size.height.max(1)));
+        let res_override = std::env::var("RCCE_RES").ok().and_then(|s| {
+            let p: Vec<u32> = s.split(['x', 'X']).filter_map(|t| t.trim().parse().ok()).collect();
+            (p.len() == 2 && p[0] > 0 && p[1] > 0).then(|| (p[0], p[1]))
+        });
+        // High-DPI handling: render at logical resolution (physical / scale) so
+        // the UI/3D are sized as on a 1× display. RCCE_UISCALE overrides the
+        // factor (1 = native physical res = crisp but small on Retina; 1.5 = a
+        // middle ground). An explicit RCCE_RES bypasses scaling entirely.
+        let ui_scale = if res_override.is_some() {
+            1.0
+        } else {
+            std::env::var("RCCE_UISCALE")
+                .ok()
+                .and_then(|s| s.trim().parse::<f32>().ok())
+                .filter(|v| *v > 0.0)
+                .unwrap_or(window.scale_factor() as f32)
+        };
+        let (cfg_w, cfg_h) = res_override.unwrap_or_else(|| {
+            (
+                ((size.width as f32 / ui_scale).round() as u32).max(1),
+                ((size.height as f32 / ui_scale).round() as u32).max(1),
+            )
+        });
         let config = wgpu::SurfaceConfiguration {
             usage: wgpu::TextureUsages::RENDER_ATTACHMENT,
             format,
@@ -153,13 +177,17 @@ impl Gfx {
             "[client-window] {}x{} via {} [{:?}] ({:?}) present={:?}",
             config.width, config.height, info.name, info.backend, format, present_mode
         );
-        (Gfx { surface, device, queue, config }, format)
+        (Gfx { surface, device, queue, config, ui_scale }, format)
     }
 
+    /// `w`/`h` are physical pixels (from winit's `Resized`); store the logical
+    /// size so the surface keeps rendering at logical resolution after a resize.
     fn resize(&mut self, w: u32, h: u32) {
-        if w > 0 && h > 0 {
-            self.config.width = w;
-            self.config.height = h;
+        let lw = (w as f32 / self.ui_scale).round() as u32;
+        let lh = (h as f32 / self.ui_scale).round() as u32;
+        if lw > 0 && lh > 0 {
+            self.config.width = lw;
+            self.config.height = lh;
             self.surface.configure(&self.device, &self.config);
         }
     }
@@ -2639,7 +2667,9 @@ impl ApplicationHandler for App {
                     gfx.resize(size.width, size.height);
                 }
                 if let (Some(view), Some(gfx)) = (self.view.as_mut(), self.gfx.as_ref()) {
-                    view.resize(&gfx.device, size.width, size.height);
+                    // Logical dims (gfx.resize already divided by ui_scale) so the
+                    // 3D viewport matches the logical surface, not the raw physical size.
+                    view.resize(&gfx.device, gfx.config.width, gfx.config.height);
                 }
             }
             WindowEvent::KeyboardInput { event, .. } => {
@@ -3070,7 +3100,11 @@ impl ApplicationHandler for App {
                 }
             }
             WindowEvent::CursorMoved { position, .. } => {
-                self.cursor = (position.x as f32, position.y as f32);
+                // winit reports physical pixels; the UI/pick space is logical
+                // (the surface renders at config dims = physical / ui_scale), so
+                // divide to keep clicks aligned with what's drawn.
+                let s = self.gfx.as_ref().map(|g| g.ui_scale).unwrap_or(1.0);
+                self.cursor = (position.x as f32 / s, position.y as f32 / s);
                 // Promote an armed press to a real drag once it moves past a small
                 // dead-zone, so a click (memorise / cast) and a drag stay distinct.
                 if let Some(drag) = self.drag.as_mut() {
@@ -8374,8 +8408,18 @@ impl App {
 
 fn main() {
     let mut args = std::env::args().skip(1);
-    let host = args.next().unwrap_or_else(|| "127.0.0.1".to_string());
-    let port: u16 = args.next().and_then(|s| s.parse().ok()).unwrap_or(25000);
+    // Server address: positional arg wins, else RCCE_HOST / RCCE_PORT, else the
+    // 127.0.0.1:25000 default. Lets a macOS/Linux client point at a Windows
+    // server host without passing CLI args (e.g. launched via compile.sh).
+    let host = args
+        .next()
+        .or_else(|| std::env::var("RCCE_HOST").ok().filter(|s| !s.trim().is_empty()))
+        .unwrap_or_else(|| "127.0.0.1".to_string());
+    let port: u16 = args
+        .next()
+        .and_then(|s| s.parse().ok())
+        .or_else(|| std::env::var("RCCE_PORT").ok().and_then(|s| s.trim().parse().ok()))
+        .unwrap_or(25000);
     let zone = args.next().unwrap_or_else(|| "Plains".to_string());
     let event_loop = EventLoop::new().expect("event loop");
     event_loop.set_control_flow(ControlFlow::Poll);

--- a/client-rs/crates/rcce-client/src/bin/client_window.rs
+++ b/client-rs/crates/rcce-client/src/bin/client_window.rs
@@ -100,7 +100,8 @@ impl Gfx {
             &wgpu::DeviceDescriptor {
                 label: Some("window"),
                 required_features: wgpu::Features::empty(),
-                required_limits: wgpu::Limits::downlevel_defaults(),
+                required_limits: wgpu::Limits::downlevel_defaults()
+                    .using_resolution(adapter.limits()),
                 memory_hints: wgpu::MemoryHints::Performance,
             },
             None,

--- a/client-rs/crates/rcce-client/src/bin/client_window.rs
+++ b/client-rs/crates/rcce-client/src/bin/client_window.rs
@@ -83,14 +83,6 @@ struct Gfx {
     device: wgpu::Device,
     queue: wgpu::Queue,
     config: wgpu::SurfaceConfiguration,
-    /// Physical-to-logical UI divisor. On a HiDPI/Retina display the window's
-    /// backing store is `scale`× the logical size; we render the surface at the
-    /// logical size (so the bitmap-font UI and 3D are sized as on a 1× display)
-    /// and let the compositor scale the drawable up to the panel. `config`
-    /// dimensions are therefore LOGICAL, and every UI/overlay/pick path that
-    /// reads them is automatically in logical space — the only other physical
-    /// input is the raw cursor position, which `CursorMoved` divides by this.
-    ui_scale: f32,
 }
 
 impl Gfx {
@@ -138,29 +130,13 @@ impl Gfx {
         // captures (the offscreen RCCE_SHOT renders at config.width/height and the
         // overlay lays out against them, so this gives a full-res HUD screenshot
         // even when the headless window's physical size is tiny).
-        let res_override = std::env::var("RCCE_RES").ok().and_then(|s| {
-            let p: Vec<u32> = s.split(['x', 'X']).filter_map(|t| t.trim().parse().ok()).collect();
-            (p.len() == 2 && p[0] > 0 && p[1] > 0).then(|| (p[0], p[1]))
-        });
-        // High-DPI handling: render at logical resolution (physical / scale) so
-        // the UI/3D are sized as on a 1× display. RCCE_UISCALE overrides the
-        // factor (1 = native physical res = crisp but small on Retina; 1.5 = a
-        // middle ground). An explicit RCCE_RES bypasses scaling entirely.
-        let ui_scale = if res_override.is_some() {
-            1.0
-        } else {
-            std::env::var("RCCE_UISCALE")
-                .ok()
-                .and_then(|s| s.trim().parse::<f32>().ok())
-                .filter(|v| *v > 0.0)
-                .unwrap_or(window.scale_factor() as f32)
-        };
-        let (cfg_w, cfg_h) = res_override.unwrap_or_else(|| {
-            (
-                ((size.width as f32 / ui_scale).round() as u32).max(1),
-                ((size.height as f32 / ui_scale).round() as u32).max(1),
-            )
-        });
+        let (cfg_w, cfg_h) = std::env::var("RCCE_RES")
+            .ok()
+            .and_then(|s| {
+                let p: Vec<u32> = s.split(['x', 'X']).filter_map(|t| t.trim().parse().ok()).collect();
+                (p.len() == 2 && p[0] > 0 && p[1] > 0).then(|| (p[0], p[1]))
+            })
+            .unwrap_or((size.width.max(1), size.height.max(1)));
         let config = wgpu::SurfaceConfiguration {
             usage: wgpu::TextureUsages::RENDER_ATTACHMENT,
             format,
@@ -177,17 +153,13 @@ impl Gfx {
             "[client-window] {}x{} via {} [{:?}] ({:?}) present={:?}",
             config.width, config.height, info.name, info.backend, format, present_mode
         );
-        (Gfx { surface, device, queue, config, ui_scale }, format)
+        (Gfx { surface, device, queue, config }, format)
     }
 
-    /// `w`/`h` are physical pixels (from winit's `Resized`); store the logical
-    /// size so the surface keeps rendering at logical resolution after a resize.
     fn resize(&mut self, w: u32, h: u32) {
-        let lw = (w as f32 / self.ui_scale).round() as u32;
-        let lh = (h as f32 / self.ui_scale).round() as u32;
-        if lw > 0 && lh > 0 {
-            self.config.width = lw;
-            self.config.height = lh;
+        if w > 0 && h > 0 {
+            self.config.width = w;
+            self.config.height = h;
             self.surface.configure(&self.device, &self.config);
         }
     }
@@ -2667,9 +2639,7 @@ impl ApplicationHandler for App {
                     gfx.resize(size.width, size.height);
                 }
                 if let (Some(view), Some(gfx)) = (self.view.as_mut(), self.gfx.as_ref()) {
-                    // Logical dims (gfx.resize already divided by ui_scale) so the
-                    // 3D viewport matches the logical surface, not the raw physical size.
-                    view.resize(&gfx.device, gfx.config.width, gfx.config.height);
+                    view.resize(&gfx.device, size.width, size.height);
                 }
             }
             WindowEvent::KeyboardInput { event, .. } => {
@@ -3100,11 +3070,7 @@ impl ApplicationHandler for App {
                 }
             }
             WindowEvent::CursorMoved { position, .. } => {
-                // winit reports physical pixels; the UI/pick space is logical
-                // (the surface renders at config dims = physical / ui_scale), so
-                // divide to keep clicks aligned with what's drawn.
-                let s = self.gfx.as_ref().map(|g| g.ui_scale).unwrap_or(1.0);
-                self.cursor = (position.x as f32 / s, position.y as f32 / s);
+                self.cursor = (position.x as f32, position.y as f32);
                 // Promote an armed press to a real drag once it moves past a small
                 // dead-zone, so a click (memorise / cast) and a drag stay distinct.
                 if let Some(drag) = self.drag.as_mut() {

--- a/client-rs/crates/rcce-client/src/bin/overlay_test.rs
+++ b/client-rs/crates/rcce-client/src/bin/overlay_test.rs
@@ -21,7 +21,8 @@ fn main() {
         &wgpu::DeviceDescriptor {
             label: Some("overlay-test"),
             required_features: wgpu::Features::empty(),
-            required_limits: wgpu::Limits::downlevel_defaults(),
+            required_limits: wgpu::Limits::downlevel_defaults()
+                .using_resolution(adapter.limits()),
             memory_hints: wgpu::MemoryHints::Performance,
         },
         None,

--- a/client-rs/crates/rcce-render/src/lib.rs
+++ b/client-rs/crates/rcce-render/src/lib.rs
@@ -39,7 +39,8 @@ pub fn probe_gpu() -> Result<String, String> {
         &wgpu::DeviceDescriptor {
             label: Some("rcce-render probe"),
             required_features: wgpu::Features::empty(),
-            required_limits: wgpu::Limits::downlevel_defaults(),
+            required_limits: wgpu::Limits::downlevel_defaults()
+                .using_resolution(adapter.limits()),
             memory_hints: wgpu::MemoryHints::Performance,
         },
         None,

--- a/client-rs/crates/rcce-render/src/render.rs
+++ b/client-rs/crates/rcce-render/src/render.rs
@@ -98,7 +98,8 @@ pub fn render_markers_png(
         &wgpu::DeviceDescriptor {
             label: Some("rcce-render"),
             required_features: wgpu::Features::empty(),
-            required_limits: wgpu::Limits::downlevel_defaults(),
+            required_limits: wgpu::Limits::downlevel_defaults()
+                .using_resolution(adapter.limits()),
             memory_hints: wgpu::MemoryHints::Performance,
         },
         None,

--- a/client-rs/crates/rcce-render/src/render3d.rs
+++ b/client-rs/crates/rcce-render/src/render3d.rs
@@ -134,7 +134,8 @@ pub fn render_model_png(
         &wgpu::DeviceDescriptor {
             label: Some("model3d"),
             required_features: wgpu::Features::empty(),
-            required_limits: wgpu::Limits::downlevel_defaults(),
+            required_limits: wgpu::Limits::downlevel_defaults()
+                .using_resolution(adapter.limits()),
             memory_hints: wgpu::MemoryHints::Performance,
         },
         None,

--- a/client-rs/crates/rcce-render/src/scene.rs
+++ b/client-rs/crates/rcce-render/src/scene.rs
@@ -118,7 +118,8 @@ pub fn render_scene_png(
         &wgpu::DeviceDescriptor {
             label: Some("scene"),
             required_features: wgpu::Features::empty(),
-            required_limits: wgpu::Limits::downlevel_defaults(),
+            required_limits: wgpu::Limits::downlevel_defaults()
+                .using_resolution(adapter.limits()),
             memory_hints: wgpu::MemoryHints::Performance,
         },
         None,
@@ -317,7 +318,8 @@ pub fn render_skinned_png(
         &wgpu::DeviceDescriptor {
             label: Some("skin"),
             required_features: wgpu::Features::empty(),
-            required_limits: wgpu::Limits::downlevel_defaults(),
+            required_limits: wgpu::Limits::downlevel_defaults()
+                .using_resolution(adapter.limits()),
             memory_hints: wgpu::MemoryHints::Performance,
         },
         None,

--- a/compile.sh
+++ b/compile.sh
@@ -81,15 +81,24 @@ fi
 
 # Drop the .ico flag on macOS until BlitzForge supports native icon embedding.
 # See https://github.com/RydeTec/blitz-forge — fix/custom-exe-icons.
+# Only true Windows bash shells (MSYS/MinGW/Cygwin) emit .exe binaries and
+# embed the .ico. macOS AND Linux produce suffix-less binaries and don't embed
+# a Windows icon — previously everything non-Darwin was treated as Windows,
+# which broke the Linux build (it looked for client-window.exe).
+IS_WINDOWS=0
+case "$(uname -s)" in
+  MINGW*|MSYS*|CYGWIN*) IS_WINDOWS=1 ;;
+esac
+
 ICON_FLAG=()
-if [[ "$(uname -s)" != "Darwin" && -f "${ROOTDIR}/res/Icon.ico" ]]; then
+if [[ "$IS_WINDOWS" == "1" && -f "${ROOTDIR}/res/Icon.ico" ]]; then
   ICON_FLAG=(-n "${ROOTDIR}/res/Icon.ico")
 fi
 
-# Match compile.bat output names on macOS: drop the .exe extension so that
+# Match compile.bat output names on macOS/Linux: drop the .exe extension so that
 # `Project Manager` (no suffix) launches as the README documents.
 EXE_SUFFIX=""
-if [[ "$(uname -s)" != "Darwin" ]]; then
+if [[ "$IS_WINDOWS" == "1" ]]; then
   EXE_SUFFIX=".exe"
 fi
 


### PR DESCRIPTION
Cross-platform bring-up of `bin/ClientRS`. Verified end-to-end on all three: **Windows** (build + run), **macOS Apple Silicon** (build, connect to a remote Windows server, render), and **Linux** (build, run). Each fix was re-verified against the Windows release build.

### Build portability (vendored ENet C)
- **`protocol.c`** — remove a Windows-only debug write (`fopen_s` to a hardcoded `c:\…` path) that was undeclared under clang (hard error on macOS/Linux) and a latent `fclose(NULL)` crash on Windows. Wire-neutral.
- **`build.rs`** — define `HAS_SOCKLEN_T` on non-Windows so `unix.c` skips its own `typedef int socklen_t;`, which collided with the system typedef (hard error under clang). Audited every other `HAS_*` guard; this is the only flag the unix build needs.

### Runtime
- **`rcce-render`** — raise the device texture-dimension limits to the adapter's real maximums (`using_resolution(adapter.limits())`) at all device-creation sites. The default `downlevel_defaults()` caps at 2048, so a Retina window surface (2560×1600) failed `Surface::configure`. Keeps the downlevel floor for low-end GL adapters (no regression).
- **`RCCE_HOST` / `RCCE_PORT`** — server address via env (positional CLI arg still wins; default `127.0.0.1:25000`), so a macOS/Linux client can target a remote Windows server host.

### Tooling
- **`compile.sh`** — only emit `.exe` / embed the `.ico` on real Windows shells (`MINGW*`/`MSYS*`/`CYGWIN*`). It previously treated *any* non-macOS host as Windows, so the Linux build looked for `client-window.exe` and the copy failed.

### Not included
A high-DPI UI-scaling attempt (rendering the surface at logical resolution) was reverted in this branch — macOS/wgpu draws a sub-physical surface into a corner rather than upscaling it. Correctly-sized-but-crisp HiDPI is deferred to a follow-up (needs the UI coordinate system scaled while the surface stays physical). macOS/Linux currently render full-physical (crisp, small UI text on HiDPI).

### Follow-up (separate)
The server's `RCEnet.dll` is byte-identical to this vendored fork, so it likely carries the same `fopen_s` debug line — the live Windows server would write that junk file (and risk the `fclose(NULL)` crash) on every client timeout-disconnect. Worth auditing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)