### PR TITLE
perf(rust-client): throttle gear/loot vertex-buffer rebake to the dyn_hash

### DIFF
--- a/client-rs/crates/rcce-client/src/bin/client_window.rs
+++ b/client-rs/crates/rcce-client/src/bin/client_window.rs
@@ -5984,68 +5984,28 @@ impl App {
                 ^ if me_jumping { 0x4A_4D_50_00 } else { 0 }
                 ^ if self.first_person { 0x46_50_00_00 } else { 0 }
                 ^ if me_fidget.is_some() { 0x46_49_44_00 } else { 0 };
-            if self.gpu_skin || hash != self.last_dyn_hash {
+            // ACTORS. The body and its gear update on two different cadences:
+            //   * GPU-skinned bodies (default) pose in the vertex shader from a tiny
+            //     per-frame bone-palette uniform — cheap, so `set_skinned` runs EVERY
+            //     frame for display-rate smoothness.
+            //   * The CPU-baked attachments (hair/beard/weapon/shield) + dropped-loot
+            //     meshes ride `set_dynamic`, which re-bakes AND re-uploads their vertex
+            //     buffers on every call. That is throttled to the dyn_hash (its pre-#468
+            //     cadence): while moving/animating the hash changes every frame so gear
+            //     still tracks the hand; at a settled idle pose the rebake is skipped.
+            // Before #468 the body was CPU-skinned and this whole block was already
+            // hash-throttled; #468 made the body GPU-skinned but the `|| self.gpu_skin`
+            // gate accidentally forced the gear/loot rebake every frame too. The
+            // RCCE_CPUSKIN path is unchanged: it only enters when a rebake is due and
+            // never runs `set_skinned`.
+            let need_rebake = hash != self.last_dyn_hash;
+            if self.gpu_skin || need_rebake {
                 let (models, textures, place, keys, skinned) = build_actors(
                     store, &net.world, elapsed, self.gpu_skin, moving, run, 0, me_attack, me_jumping,
                     me_jump_offset, self.first_person, me_fidget, self.height_field.as_ref(),
                 );
-                // CPU drawables: attachments (+ bodies when GPU skinning is off).
-                let mut instances: Vec<SceneInstance> = place
-                    .iter()
-                    .map(|&(idx, t, r, color, s)| SceneInstance {
-                        model: &models[idx],
-                        textures: &textures[idx][..],
-                        lightmaps: &[],
-                        translation: t,
-                        rot: r,
-                        scale: s,
-                        color,
-                    })
-                    .collect();
-                // Dropped loot (DROP-1): render each item's world mesh (its `mmesh`)
-                // seated on the ground, or the Loot Bag fallback for items with no
-                // world mesh (most shipped items) — like Blitz (ClientNet.bb:1378).
-                // Replaces the flat 2D pip with a real, terrain-occluded 3D object.
-                let mut loot_models: Vec<std::rc::Rc<rcce_data::B3dModel>> = Vec::new();
-                let mut loot_texs: Vec<Vec<Option<rcce_data::Image>>> = Vec::new();
-                let mut loot_xf: Vec<([f32; 3], f32, String)> = Vec::new();
-                if !net.world.dropped_items.is_empty() {
-                    if self.loot_bag.is_none() {
-                        self.loot_bag = store.mesh_by_path("Loot Bag.b3d").map(|(m, t, _)| (m, t));
-                    }
-                    for d in net.world.dropped_items.values() {
-                        let (model, texs, s, key) = match store.gear_attachment(d.item_id) {
-                            // Item's own world mesh (Blitz: LoadedMeshScales × 0.05).
-                            Some(att) => (att.model, att.textures, att.scale * 0.05, format!("loot:i{}", d.item_id)),
-                            // Fallback Loot Bag (Blitz scales it 0.075).
-                            None => match &self.loot_bag {
-                                Some((m, t)) => (m.clone(), t.clone(), 0.075, "loot:bag".to_string()),
-                                None => continue,
-                            },
-                        };
-                        // Seat the mesh's lowest vertex on the terrain under it.
-                        let (min, _) = model.bounds();
-                        let ground = self.height_field.as_ref().and_then(|h| h.height_at(d.x, d.z)).unwrap_or(d.y);
-                        loot_models.push(model);
-                        loot_texs.push(texs);
-                        loot_xf.push(([d.x, ground - min[1] * s, d.z], s, key));
-                    }
-                }
-                let mut keys = keys;
-                for (i, (pos, s, key)) in loot_xf.iter().enumerate() {
-                    instances.push(SceneInstance {
-                        model: &loot_models[i],
-                        textures: &loot_texs[i][..],
-                        lightmaps: &[],
-                        translation: *pos,
-                        rot: [0.0, 0.0, 0.0],
-                        scale: [*s, *s, *s],
-                        color: [1.0, 1.0, 1.0],
-                    });
-                    keys.push(key.clone());
-                }
-                view.set_dynamic(&gfx.device, &gfx.queue, &instances, &keys);
-                // GPU-skinned bodies (when enabled) — static mesh + pose uniform.
+                // GPU-skinned bodies (when enabled) — static mesh + pose uniform. Cheap;
+                // runs every frame so the body animates at display rate.
                 if self.gpu_skin {
                     let sinst: Vec<rcce_render::SkinnedInstance> = skinned
                         .iter()
@@ -6060,7 +6020,66 @@ impl App {
                         .collect();
                     view.set_skinned(&gfx.device, &gfx.queue, &sinst);
                 }
-                self.last_dyn_hash = hash;
+                // CPU drawables: attachments (+ bodies when GPU skinning is off) and
+                // dropped loot. Only re-baked when the dyn_hash changed.
+                if need_rebake {
+                    let mut instances: Vec<SceneInstance> = place
+                        .iter()
+                        .map(|&(idx, t, r, color, s)| SceneInstance {
+                            model: &models[idx],
+                            textures: &textures[idx][..],
+                            lightmaps: &[],
+                            translation: t,
+                            rot: r,
+                            scale: s,
+                            color,
+                        })
+                        .collect();
+                    // Dropped loot (DROP-1): render each item's world mesh (its `mmesh`)
+                    // seated on the ground, or the Loot Bag fallback for items with no
+                    // world mesh (most shipped items) — like Blitz (ClientNet.bb:1378).
+                    // Replaces the flat 2D pip with a real, terrain-occluded 3D object.
+                    let mut loot_models: Vec<std::rc::Rc<rcce_data::B3dModel>> = Vec::new();
+                    let mut loot_texs: Vec<Vec<Option<rcce_data::Image>>> = Vec::new();
+                    let mut loot_xf: Vec<([f32; 3], f32, String)> = Vec::new();
+                    if !net.world.dropped_items.is_empty() {
+                        if self.loot_bag.is_none() {
+                            self.loot_bag = store.mesh_by_path("Loot Bag.b3d").map(|(m, t, _)| (m, t));
+                        }
+                        for d in net.world.dropped_items.values() {
+                            let (model, texs, s, key) = match store.gear_attachment(d.item_id) {
+                                // Item's own world mesh (Blitz: LoadedMeshScales × 0.05).
+                                Some(att) => (att.model, att.textures, att.scale * 0.05, format!("loot:i{}", d.item_id)),
+                                // Fallback Loot Bag (Blitz scales it 0.075).
+                                None => match &self.loot_bag {
+                                    Some((m, t)) => (m.clone(), t.clone(), 0.075, "loot:bag".to_string()),
+                                    None => continue,
+                                },
+                            };
+                            // Seat the mesh's lowest vertex on the terrain under it.
+                            let (min, _) = model.bounds();
+                            let ground = self.height_field.as_ref().and_then(|h| h.height_at(d.x, d.z)).unwrap_or(d.y);
+                            loot_models.push(model);
+                            loot_texs.push(texs);
+                            loot_xf.push(([d.x, ground - min[1] * s, d.z], s, key));
+                        }
+                    }
+                    let mut keys = keys;
+                    for (i, (pos, s, key)) in loot_xf.iter().enumerate() {
+                        instances.push(SceneInstance {
+                            model: &loot_models[i],
+                            textures: &loot_texs[i][..],
+                            lightmaps: &[],
+                            translation: *pos,
+                            rot: [0.0, 0.0, 0.0],
+                            scale: [*s, *s, *s],
+                            color: [1.0, 1.0, 1.0],
+                        });
+                        keys.push(key.clone());
+                    }
+                    view.set_dynamic(&gfx.device, &gfx.queue, &instances, &keys);
+                    self.last_dyn_hash = hash;
+                }
             }
             // Follow the SMOOTHED player render position (MOVE-SMOOTH) — the body
             // renders there too, so camera + body move in lockstep and there's no

--- a/client-rs/crates/rcce-render/src/gpu.rs
+++ b/client-rs/crates/rcce-render/src/gpu.rs
@@ -26,6 +26,13 @@ pub type TexCache = HashMap<String, Rc<wgpu::BindGroup>>;
 /// water — which is rebuilt every frame — re-uploading its texture each frame).
 pub static TEX_UPLOADS: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
 
+/// Cumulative count of dynamic-geometry rebakes (`WorldView::set_dynamic` calls).
+/// Each call re-bakes + re-uploads the vertex buffers for every actor attachment
+/// (hair/beard/weapon/shield) and dropped-loot mesh. Used by `RCCE_DRAWSTATS` to
+/// confirm the dyn_hash throttle suppresses redundant rebakes at idle: this should
+/// climb roughly once per frame while moving but plateau when the pose is settled.
+pub static DYN_REBUILDS: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
+
 /// Cheap content fingerprint for a `(texture, lightmap)` pair so identical
 /// textures share one GPU upload. Dims + byte length + a spread of sampled bytes
 /// — collision-proof for distinct real textures, far cheaper than repeating the

--- a/client-rs/crates/rcce-render/src/world_view.rs
+++ b/client-rs/crates/rcce-render/src/world_view.rs
@@ -395,6 +395,7 @@ impl WorldView {
         instances: &[SceneInstance],
         keys: &[String],
     ) {
+        gpu::DYN_REBUILDS.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
         self.dynamics = gpu::build_actor_drawables_cached(
             device,
             queue,
@@ -714,7 +715,8 @@ impl WorldView {
             }
             if std::env::var_os("RCCE_DRAWSTATS").is_some() {
                 let uploads = gpu::TEX_UPLOADS.load(std::sync::atomic::Ordering::Relaxed);
-                eprintln!("[world] drawables drawn={wdrawn} culled={wculled} tex_uploads={uploads} tex_cache={}", self.static_tex_cache.len());
+                let dyn_rebuilds = gpu::DYN_REBUILDS.load(std::sync::atomic::Ordering::Relaxed);
+                eprintln!("[world] drawables drawn={wdrawn} culled={wculled} tex_uploads={uploads} dyn_rebuilds={dyn_rebuilds} tex_cache={}", self.static_tex_cache.len());
             }
             // 5) Particles: unlit camera-facing billboards, additive/alpha blended,
             //    depth-tested against the world but writing no depth.


### PR DESCRIPTION
## What

Restore the actor **attachment + dropped-loot** vertex-buffer rebake to the `dyn_hash` throttle, while keeping the GPU-skinned body pose per-frame. Adds a `dyn_rebuilds=` counter to the `RCCE_DRAWSTATS` line to make the throttle measurable.

## Why

GPU linear-blend skinning became the default actor body path in #468 (the body poses in the vertex shader from a tiny per-frame uniform — cheap). But the actor's CPU-baked attachments (hair/beard/weapon/shield) and dropped-loot meshes ride `WorldView::set_dynamic`, which **re-bakes and re-uploads their vertex buffers (`create_buffer_init`) on every call**.

The gate was `if self.gpu_skin || hash != self.last_dyn_hash`. Before #468 `gpu_skin` was off, so this whole block was always throttled to the `dyn_hash`. #468 made the body GPU-skinned but the `|| self.gpu_skin` then forced the **gear/loot rebake every frame** — relocating the exact per-frame CPU-pose + vbuf-realloc cost the GPU-skin work was meant to remove onto the equipment.

## How

Split the gate: the cheap `set_skinned` (body pose) runs every frame for display-rate smoothness; the expensive `set_dynamic` (attachments + loot) runs only when the `dyn_hash` changes — its long-standing pre-#468 cadence. While moving/animating the hash changes every frame so gear still tracks the hand; at a settled idle pose the rebake is skipped.

The `RCCE_CPUSKIN` diagnostic path is **unchanged**: it only enters the block when a rebake is due and never runs `set_skinned`.

## Verification

- `cargo test -p rcce-data -p rcce-net -p rcce-render -p rcce-client --locked` — green. Release build clean (no warnings).
- **Throttle active + differential** (Plains, 2 actors, `RCCE_DRAWSTATS` over 260 frames): `dyn_rebuilds` = **150 idle / 230 walking** vs ~260 (every frame) before — ~42% of rebakes saved at idle; gear still rebuilt ~88% of frames while moving.
- **No visual regression**: walking `RCCE_SHOT` confirms the body is correctly posed mid-stride with gear attached (no detach/lag).
- fps is flat on the 2-actor starter zone, as expected — the saved work scales with actor population × equipped attachments + dropped loot (architectural win, like #468 itself).

🤖 Generated with [Claude Code](https://claude.com/claude-code)