### PR TITLE
fix(rust-client): apply live level/XP/reputation updates (character sheet was frozen at login)

### DIFF
--- a/client-rs/crates/rcce-client/src/bin/client_window.rs
+++ b/client-rs/crates/rcce-client/src/bin/client_window.rs
@@ -3370,6 +3370,13 @@ impl App {
             // started at 0, so the HUD gold (which now reads me_gold) would have
             // shown a balance relative to login instead of the real total.
             world.me_gold = s.gold as i32;
+            // Seed the LIVE progression fields the same way. The character sheet
+            // panel now reads these (kept live by P_XPUpdate "U" / P_StatUpdate
+            // "R") instead of the frozen login snapshot; without the seed they'd
+            // read 0 until the first in-world update.
+            world.me_level = s.level;
+            world.me_xp = s.xp as i32;
+            world.me_reputation = s.reputation as i32;
             // Populate the spellbook's known-spell list from the login sheet.
             // Login spells arrive via P_FetchCharacter, NOT P_KnownSpellUpdate, so
             // without this the spellbook was EMPTY at login for any character that
@@ -7839,7 +7846,8 @@ impl App {
                     // LIVE gold (me_gold, seeded from the sheet at login + updated by
                     // P_GoldChange) so buy/sell/loot are reflected immediately.
                     let gold = self.net.as_ref().map(|n| n.world.me_gold).unwrap_or(sheet.gold as i32);
-                    let line = format!("Lv {}   {}g", sheet.level, gold);
+                    let level = self.net.as_ref().map(|n| n.world.me_level).unwrap_or(sheet.level);
+                    let line = format!("Lv {}   {}g", level, gold);
                     let tw = rcce_render::font::text_width(&line, 1.0);
                     overlay.text_shadow(sw - tw - 12.0, 24.0, 1.0, &line, [1.0, 0.88, 0.4, 1.0]);
                     let money = store.money().format(gold as i64);
@@ -7936,14 +7944,25 @@ impl App {
                         .filter(|n| !n.is_empty())
                         .unwrap_or(self.login_user.as_str())
                         .to_string();
+                    // Live progression (seeded from the sheet at login, kept live by
+                    // P_XPUpdate "U" / P_StatUpdate "R") — disjoint `self.net` access
+                    // so it coexists with the `self.overlay` mutable borrow.
+                    let live = self.net.as_ref().map(|n| &n.world);
+                    let level = live.map(|w| w.me_level).unwrap_or(sheet.level);
+                    let xp = live.map(|w| w.me_xp as i64).unwrap_or(sheet.xp as i64);
+                    let rep = live.map(|w| w.me_reputation).unwrap_or(sheet.reputation as i32);
                     let mut rows: Vec<(String, [f32; 4])> = Vec::new();
-                    rows.push((format!("Level {}", sheet.level), [0.7, 1.0, 0.7, 1.0]));
-                    rows.push((format!("XP {}", sheet.xp), [0.92, 0.86, 0.6, 1.0]));
-                    rows.push((format!("Reputation {}", sheet.reputation), [0.85, 0.85, 1.0, 1.0]));
+                    rows.push((format!("Level {}", level), [0.7, 1.0, 0.7, 1.0]));
+                    rows.push((format!("XP {}", xp), [0.92, 0.86, 0.6, 1.0]));
+                    rows.push((format!("Reputation {}", rep), [0.85, 0.85, 1.0, 1.0]));
                     rows.push((String::new(), white)); // spacer before attributes
                     for i in 0..sheet.attributes.len().min(rcce_data::AttributeNames::COUNT) {
                         if let Some(name) = store.attribute_name(i) {
-                            let (val, mx) = sheet.attributes[i];
+                            // Prefer the live attribute (P_StatUpdate keeps `me_attributes`
+                            // current); fall back to the login snapshot before any update.
+                            let (val, mx) = live
+                                .and_then(|w| w.me_attributes.get(&(i as u8)).copied())
+                                .unwrap_or(sheet.attributes[i]);
                             let line = if i <= 1 && mx > 0 {
                                 format!("{name}: {val}/{mx}")
                             } else {
@@ -8037,7 +8056,9 @@ impl App {
                     // Header line: level / gold (live) / xp.
                     if let Some(s) = &self.sheet {
                         let gold = self.net.as_ref().map(|n| n.world.me_gold).unwrap_or(s.gold as i32);
-                        overlay.text_shadow(px + 10.0, py + 26.0, 1.0, &format!("Lv {}   {} gold   {} xp", s.level, gold, s.xp), [1.0, 0.88, 0.4, 1.0]);
+                        let level = self.net.as_ref().map(|n| n.world.me_level).unwrap_or(s.level);
+                        let xp = self.net.as_ref().map(|n| n.world.me_xp as i64).unwrap_or(s.xp as i64);
+                        overlay.text_shadow(px + 10.0, py + 26.0, 1.0, &format!("Lv {}   {} gold   {} xp", level, gold, xp), [1.0, 0.88, 0.4, 1.0]);
                     }
                     for (i, b) in iface.inventory_buttons.iter().enumerate() {
                         // Window-relative fraction -> screen pixels.
@@ -8137,7 +8158,8 @@ impl App {
                 } else if let Some(s) = &self.sheet {
                     // Fallback text list when Interface.dat is absent.
                     let gold = self.net.as_ref().map(|n| n.world.me_gold).unwrap_or(s.gold as i32);
-                    overlay.text_shadow(px + 10.0, py + 30.0, 1.0, &format!("Lv {}   {} gold", s.level, gold), [1.0, 0.88, 0.4, 1.0]);
+                    let level = self.net.as_ref().map(|n| n.world.me_level).unwrap_or(s.level);
+                    overlay.text_shadow(px + 10.0, py + 30.0, 1.0, &format!("Lv {}   {} gold", level, gold), [1.0, 0.88, 0.4, 1.0]);
                 } else {
                     overlay.text(px + 10.0, py + 30.0, 1.0, "(no character data)", dim);
                 }

--- a/client-rs/crates/rcce-client/src/world.rs
+++ b/client-rs/crates/rcce-client/src/world.rs
@@ -252,6 +252,13 @@ pub struct World {
     // Local player progression / stats.
     pub me_xp: i32,
     pub me_xp_bar: u8,
+    /// Local player level. Seeded from the login sheet (`enter_outcome`) and kept
+    /// live by `P_XPUpdate "U"` (level changed → XP resets to 0). The character
+    /// sheet panel reads this, not the frozen login snapshot.
+    pub me_level: u16,
+    /// Local player reputation (signed). Seeded from the login sheet and kept live
+    /// by `P_StatUpdate "R"` (which the handler previously dropped).
+    pub me_reputation: i32,
     pub me_gold: i32,
     /// Server day/night clock from the `P_FetchActors` `"E"` env block. When
     /// `time_known`, the client advances it locally (one game-minute = `60000 /
@@ -790,7 +797,15 @@ impl World {
         }
     }
 
-    /// `P_XPUpdate` (ClientNet.bb:689): `'B'`+barLevel(u8), or `'M'`+xpGain(i32).
+    /// `P_XPUpdate` (ClientNet.bb:689):
+    ///   `'B'` + barLevel(u8)  — XP bar position.
+    ///   `'M'` + xpGain(i32)   — XP points received (added to total).
+    ///   `'U'` + level(u16)    — MY level changed (XP resets to 0).
+    /// `'U'` was previously dropped, so the character sheet's Level stayed frozen
+    /// at the login snapshot all session. The server sends the level as a 2-byte
+    /// field (ScriptingCommands.bb:2085) — read u16, not i32, or the parse fails
+    /// and the level silently never updates. (`'L'`, another actor's level, is
+    /// not handled: the Rust client has no per-actor level display to feed.)
     fn on_xp_update(&mut self, d: &[u8]) {
         match d.first() {
             Some(b'B') => {
@@ -801,6 +816,12 @@ impl World {
             Some(b'M') => {
                 if let Some(gain) = MsgReader::new(&d[1..]).i32() {
                     self.me_xp = self.me_xp.saturating_add(gain);
+                }
+            }
+            Some(b'U') => {
+                if let Some(level) = MsgReader::new(&d[1..]).u16() {
+                    self.me_level = level;
+                    self.me_xp = 0;
                 }
             }
             _ => {}
@@ -817,13 +838,29 @@ impl World {
         }
     }
 
-    /// `P_StatUpdate` (ClientNet.bb:996): byte0 `'A'`(value)/`'M'`(max) +
-    /// RuntimeID(u16) + attrIndex(u8) + value(u16). (`'R'` resistances ignored.)
+    /// `P_StatUpdate` (ClientNet.bb:996):
+    ///   `'A'`/`'M'` + rid(u16) + attrIndex(u8) + value(u16) — attribute value/max.
+    ///   `'R'` + rid(u16) + reputation(i16 signed) — reputation (NO attr byte).
+    /// The `'R'` case was previously dropped (and the doc mislabelled it
+    /// "resistances"), so the character sheet's Reputation stayed frozen at login.
     fn on_stat_update(&mut self, d: &[u8]) {
         let kind = match d.first() {
             Some(&k) => k,
             None => return,
         };
+        // 'R' has a distinct layout (no attribute byte) and is signed — handle it
+        // before the attribute parse below.
+        if kind == b'R' {
+            let mut r = MsgReader::new(&d[1..]);
+            if let (Some(rid), Some(rep)) = (r.u16(), r.u16()) {
+                if rid == self.my_runtime_id {
+                    // Reinterpret the 16-bit field as signed (reputation can be
+                    // negative), then widen — mirrors RCE_SignedShortFromStr.
+                    self.me_reputation = rep as i16 as i32;
+                }
+            }
+            return;
+        }
         let mut r = MsgReader::new(&d[1..]);
         let (Some(rid), Some(attr), Some(val)) = (r.u16(), r.u8(), r.u16()) else {
             return;
@@ -2108,6 +2145,41 @@ mod tests {
         // ActorDead marks the NPC dead.
         w.apply(&msg(pk::ACTOR_DEAD, pkt(|p| { p.u16(50); })));
         assert!(!w.actors[&50].alive);
+    }
+
+    #[test]
+    fn xp_update_my_level_change_resets_xp() {
+        let mut w = World { my_runtime_id: 7, ..Default::default() };
+        // Accumulate some XP first.
+        w.apply(&msg(pk::XP_UPDATE, pkt(|p| { p.u8(b'M').i32(150); })));
+        assert_eq!(w.me_xp, 150);
+
+        // 'U' = MY level changed → level updates and XP resets to 0. The server
+        // sends the level as a 2-byte field (ScriptingCommands.bb:2085); reading
+        // it as i32 would fail the parse and silently never update the level.
+        w.apply(&msg(pk::XP_UPDATE, pkt(|p| { p.u8(b'U').u16(5); })));
+        assert_eq!(w.me_level, 5, "'U' sets my level");
+        assert_eq!(w.me_xp, 0, "'U' resets XP to 0 (matches Me\\XP = 0)");
+
+        // A truncated 'U' (no level bytes) is a safe no-op (soft-fail, no panic).
+        w.apply(&msg(pk::XP_UPDATE, pkt(|p| { p.u8(b'U'); })));
+        assert_eq!(w.me_level, 5, "truncated 'U' leaves the level unchanged");
+    }
+
+    #[test]
+    fn stat_update_reputation_is_signed_and_self_only() {
+        let mut w = World { my_runtime_id: 7, ..Default::default() };
+        // 'R' = reputation: rid(u16) + reputation(i16 signed), NO attr byte.
+        // Negative reputation must sign-extend (RCE_SignedShortFromStr).
+        w.apply(&msg(pk::STAT_UPDATE, pkt(|p| { p.u8(b'R').u16(7).u16((-30i16) as u16); })));
+        assert_eq!(w.me_reputation, -30, "negative reputation sign-extends");
+        w.apply(&msg(pk::STAT_UPDATE, pkt(|p| { p.u8(b'R').u16(7).u16(450); })));
+        assert_eq!(w.me_reputation, 450, "positive reputation");
+        // Another actor's reputation ('R' for a non-self rid) does not touch mine.
+        w.apply(&msg(pk::STAT_UPDATE, pkt(|p| { p.u8(b'R').u16(50).u16((-9i16) as u16); })));
+        assert_eq!(w.me_reputation, 450, "other actors' reputation leaves mine unchanged");
+        // The 'R' layout (no attr byte) must not be misparsed as an attribute.
+        assert!(w.me_attributes.is_empty(), "'R' does not write an attribute slot");
     }
 
     #[test]


### PR DESCRIPTION
## What

Make the Rust client's level, XP, and reputation update **live** in-world. Before this PR the character-sheet panel (and the HUD level/XP readouts) rendered the `P_CharacterSheet` snapshot taken once at login and never refreshed — so after a level-up, XP gain, or reputation change, the panel showed stale login values for the entire session, even though the updates were arriving on the wire.

## Why

Two packet sub-cases were silently dropped:
- **`P_XPUpdate "U"`** (my level changed → XP resets to 0) — `on_xp_update` handled only `'B'`/`'M'`.
- **`P_StatUpdate "R"`** (reputation) — `on_stat_update` handled only `'A'`/`'M'`; its doc-comment even mislabelled `'R'` as "resistances".

And even the data the client *did* track (live XP, attributes) wasn't shown — the sheet panel read the frozen `sheet.*` instead of the live `me_*`.

Blitz reference: `ClientNet.bb:706-709` (`'U'` → `Me\Level = Level : Me\XP = 0`), `ClientNet.bb:1014-1015` (`'R'` → `Me\Reputation = RCE_SignedShortFromStr(...)`).

## How

- `world.rs`: handle `'U'` (read level as **u16** — the server sends a 2-byte field, `ScriptingCommands.bb:2085`; reading i32 would fail the parse and silently never update) → set `me_level`, reset `me_xp`. Handle `'R'` with its distinct layout (rid + signed i16 reputation, **no** attr byte) before the attribute parse, applied only for the local player. New `me_level`/`me_reputation` World fields. (`'L'`, another actor's level, is intentionally not handled — the Rust client has no per-actor level display to feed.)
- `client_window.rs`: seed `me_level`/`me_xp`/`me_reputation` from the login sheet in `enter_outcome` (same pattern as `me_gold`), then read them at the five display sites via disjoint `self.net` access (the established `gold` idiom). The sheet's attribute rows now prefer live `me_attributes`, falling back to the login snapshot before the first update.

## Verification

- `cargo test -p rcce-data -p rcce-net -p rcce-render -p rcce-client --locked` — green (102 lib tests, +2). Release build clean (no warnings).
- **New unit tests**: `'U'` sets level + resets XP (and a truncated `'U'` soft-fails, no panic); `'R'` sign-extends a negative reputation, applies self-only, and is not misparsed as an attribute slot.
- **Headless HUD smoke shot** confirms the reworked display path renders the seeded value correctly at runtime ("Lv 1   5000g"). The default project is byte-identical at login (the seed equals the snapshot); the in-world *change* needs a kill/level-up event (not triggerable headlessly), so the unit tests carry that proof — the display half uses the same disjoint-access pattern as the already-live gold readout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)