### PR TITLE
perf: cache particle-emitter textures (fix per-frame upload leak, ~2x fps)

### DIFF
--- a/client-rs/crates/rcce-client/src/bin/client_window.rs
+++ b/client-rs/crates/rcce-client/src/bin/client_window.rs
@@ -2089,7 +2089,7 @@ fn particle_batches(
     eye: [f32; 3],
     target: [f32; 3],
     dt: f32,
-) -> Vec<(Option<rcce_data::Image>, bool, Vec<rcce_render::gpu::Vertex>)> {
+) -> Vec<(u16, Option<rcce_data::Image>, bool, Vec<rcce_render::gpu::Vertex>)> {
     let cross = |a: [f32; 3], b: [f32; 3]| [a[1] * b[2] - a[2] * b[1], a[2] * b[0] - a[0] * b[2], a[0] * b[1] - a[1] * b[0]];
     let normd = |v: [f32; 3]| {
         let l = (v[0] * v[0] + v[1] * v[1] + v[2] * v[2]).sqrt().max(1e-4);
@@ -2106,7 +2106,7 @@ fn particle_batches(
         e.update(delta);
         let mut verts = Vec::new();
         e.billboards(right, up, gain, &mut verts);
-        batches.push((tex.clone(), e.blend_add, verts));
+        batches.push((e.tex_id, tex.clone(), e.blend_add, verts));
     }
     batches
 }
@@ -4930,7 +4930,7 @@ impl App {
             let mut batches = particle_batches(&mut self.emitters, eye, target, 1.0 / 60.0);
             let mut verts = Vec::new();
             projectile_billboards(std::slice::from_ref(&pr), eye, target, &mut verts);
-            batches.push((Some(projectile_glow_image()), true, verts));
+            batches.push((u16::MAX, Some(projectile_glow_image()), true, verts));
             if let (Some(gfx), Some(view)) = (self.gfx.as_ref(), self.view.as_mut()) {
                 view.set_particles(&gfx.device, &gfx.queue, &batches);
             }
@@ -7126,7 +7126,7 @@ impl App {
                 let mut verts = Vec::new();
                 projectile_billboards(&net.world.projectiles, eye, cam_target, &mut verts);
                 if !verts.is_empty() {
-                    pbatches.push((Some(projectile_glow_image()), true, verts));
+                    pbatches.push((u16::MAX, Some(projectile_glow_image()), true, verts));
                 }
             }
         }

--- a/client-rs/crates/rcce-render/src/world_view.rs
+++ b/client-rs/crates/rcce-render/src/world_view.rs
@@ -105,6 +105,10 @@ pub struct WorldView {
     /// Static skinned geometry per `key:mesh` (vbuf + ibuf + n_idx + texture),
     /// uploaded ONCE — the GPU skinning path poses it via the per-actor uniform.
     skin_static: HashMap<String, (Rc<wgpu::Buffer>, Rc<wgpu::Buffer>, u32, Rc<wgpu::BindGroup>)>,
+    /// Particle-emitter billboard textures, cached by emitter `tex_id` so they
+    /// upload ONCE instead of every frame (the verts rebuild per frame, the
+    /// texture does not). Cleared on zone change in `set_scene`.
+    particle_tex: HashMap<u16, Rc<wgpu::BindGroup>>,
     /// Reusable per-actor skinning uniform buffers + binds (grown as needed).
     actor_pool: Vec<(wgpu::Buffer, wgpu::BindGroup)>,
     /// This frame's skinned draws.
@@ -129,7 +133,7 @@ pub struct WorldView {
 /// One frame's particle geometry for an emitter: its texture bind + blend +
 /// camera-facing billboard vertices.
 struct ParticleBatch {
-    tex_bind: wgpu::BindGroup,
+    tex_bind: Rc<wgpu::BindGroup>,
     add: bool,
     vbuf: wgpu::Buffer,
     n: u32,
@@ -266,6 +270,7 @@ impl WorldView {
             tex_cache: TexCache::new(),
             idx_cache: IndexCache::new(),
             skin_static: HashMap::new(),
+            particle_tex: HashMap::new(),
             actor_pool: Vec::new(),
             skinned: Vec::new(),
             zone_lights: Vec::new(),
@@ -284,9 +289,12 @@ impl WorldView {
 
     /// Replace this frame's particle billboards: `(texture, additive?, verts)` per
     /// emitter. Verts are camera-facing quads (6 per particle). Rebuilt each frame.
-    pub fn set_particles(&mut self, device: &wgpu::Device, queue: &wgpu::Queue, batches: &[(Option<Image>, bool, Vec<gpu::Vertex>)]) {
+    pub fn set_particles(&mut self, device: &wgpu::Device, queue: &wgpu::Queue, batches: &[(u16, Option<Image>, bool, Vec<gpu::Vertex>)]) {
         self.particles.clear();
-        for (img, add, verts) in batches {
+        // Disjoint-field borrows: the texture cache (mut) + the pipeline (shared).
+        let particle_tex = &mut self.particle_tex;
+        let pipeline = &self.pipeline;
+        for (tex_id, img, add, verts) in batches {
             if verts.is_empty() {
                 continue;
             }
@@ -295,7 +303,19 @@ impl WorldView {
                 contents: bytemuck::cast_slice(verts),
                 usage: wgpu::BufferUsages::VERTEX,
             });
-            let tex_bind = self.pipeline.texture_bind(device, queue, img.as_ref());
+            // A zone emitter's billboard texture is constant across frames (only
+            // the verts move), so upload + bind it ONCE per tex_id instead of
+            // every frame (cleared on zone change in `set_scene`). `u16::MAX` is
+            // reserved for app-procedural one-off batches (e.g. the projectile
+            // glow) that aren't stable zone emitters — bind those fresh.
+            let tex_bind = if *tex_id == u16::MAX {
+                Rc::new(pipeline.texture_bind(device, queue, img.as_ref()))
+            } else {
+                particle_tex
+                    .entry(*tex_id)
+                    .or_insert_with(|| Rc::new(pipeline.texture_bind(device, queue, img.as_ref())))
+                    .clone()
+            };
             self.particles.push(ParticleBatch { tex_bind, add: *add, vbuf, n: verts.len() as u32 });
         }
     }
@@ -357,8 +377,11 @@ impl WorldView {
         ground_y: f32,
     ) {
         // New zone: drop the previous zone's cached textures so stale entries can't
-        // be reused, then build (deduping identical scenery textures).
+        // be reused, then build (deduping identical scenery textures). Also drop
+        // the particle-emitter texture cache (keyed by tex_id, which a new zone
+        // can reuse for a different texture).
         self.static_tex_cache.clear();
+        self.particle_tex.clear();
         self.statics = gpu::build_drawables(device, queue, &self.pipeline, instances, ground_y, &mut self.static_tex_cache);
     }
 


### PR DESCRIPTION
## Summary (non-technical)

The client was re-uploading every particle emitter's texture to the GPU **every single frame** — and rebuilding a full image mip chain on the CPU each time — for the whole session. In the starter zone that's ~22 wasted texture uploads per frame, unbounded. Caching them (the texture never changes; only the moving particles do) roughly **doubled the frame rate** with no visual change.

## Technical summary

`WorldView::set_particles` runs every frame (billboards are camera-facing, rebuilt per frame), and it called `pipeline.texture_bind` for **every** emitter batch every frame, re-uploading each emitter's billboard texture (`upload_tex` → full RGBA8 mip chain + GPU upload). The static/scenery path is correctly cached; the per-frame particle path was not. It's skin-mode-independent (particles don't go through the skinning path), which is why #468's GPU-skin work didn't touch it.

- Cache the emitter bind by `tex_id` in a new `particle_tex: HashMap<u16, Rc<BindGroup>>`, cleared on zone change in `set_scene` (a new zone can reuse a `tex_id` for a different texture).
- `u16::MAX` is reserved for app-procedural one-off batches (the projectile glow) — bound fresh, so it can't collide with a real emitter or hold a stale entry.
- `ParticleBatch.tex_bind` becomes `Rc<BindGroup>` shared from the cache; the batch tuple carries the `tex_id` (threaded from `particle_batches`).

## Acceptance criteria (measured: Plains, 2 actors, `RCCE_USER=rustbot RCCE_BENCH=150 RCCE_AUTOWALK=1 RCCE_DRAWSTATS=1`)
- [x] `tex_uploads` was climbing **+~22/frame (110 → 4026 over 180 frames), unbounded** → now **PLATEAUS at 92** (one-time startup uploads), in both default (GPU) and `RCCE_CPUSKIN`.
- [x] avg fps: default **~84 → 175.9**; `RCCE_CPUSKIN` **~70 → 146.9** (~2×).
- [x] `RCCE_SHOT` of the live world is visually unchanged — particles render identically (cache correctness: the bind groups are content-identical).
- [x] `cargo build --release --bin client-window` clean, 0 warnings; `rcce-render`/`rcce-data`/`rcce-net` (14 suites) + client (41) tests green.

## Verification note
This is a GPU-render-path fix, so the verification is the **deterministic `RCCE_DRAWSTATS` upload-count plateau** (110→4026 unbounded → flat 92) + the RCCE_BENCH fps + an RCCE_SHOT confirming identical pixels — the right evidence tier for a render-path change (a unit test would need a headless GPU device). The win scales further with emitter count and on projects with more foliage/FX.

## Scope
Only the per-frame particle texture bind caching. Does NOT touch the particle simulation/verts (still rebuilt per frame — correct, they move), the static/scenery path, or the actor body/skinning path (a separate, latent `set_skinned` `{key}:0`-sentinel re-upload on empty-mesh-0 appearances was investigated but isn't the measured leak — left as a documented follow-up).

🤖 Generated with [Claude Code](https://claude.com/claude-code)