### PR TITLE
Harden + CI-gate the Rust client's parser soft-fail invariant

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,6 +77,30 @@ jobs:
         shell: cmd
         run: test.bat
 
+      # The Rust client (client-rs/) ships its own deterministic unit + parser
+      # robustness tests. windows-latest has the Rust toolchain preinstalled.
+      # Gate the pure-logic crates (rcce-data parsers + rcce-net wire codec) on
+      # every PR — these read server-controlled files and packets, so their
+      # "soft-fail, never panic on hostile input" invariant is exactly what must
+      # not regress. The GUI crates (rcce-render/rcce-client) are skipped here:
+      # they pull the full wgpu/winit toolchain and have no headless tests.
+      - name: Cache Rust build (client-rs)
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry/index
+            ~/.cargo/registry/cache
+            ~/.cargo/git/db
+            client-rs/target
+          key: cargo-${{ runner.os }}-${{ hashFiles('client-rs/Cargo.lock') }}
+          restore-keys: |
+            cargo-${{ runner.os }}-
+
+      - name: Run Rust client tests (pure-logic crates)
+        shell: bash
+        working-directory: client-rs
+        run: cargo test -p rcce-data -p rcce-net --locked
+
       # Two reference docs (the wire-protocol packet catalog and the BVM
       # scripting-API catalog) are produced by generator scripts that read
       # line numbers + signatures out of the source. Their `--check` mode

