### PR TITLE
fix(rust-client): trade offers send the backpack-relative slot (Phase 1B follow-up)

### DIFF
--- a/client-rs/crates/rcce-client/src/bin/client_window.rs
+++ b/client-rs/crates/rcce-client/src/bin/client_window.rs
@@ -730,6 +730,20 @@ struct ContextMenu {
 }
 const CTX_W: f32 = 104.0;
 const CTX_ROW: f32 = 22.0;
+/// First backpack inventory slot (`SlotI_Backpack`, Inventories.bb:29). Slots
+/// 0..13 are equipment; 14..45 are the backpack. The trade wire offers a
+/// BACKPACK-RELATIVE slot (0..31), so an item at absolute slot `s` is offered as
+/// `s - SLOT_BACKPACK`.
+const SLOT_BACKPACK: u8 = 14;
+
+/// Convert an absolute inventory slot to the backpack-relative slot used on the
+/// trade wire (`P_UpdateTrading` `Slot`, `Interface3D.bb:2404`; the server bounds
+/// it `<= 31` and indexes `Amounts[Slot + SlotI_Backpack]`, `ServerNet.bb:798`).
+/// Equipment slots (< `SLOT_BACKPACK`) clamp to 0, but they are never offered —
+/// the offer list filters to `slot >= SLOT_BACKPACK`.
+fn backpack_wire_slot(abs_slot: u8) -> u8 {
+    abs_slot.saturating_sub(SLOT_BACKPACK)
+}
 
 impl ContextMenu {
     /// Build the menu for an actor at `(x,y)`; non-players also get Attack +
@@ -3010,13 +3024,18 @@ impl ApplicationHandler for App {
                                     bp.get(idx).copied()
                                 };
                                 if let Some((slot, item_id, amount)) = item {
+                                    // The wire offer slot is BACKPACK-RELATIVE (0..31);
+                                    // `mine`/`his` are keyed in that same space so the
+                                    // confirm blocks need no per-slot conversion. The
+                                    // panel render converts back for the staged mark.
+                                    let rel = backpack_wire_slot(slot);
                                     if let Some(net) = self.net.as_mut() {
                                         if let Some(pt) = net.world.player_trade.as_mut() {
-                                            let send_amt = pt.toggle_mine(slot, item_id, amount);
+                                            let send_amt = pt.toggle_mine(rel, item_id, amount);
                                             net.transport.send(
                                                 net.peer,
                                                 rcce_net::packet_id::UPDATE_TRADING,
-                                                &rcce_client::net::trade_offer_packet(slot, send_amt),
+                                                &rcce_client::net::trade_offer_packet(rel, send_amt),
                                                 true,
                                             );
                                         }
@@ -7051,8 +7070,8 @@ impl App {
                                 PlayerTradeSlot { slot: 0, item_id: 1, amount: 1 },
                                 PlayerTradeSlot { slot: 1, item_id: 2, amount: 5 },
                             ],
-                            // One backpack slot (14) staged into my offer.
-                            mine: vec![PlayerTradeSlot { slot: 14, item_id: 3, amount: 1 }],
+                            // Backpack-relative slot 0 (= absolute slot 14) staged.
+                            mine: vec![PlayerTradeSlot { slot: 0, item_id: 3, amount: 1 }],
                         });
                         // A couple of backpack items so the numbered "Your items" list
                         // renders (slot 14 is the staged one).
@@ -8369,7 +8388,9 @@ impl App {
                     } else {
                         for (i, &(slot, item_id, amount)) in my_backpack.iter().enumerate() {
                             if y + row_h > foot { break; }
-                            let staged = my_staged.contains(&slot);
+                            // `my_staged` is keyed by backpack-relative slot (the wire
+                            // space); convert this item's absolute slot to match.
+                            let staged = my_staged.contains(&slot.saturating_sub(SLOT_BACKPACK));
                             if staged {
                                 overlay.rect(px + 8.0, y - 1.0, pw - 16.0, row_h, [0.25, 0.5, 0.25, 0.5]);
                             }
@@ -8967,6 +8988,18 @@ mod tests {
         fn assert_send<T: Send>() {}
         assert_send::<EnetTransport>();
         assert_send::<LoginResult>();
+    }
+
+    #[test]
+    fn backpack_wire_slot_is_relative() {
+        // The trade wire offers a BACKPACK-RELATIVE slot: absolute 14 → 0, 21 → 7
+        // (the server rejects > 31 and indexes Amounts[Slot + 14]). Regression for
+        // the bug where the absolute slot was sent, trading the wrong/empty slot.
+        assert_eq!(backpack_wire_slot(SLOT_BACKPACK), 0);
+        assert_eq!(backpack_wire_slot(SLOT_BACKPACK + 7), 7);
+        assert_eq!(backpack_wire_slot(45), 31, "last backpack slot maps to 31");
+        // Equipment slots never reach here, but the conversion must not underflow.
+        assert_eq!(backpack_wire_slot(0), 0);
     }
 
     #[test]

--- a/client-rs/crates/rcce-client/src/bin/trade_test.rs
+++ b/client-rs/crates/rcce-client/src/bin/trade_test.rs
@@ -16,7 +16,7 @@ use enet_sys::EnetTransport;
 use rcce_net::{packet_id as pk, Transport};
 
 use rcce_client::login::{login, Credentials};
-use rcce_client::net::trade_offer_packet;
+use rcce_client::net::{inv_move_packet, trade_offer_packet};
 use rcce_client::world::World;
 
 fn creds(user: &str) -> Credentials {
@@ -94,13 +94,29 @@ fn main() {
         std::process::exit(1);
     }
 
-    // 3. A stages backpack offers (slots 14..=20). The server forwards each that
-    //    A actually owns to B as an inbound P_UpdateTrading.
-    for slot in 14u8..=20 {
-        ta.send(a.peer, pk::UPDATE_TRADING, &trade_offer_packet(slot, 1), true);
+    // 3. Give A something to offer. The wire offer slot is BACKPACK-RELATIVE
+    //    (0..31 = absolute 14..45). If A has no backpack item, move an equipped
+    //    one into backpack slot 14 first.
+    let inv: Vec<(u8, u16)> = a.sheet.as_ref().map(|s| s.inventory.iter().map(|it| (it.slot, it.item_id)).collect()).unwrap_or_default();
+    println!("[trade] A inventory (slot,item): {inv:?}");
+    let has_backpack = inv.iter().any(|&(slot, _)| slot >= 14);
+    let mut tried_offer = has_backpack;
+    if !has_backpack {
+        if let Some(&(eqslot, _)) = inv.iter().find(|&&(slot, _)| slot < 14) {
+            println!("[trade] A has no backpack item; moving equipped slot {eqslot} -> backpack slot 14");
+            ta.send(a.peer, pk::INVENTORY_UPDATE, &inv_move_packet(a.runtime_id, eqslot, 14, 0, false), true);
+            settle(&mut ta, &mut wa, 700);
+            tried_offer = true;
+        }
+    }
+
+    // Offer backpack-RELATIVE slots 0..=7 (absolute 14..=21). The server forwards
+    // each one A actually owns to B as an inbound P_UpdateTrading.
+    for rel in 0u8..=7 {
+        ta.send(a.peer, pk::UPDATE_TRADING, &trade_offer_packet(rel, 1), true);
         for _ in 0..2 { ta.poll(); sleep(Duration::from_millis(40)); }
     }
-    settle(&mut tb, &mut wb, 1200);
+    settle(&mut tb, &mut wb, 1400);
 
     let his = wb.player_trade.as_ref().map(|pt| pt.his.len()).unwrap_or(0);
     println!("[trade] B sees {his} offered item(s) from A: {:?}",
@@ -109,8 +125,13 @@ fn main() {
     ta.disconnect(a.peer);
     tb.disconnect(b.peer);
 
-    // The handshake (both boards open) is the hard pass. Offer-visibility is a
-    // bonus that only fires when A's character has a backpack item to give.
-    println!("[trade] RESULT: PASS — player-trade handshake opened both windows{}.",
-        if his > 0 { format!("; B saw {his} offered item(s)") } else { " (A had no backpack item to offer)".to_string() });
+    // The handshake (both boards open) is the hard pass. When A had an item to
+    // offer, B must observe it — that proves the backpack-relative offer slot is
+    // correct end-to-end (the bug where an absolute slot was sent showed his==0).
+    if tried_offer && his == 0 {
+        eprintln!("[trade] RESULT: FAIL — A offered an item but B saw none (offer slot space wrong?).");
+        std::process::exit(1);
+    }
+    println!("[trade] RESULT: PASS — handshake opened both windows{}.",
+        if his > 0 { format!("; B saw {his} offered item(s) — relative offer slot verified E2E") } else { " (A had no item to offer)".to_string() });
 }


### PR DESCRIPTION
## What

Fixes a correctness bug found in the Phase 1B review (#478): `P_UpdateTrading` offers sent the **absolute** inventory slot (14..45) where the server expects a **backpack-relative** offset (0..31).

## Why it mattered

- `ServerNet.bb:798` bounds the offer `Slot <= 31` and indexes `Amounts[Slot + SlotI_Backpack]` (SlotI_Backpack = 14).
- The Blitz client sends the 0-based backpack index (`Interface3D.bb:2404`).
- So staging an item at absolute slot 14 sent `Slot=14` → the server clamped against slot 28 (usually empty → **silent no-op**) or, for absolute slots > 31, **rejected** the offer. The empty test-account backpack masked this in `trade-test` (his==0 read as "no item to offer").

## How

- `backpack_wire_slot(abs) = abs - SLOT_BACKPACK` converts at the wire boundary (offer send).
- `mine`/`his` are now keyed in the backpack-relative space, so `player_confirm_trade`'s his/mine blocks need no per-slot conversion; the panel converts back only for the staged "+" highlight.
- New `backpack_wire_slot_is_relative` unit test (14→0, 21→7, 45→31, no underflow).
- `trade_test` now moves an equipped item into the backpack when A has none, offers the correct relative slots, and **hard-fails** if A offered an item but B saw none — so a regression is caught E2E once a test account has any item.

## Verification

- `cargo test -p rcce-data -p rcce-net -p rcce-render -p rcce-client --locked` — green (the new conversion test passes; client-window bin 42 tests). Release build clean.
- `RCCE_PLAYERTRADETEST` + `RCCE_SHOT` — the staged "+" mark still renders correctly with relative keying.
- `trade-test` vs the live server — handshake still PASS. (Offer-visibility still 0 because the `rustbot`/`rustbot2` characters have genuinely empty inventories — confirmed via the login sheet — so a live offer demo isn't possible with these accounts; the conversion is locked by the unit test + matches the Blitz reference.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)