### PR TITLE
ci: gate rcce-render + rcce-client (147 headless tests + a compile check)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,11 +79,17 @@ jobs:
 
       # The Rust client (client-rs/) ships its own deterministic unit + parser
       # robustness tests. windows-latest has the Rust toolchain preinstalled.
-      # Gate the pure-logic crates (rcce-data parsers + rcce-net wire codec) on
-      # every PR — these read server-controlled files and packets, so their
-      # "soft-fail, never panic on hostile input" invariant is exactly what must
-      # not regress. The GUI crates (rcce-render/rcce-client) are skipped here:
-      # they pull the full wgpu/winit toolchain and have no headless tests.
+      # Gate ALL four logic crates on every PR:
+      #   - rcce-data / rcce-net: parsers + wire codec — the "soft-fail, never
+      #     panic on hostile input" invariant must not regress.
+      #   - rcce-render / rcce-client: despite pulling wgpu/winit, they carry
+      #     ~150 PURELY HEADLESS unit tests (overlay projection math, world.rs
+      #     packet-handler regressions, HUD/menu geometry, the EnetTransport Send
+      #     contract, etc.) that run with no GPU/window in <1s. Compiling them
+      #     here also makes CI catch a build break in the client/renderer (the
+      #     crates the project changes most) on a fresh checkout. The one-time
+      #     wgpu/winit compile is amortised by the cache step below (which already
+      #     lists client-rs/target). The i686-only rcenet-ffi-probe is excluded.
       - name: Cache Rust build (client-rs)
         uses: actions/cache@v4
         with:
@@ -96,10 +102,10 @@ jobs:
           restore-keys: |
             cargo-${{ runner.os }}-
 
-      - name: Run Rust client tests (pure-logic crates)
+      - name: Run Rust client tests (logic crates)
         shell: bash
         working-directory: client-rs
-        run: cargo test -p rcce-data -p rcce-net --locked
+        run: cargo test -p rcce-data -p rcce-net -p rcce-render -p rcce-client --locked
 
       # Two reference docs (the wire-protocol packet catalog and the BVM
       # scripting-API catalog) are produced by generator scripts that read


### PR DESCRIPTION
## Summary

CI's Rust step ran only `cargo test -p rcce-data -p rcce-net`, so **`rcce-render` and `rcce-client` were never compiled or tested in CI**. The in-file comment justified this by claiming they "have no headless tests" — which is **false**. This PR closes that gap.

## The gap (and why it matters now)

- The two GUI crates carry **~150 purely headless unit tests** that run with no GPU/window in <1s: `rcce-client` = 96 (lib) + 41 (`client-window` bin) — `world.rs` malformed-packet **handler regressions**, `vitals_value`, menu/HUD geometry, the `EnetTransport: Send` contract, interp/ease math; `rcce-render` = 10 — overlay `project`/`unproject_ground`, light parse.
- This bit the project concretely: every recent iteration (#466–#472) adds `rcce-client`/`rcce-render` logic + tests that **gated nothing in CI**, and **#472 was a render-only change CI never compiled** — a type/syntax break on a fresh checkout would have merged green.

## Change

One line + the stale comment. Add the two crates to the test command:

```diff
- run: cargo test -p rcce-data -p rcce-net --locked
+ run: cargo test -p rcce-data -p rcce-net -p rcce-render -p rcce-client --locked
```

This runs their headless tests **and** compile-checks the client + renderer (the code the project changes most). The one-time wgpu/winit compile is amortised by the **existing** cache step (it already lists `client-rs/target`); the i686-only `rcenet-ffi-probe` stays excluded.

## Acceptance criteria
- [x] Verified locally — the **exact** command `cargo test -p rcce-data -p rcce-net -p rcce-render -p rcce-client --locked` exits 0, compiling `rcce-render`/`rcce-client` and running all four crates' suites green (rcce-client 96 + 41, rcce-render 10, plus rcce-data/net).
- [x] The compile gate is live: the command compiles the GUI crates, so a future build break in them now fails CI (whereas today it would pass).
- [x] `git diff` touches only `.github/workflows/ci.yml`.
- [ ] **This PR's own CI run** is the end-to-end proof — it will compile `rcce-render`/`rcce-client` in CI for the first time (a one-time cold wgpu/winit compile, then cached) and run the 147 headless tests.

## Scope / cost
CI-config only — cannot affect the shipped client. First post-merge run pays the cold wgpu compile once (~1–2 min); steady-state is the cached incremental compile + sub-second tests. No new tests, no source changes, cache key untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)