--- a/client-rs/crates/rcce-data/src/area.rs
+++ b/client-rs/crates/rcce-data/src/area.rs
@@ -271,7 +271,21 @@ impl AreaScenery {
             for _ in 0..n_terr {
                 let base_tex_id = r.read_short_u()?;
                 let detail_tex_id = r.read_short_u()?;
-                let grid = r.read_int()? as u32;
+                let grid = r.read_int()?;
+                // `grid` comes straight off disk. A corrupt or hostile area file
+                // can carry a negative or absurd value; `(grid+1)^2` would then
+                // overflow the vertex count (the multiply itself wraps `usize`,
+                // and `Vec::with_capacity` panics past `isize::MAX`). Real LOD
+                // terrain grids are tiny — reject anything implausible and let
+                // the caller soft-fail the zone rather than crash the client.
+                const MAX_TERRAIN_GRID: i32 = 4096;
+                if !(0..=MAX_TERRAIN_GRID).contains(&grid) {
+                    return Err(ReadError::CountTooLarge {
+                        count: grid as i64,
+                        max: MAX_TERRAIN_GRID as usize,
+                    });
+                }
+                let grid = grid as u32;
                 let verts = (grid as usize + 1) * (grid as usize + 1);
                 let mut heights = Vec::with_capacity(verts);
                 for _ in 0..verts {

--- a/client-rs/crates/rcce-data/src/reader.rs
+++ b/client-rs/crates/rcce-data/src/reader.rs
@@ -26,6 +26,8 @@ pub enum ReadError {
     SeekOutOfBounds { target: usize, len: usize },
     #[error("string length {len} exceeds the maximum {max} (corrupt or hostile file)")]
     StringTooLong { len: i32, max: usize },
+    #[error("declared count/size {count} exceeds the maximum {max} (corrupt or hostile file)")]
+    CountTooLarge { count: i64, max: usize },
 }
 
 /// A cursor over an in-memory Blitz binary file.

--- a/client-rs/crates/rcce-data/src/texture.rs
+++ b/client-rs/crates/rcce-data/src/texture.rs
@@ -177,6 +177,13 @@ pub fn decode_tga(b: &[u8]) -> Option<Image> {
     if width == 0 || height == 0 || cmap_type != 0 {
         return None;
     }
+    // Clamp absurd dimensions before allocating, matching decode_dds. A hostile
+    // .tga declaring e.g. 65535x65535 @ 32bpp would otherwise force a ~17 GB
+    // zero-filled allocation below (vec![0u8; width*height*bpp]) → OOM abort =
+    // client crash. Real textures are well under this bound.
+    if width > 16384 || height > 16384 {
+        return None;
+    }
     if !(bpp == 24 || bpp == 32) {
         return None;
     }

--- a/client-rs/crates/rcce-data/tests/malformed_input.rs
+++ b/client-rs/crates/rcce-data/tests/malformed_input.rs
@@ -1,0 +1,841 @@
+//! Adversarial / malformed-input acceptance suite for the `rcce-data` on-disk
+//! parsers.
+//!
+//! Core invariant under test (see repo `CLAUDE.md`, "Soft-fail on
+//! server-controlled data"): **parsing malformed or hostile bytes must NEVER
+//! panic.** A parser panic is a full client crash. Every public parse/decode
+//! entry point must, for garbage / truncated / count-bomb input, return an
+//! `Err`/`None`/graceful value instead of panicking, indexing out of bounds,
+//! `unwrap()`-ing a short read, or multiply-overflowing a `count * size`
+//! allocation.
+//!
+//! These are all synthetic byte arrays built in-test; the suite needs no files
+//! from `data/` and runs on a clean checkout.
+//!
+//! Where a parser is *documented* infallible/no-panic, the test simply calls it
+//! inside `catch_unwind` and fails on a captured panic. Where a parser returns
+//! `Result`/`Option`, we additionally assert the error/None.
+
+use std::panic::{catch_unwind, AssertUnwindSafe};
+
+use rcce_data::{
+    actors::ActorCatalog,
+    anim::AnimSetCatalog,
+    area::AreaScenery,
+    attributes::AttributeNames,
+    b3d::B3dModel,
+    catalog::{MeshCatalog, MusicCatalog, SoundCatalog, TextureCatalog, CATALOG_SLOTS},
+    emitter::EmitterConfig,
+    interface::InterfaceLayout,
+    items::ItemCatalog,
+    money::MoneyConfig,
+    reader::BlitzReader,
+    texture::{decode_bmp, decode_dds, decode_jpeg, decode_png, decode_tga},
+};
+
+// ---------------------------------------------------------------------------
+// Shared corpus of "hostile" byte slices that every parser must survive.
+// ---------------------------------------------------------------------------
+
+/// A small bundle of generically-malformed inputs. None of these is a valid
+/// file of any format; a robust parser degrades gracefully on all of them.
+fn garbage_corpus() -> Vec<(&'static str, Vec<u8>)> {
+    vec![
+        ("empty", vec![]),
+        ("one_byte", vec![0x7F]),
+        ("two_bytes", vec![0xFF, 0x00]),
+        ("ff_64", vec![0xFF; 64]),
+        ("zero_64", vec![0x00; 64]),
+        ("ascii_64", vec![b'A'; 64]),
+        ("ff_4096", vec![0xFF; 4096]),
+        ("alt_256", (0..256).map(|i| (i & 0xFF) as u8).collect()),
+    ]
+}
+
+/// Run `f` on each corpus input under `catch_unwind`; any panic is a hard
+/// failure with the input name. `f`'s own return value is ignored — the point
+/// is "does not panic". Used for parsers whose graceful return is checked
+/// separately (or that are infallible).
+fn assert_no_panic_over_corpus<F>(label: &str, f: F)
+where
+    F: Fn(&[u8]),
+{
+    for (name, bytes) in garbage_corpus() {
+        let r = catch_unwind(AssertUnwindSafe(|| f(&bytes)));
+        assert!(
+            r.is_ok(),
+            "{label}: PANICKED on malformed input '{name}' ({} bytes) — soft-fail violation",
+            bytes.len()
+        );
+    }
+}
+
+// ===========================================================================
+// reader::BlitzReader — the bounds-checking foundation everything else sits on.
+// ===========================================================================
+
+#[test]
+fn blitz_reader_short_reads_error_never_panic() {
+    // Each getter on an under-length buffer must return Err, not panic / index OOB.
+    let inputs: Vec<Vec<u8>> = vec![vec![], vec![0x01], vec![0x01, 0x02], vec![0x01, 0x02, 0x03]];
+    for bytes in inputs {
+        let r = catch_unwind(AssertUnwindSafe(|| {
+            // byte ok only with >=1; everything wider must Err on the short ones.
+            let mut a = BlitzReader::new(&bytes);
+            let _ = a.read_byte();
+            let mut b = BlitzReader::new(&bytes);
+            let _ = b.read_short();
+            let mut c = BlitzReader::new(&bytes);
+            let _ = c.read_short_u();
+            let mut d = BlitzReader::new(&bytes);
+            let _ = d.read_int();
+            let mut e = BlitzReader::new(&bytes);
+            let _ = e.read_float();
+            let mut f = BlitzReader::new(&bytes);
+            let _ = f.read_tag();
+        }));
+        assert!(r.is_ok(), "BlitzReader panicked on {} bytes", bytes.len());
+    }
+
+    // Concrete error assertions on an empty buffer.
+    let mut r = BlitzReader::new(&[]);
+    assert!(r.read_int().is_err());
+    assert!(r.read_float().is_err());
+    assert!(r.read_tag().is_err());
+}
+
+#[test]
+fn blitz_reader_string_length_bomb_errors() {
+    // A length prefix claiming i32::MAX bytes must Err (StringTooLong), never try
+    // to allocate/index that many. This is the canonical "count bomb" at the
+    // string primitive: a naive `take(len)` would index far past the slice.
+    let mut buf = Vec::new();
+    buf.extend_from_slice(&i32::MAX.to_le_bytes());
+    buf.extend_from_slice(b"only a few bytes follow");
+    let mut r = BlitzReader::new(&buf);
+    assert!(r.read_string(260).is_err(), "huge string length must error");
+
+    // A length within `max` but past the actual data must Err (UnexpectedEof),
+    // not panic on the slice index.
+    let mut buf2 = Vec::new();
+    buf2.extend_from_slice(&200i32.to_le_bytes()); // <= max 260, but no bytes follow
+    let mut r2 = BlitzReader::new(&buf2);
+    assert!(r2.read_string(260).is_err());
+
+    // A NEGATIVE length must be treated as empty, never as a giant unsigned size.
+    let neg = (-1000i32).to_le_bytes();
+    let mut r3 = BlitzReader::new(&neg);
+    assert_eq!(r3.read_string(260).unwrap(), "");
+}
+
+#[test]
+fn blitz_reader_cstr_unterminated_is_bounded() {
+    // An unterminated cstr (no NUL) must stop at `max`, not run off the end.
+    let bytes = vec![b'x'; 1000];
+    let mut r = BlitzReader::new(&bytes);
+    let s = r.read_cstr(16).expect("cstr should bound, not error");
+    assert_eq!(s.len(), 16, "cstr must cap at max when unterminated");
+
+    // cstr on empty input errors (can't read the first byte), no panic.
+    let mut e = BlitzReader::new(&[]);
+    assert!(e.read_cstr(16).is_err());
+}
+
+#[test]
+fn blitz_reader_seek_out_of_bounds_errors() {
+    let mut r = BlitzReader::new(&[0u8; 4]);
+    assert!(r.seek(5).is_err(), "seek past end must error");
+    assert!(r.seek(4).is_ok(), "seek to exactly len is allowed (EOF cursor)");
+}
+
+// ===========================================================================
+// catalog::{Mesh,Texture,Music,Sound}Catalog — 65535-slot index + records.
+// ===========================================================================
+
+const INDEX_BYTES: usize = CATALOG_SLOTS * 4;
+
+#[test]
+fn catalogs_reject_short_index() {
+    // Anything smaller than the 262_140-byte index must error, not index OOB.
+    for n in [0usize, 1, 64, INDEX_BYTES - 1] {
+        let data = vec![0u8; n];
+        assert!(MeshCatalog::parse(&data).is_err(), "mesh n={n}");
+        assert!(TextureCatalog::parse(&data).is_err(), "tex n={n}");
+        assert!(MusicCatalog::parse(&data).is_err(), "music n={n}");
+        assert!(SoundCatalog::parse(&data).is_err(), "sound n={n}");
+    }
+}
+
+#[test]
+fn catalogs_do_not_panic_on_garbage() {
+    // Full corpus including the over-index 4096-byte case (still < index, must Err),
+    // plus an all-0xFF *index-sized* buffer (every slot points to a bogus offset).
+    assert_no_panic_over_corpus("MeshCatalog", |b| {
+        let _ = MeshCatalog::parse(b);
+    });
+    assert_no_panic_over_corpus("TextureCatalog", |b| {
+        let _ = TextureCatalog::parse(b);
+    });
+    assert_no_panic_over_corpus("MusicCatalog", |b| {
+        let _ = MusicCatalog::parse(b);
+    });
+    assert_no_panic_over_corpus("SoundCatalog", |b| {
+        let _ = SoundCatalog::parse(b);
+    });
+}
+
+#[test]
+fn catalog_offset_bomb_index_into_void_does_not_panic() {
+    // A structurally-valid index whose every slot points WAY past EOF. A naive
+    // reader would seek+read out of bounds. Must skip the slot, not panic.
+    let mut data = vec![0u8; INDEX_BYTES];
+    // slot 7 -> offset 0x7FFFFFF0 (huge but positive); slot 9 -> just past EOF.
+    data[7 * 4..7 * 4 + 4].copy_from_slice(&0x7FFF_FFF0i32.to_le_bytes());
+    let near_eof = (INDEX_BYTES as i32) + 1;
+    data[9 * 4..9 * 4 + 4].copy_from_slice(&near_eof.to_le_bytes());
+    // slot 11 -> a negative offset (must be treated as "skip", never as index).
+    data[11 * 4..11 * 4 + 4].copy_from_slice(&(-5i32).to_le_bytes());
+
+    let m = MeshCatalog::parse(&data).expect("index present");
+    assert!(m.value.get(7).is_none(), "bad-offset slot must not resolve");
+    assert!(m.value.get(9).is_none());
+    assert!(m.value.get(11).is_none());
+    // Texture/Music/Sound take the same offset path.
+    assert!(TextureCatalog::parse(&data).is_ok());
+    assert!(MusicCatalog::parse(&data).is_ok());
+    assert!(SoundCatalog::parse(&data).is_ok());
+}
+
+#[test]
+fn catalog_record_truncated_string_skips_not_panics() {
+    // Valid index, one slot points to a record whose string length prefix claims
+    // more bytes than exist. The slot must be skipped (logged), parse succeeds.
+    let mut data = vec![0u8; INDEX_BYTES];
+    let rec_off = INDEX_BYTES as i32;
+    data[3 * 4..3 * 4 + 4].copy_from_slice(&rec_off.to_le_bytes());
+    // Music record = just a string. Length prefix = 9999, but no bytes follow.
+    data.extend_from_slice(&9999i32.to_le_bytes());
+    let parsed = MusicCatalog::parse(&data).expect("index present");
+    assert!(parsed.value.get(3).is_none(), "truncated record must be skipped");
+    assert_eq!(parsed.value.entries.len(), 0);
+}
+
+// ===========================================================================
+// b3d::B3dModel — the deepest/riskiest format (nested length-tagged chunks).
+// ===========================================================================
+
+/// Build a minimal `BB3D` container: magic + size + version, then `body`.
+fn b3d_container(body: &[u8]) -> Vec<u8> {
+    let mut v = Vec::new();
+    v.extend_from_slice(b"BB3D");
+    // size = remaining bytes after this i32 (version + body)
+    let size = (4 + body.len()) as i32;
+    v.extend_from_slice(&size.to_le_bytes());
+    v.extend_from_slice(&1i32.to_le_bytes()); // version
+    v.extend_from_slice(body);
+    v
+}
+
+#[test]
+fn b3d_bad_magic_errors() {
+    assert!(B3dModel::parse(b"NOTB").is_err());
+    assert!(B3dModel::parse(b"XXXXYYYY").is_err());
+}
+
+#[test]
+fn b3d_garbage_does_not_panic() {
+    assert_no_panic_over_corpus("B3dModel", |b| {
+        let _ = B3dModel::parse(b);
+    });
+}
+
+#[test]
+fn b3d_truncated_header_does_not_panic() {
+    // "BB3D" then a size, cut off before the version int.
+    let mut v = Vec::new();
+    v.extend_from_slice(b"BB3D");
+    v.extend_from_slice(&100i32.to_le_bytes()); // claims 100 bytes
+                                                // (no version, no body)
+    let r = catch_unwind(AssertUnwindSafe(|| B3dModel::parse(&v)));
+    assert!(r.is_ok(), "B3d truncated header panicked");
+    assert!(r.unwrap().is_err());
+}
+
+#[test]
+fn b3d_chunk_size_overruns_container_does_not_panic() {
+    // A NODE chunk whose declared size is enormous (far past the file). The chunk
+    // walker clamps chunk_end to the container end; a naive seek would jump OOB.
+    let mut body = Vec::new();
+    body.extend_from_slice(b"NODE");
+    body.extend_from_slice(&0x7FFF_FFFFi32.to_le_bytes()); // absurd chunk size
+    body.extend_from_slice(b"\0"); // an empty node name then nothing
+    let file = b3d_container(&body);
+    let r = catch_unwind(AssertUnwindSafe(|| B3dModel::parse(&file)));
+    assert!(r.is_ok(), "B3d oversized chunk panicked");
+    // Whatever it returns (Ok with empty meshes or Err) is fine; not panicking is.
+}
+
+#[test]
+fn b3d_negative_chunk_size_does_not_panic() {
+    // chunk_header does `.max(0)` on the size; a negative size must become 0,
+    // not a giant unsigned seek.
+    let mut body = Vec::new();
+    body.extend_from_slice(b"TEXS");
+    body.extend_from_slice(&(-1i32).to_le_bytes()); // negative size
+    body.extend_from_slice(&[0xFF; 16]);
+    let file = b3d_container(&body);
+    let r = catch_unwind(AssertUnwindSafe(|| B3dModel::parse(&file)));
+    assert!(r.is_ok(), "B3d negative chunk size panicked");
+}
+
+#[test]
+fn b3d_truncated_mid_node_does_not_panic() {
+    // A well-formed header + a NODE chunk header that promises more body than is
+    // present (the node's float transform block is cut off mid-record).
+    let mut body = Vec::new();
+    body.extend_from_slice(b"NODE");
+    body.extend_from_slice(&200i32.to_le_bytes()); // promises 200 bytes
+    body.extend_from_slice(b"Joint\0"); // name
+    body.extend_from_slice(&1.0f32.to_le_bytes()); // px ... then truncated
+    let file = b3d_container(&body);
+    let r = catch_unwind(AssertUnwindSafe(|| B3dModel::parse(&file)));
+    assert!(r.is_ok(), "B3d truncated NODE panicked");
+}
+
+#[test]
+fn b3d_deeply_nested_nodes_do_not_stack_overflow() {
+    // NODE parsing recurses on child NODEs. A long chain of nested NODE chunks
+    // exercises the recursion depth; a runaway recursion would stack-overflow
+    // (which surfaces as a process abort, not a catchable panic — so if this
+    // test ever "passes by crashing", investigate). We keep depth modest (256)
+    // to document the recursion without risking the test process.
+    fn nested(depth: usize) -> Vec<u8> {
+        // innermost: an empty node (name NUL + 10 floats of transform)
+        let mut inner = Vec::new();
+        inner.extend_from_slice(b"\0"); // empty name
+        for _ in 0..10 {
+            inner.extend_from_slice(&0.0f32.to_le_bytes());
+        }
+        let mut cur = inner;
+        for _ in 0..depth {
+            let mut node = Vec::new();
+            node.extend_from_slice(b"\0"); // name
+            for _ in 0..10 {
+                node.extend_from_slice(&0.0f32.to_le_bytes());
+            }
+            // wrap `cur` as a child NODE chunk
+            let mut child = Vec::new();
+            child.extend_from_slice(b"NODE");
+            child.extend_from_slice(&(cur.len() as i32).to_le_bytes());
+            child.extend_from_slice(&cur);
+            node.extend_from_slice(&child);
+            cur = node;
+        }
+        // top-level NODE chunk
+        let mut body = Vec::new();
+        body.extend_from_slice(b"NODE");
+        body.extend_from_slice(&(cur.len() as i32).to_le_bytes());
+        body.extend_from_slice(&cur);
+        body
+    }
+    let file = b3d_container(&nested(256));
+    let r = catch_unwind(AssertUnwindSafe(|| B3dModel::parse(&file)));
+    assert!(r.is_ok(), "B3d deep nesting panicked");
+}
+
+// ===========================================================================
+// actors::ActorCatalog — back-to-back variable-length records to EOF.
+// ===========================================================================
+
+#[test]
+fn actors_garbage_does_not_panic_and_returns_ok() {
+    // ActorCatalog stops at the first bad record; on pure garbage it yields an
+    // empty/partial catalog, never panics.
+    assert_no_panic_over_corpus("ActorCatalog", |b| {
+        let _ = ActorCatalog::parse(b);
+    });
+    // Concrete: empty input parses to an empty catalog (Ok).
+    let cat = ActorCatalog::parse(&[]).expect("empty actors");
+    assert!(cat.templates.is_empty());
+}
+
+#[test]
+fn actors_truncated_record_stops_cleanly() {
+    // A record that starts (id short) but is cut off in the first string must not
+    // panic and must yield no completed templates.
+    let mut data = Vec::new();
+    data.extend_from_slice(&5u16.to_le_bytes()); // id
+    data.extend_from_slice(&9_000_000i32.to_le_bytes()); // race string len: huge
+    let cat = ActorCatalog::parse(&data).expect("parse");
+    assert!(cat.templates.is_empty(), "truncated record must not complete");
+}
+
+// ===========================================================================
+// anim::AnimSetCatalog — back-to-back records, 150 clips each.
+// ===========================================================================
+
+#[test]
+fn anim_garbage_does_not_panic() {
+    assert_no_panic_over_corpus("AnimSetCatalog", |b| {
+        let _ = AnimSetCatalog::parse(b);
+    });
+    let cat = AnimSetCatalog::parse(&[]).expect("empty anim");
+    assert!(cat.sets.is_empty());
+}
+
+#[test]
+fn anim_truncated_mid_clip_stops_cleanly() {
+    // id + set-name then a clip whose name length is bogus. The 150-clip loop
+    // must abort the set (not panic) when a string read fails.
+    let mut data = Vec::new();
+    data.extend_from_slice(&1u16.to_le_bytes()); // set id
+    data.extend_from_slice(&0i32.to_le_bytes()); // set name "" (len 0)
+    data.extend_from_slice(&50_000_000i32.to_le_bytes()); // first clip name len: huge
+    let cat = AnimSetCatalog::parse(&data).expect("parse");
+    assert!(cat.sets.is_empty(), "an aborted set must not be inserted");
+}
+
+// ===========================================================================
+// area::AreaScenery — 41-byte header, then count-prefixed scenery/water/terrain.
+// ===========================================================================
+
+#[test]
+fn area_garbage_does_not_panic() {
+    assert_no_panic_over_corpus("AreaScenery", |b| {
+        let _ = AreaScenery::parse(b);
+    });
+}
+
+#[test]
+fn area_truncated_header_errors_or_empty_no_panic() {
+    // Inputs shorter than the 41-byte header + 2-byte count. parse() seeks to 41
+    // then reads the scenery count; a buffer < 43 bytes must error on the count
+    // read, not panic.
+    for n in [0usize, 1, 10, 41, 42] {
+        let data = vec![0u8; n];
+        let r = catch_unwind(AssertUnwindSafe(|| AreaScenery::parse(&data)));
+        assert!(r.is_ok(), "area n={n} panicked");
+    }
+}
+
+#[test]
+fn area_scenery_count_bomb_does_not_panic() {
+    // Valid 41-byte header, then a scenery count of 65535 but NO record bytes.
+    // The per-record reads must error out and stop, not panic / index OOB. (The
+    // count is u16 so Vec::with_capacity(65535) is bounded — the risk is the
+    // unguarded per-field reads against a truncated body.)
+    let mut data = vec![0u8; 41];
+    data.extend_from_slice(&65535u16.to_le_bytes()); // claims 65535 sceneries
+    let r = catch_unwind(AssertUnwindSafe(|| AreaScenery::parse(&data)));
+    assert!(r.is_ok(), "area scenery-count bomb panicked");
+    // Graceful outcome: parse returns Err (UnexpectedEof on the first record's
+    // missing bytes) — the important property is that it errors rather than
+    // panicking or fabricating 65535 sceneries. If a future impl instead returns
+    // Ok, the scenery list must be empty.
+    match r.unwrap() {
+        Ok(area) => assert!(
+            area.sceneries.is_empty(),
+            "no record bytes -> no sceneries should be decoded"
+        ),
+        Err(_) => {} // erroring out on the truncated body is also graceful
+    }
+}
+
+/// AREA TERRAIN GRID BOMB. `AreaScenery::parse` reads the LOD-terrain `grid`
+/// field as an `i32` (then `as u32`) straight off disk and computes
+/// `verts = (grid + 1) * (grid + 1)`, then calls `Vec::with_capacity(verts)`
+/// BEFORE reading a single height float (`area.rs:275-276`). A hostile/corrupt
+/// area `.dat` declaring `grid = i32::MAX` makes `verts ≈ 4.6e18`, and
+/// `Vec::with_capacity` PANICS with "capacity overflow" (the value exceeds
+/// `isize::MAX`). The terrain block is wrapped in a closure whose `Result` is
+/// discarded (`let _ = parsed`), but a `panic!` is NOT a `Result` — it
+/// propagates out of `parse` and crashes the client. A negative i32 grid (e.g.
+/// `0xFFFFFFFF as u32 = 4.29e9`) triggers the same.
+///
+/// FIXED: `AreaScenery::parse` now rejects an implausible terrain `grid`
+/// (negative or > 4096) with `ReadError::CountTooLarge` BEFORE the
+/// `(grid+1)^2` allocation, so it soft-fails instead of panicking. This test
+/// gates that fix.
+#[test]
+fn area_terrain_grid_bomb_does_not_oom_or_panic() {
+    // The terrain block computes verts = (grid+1)^2 from a wire i32 and
+    // Vec::with_capacity(verts) BEFORE reading any height. A hostile `grid` near
+    // i32::MAX makes (grid+1)^2 a ~4.6e18 capacity request -> capacity-overflow
+    // panic / OOM in a naive impl. We drive the parser all the way to the terrain
+    // block (empty scenery/water/colbox/emitter) then feed a giant grid.
+    let mut data = vec![0u8; 41]; // zeroed header
+    let push_u16 = |d: &mut Vec<u8>, v: u16| d.extend_from_slice(&v.to_le_bytes());
+    let push_i32 = |d: &mut Vec<u8>, v: i32| d.extend_from_slice(&v.to_le_bytes());
+    push_u16(&mut data, 0); // scenery count = 0
+    push_u16(&mut data, 0); // water count = 0
+    push_u16(&mut data, 0); // collision-box count = 0
+    push_u16(&mut data, 0); // emitter count = 0
+    push_u16(&mut data, 1); // ONE terrain
+    push_u16(&mut data, 0); // base tex
+    push_u16(&mut data, 0); // detail tex
+    push_i32(&mut data, 0x7FFF_FFFF); // grid = i32::MAX -> (grid+1)^2 overflows usize math
+                                      // (no height bytes follow)
+    let r = catch_unwind(AssertUnwindSafe(|| AreaScenery::parse(&data)));
+    assert!(
+        r.is_ok(),
+        "area terrain grid-bomb panicked/OOM'd — Vec::with_capacity((grid+1)^2) is unguarded"
+    );
+}
+
+// ===========================================================================
+// attributes::AttributeNames — assignment byte + 40 records.
+// ===========================================================================
+
+#[test]
+fn attributes_garbage_does_not_panic() {
+    assert_no_panic_over_corpus("AttributeNames", |b| {
+        let _ = AttributeNames::parse(b);
+    });
+}
+
+#[test]
+fn attributes_truncated_errors() {
+    // assignment byte present but the 40-record body cut off mid-string.
+    let mut data = vec![0u8]; // assignment
+    data.extend_from_slice(&9_000_000i32.to_le_bytes()); // first name len: huge
+    assert!(AttributeNames::parse(&data).is_err(), "truncated attrs must error");
+    // Empty input: can't even read the assignment byte.
+    assert!(AttributeNames::parse(&[]).is_err());
+}
+
+// ===========================================================================
+// emitter::EmitterConfig — fixed field sequence.
+// ===========================================================================
+
+#[test]
+fn emitter_garbage_does_not_panic() {
+    assert_no_panic_over_corpus("EmitterConfig", |b| {
+        let _ = EmitterConfig::parse(b);
+    });
+}
+
+#[test]
+fn emitter_truncated_errors() {
+    // A few ints then EOF mid-field must Err, not panic.
+    let mut data = Vec::new();
+    data.extend_from_slice(&100i32.to_le_bytes()); // max_particles
+    data.extend_from_slice(&1i32.to_le_bytes()); // particles_per_frame
+    data.extend_from_slice(&[0x00, 0x01]); // partial next field
+    assert!(EmitterConfig::parse(&data).is_err());
+    assert!(EmitterConfig::parse(&[]).is_err());
+    assert!(EmitterConfig::parse(&[0xFF; 7]).is_err());
+}
+
+// ===========================================================================
+// interface::InterfaceLayout — fixed component sequence.
+// ===========================================================================
+
+#[test]
+fn interface_garbage_does_not_panic() {
+    assert_no_panic_over_corpus("InterfaceLayout", |b| {
+        let _ = InterfaceLayout::parse(b);
+    });
+}
+
+#[test]
+fn interface_truncated_errors() {
+    // The layout needs ~1.4 KB; anything short must Err (mirrors the in-crate
+    // rejects_truncated test but over a wider range).
+    for n in [0usize, 10, 23, 100, 500] {
+        assert!(InterfaceLayout::parse(&vec![0u8; n]).is_err(), "iface n={n}");
+    }
+}
+
+// ===========================================================================
+// money::MoneyConfig — 4 strings + 3 shorts.
+// ===========================================================================
+
+#[test]
+fn money_garbage_does_not_panic() {
+    assert_no_panic_over_corpus("MoneyConfig", |b| {
+        let _ = MoneyConfig::parse(b);
+    });
+}
+
+#[test]
+fn money_truncated_errors() {
+    assert!(MoneyConfig::parse(&[]).is_err());
+    // A valid first string then EOF before the second.
+    let mut data = Vec::new();
+    data.extend_from_slice(&6i32.to_le_bytes());
+    data.extend_from_slice(b"Copper");
+    assert!(MoneyConfig::parse(&data).is_err());
+    // An over-long name length must Err (StringTooLong), not allocate.
+    let mut bomb = Vec::new();
+    bomb.extend_from_slice(&1_000_000i32.to_le_bytes());
+    assert!(MoneyConfig::parse(&bomb).is_err());
+}
+
+#[test]
+fn money_format_never_panics_on_extreme_amounts() {
+    // format() does integer division by tier multipliers; a degenerate config
+    // (zero multipliers) must not divide-by-zero. The impl guards with `.max(1)`.
+    let cfg = MoneyConfig {
+        name1: "a".into(),
+        name2: "b".into(),
+        name3: "c".into(),
+        name4: "d".into(),
+        mult2: 0,
+        mult3: 0,
+        mult4: 0,
+    };
+    let r = catch_unwind(AssertUnwindSafe(|| {
+        let _ = cfg.format(i64::MAX);
+        let _ = cfg.format(i64::MIN);
+        let _ = cfg.format(0);
+    }));
+    assert!(r.is_ok(), "MoneyConfig::format panicked / divided by zero");
+}
+
+// ===========================================================================
+// items::ItemCatalog — INFALLIBLE (no Result). Must simply return on garbage.
+// ===========================================================================
+
+#[test]
+fn items_infallible_parse_never_panics() {
+    // The public contract: parse() returns an ItemCatalog (possibly empty) for
+    // ANY input, never panicking. Run the full corpus plus targeted truncations.
+    assert_no_panic_over_corpus("ItemCatalog", |b| {
+        let _ = ItemCatalog::parse(b);
+    });
+}
+
+#[test]
+fn items_empty_and_garbage_yield_empty_catalog() {
+    assert_eq!(ItemCatalog::parse(&[]).items.len(), 0);
+    // A lone negative id short is treated as corrupt -> empty.
+    let neg = (-1i16).to_le_bytes();
+    assert_eq!(ItemCatalog::parse(&neg).items.len(), 0);
+    // All-0xFF: first short is negative id -> stop immediately, empty.
+    assert_eq!(ItemCatalog::parse(&[0xFF; 64]).items.len(), 0);
+}
+
+#[test]
+fn items_truncated_record_stops_without_panic() {
+    // A valid id + name then a bogus string length deep in the record. Must stop,
+    // keeping zero completed items, never panic.
+    let mut data = Vec::new();
+    data.extend_from_slice(&3i16.to_le_bytes()); // id
+    data.extend_from_slice(&5i32.to_le_bytes()); // name len 5
+    data.extend_from_slice(b"Sword");
+    data.extend_from_slice(&9_000_000i32.to_le_bytes()); // excl_race len: huge -> abort
+    let r = catch_unwind(AssertUnwindSafe(|| ItemCatalog::parse(&data)));
+    assert!(r.is_ok(), "ItemCatalog panicked on truncated record");
+    assert_eq!(r.unwrap().items.len(), 0);
+}
+
+// ===========================================================================
+// texture decoders — decode_dds / decode_tga / decode_jpeg / decode_bmp /
+// decode_png. Each returns Option<Image>; None on bad/unsupported input.
+// ===========================================================================
+
+#[test]
+fn texture_decoders_garbage_return_none_no_panic() {
+    for (name, bytes) in garbage_corpus() {
+        for (dec_name, dec) in [
+            ("dds", decode_dds as fn(&[u8]) -> _),
+            ("tga", decode_tga),
+            ("jpeg", decode_jpeg),
+            ("bmp", decode_bmp),
+            ("png", decode_png),
+        ] {
+            let r = catch_unwind(AssertUnwindSafe(|| dec(&bytes)));
+            assert!(
+                r.is_ok(),
+                "decode_{dec_name} PANICKED on garbage '{name}' ({} bytes)",
+                bytes.len()
+            );
+            // Garbage is never a valid image.
+            assert!(
+                r.unwrap().is_none(),
+                "decode_{dec_name} accepted garbage '{name}' as an image"
+            );
+        }
+    }
+}
+
+#[test]
+fn dds_dimension_bomb_returns_none() {
+    // Valid "DDS " magic + 128-byte header declaring 100000x100000 (> the
+    // documented 16384 clamp). Must return None (rejected), never allocate
+    // 100000*100000*4 bytes or panic.
+    let mut b = vec![0u8; 128];
+    b[0..4].copy_from_slice(b"DDS ");
+    b[12..16].copy_from_slice(&100_000u32.to_le_bytes()); // height
+    b[16..20].copy_from_slice(&100_000u32.to_le_bytes()); // width
+    b[84..88].copy_from_slice(b"DXT1");
+    let r = catch_unwind(AssertUnwindSafe(|| decode_dds(&b)));
+    assert!(r.is_ok(), "decode_dds dimension bomb panicked");
+    assert!(r.unwrap().is_none(), "decode_dds must reject >16384 dims");
+}
+
+#[test]
+fn dds_dimension_bomb_zero_dims_returns_none() {
+    let mut b = vec![0u8; 128];
+    b[0..4].copy_from_slice(b"DDS ");
+    b[12..16].copy_from_slice(&0u32.to_le_bytes()); // height 0
+    b[16..20].copy_from_slice(&0u32.to_le_bytes()); // width 0
+    b[84..88].copy_from_slice(b"DXT1");
+    assert!(decode_dds(&b).is_none());
+}
+
+#[test]
+fn dds_truncated_block_data_returns_none() {
+    // Valid 4x4 DXT1 header but the 8-byte color block is missing.
+    let mut b = vec![0u8; 128];
+    b[0..4].copy_from_slice(b"DDS ");
+    b[12..16].copy_from_slice(&4u32.to_le_bytes());
+    b[16..20].copy_from_slice(&4u32.to_le_bytes());
+    b[84..88].copy_from_slice(b"DXT1");
+    // (no block bytes appended -> data.len() < bw*bh*block_bytes)
+    assert!(decode_dds(&b).is_none(), "truncated DXT1 must return None");
+}
+
+#[test]
+fn bmp_dimension_bomb_returns_none() {
+    // Valid "BM" + header declaring 100000x100000 @ 32bpp, but only the 54-byte
+    // header present. decode_bmp checks `b.len() < data_offset + stride*height`
+    // FIRST, so it must return None without allocating width*height*4.
+    let mut b = vec![0u8; 54];
+    b[0] = b'B';
+    b[1] = b'M';
+    b[10] = 54; // data offset
+    b[14] = 40; // header size
+    b[18..22].copy_from_slice(&100_000i32.to_le_bytes()); // width
+    b[22..26].copy_from_slice(&100_000i32.to_le_bytes()); // height
+    b[28] = 32; // bpp
+    let r = catch_unwind(AssertUnwindSafe(|| decode_bmp(&b)));
+    assert!(r.is_ok(), "decode_bmp dimension bomb panicked");
+    assert!(r.unwrap().is_none(), "decode_bmp must reject when data is absent");
+}
+
+#[test]
+fn bmp_negative_or_zero_height_handled() {
+    // height == 0 is invalid; a negative height is "top-down" (valid in BMP). Both
+    // must be handled without panicking.
+    let mut b = vec![0u8; 54];
+    b[0] = b'B';
+    b[1] = b'M';
+    b[10] = 54;
+    b[14] = 40;
+    b[18..22].copy_from_slice(&2i32.to_le_bytes()); // width 2
+    b[22..26].copy_from_slice(&0i32.to_le_bytes()); // height 0 -> invalid
+    b[28] = 24;
+    assert!(decode_bmp(&b).is_none(), "zero height must be rejected");
+}
+
+#[test]
+fn bmp_bad_bpp_returns_none() {
+    let mut b = vec![0u8; 54];
+    b[0] = b'B';
+    b[1] = b'M';
+    b[10] = 54;
+    b[14] = 40;
+    b[18] = 2;
+    b[22] = 2;
+    b[28] = 8; // 8bpp unsupported
+    assert!(decode_bmp(&b).is_none());
+}
+
+#[test]
+fn tga_truncated_pixel_data_returns_none() {
+    // Type 2 (uncompressed) TGA header declaring 8x8x32 but with no pixel bytes.
+    // The `b.len() < end` check must catch it -> None, no panic.
+    let mut b = vec![0u8; 18];
+    b[2] = 2; // uncompressed true-color
+    b[12] = 8; // width 8
+    b[14] = 8; // height 8
+    b[16] = 32; // bpp
+    let r = catch_unwind(AssertUnwindSafe(|| decode_tga(&b)));
+    assert!(r.is_ok(), "decode_tga truncated pixels panicked");
+    assert!(r.unwrap().is_none(), "truncated TGA pixels must return None");
+}
+
+#[test]
+fn tga_rle_runaway_does_not_panic() {
+    // RLE (type 10) TGA whose RLE packets claim more pixels than data provides.
+    // The decoder must bail (None) at the bounds check, not index OOB.
+    let mut b = vec![0u8; 18];
+    b[2] = 10; // RLE
+    b[12] = 16; // width 16
+    b[14] = 16; // height 16 -> 256 px
+    b[16] = 32; // bpp
+                // A single RLE packet header claiming a 128-run, but no pixel bytes follow.
+    b.push(0x80 | 0x7F); // run of 128
+    let r = catch_unwind(AssertUnwindSafe(|| decode_tga(&b)));
+    assert!(r.is_ok(), "decode_tga RLE runaway panicked");
+    assert!(r.unwrap().is_none());
+}
+
+#[test]
+fn tga_bad_bpp_and_colormap_return_none() {
+    let mut b = vec![0u8; 18];
+    b[2] = 2;
+    b[12] = 4;
+    b[14] = 4;
+    b[16] = 8; // 8bpp unsupported
+    assert!(decode_tga(&b).is_none());
+
+    let mut c = vec![0u8; 18];
+    c[1] = 1; // colormap present -> unsupported
+    c[2] = 2;
+    c[12] = 4;
+    c[14] = 4;
+    c[16] = 32;
+    assert!(decode_tga(&c).is_none());
+}
+
+/// TGA DIMENSION BOMB. `decode_tga` allocates `vec![0u8; width*height*bytes_pp]`
+/// at the TOP of the function — BEFORE any data-length validation — and (unlike
+/// `decode_dds`) applies NO max-dimension clamp. A TGA header declaring the
+/// maximum 65535x65535 @ 32bpp forces a ~17 GB zero-filled allocation, which
+/// OOM-aborts the process (an uncatchable abort, not a Rust panic). This is a
+/// genuine soft-fail violation: a hostile/corrupt .tga from `data/` (or any
+/// texture path) crashes the client.
+///
+/// FIXED: `decode_tga` now clamps width/height to 16384 (matching `decode_dds`)
+/// BEFORE the `vec![0u8; w*h*bpp]` allocation, so an absurd header returns
+/// `None` instead of OOM-aborting. This test gates that fix.
+#[test]
+fn tga_dimension_bomb_should_return_none() {
+    // 65535 x 65535 @ 32bpp => ~17.18 GB requested allocation.
+    let mut b = vec![0u8; 18];
+    b[2] = 2; // uncompressed true-color
+    b[12..14].copy_from_slice(&65535u16.to_le_bytes()); // width
+    b[14..16].copy_from_slice(&65535u16.to_le_bytes()); // height
+    b[16] = 32; // bpp
+    let r = catch_unwind(AssertUnwindSafe(|| decode_tga(&b)));
+    // If decode_tga were fixed, it would return None here without OOM.
+    assert!(r.is_ok(), "decode_tga panicked on dimension bomb");
+    assert!(
+        r.unwrap().is_none(),
+        "decode_tga must reject an absurd 65535x65535 header"
+    );
+}
+
+#[test]
+fn png_garbage_returns_none() {
+    // A valid PNG magic but truncated stream -> None via the png crate's error
+    // path, never a panic.
+    let png_magic = [0x89, b'P', b'N', b'G', 0x0D, 0x0A, 0x1A, 0x0A];
+    let mut b = png_magic.to_vec();
+    b.extend_from_slice(&[0xFF; 32]); // junk after the signature
+    let r = catch_unwind(AssertUnwindSafe(|| decode_png(&b)));
+    assert!(r.is_ok(), "decode_png panicked on truncated stream");
+    assert!(r.unwrap().is_none());
+}
+
+#[test]
+fn jpeg_garbage_returns_none() {
+    // SOI marker then junk -> the jpeg_decoder errors out to None.
+    let mut b = vec![0xFF, 0xD8]; // JPEG SOI
+    b.extend_from_slice(&[0xFF; 32]);
+    let r = catch_unwind(AssertUnwindSafe(|| decode_jpeg(&b)));
+    assert!(r.is_ok(), "decode_jpeg panicked on junk");
+    assert!(r.unwrap().is_none());
+}

--- a/client-rs/crates/rcce-net/tests/malformed_input.rs
+++ b/client-rs/crates/rcce-net/tests/malformed_input.rs
@@ -1,0 +1,221 @@
+//! Adversarial / malformed-input acceptance suite for the `rcce-net` wire codec.
+//!
+//! The server is untrusted from the client's perspective (a buggy or malicious
+//! server can put arbitrary bytes on the wire). Decoding a hostile packet
+//! payload must NEVER panic — every reader getter must return `None` on
+//! underflow rather than indexing out of bounds or `unwrap()`-ing a short read.
+//!
+//! Public `&[u8]` entry points exercised here:
+//!   * `rcce_net::unframe(&[u8]) -> Option<(u8, &[u8])>`
+//!   * `rcce_net::codec::MsgReader::new(&[u8])` + its getters
+//!     (`u8/u16/u32/i32/f32`, `bytes(n)`, `str8`, `str16`, `rest`, `remaining`).
+//!
+//! All inputs are synthetic; no `data/` files are required.
+
+use std::panic::{catch_unwind, AssertUnwindSafe};
+
+use rcce_net::codec::{MsgReader, MsgWriter};
+use rcce_net::unframe;
+
+fn garbage_corpus() -> Vec<(&'static str, Vec<u8>)> {
+    vec![
+        ("empty", vec![]),
+        ("one_byte", vec![0x00]),
+        ("two_bytes", vec![0xFF, 0xFF]),
+        ("ff_64", vec![0xFF; 64]),
+        ("zero_64", vec![0x00; 64]),
+        ("alt_256", (0..256).map(|i| (i & 0xFF) as u8).collect()),
+    ]
+}
+
+// ---------------------------------------------------------------------------
+// unframe — splits [type][payload]; only `empty` is rejected.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn unframe_empty_is_none_others_split() {
+    assert!(unframe(&[]).is_none());
+    // A single byte is a typed packet with an empty payload.
+    assert_eq!(unframe(&[42]), Some((42u8, &[][..])));
+    let (t, p) = unframe(&[0x0E, 0xDE, 0xAD]).unwrap();
+    assert_eq!(t, 0x0E);
+    assert_eq!(p, &[0xDE, 0xAD]);
+}
+
+#[test]
+fn unframe_never_panics() {
+    for (name, bytes) in garbage_corpus() {
+        let r = catch_unwind(AssertUnwindSafe(|| unframe(&bytes)));
+        assert!(r.is_ok(), "unframe panicked on '{name}'");
+    }
+}
+
+// ---------------------------------------------------------------------------
+// MsgReader scalar getters — every getter returns None on underflow.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn reader_scalar_underflow_returns_none() {
+    // For each width, a buffer one byte short must yield None on that getter and
+    // never panic.
+    let cases: &[(usize, fn(&mut MsgReader) -> bool)] = &[
+        (2, |r| r.u16().is_none()),
+        (4, |r| r.u32().is_none()),
+        (4, |r| r.i32().is_none()),
+        (4, |r| r.f32().is_none()),
+    ];
+    for &(width, getter) in cases {
+        let short = vec![0u8; width - 1];
+        let mut r = MsgReader::new(&short);
+        assert!(getter(&mut r), "getter of width {width} did not return None on short buffer");
+    }
+    // u8 on empty.
+    let mut e = MsgReader::new(&[]);
+    assert!(e.u8().is_none());
+}
+
+#[test]
+fn reader_scalar_getters_never_panic_over_corpus() {
+    for (name, bytes) in garbage_corpus() {
+        let r = catch_unwind(AssertUnwindSafe(|| {
+            let mut rd = MsgReader::new(&bytes);
+            // Drain a mixed sequence of getters; each must gracefully None at EOF.
+            for _ in 0..64 {
+                let _ = rd.u8();
+                let _ = rd.u16();
+                let _ = rd.u32();
+                let _ = rd.i32();
+                let _ = rd.f32();
+            }
+        }));
+        assert!(r.is_ok(), "scalar getters panicked on '{name}'");
+    }
+}
+
+// ---------------------------------------------------------------------------
+// str8 / str16 — length-prefixed strings. The classic wire "length bomb":
+// a length prefix larger than the remaining payload must yield None, never a
+// huge allocation or an OOB slice.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn str8_length_exceeds_payload_returns_none() {
+    // 1-byte length = 200, but only 3 bytes follow.
+    let mut data = vec![200u8];
+    data.extend_from_slice(b"abc");
+    let mut r = MsgReader::new(&data);
+    assert!(r.str8().is_none(), "str8 must None when length overruns payload");
+
+    // str8 length prefix present but ZERO following bytes claimed length>0.
+    let mut r2 = MsgReader::new(&[5u8]); // claims 5 bytes, none follow
+    assert!(r2.str8().is_none());
+
+    // length 0 is a valid empty string.
+    let mut r3 = MsgReader::new(&[0u8]);
+    assert_eq!(r3.str8().unwrap(), "");
+}
+
+#[test]
+fn str16_length_exceeds_payload_returns_none() {
+    // 2-byte LE length = 0xFFFF (65535), but only a few bytes follow. A naive
+    // reader would index 65535 bytes past a 6-byte slice.
+    let mut data = vec![0xFF, 0xFF]; // length 65535
+    data.extend_from_slice(b"oops");
+    let mut r = MsgReader::new(&data);
+    assert!(r.str16().is_none(), "str16 must None on a 65535-len bomb");
+
+    // Truncated length prefix itself (1 byte) -> None.
+    let mut r2 = MsgReader::new(&[0x01]);
+    assert!(r2.str16().is_none());
+
+    // Empty -> None.
+    let mut r3 = MsgReader::new(&[]);
+    assert!(r3.str16().is_none());
+}
+
+#[test]
+fn str_getters_never_panic_over_corpus() {
+    for (name, bytes) in garbage_corpus() {
+        let r = catch_unwind(AssertUnwindSafe(|| {
+            let mut rd = MsgReader::new(&bytes);
+            for _ in 0..32 {
+                let _ = rd.str8();
+            }
+            let mut rd2 = MsgReader::new(&bytes);
+            for _ in 0..32 {
+                let _ = rd2.str16();
+            }
+        }));
+        assert!(r.is_ok(), "str getters panicked on '{name}'");
+    }
+}
+
+#[test]
+fn str8_invalid_utf8_is_lossy_not_panic() {
+    // Length 4 + 4 invalid-UTF-8 bytes. Must decode lossily (no panic, no None).
+    let data = vec![4u8, 0xFF, 0xFE, 0x80, 0x81];
+    let mut r = MsgReader::new(&data);
+    let s = r.str8().expect("str8 should return a (lossy) string, not None");
+    assert!(!s.is_empty(), "lossy decode should produce replacement chars");
+}
+
+// ---------------------------------------------------------------------------
+// bytes(n) — raw take. A request for more than remains must be None.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn bytes_request_past_end_returns_none() {
+    let mut r = MsgReader::new(&[1, 2, 3]);
+    assert!(r.bytes(4).is_none(), "bytes(4) over a 3-byte buffer must be None");
+    // Exactly-remaining is fine.
+    assert_eq!(r.bytes(3).unwrap(), &[1, 2, 3]);
+    // Now empty: any further take is None.
+    assert!(r.bytes(1).is_none());
+    // A huge request must not overflow / panic.
+    let mut r2 = MsgReader::new(&[0u8; 8]);
+    assert!(r2.bytes(usize::MAX).is_none());
+}
+
+#[test]
+fn bytes_zero_is_empty_slice() {
+    let mut r = MsgReader::new(&[]);
+    assert_eq!(r.bytes(0), Some(&[][..]));
+}
+
+// ---------------------------------------------------------------------------
+// Mixed adversarial sequence: simulate a hostile packet that lies about its
+// internal structure (a string-length field that overruns, then more reads).
+// ---------------------------------------------------------------------------
+
+#[test]
+fn hostile_packet_shape_degrades_gracefully() {
+    // Shape loosely modelled on a login/character payload: str8 name, u16 id,
+    // str16 blob. Feed a payload that lies about the str16 length.
+    let mut w = MsgWriter::new();
+    w.str8("rustbot").u16(0x0102);
+    let mut data = w.into_bytes();
+    data.extend_from_slice(&0xFFFFu16.to_le_bytes()); // str16 length 65535 (a lie)
+    data.extend_from_slice(b"short");
+
+    let r = catch_unwind(AssertUnwindSafe(|| {
+        let mut rd = MsgReader::new(&data);
+        let _name = rd.str8();
+        let _id = rd.u16();
+        let blob = rd.str16(); // must be None, not panic / OOB
+        assert!(blob.is_none());
+        // Subsequent reads after a failed one keep returning None.
+        assert!(rd.u8().is_some() || rd.u8().is_none()); // either, just no panic
+    }));
+    assert!(r.is_ok(), "hostile packet shape panicked");
+}
+
+#[test]
+fn reader_remaining_and_rest_consistent_at_eof() {
+    let mut r = MsgReader::new(&[10, 20, 30, 40]);
+    assert_eq!(r.remaining(), 4);
+    let _ = r.u32();
+    assert_eq!(r.remaining(), 0);
+    assert_eq!(r.rest(), &[][..]);
+    // Past-EOF getters stay None.
+    assert!(r.u8().is_none());
+}


