### PR TITLE
fix: read the Health attribute slot from Fixed Attributes.dat (don't hardcode 0)

### DIFF
--- a/client-rs/crates/rcce-client/src/assets.rs
+++ b/client-rs/crates/rcce-client/src/assets.rs
@@ -35,6 +35,10 @@ pub struct AssetStore {
     /// Defaults to the stock Copper/Silver/Gold/Platinum if the file is absent.
     money: MoneyConfig,
     attribute_names: Option<rcce_data::AttributeNames>,
+    /// Project-assigned role→slot indices (Health/Energy/… ) from
+    /// `Game Data/Fixed Attributes.dat`. `None` when the file is absent (the
+    /// `health_stat()` accessor then falls back to the index-0 default).
+    fixed_attributes: Option<rcce_data::FixedAttributes>,
     cache: HashMap<u16, Option<Rc<B3dModel>>>,
     /// Memoised decoded actor skins, keyed by appearance, so per-frame actor
     /// rebuilds don't re-read + re-decode the skin files from disk.
@@ -147,6 +151,10 @@ impl AssetStore {
         let attribute_names = std::fs::read(data_root.join("Server Data/Attributes.dat"))
             .ok()
             .and_then(|b| rcce_data::AttributeNames::parse(&b).ok());
+        // Which attribute slot is Health/Energy/etc. (project-configurable).
+        let fixed_attributes = std::fs::read(data_root.join("Game Data/Fixed Attributes.dat"))
+            .ok()
+            .and_then(|b| rcce_data::FixedAttributes::parse(&b).ok());
         Ok(Self {
             data_root,
             actors,
@@ -159,9 +167,18 @@ impl AssetStore {
             interface,
             money,
             attribute_names,
+            fixed_attributes,
             cache: HashMap::new(),
             actor_tex_cache: HashMap::new(),
         })
+    }
+
+    /// Which attribute slot is Health for this project (from
+    /// `Fixed Attributes.dat`). Falls back to `0` when the file is absent or
+    /// Health is unassigned, matching the prior hardcoded behaviour and the
+    /// shipped default project (Health = slot 0).
+    pub fn health_stat(&self) -> u8 {
+        self.fixed_attributes.and_then(|f| f.health).unwrap_or(0)
     }
 
     /// Display name for attribute slot `i` (Health, Mana, Strength, …), or

--- a/client-rs/crates/rcce-client/src/bin/client_window.rs
+++ b/client-rs/crates/rcce-client/src/bin/client_window.rs
@@ -3218,6 +3218,9 @@ impl App {
         let mut world = World {
             my_runtime_id: outcome.runtime_id,
             template_genders: store.template_genders(),
+            // Which attribute slot is Health for this project (default 0);
+            // P_StatUpdate reports HP under this slot.
+            health_stat: store.health_stat(),
             ..Default::default()
         };
         for m in &outcome.world_packets {

--- a/client-rs/crates/rcce-client/src/world.rs
+++ b/client-rs/crates/rcce-client/src/world.rs
@@ -233,6 +233,11 @@ pub struct World {
     pub me_beard: u8,
     pub me_health: i16,
     pub me_health_max: i16,
+    /// Which attribute slot carries Health for this project (read from
+    /// `Game Data/Fixed Attributes.dat` at enter-world; default 0). The server's
+    /// `P_StatUpdate` reports HP under this slot index, so it must match the
+    /// project — a hardcoded 0 froze HP bars on any project where Health != 0.
+    pub health_stat: u8,
     /// Template gender mode (`Actors.dat` `Genders`) keyed by template id.
     /// Populated by the host before applying packets so `on_new_actor` knows
     /// whether the wire carries a gender byte (only when mode == 0). Empty map
@@ -827,10 +832,10 @@ impl World {
             return;
         }
         let val = val as i16;
-        // Health is attribute 0 (Server.bb reads HealthStat from
-        // Fixed Attributes.dat → 0); mirror it onto the actor's health field so
-        // the HP bars reflect live combat damage.
-        const HEALTH_STAT: u8 = 0;
+        // Mirror the Health attribute onto the actor's health field so the HP
+        // bars reflect live combat damage. Which slot is Health is project-
+        // configurable (Fixed Attributes.dat → `health_stat`), NOT always 0.
+        let health_stat = self.health_stat;
         if rid == self.my_runtime_id {
             let e = self.me_attributes.entry(attr).or_default();
             match kind {
@@ -838,7 +843,7 @@ impl World {
                 b'M' => e.1 = val,
                 _ => {}
             }
-            if attr == HEALTH_STAT {
+            if attr == health_stat {
                 match kind {
                     b'A' => self.me_health = val,
                     b'M' => self.me_health_max = val,
@@ -852,7 +857,7 @@ impl World {
                 b'M' => e.1 = val,
                 _ => {}
             }
-            if attr == HEALTH_STAT {
+            if attr == health_stat {
                 match kind {
                     b'A' => a.health = val,
                     b'M' => a.health_max = val,
@@ -2103,6 +2108,24 @@ mod tests {
         // ActorDead marks the NPC dead.
         w.apply(&msg(pk::ACTOR_DEAD, pkt(|p| { p.u16(50); })));
         assert!(!w.actors[&50].alive);
+    }
+
+    #[test]
+    fn health_stat_is_project_configurable() {
+        // A project that assigns Health to slot 3 (not 0). The server's
+        // P_StatUpdate reports HP under slot 3, so the client must mirror THAT
+        // onto me_health (the HP-bar source) and must NOT treat slot 0 as Health.
+        // Regression for the old hardcoded `HEALTH_STAT = 0`, which froze HP bars
+        // (combat damage invisible) on any project where Health != 0.
+        let mut w = World { my_runtime_id: 1, health_stat: 3, ..Default::default() };
+        w.apply(&msg(pk::STAT_UPDATE, pkt(|p| { p.u8(b'M').u16(1).u8(3).u16(200); })));
+        w.apply(&msg(pk::STAT_UPDATE, pkt(|p| { p.u8(b'A').u16(1).u8(3).u16(150); })));
+        assert_eq!((w.me_health, w.me_health_max), (150, 200), "HP mirrors slot 3");
+
+        // Slot 0 is just another attribute here — it must not touch HP.
+        w.apply(&msg(pk::STAT_UPDATE, pkt(|p| { p.u8(b'A').u16(1).u8(0).u16(9); })));
+        assert_eq!(w.me_health, 150, "slot 0 must not touch HP when health_stat=3");
+        assert_eq!(w.me_attributes[&0], (9, 0), "slot 0 still recorded as a normal attribute");
     }
 
     #[test]

--- a/client-rs/crates/rcce-data/src/attributes.rs
+++ b/client-rs/crates/rcce-data/src/attributes.rs
@@ -1,7 +1,8 @@
 //! `Attributes.dat` (Server Data) — the project's 40 attribute slot names plus
-//! skill / hidden flags, loaded by `Actors.bb` `LoadAttributes`. By convention
-//! index 0 = Health and 1 = Energy (matching the Interface.dat vitals bars); the
-//! rest are project-defined attributes/skills.
+//! skill / hidden flags, loaded by `Actors.bb` `LoadAttributes`. The slot *names*
+//! live here; which slot plays a role like Health/Energy/Strength/Speed is
+//! project-configurable and read separately from `Game Data/Fixed Attributes.dat`
+//! (see [`crate::fixed_attributes`]) — do NOT assume Health is index 0.
 //!
 //! Layout: `AttributeAssignment` (u8), then 40 records of `Name`
 //! (4-byte-length-prefixed file string) + `IsSkill` (u8) + `Hidden` (u8).

--- a/client-rs/crates/rcce-data/src/fixed_attributes.rs
+++ b/client-rs/crates/rcce-data/src/fixed_attributes.rs
@@ -1,0 +1,87 @@
+//! `Game Data/Fixed Attributes.dat` — the five "fixed" attribute-slot indices a
+//! project assigns: which of the 40 attribute slots plays the role of Health,
+//! Energy, Breath, Strength, and Speed. The Blitz client reads this at startup
+//! (`Client.bb:172-184`) into `HealthStat`/`EnergyStat`/`BreathStat`/
+//! `StrengthStat`/`SpeedStat`, and the server reads the same file.
+//!
+//! These are **project-configurable** — a server owner can put Health on any of
+//! the 40 slots. The shipped default project uses `Health=0, Strength=2,
+//! Speed=4` (Energy/Breath unselected), so the indices are genuinely
+//! non-contiguous and must be read, never assumed to be index 0.
+//!
+//! Layout: 5 little-endian `u16`, in order Health, Energy, Breath, Strength,
+//! Speed. `65535` means "no slot assigned" for that role. A value outside the
+//! valid attribute range (`>= 40`) is also treated as unassigned (soft-fail
+//! instead of producing an out-of-range index).
+
+use crate::reader::{BlitzReader, ReadError};
+
+/// The five project-assigned attribute-slot indices. `None` = that role has no
+/// attribute slot in this project (`65535` on disk, or an out-of-range value).
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct FixedAttributes {
+    pub health: Option<u8>,
+    pub energy: Option<u8>,
+    pub breath: Option<u8>,
+    pub strength: Option<u8>,
+    pub speed: Option<u8>,
+}
+
+impl FixedAttributes {
+    /// Attribute slots are indexed `0..ATTR_COUNT`.
+    pub const ATTR_COUNT: u16 = 40;
+
+    pub fn parse(data: &[u8]) -> Result<FixedAttributes, ReadError> {
+        let mut r = BlitzReader::new(data);
+        // 65535 = unassigned; anything outside 0..40 is an invalid slot → None.
+        let to_slot = |v: u16| (v < Self::ATTR_COUNT).then_some(v as u8);
+        Ok(FixedAttributes {
+            health: to_slot(r.read_short_u()?),
+            energy: to_slot(r.read_short_u()?),
+            breath: to_slot(r.read_short_u()?),
+            strength: to_slot(r.read_short_u()?),
+            speed: to_slot(r.read_short_u()?),
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn bytes(vals: [u16; 5]) -> Vec<u8> {
+        vals.iter().flat_map(|v| v.to_le_bytes()).collect()
+    }
+
+    #[test]
+    fn parses_indices_and_unassigned() {
+        // Mirrors the shape of the shipped default project.
+        let f = FixedAttributes::parse(&bytes([3, 65535, 65535, 2, 4])).unwrap();
+        assert_eq!(f.health, Some(3));
+        assert_eq!(f.energy, None); // 65535 → unassigned
+        assert_eq!(f.breath, None);
+        assert_eq!(f.strength, Some(2));
+        assert_eq!(f.speed, Some(4));
+    }
+
+    #[test]
+    fn default_project_health_is_zero() {
+        let f = FixedAttributes::parse(&bytes([0, 65535, 65535, 2, 4])).unwrap();
+        assert_eq!(f.health, Some(0));
+    }
+
+    #[test]
+    fn out_of_range_index_is_unassigned() {
+        // >= 40 (but not 65535) is an invalid slot → None, never a bad index.
+        let f = FixedAttributes::parse(&bytes([40, 100, 0, 0, 0])).unwrap();
+        assert_eq!(f.health, None);
+        assert_eq!(f.energy, None);
+        assert_eq!(f.breath, Some(0));
+    }
+
+    #[test]
+    fn truncated_does_not_panic_and_errors() {
+        assert!(FixedAttributes::parse(&[0u8; 9]).is_err()); // 9 < 10 bytes
+        assert!(FixedAttributes::parse(&[]).is_err());
+    }
+}

--- a/client-rs/crates/rcce-data/src/lib.rs
+++ b/client-rs/crates/rcce-data/src/lib.rs
@@ -13,6 +13,7 @@ pub mod attributes;
 pub mod b3d;
 pub mod emitter;
 pub mod catalog;
+pub mod fixed_attributes;
 pub mod interface;
 pub mod items;
 pub mod money;
@@ -30,6 +31,7 @@ pub use catalog::{
     TextureCatalog, TextureEntry, CATALOG_SLOTS,
 };
 pub use attributes::{AttributeDef, AttributeNames};
+pub use fixed_attributes::FixedAttributes;
 pub use items::{equip_slot, equip_slot_name, ItemCatalog, ItemDef};
 pub use interface::{IComp, InterfaceLayout};
 pub use money::MoneyConfig;


### PR DESCRIPTION
## Summary (non-technical)

The engine lets a server owner decide which "attribute slot" is Health (and Energy, Strength, Speed) via `Game Data/Fixed Attributes.dat` — the real client reads this at startup. The Rust client didn't: it assumed Health was always slot 0. On any customized-but-valid project that put Health on a different slot, the Rust client's HP bars would **freeze at spawn value and combat damage would be invisible** — a drop-in-parity break. This reads the file like the Blitz client does, so HP works on any project. The default project is unaffected.

## Technical summary

The Blitz client/server read 5 indices (Health/Energy/Breath/Strength/Speed) from `Fixed Attributes.dat` (`Client.bb:172-184`). The Rust client hardcoded `const HEALTH_STAT: u8 = 0` in `world.rs::on_stat_update`, so `P_StatUpdate` for the real Health attribute never reached `me_health` / `actor.health` when Health ≠ slot 0.

- **`rcce-data`:** new `FixedAttributes::parse` (5 LE u16; `65535` or `>= 40` → `None`, soft-fail). Also corrects the stale `attributes.rs` doc that claimed "index 0 = Health by convention".
- **`rcce-client`:** `AssetStore` loads `Game Data/Fixed Attributes.dat` (soft-fails to index 0 when absent), exposes `health_stat()`, threads it onto `World.health_stat` at enter-world, and gates `on_stat_update`'s HP mirror on it.

The default project assigns Health=0 (which is why the bug was latent) but **Strength=2 / Speed=4 in that same file prove the indices are genuinely project-defined**.

## Acceptance criteria
- [x] `cargo test -p rcce-data`: `FixedAttributes::parse` — default-shape (Health=Some(3)), `65535`→None, out-of-range index→None, truncated→Err (no panic). 4 tests.
- [x] `cargo test -p rcce-client` (`world.rs`): a `health_stat=3` project — `P_StatUpdate` for slot 3 updates `me_health`/`me_health_max`; slot 0 records a normal attribute and does **not** touch HP. 1 regression test.
- [x] `cargo build --release --bin client-window` clean, 0 warnings.
- [x] Regression: default `data/` (Health=0) headless login→world renders the HP bars (player HUD + NPC nameplate health bar) — PNG-confirmed, behavior unchanged.

## Trade-offs / scope
- Only **Health** is consumed today (it's the load-bearing one for HP/combat). All five indices are parsed for completeness/future use (Energy for the vitals label, etc.), but the 40-slot attribute HUD loop is already correctly per-index and is left untouched.
- The HUD vitals bar still draws the Health bar from `me_health` (now correct for any project); no Interface.dat or HUD-layout changes.
- Soft-fails to the prior behavior (index 0) when the file is missing or Health is unassigned, so uncustomized installs are byte-for-byte unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)