### PR TITLE
feat(rust-client): tint the water sun-glint by the active sun colour

### DIFF
--- a/client-rs/crates/rcce-render/src/gpu.rs
+++ b/client-rs/crates/rcce-render/src/gpu.rs
@@ -549,7 +549,13 @@ struct VO { @builtin(position) clip: vec4<f32>, @location(0) uv: vec2<f32>, @loc
     let H = normalize(L + V);
     let sun_up = smoothstep(0.0, 0.30, L.y);
     let spec = pow(max(dot(Ns, H), 0.0), 70.0) * sun_up;
-    let glint = vec3<f32>(1.0, 0.96, 0.86) * spec * 1.1;
+    // Tint the sun-glint by the active sun colour (Suns.dat, the same light that
+    // tints the terrain/actor diffuse since #480), so the water sparkle agrees
+    // with the sky's sun instead of a fixed warm-white. A `mix` (not a raw
+    // multiply) keeps a partial white floor so a dim/cool dusk sun shifts the hue
+    // without extinguishing the sparkle. White light (no Suns.dat) → unchanged.
+    let glint_tint = mix(vec3<f32>(1.0, 1.0, 1.0), u.light_color, 0.6);
+    let glint = vec3<f32>(1.0, 0.96, 0.86) * spec * 1.1 * glint_tint;
     return vec4<f32>(rgb + glint, a);
 }
 "#;


### PR DESCRIPTION
## What

The water specular sun-glint was a fixed warm-white `vec3(1.0, 0.96, 0.86)`. Since #480 the directional diffuse (terrain + actors) is tinted by the project's authored `Suns.dat` sun colour, but the water sparkle stayed daylight-white — so at dawn/dusk the lake glinted warm-white while everything else took the sun's hue. This tints the glint by the same `u.light_color`, closing the inconsistency on the renderer's showcase surface.

## How

A **single shader line** (`gpu.rs` ~552): `glint *= mix(vec3(1.0), u.light_color, 0.6)`.
- `u.light_color` is **already** in the water uniform struct (added in #480) — **no uniform-layout change**, so the actors-black misalignment failure mode can't recur.
- The `mix` (not a raw multiply) keeps a partial white floor so a dim/cool dusk sun shifts the sparkle's hue without extinguishing it.
- **White light** (no `Suns.dat`, or sun below the horizon → `sun_up` already fades the glint) → **byte-identical** to before (`mix(white, white, 0.6) == white`).

## Verification

- `cargo test -p rcce-data -p rcce-net -p rcce-render -p rcce-client --locked` — green. Release build clean.
- **Live render** (the validation for a shader change — WGSL has no GPU under `cargo test`): started `bin/Server.exe -UNLOCK`, captured the Plains water plane via `RCCE_CAMAT="43.2,-4.6,50.56"`. The water shader **validates and renders** correctly with the tinted glint (no validation crash / black). An **A/B vs the un-tinted baseline** at the same angle shows the scene renders correctly with no regression. The white-light path is byte-identical by the `mix` math.

## Follow-up
The bigger visual lever found in recon: a **sun disc + lens-flare** pass (Blitz draws a Sun entity + an 11-slot lens-flare system + ships `Textures/Flares/`; the Rust client renders neither and discards the `ShowFlares` byte). Queued as the next high-impact visual increment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)