### PR TITLE
feat(rust-client): colored directional sun from Suns.dat (warm day / cool night)

### DIFF
--- a/client-rs/crates/rcce-client/src/assets.rs
+++ b/client-rs/crates/rcce-client/src/assets.rs
@@ -39,6 +39,9 @@ pub struct AssetStore {
     /// `Game Data/Fixed Attributes.dat`. `None` when the file is absent (the
     /// `health_stat()` accessor then falls back to the index-0 default).
     fixed_attributes: Option<rcce_data::FixedAttributes>,
+    /// Project sun/moon directional lights from `Game Data/Suns.dat`. `None` when
+    /// absent → the renderer uses a neutral white sun. See `sun_light`.
+    suns: Option<rcce_data::Suns>,
     cache: HashMap<u16, Option<Rc<B3dModel>>>,
     /// Memoised decoded actor skins, keyed by appearance, so per-frame actor
     /// rebuilds don't re-read + re-decode the skin files from disk.
@@ -155,6 +158,10 @@ impl AssetStore {
         let fixed_attributes = std::fs::read(data_root.join("Game Data/Fixed Attributes.dat"))
             .ok()
             .and_then(|b| rcce_data::FixedAttributes::parse(&b).ok());
+        // Project sun/moon directional light colours (warm day / cool night).
+        let suns = std::fs::read(data_root.join("Game Data/Suns.dat"))
+            .ok()
+            .and_then(|b| rcce_data::Suns::parse(&b).ok());
         Ok(Self {
             data_root,
             actors,
@@ -168,6 +175,7 @@ impl AssetStore {
             money,
             attribute_names,
             fixed_attributes,
+            suns,
             cache: HashMap::new(),
             actor_tex_cache: HashMap::new(),
         })
@@ -179,6 +187,15 @@ impl AssetStore {
     /// shipped default project (Health = slot 0).
     pub fn health_stat(&self) -> u8 {
         self.fixed_attributes.and_then(|f| f.health).unwrap_or(0)
+    }
+
+    /// The project's active directional sun colour at `minutes` (game-minutes
+    /// since midnight), normalised `0..1`, or `None` when no sun is visible /
+    /// `Suns.dat` is absent (caller falls back to neutral white). Season 0 (the
+    /// renderer doesn't yet track seasons). The shipped project gives a warm amber
+    /// by day and a cool blue at night.
+    pub fn sun_light(&self, minutes: u16) -> Option<[f32; 3]> {
+        self.suns.as_ref().and_then(|s| s.light_at(minutes, 0))
     }
 
     /// Display name for attribute slot `i` (Health, Mana, Strength, …), or

--- a/client-rs/crates/rcce-client/src/bin/client_window.rs
+++ b/client-rs/crates/rcce-client/src/bin/client_window.rs
@@ -5377,6 +5377,9 @@ impl App {
             // Far shadow centre → menu geometry projects out of the shadow region
             // (always lit): the Set.b3d keeps its baked-lightmap look, no dynamic
             // shadows from the frontal key light.
+            // Neutral white sun for the menu/char-select preview (don't inherit the
+            // world's time-of-day tint after a world→menu transition).
+            view.set_sun_color([1.0; 3]);
             view.render(&gfx.device, &gfx.queue, &oview, vp, eye, fog, menu_fog_near, menu_fog_far, menu_ambient, menu_light, clear, ang, elapsed, 0.0, [1.0e6, 0.0, 1.0e6]);
             overlay.render(&gfx.device, &gfx.queue, &oview, sw, sh);
             match rcce_render::save_texture_png(&gfx.device, &gfx.queue, &tex, w, h, gfx.config.format, &path) {
@@ -5398,6 +5401,8 @@ impl App {
             }
         };
         let tview = frame.texture.create_view(&Default::default());
+        // Neutral white sun for the menu/char-select preview (see above).
+        view.set_sun_color([1.0; 3]);
         view.render(&gfx.device, &gfx.queue, &tview, vp, eye, fog, menu_fog_near, menu_fog_far, menu_ambient, menu_light, clear, ang, elapsed, 0.0, [1.0e6, 0.0, 1.0e6]);
         overlay.render(&gfx.device, &gfx.queue, &tview, sw, sh);
         frame.present();
@@ -7227,6 +7232,13 @@ impl App {
                 }
             });
         let sky = rcce_client::daynight::daynight(phase);
+        // Directional sun colour for the current time-of-day from the project's
+        // Suns.dat (warm amber by day, cool blue at night in the shipped project);
+        // neutral white when the file is absent. The Blitz client colours its
+        // directional light the same way (Environment3D.bb LightColor) — the Rust
+        // client previously lit with a fixed white sun.
+        let sun_minutes = ((phase.rem_euclid(1.0) * 1440.0) as u16) % 1440;
+        view.set_sun_color(store.sun_light(sun_minutes).unwrap_or([1.0; 3]));
         // Weather-driven fog (Blitz Environment3D.bb SetWeather): rain/snow/storm
         // pull the far plane in and snow whitens the fog colour; fog weather pulls
         // it in hard. Clear/Wind leave the authored fog untouched (default path is

--- a/client-rs/crates/rcce-data/src/lib.rs
+++ b/client-rs/crates/rcce-data/src/lib.rs
@@ -18,6 +18,7 @@ pub mod interface;
 pub mod items;
 pub mod money;
 pub mod reader;
+pub mod suns;
 pub mod texture;
 
 pub use actors::{ActorCatalog, ActorTemplate};
@@ -32,6 +33,7 @@ pub use catalog::{
 };
 pub use attributes::{AttributeDef, AttributeNames};
 pub use fixed_attributes::FixedAttributes;
+pub use suns::{Sun, Suns};
 pub use items::{equip_slot, equip_slot_name, ItemCatalog, ItemDef};
 pub use interface::{IComp, InterfaceLayout};
 pub use money::MoneyConfig;

--- a/client-rs/crates/rcce-data/src/suns.rs
+++ b/client-rs/crates/rcce-data/src/suns.rs
@@ -1,0 +1,167 @@
+//! `Game Data/Suns.dat` — the project's directional sun/moon lights. The Blitz
+//! client reads this (`Environment.bb::LoadSuns`, :236-272) and colours the
+//! scene's directional light with the *active* sun's authored RGB
+//! (`Environment3D.bb:430-548` selects by time-of-day window and applies
+//! `LightColor(L\EN, S\LightR, S\LightG, S\LightB)`), turning the plain white
+//! default light off whenever a colored sun is visible.
+//!
+//! The shipped default project is **not** white: the day sun is a warm amber
+//! `(167,153,124)` and the night/moon sun a cool blue `(51,68,93)`. A renderer
+//! that lights with a fixed white sun therefore diverges from the engine across
+//! every sunlit surface — this parser exposes the authored colours so the
+//! directional term can match.
+//!
+//! Per-sun on-disk layout (little-endian, `Environment.bb:248-267`):
+//! `TexID[8] i16 · ShowPhases u8 · Phase_Length u8 · Size f32 · LightR/G/B u8 ·
+//! PathAngle f32 · 12×{StartH,StartM,EndH,EndM} u8 · ShowFlares u8` = 78 bytes,
+//! preceded by a 4-byte sun count.
+
+use crate::reader::{BlitzReader, ReadError};
+
+/// Number of per-sun visibility windows (one per season, `Environment3D.bb`
+/// indexes them by `CurrentSeason`).
+pub const SEASONS: usize = 12;
+
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct Sun {
+    /// Directional light colour, normalised to `0.0..=1.0` (on disk: `u8` RGB).
+    pub light: [f32; 3],
+    /// Per-season visibility window `[start_minute, end_minute)` of the game day
+    /// (minutes since midnight, `0..1440`). When `start > end` the window wraps
+    /// past midnight (e.g. a moon visible 18:00→06:00).
+    pub windows: [(u16, u16); SEASONS],
+}
+
+#[derive(Debug, Clone, Default, PartialEq)]
+pub struct Suns {
+    pub suns: Vec<Sun>,
+}
+
+/// `[start, end)` minute window, wrapping past midnight when `start > end`.
+fn window_contains((start, end): (u16, u16), t: u16) -> bool {
+    if start <= end {
+        t >= start && t < end
+    } else {
+        t >= start || t < end
+    }
+}
+
+impl Suns {
+    pub fn parse(data: &[u8]) -> Result<Suns, ReadError> {
+        let mut r = BlitzReader::new(data);
+        let count = r.read_int()?;
+        // Soft-fail on a corrupt/huge header rather than allocating wildly.
+        if !(0..=64).contains(&count) {
+            return Err(ReadError::CountTooLarge { count: count as i64, max: 64 });
+        }
+        let mut suns = Vec::with_capacity(count as usize);
+        for _ in 0..count {
+            for _ in 0..8 {
+                r.read_short()?; // TexID[8] — unused (phase textures)
+            }
+            r.read_byte()?; // ShowPhases
+            r.read_byte()?; // Phase_Length
+            r.read_float()?; // Size
+            let lr = r.read_byte()? as f32 / 255.0;
+            let lg = r.read_byte()? as f32 / 255.0;
+            let lb = r.read_byte()? as f32 / 255.0;
+            r.read_float()?; // PathAngle
+            let mut windows = [(0u16, 0u16); SEASONS];
+            for w in windows.iter_mut() {
+                let sh = r.read_byte()? as u16;
+                let sm = r.read_byte()? as u16;
+                let eh = r.read_byte()? as u16;
+                let em = r.read_byte()? as u16;
+                // Clamp into a valid day-minute (corrupt hours/minutes soft-fail
+                // to a bounded value instead of a wild window).
+                *w = ((sh * 60 + sm).min(1440), (eh * 60 + em).min(1440));
+            }
+            r.read_byte()?; // ShowFlares
+            suns.push(Sun { light: [lr, lg, lb], windows });
+        }
+        Ok(Suns { suns })
+    }
+
+    /// The directional light colour active at `minutes` (game-minutes since
+    /// midnight) for `season` (`0..SEASONS`), or `None` when no sun is visible
+    /// (the caller then falls back to a neutral white light). Mirrors
+    /// `Environment3D.bb:430-455`: the first sun whose season window contains the
+    /// time is the active directional sun.
+    pub fn light_at(&self, minutes: u16, season: usize) -> Option<[f32; 3]> {
+        let t = minutes % 1440;
+        let s = season.min(SEASONS - 1);
+        self.suns
+            .iter()
+            .find(|sun| window_contains(sun.windows[s], t))
+            .map(|sun| sun.light)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Build a one-sun `Suns.dat` body with a single season-0 window and a colour.
+    fn sun_bytes(rgb: [u8; 3], start: (u8, u8), end: (u8, u8)) -> Vec<u8> {
+        let mut v = Vec::new();
+        for _ in 0..8 {
+            v.extend_from_slice(&0i16.to_le_bytes()); // TexID
+        }
+        v.push(0); // ShowPhases
+        v.push(0); // Phase_Length
+        v.extend_from_slice(&1.0f32.to_le_bytes()); // Size
+        v.extend_from_slice(&rgb); // LightR/G/B
+        v.extend_from_slice(&0.0f32.to_le_bytes()); // PathAngle
+        // 12 season windows; season 0 = the given window, the rest 0,0.
+        v.extend_from_slice(&[start.0, start.1, end.0, end.1]);
+        for _ in 1..SEASONS {
+            v.extend_from_slice(&[0, 0, 0, 0]);
+        }
+        v.push(0); // ShowFlares
+        v
+    }
+
+    #[test]
+    fn parses_day_and_night_suns() {
+        // Mirrors the shipped default: warm day sun (06:00-18:00) + cool night sun
+        // (18:00-06:00, wrapping midnight).
+        let mut data = 2i32.to_le_bytes().to_vec();
+        data.extend(sun_bytes([167, 153, 124], (6, 0), (18, 0))); // day
+        data.extend(sun_bytes([51, 68, 93], (18, 0), (6, 0))); // night (wraps)
+        let suns = Suns::parse(&data).unwrap();
+        assert_eq!(suns.suns.len(), 2);
+        // Day colour ≈ 167/255, 153/255, 124/255.
+        let day = suns.suns[0].light;
+        assert!((day[0] - 167.0 / 255.0).abs() < 1e-4);
+        assert!((day[1] - 153.0 / 255.0).abs() < 1e-4);
+        assert!((day[2] - 124.0 / 255.0).abs() < 1e-4);
+
+        // Noon → the warm day sun; midnight → the cool night sun.
+        assert_eq!(suns.light_at(12 * 60, 0), Some([167.0 / 255.0, 153.0 / 255.0, 124.0 / 255.0]));
+        assert_eq!(suns.light_at(0, 0), Some([51.0 / 255.0, 68.0 / 255.0, 93.0 / 255.0]));
+        // 03:00 is still night (wrap window); 09:00 is day.
+        assert_eq!(suns.light_at(3 * 60, 0), Some([51.0 / 255.0, 68.0 / 255.0, 93.0 / 255.0]));
+        assert_eq!(suns.light_at(9 * 60, 0), Some([167.0 / 255.0, 153.0 / 255.0, 124.0 / 255.0]));
+    }
+
+    #[test]
+    fn no_visible_sun_is_none() {
+        // A single sun visible only 06:00-07:00; any other time → None (white).
+        let mut data = 1i32.to_le_bytes().to_vec();
+        data.extend(sun_bytes([200, 200, 200], (6, 0), (7, 0)));
+        let suns = Suns::parse(&data).unwrap();
+        assert_eq!(suns.light_at(6 * 60 + 30, 0), Some([200.0 / 255.0; 3]));
+        assert_eq!(suns.light_at(12 * 60, 0), None);
+    }
+
+    #[test]
+    fn truncated_and_corrupt_soft_fail() {
+        assert!(Suns::parse(&[]).is_err()); // no count
+        assert!(Suns::parse(&1i32.to_le_bytes()).is_err()); // count=1 but no sun body
+        // A huge count is rejected, not allocated.
+        assert!(Suns::parse(&1_000_000i32.to_le_bytes()).is_err());
+        // A zero-sun file is valid + empty.
+        assert_eq!(Suns::parse(&0i32.to_le_bytes()).unwrap().suns.len(), 0);
+        assert_eq!(Suns { suns: vec![] }.light_at(720, 0), None);
+    }
+}

--- a/client-rs/crates/rcce-render/src/gpu.rs
+++ b/client-rs/crates/rcce-render/src/gpu.rs
@@ -138,6 +138,12 @@ pub struct Uniforms {
     pub light_intensity: f32,
     pub light_dir: [f32; 3],
     pub num_lights: f32,
+    /// Directional sun colour (the project's active `Suns.dat` light, normalised).
+    /// `[1,1,1]` = neutral white. Packed with a trailing pad to keep the 16-byte
+    /// slot alignment; every WGSL `struct U` MUST add this field in the same place
+    /// or the uniform buffer mis-binds (the point lights / actors render wrong).
+    pub light_color: [f32; 3],
+    pub _pad_lc: f32,
     pub lights: [GpuLight; MAX_LIGHTS],
 }
 
@@ -150,6 +156,7 @@ impl Uniforms {
         fog_far: f32,
         ambient: [f32; 3],
         light_dir: [f32; 3],
+        light_color: [f32; 3],
         light_vp: [f32; 16],
     ) -> Uniforms {
         Uniforms {
@@ -163,6 +170,8 @@ impl Uniforms {
             light_intensity: LIGHT_INTENSITY,
             light_dir,
             num_lights: 0.0,
+            light_color,
+            _pad_lc: 0.0,
             lights: [GpuLight { pos_range: [0.0; 4], color: [0.0; 4] }; MAX_LIGHTS],
         }
     }
@@ -497,6 +506,8 @@ struct U {
     light_intensity: f32,
     light_dir: vec3<f32>,
     num_lights: f32,
+    light_color: vec3<f32>,
+    _pad_lc: f32,
     lights: array<Light, 16>,
 };
 @group(0) @binding(0) var<uniform> u: U;
@@ -612,6 +623,8 @@ struct U {
     light_intensity: f32,
     light_dir: vec3<f32>,
     num_lights: f32,
+    light_color: vec3<f32>,
+    _pad_lc: f32,
     lights: array<Light, 16>,
 };
 @group(0) @binding(0) var<uniform> u: U;
@@ -716,7 +729,9 @@ fn cloud_dapple(p: vec2<f32>) -> f32 {
     let sky_amb = u.ambient * vec3<f32>(0.90, 1.02, 1.32);   // cool + brighter (sky)
     let gnd_amb = u.ambient * vec3<f32>(1.02, 0.84, 0.60);   // warm + darker (ground bounce)
     let amb = mix(gnd_amb, sky_amb, up);
-    let shade = amb + vec3<f32>(diff) + point;
+    // Tint the directional (sun) term with the project's active sun colour
+    // (Suns.dat); ambient + point lights keep their own colour. White = neutral.
+    let shade = amb + vec3<f32>(diff) * u.light_color + point;
     // Baked lightmap (1.0 for non-lightmapped meshes via the grey default).
     let lm = textureSample(lmtex, samp, in.uv2).rgb * 2.0;
     let lit = c.rgb * in.color.rgb * shade * lm;
@@ -1611,6 +1626,11 @@ struct U {
     light_intensity: f32,
     light_dir: vec3<f32>,
     _pad: f32,
+    // Mirrors the shared Uniforms slot after num_lights (here `_pad`); the skin
+    // pass tints its diffuse with the directional sun colour. `lights` is still
+    // omitted (skinned actors take no point lights), so this is the last field.
+    light_color: vec3<f32>,
+    _pad_lc: f32,
 };
 @group(0) @binding(0) var<uniform> u: U;
 // Sun shadow map (same group-0 bind0 the scene pass uses) so GPU-skinned actors
@@ -1693,7 +1713,9 @@ struct VsOut {
     // sun-shadow map so GPU-skinned actors fall into shade like the CPU path.
     let ndl = abs(dot(N, L));
     let diff = ndl * u.light_intensity * sun_shadow(in.world, ndl);
-    let shade = u.ambient + vec3<f32>(diff);
+    // Directional sun term tinted by the active sun colour (Suns.dat); ambient
+    // keeps its own colour. White = neutral (matches the pre-Suns.dat behaviour).
+    let shade = u.ambient + vec3<f32>(diff) * u.light_color;
     let lit = c.rgb * in.color * shade;
     let dist = distance(in.world, u.eye);
     let f = clamp((dist - u.fog_near) / max(u.fog_far - u.fog_near, 1.0), 0.0, 1.0);

--- a/client-rs/crates/rcce-render/src/scene.rs
+++ b/client-rs/crates/rcce-render/src/scene.rs
@@ -103,6 +103,7 @@ pub fn render_scene_png(
         fog_far,
         ambient,
         light_dir,
+        [1.0; 3], // neutral sun colour for the offscreen tool render
         no_shadow_vp(),
     );
 
@@ -304,7 +305,7 @@ pub fn render_skinned_png(
     let aspect = width as f32 / height as f32;
     let proj = Mat4::perspective_rh(50f32.to_radians(), aspect, 1.0, 100_000.0);
     let view = Mat4::look_at_rh(Vec3::from(eye), Vec3::from(target), Vec3::Y);
-    let uniforms = Uniforms::new((proj * view).to_cols_array(), eye, fog_color, fog_near, fog_far, ambient, light_dir, no_shadow_vp());
+    let uniforms = Uniforms::new((proj * view).to_cols_array(), eye, fog_color, fog_near, fog_far, ambient, light_dir, [1.0; 3], no_shadow_vp());
 
     let instance = wgpu::Instance::default();
     let adapter = block_on(instance.request_adapter(&wgpu::RequestAdapterOptions {

--- a/client-rs/crates/rcce-render/src/world_view.rs
+++ b/client-rs/crates/rcce-render/src/world_view.rs
@@ -109,6 +109,11 @@ pub struct WorldView {
     /// upload ONCE instead of every frame (the verts rebuild per frame, the
     /// texture does not). Cleared on zone change in `set_scene`.
     particle_tex: HashMap<u16, Rc<wgpu::BindGroup>>,
+    /// Directional sun colour for the next `render` (the project's active
+    /// `Suns.dat` light, normalised). `[1,1,1]` = neutral white. Set per frame via
+    /// `set_sun_color` — a `Cell` so it works through `&self` (the menu render path
+    /// holds the view immutably). WorldView is render-thread-only, so `Cell` is fine.
+    sun_color: std::cell::Cell<[f32; 3]>,
     /// Reusable per-actor skinning uniform buffers + binds (grown as needed).
     actor_pool: Vec<(wgpu::Buffer, wgpu::BindGroup)>,
     /// This frame's skinned draws.
@@ -200,7 +205,7 @@ impl WorldView {
         let uniform_buf = device.create_buffer_init(&wgpu::util::BufferInitDescriptor {
             label: Some("u"),
             contents: bytemuck::bytes_of(&Uniforms::new(
-                [0.0; 16], [0.0; 3], [0.0; 3], 1.0, 2.0, [0.5; 3], [0.0, 1.0, 0.0],
+                [0.0; 16], [0.0; 3], [0.0; 3], 1.0, 2.0, [0.5; 3], [0.0, 1.0, 0.0], [1.0; 3],
                 glam::Mat4::IDENTITY.to_cols_array(),
             )),
             usage: wgpu::BufferUsages::UNIFORM | wgpu::BufferUsages::COPY_DST,
@@ -271,6 +276,7 @@ impl WorldView {
             idx_cache: IndexCache::new(),
             skin_static: HashMap::new(),
             particle_tex: HashMap::new(),
+            sun_color: std::cell::Cell::new([1.0; 3]),
             actor_pool: Vec::new(),
             skinned: Vec::new(),
             zone_lights: Vec::new(),
@@ -366,6 +372,12 @@ impl WorldView {
                 }
             }
         }
+    }
+
+    /// Set the directional sun colour for subsequent `render` calls (the active
+    /// `Suns.dat` light, normalised; `[1,1,1]` = neutral white).
+    pub fn set_sun_color(&self, color: [f32; 3]) {
+        self.sun_color.set(color);
     }
 
     /// Replace the static scene geometry (terrain/scenery + ground plane).
@@ -502,7 +514,7 @@ impl WorldView {
             (proj * view).to_cols_array()
         };
         queue.write_buffer(&self.light_buf, 0, bytemuck::cast_slice(&light_vp));
-        let mut u = Uniforms::new(view_proj, eye, fog_color, fog_near, fog_far, ambient, light_dir, light_vp);
+        let mut u = Uniforms::new(view_proj, eye, fog_color, fog_near, fog_far, ambient, light_dir, self.sun_color.get(), light_vp);
         // Upload the nearest point lights to the focus point (the shadow centre).
         if !self.zone_lights.is_empty() {
             let c = glam::Vec3::from(shadow_center);


### PR DESCRIPTION
## What

The Rust client lit the scene's directional sun as fixed **white**. The Blitz client colours it with the project's active sun RGB (`Environment3D.bb` `LightColor`), and the shipped project authors a **warm amber day sun (167,153,124)** and a **cool blue night sun (51,68,93)** in `Suns.dat`. This PR parses that file and tints the directional light accordingly — a whole-scene visual improvement and a parity fix, while respecting the engine's customizable lighting (a project's authored sun colours are honoured as-authored).

## How

- **rcce-data**: `Suns::parse` reads the 78-byte-per-sun records (LightRGB + 12 per-season visibility windows) and `light_at(minutes, season)` returns the active sun's normalised colour — the first sun whose time window contains the moment, mirroring `Environment3D.bb:430-455` including the midnight-wrap. Soft-fails on corrupt/truncated input.
- **rcce-render**: a `light_color` uniform tints the directional diffuse in the scene + skin shaders (ambient + point lights keep their own colour; white = neutral, byte-identical to before). Added to the shared `Uniforms` and **all three** WGSL `U` structs (scene/water/skin) in lockstep — the skin struct alignment is load-bearing. `WorldView::set_sun_color` (a `Cell`, so the menu render path's `&` view can reset it).
- **rcce-client**: load `Suns.dat` into `AssetStore`; each in-world frame derive the game-minute from the day/night phase and set the sun colour. Menu/char-select preview resets to white.

## Verification

- `cargo test -p rcce-data -p rcce-net -p rcce-render -p rcce-client --locked` — green (rcce-data +3 suns tests, incl. day/night window selection with midnight-wrap, no-visible-sun, and truncated/corrupt soft-fail). Release build clean. Real `Suns.dat` decode confirmed (sun0 = 167,153,124 @ 07:00-16:00; sun1 = 51,68,93 @ 16:01-06:59).
- **Headless RCCE_SHOT** (screenshots in the iteration report): default noon renders **warm** with the actor correctly lit (**not black** — confirming the 3-struct uniform alignment is correct); `RCCE_PHASE=0` midnight renders **cool blue**.

## Deferred
Cross-fade between overlapping suns at dawn/dusk (Blitz lerps `DestR/G/B`); season tracking (uses season 0); the sun colour could also tint water specular.

🤖 Generated with [Claude Code](https://claude.com/claude-code)