### PR DESCRIPTION
## Summary (non-technical)

The Rust client (`bin/ClientRS`) reads project files and network packets that, in production, can be corrupt or hostile. The codebase's core safety rule (CLAUDE.md, "Soft-fail on server-controlled data") is: parsing bad data must **never crash** — it must fail gracefully. This PR proves that rule with a real test suite, **wires those tests into CI** (they previously ran on no PR at all), and **fixes two genuine client-crash bugs** the suite caught.

## Technical summary

**1. CI gate (DevEx).** CI ran only the BlitzForge `.bb` suite — the Rust client's ~110 unit + parser tests gated nothing. Added a `cargo test -p rcce-data -p rcce-net --locked` step on the existing `windows-latest` runner (Rust preinstalled) with a `Cargo.lock`-keyed cache. GUI crates (`rcce-render`/`rcce-client`) excluded — they pull the full wgpu/winit toolchain and have no headless tests.

**2. Robustness test suite (Test coverage).** 60 new deterministic, synthetic-input tests (no `data/` files) across `crates/rcce-data/tests/malformed_input.rs` and `crates/rcce-net/tests/malformed_input.rs`. Every parse/decode entry point is fed empty / 1-byte / truncated-mid-record / garbage / count-and-dimension-bomb inputs and must return `Err`/`None`/degrade — never panic. Covers actors, anim, area, attributes, b3d (nested chunks), all 4 catalog kinds, emitter, interface, items (infallible), money, `BlitzReader`, all 5 texture decoders, and the `rcce-net` codec (`unframe` + `MsgReader` scalar/str8/str16/bytes underflow).

**3. Two real soft-fail fixes (Bug/Reliability)** the suite caught — both unvalidated allocations from on-disk values:
- `area::AreaScenery::parse` allocated `(grid+1)²` terrain vertices from a raw `i32` before validation; a corrupt grid overflowed `usize` and panicked `Vec::with_capacity` (*capacity overflow*, confirmed at runtime). Now rejects grids outside `0..=4096` via a new additive `ReadError::CountTooLarge`.
- `texture::decode_tga` allocated `width*height*bpp` from 16-bit header dims with no clamp; a `65535×65535@32bpp` `.tga` forced a ~17 GB alloc → OOM abort. Now clamps to 16384, matching `decode_dds`.

### Implementation plan (as executed)
1. Test-writer subagent authored the malformed-input suite from acceptance criteria alone (no implementation bias); it surfaced the two panics, which it `#[ignore]`'d and reported.
2. Fixed both production sites minimally (validate/clamp before allocating), mirroring the existing `decode_dds` clamp and `StringTooLong` "corrupt or hostile file" precedent.
3. Un-`#[ignore]`'d the two tests so they now gate the fixes.
4. Wired the CI step + cache.

## Acceptance criteria
- [x] Every parse/decode entry point has malformed-input coverage (empty/1-byte/truncated/garbage/bomb) — 60 tests.
- [x] ≥1 input per parser that would panic under a naive unchecked impl.
- [x] `items::parse` (infallible) covered for no-panic.
- [x] Suite needs no `data/` files; runs on a clean checkout.
- [x] `cargo test -p rcce-data -p rcce-net` green: `45 + 48` (rcce-data lib + robustness) and `7 + 12` (rcce-net), **0 ignored, 0 failed**.
- [x] CI now runs the Rust tests (fails the job on any Rust-core test failure).
- [x] Full client still builds clean (`cargo build --release --bin client-window`, 1m19s).

## Trade-offs / deferred
- CI gates only the pure-logic crates; `rcce-render`/`rcce-client` GUI tests are deferred (heavy toolchain, no headless tests today).
- No fuzzing/property-test infra — plain table-driven cases, deliberately.
- The grid bound (4096) and tex clamp (16384) are generous sanity caps that reject only implausible values; real assets are far below them.
- Behavior change is confined to two malformed-input paths; well-formed files parse identically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)