### PR TITLE
feat(rust-client): actor combat voice sounds (Attack/Hit/Death) — parity with PlayActorSound

### DIFF
--- a/client-rs/crates/rcce-client/src/assets.rs
+++ b/client-rs/crates/rcce-client/src/assets.rs
@@ -463,6 +463,14 @@ impl AssetStore {
         self.mesh_model(mesh_id)
     }
 
+    /// The voice sound id for an actor `template_id`+`gender` at `Speech_*` `slot`,
+    /// or `None` when unknown/unset. Pair with `sound_path_by_id` to resolve a
+    /// playable file (which returns `None` for a project that ships no such voice
+    /// sound — so combat voices are silent-safe on the default data).
+    pub fn actor_speech_id(&self, template_id: u16, gender: u8, slot: u8) -> Option<u16> {
+        self.actors.speech_id(template_id, gender, slot as usize)
+    }
+
     /// Playable races offered in character create: `(template_id, race_name)`
     /// for every `playable` template that has a usable body mesh, sorted by id.
     pub fn playable_templates(&self) -> Vec<(u16, String)> {

--- a/client-rs/crates/rcce-client/src/bin/client_window.rs
+++ b/client-rs/crates/rcce-client/src/bin/client_window.rs
@@ -6067,6 +6067,22 @@ impl App {
                         audio.play_oneshot(&path, 0.7);
                     }
                 }
+                // Combat voice sounds (Attack/Hit/Death): resolve each (rid, slot)
+                // intent to the actor's template+gender voice id, then a file. All
+                // soft-fail to silence (unknown actor / unset slot / no sound file
+                // shipped), so the default project — which ships no combat voices —
+                // is silent, exactly like the engine's `If Result < 65535` gate.
+                // Collect first to release the drain borrow before the actor lookup.
+                let combat: Vec<(u16, u8)> = net.world.pending_combat_sounds.drain(..).collect();
+                for (rid, slot) in combat {
+                    if let Some(a) = net.world.actors.get(&rid) {
+                        if let Some(sid) = store.actor_speech_id(a.template_id, a.gender, slot) {
+                            if let Some(path) = store.sound_path_by_id(sid) {
+                                audio.play_oneshot(&path, 0.7);
+                            }
+                        }
+                    }
+                }
                 if let Some(mid) = net.world.pending_music.take() {
                     audio.set_music(mid, 0.4, |id| store.music_path(id));
                     println!("[audio] P_Music -> music id {mid}");

--- a/client-rs/crates/rcce-client/src/world.rs
+++ b/client-rs/crates/rcce-client/src/world.rs
@@ -13,6 +13,12 @@ use rcce_net::{packet_id as pk, RecvMessage};
 /// Roughly the airborne duration of the local jump arc.
 pub const JUMP_ANIM_SECS: f32 = 0.5;
 
+// Combat-voice `Speech_*` slots queued into `pending_combat_sounds` (the App
+// resolves them per actor template+gender). Tied to the rcce-data source of truth.
+const SPEECH_ATTACK1: u8 = rcce_data::actors::speech::ATTACK1 as u8;
+const SPEECH_HIT1: u8 = rcce_data::actors::speech::HIT1 as u8;
+const SPEECH_DEATH: u8 = rcce_data::actors::speech::DEATH as u8;
+
 /// How long a remote actor plays its attack swing after a `P_AttackActor`
 /// broadcast (CBT-3). Matches the local player's `me_attack_until` ~0.8 s window.
 pub const ATTACK_ANIM_SECS: f32 = 0.8;
@@ -331,6 +337,13 @@ pub struct World {
     /// App drains these to `audio.play_oneshot` each frame. 2D playback for the
     /// alpha; the `P_Speech`/3D positional attenuation is a noted follow-up.
     pub pending_sounds: Vec<u16>,
+    /// Pending combat voice sounds as `(runtime_id, Speech_* slot)` intents: an
+    /// actor's Attack/Hit/Death cry. The handlers can't resolve the sound id here
+    /// (the speech ids live in the actor *template* in the AssetStore, which the
+    /// `World` doesn't hold), so the App drains these, looks the actor up by
+    /// template+gender, resolves via `ActorCatalog::speech_id`, and plays. Mirrors
+    /// Blitz `PlayActorSound` on combat (ClientNet.bb:1094/1122/1166).
+    pub pending_combat_sounds: Vec<(u16, u8)>,
     /// A pending mid-zone music switch (`P_Music`, AUD-1): the App applies it via
     /// `audio.set_music`, replacing the looping track. `None` when unchanged.
     pub pending_music: Option<u16>,
@@ -951,6 +964,9 @@ impl World {
             .unwrap_or_else(|| "Someone".to_string());
         if let Some(a) = self.actors.get_mut(&rid) {
             a.alive = false;
+            // The dying actor cries out (Death). Only for a known actor (so a
+            // P_ActorDead for an unknown rid queues nothing).
+            self.pending_combat_sounds.push((rid, SPEECH_DEATH));
         }
         if killer == Some(self.my_runtime_id) {
             self.chat.push((format!("You killed {name}!"), [0.3, 1.0, 0.3, 1.0]));
@@ -971,7 +987,7 @@ impl World {
         let Some(rid) = r.u16() else { return };
         match sub {
             b'H' => {
-                // RID is the target I hit (I am the attacker).
+                // RID is the target I hit (I am the attacker): it grunts (Hit1).
                 let (Some(raw_dmg), Some(dtype)) = (r.u16(), r.u8()) else { return };
                 self.combat_events.push(CombatEvent {
                     target: rid,
@@ -979,10 +995,13 @@ impl World {
                     damage: raw_dmg.saturating_sub(1),
                     damage_type: dtype,
                 });
+                self.pending_combat_sounds.push((rid, SPEECH_HIT1));
             }
             b'Y' => {
-                // RID is the attacker who hit me: animate it + floater on me.
+                // RID is the attacker who hit me: animate + voice its swing (Attack1),
+                // floater on me.
                 self.attack_anims.insert(rid, ATTACK_ANIM_SECS);
+                self.pending_combat_sounds.push((rid, SPEECH_ATTACK1));
                 if let (Some(raw_dmg), Some(dtype)) = (r.u16(), r.u8()) {
                     self.combat_events.push(CombatEvent {
                         target: self.my_runtime_id,
@@ -993,8 +1012,10 @@ impl World {
                 }
             }
             _ => {
-                // Broadcast: RID is the attacker (target is RID2, not needed here).
+                // Broadcast: RID is the attacker (target is RID2, not needed here):
+                // animate + voice its swing (Attack1).
                 self.attack_anims.insert(rid, ATTACK_ANIM_SECS);
+                self.pending_combat_sounds.push((rid, SPEECH_ATTACK1));
             }
         }
     }
@@ -1908,6 +1929,38 @@ mod tests {
         // Tick expires the timers.
         w.tick_attack_anims(ATTACK_ANIM_SECS + 0.01);
         assert!(w.attack_anims.is_empty());
+    }
+
+    #[test]
+    fn combat_voice_sound_intents() {
+        let mut w = World { my_runtime_id: 1, ..Default::default() };
+        // Register an actor (rnid 50) so the death cry (which only fires for a
+        // known actor) has a target.
+        w.apply(&msg(
+            pk::NEW_ACTOR,
+            pkt(|p| {
+                p.u32(0).u16(50).u16(1).u32(0).u16(3);
+                p.f32(0.0).f32(0.0).f32(0.0).f32(0.0);
+                p.u8(0).str8("Stag");
+            }),
+        ));
+
+        // 'H' I hit target 9 → the target grunts (Hit1).
+        w.apply(&msg(pk::ATTACK_ACTOR, pkt(|p| { p.u8(b'H').u16(9).u16(6).u8(2); })));
+        // 'Y' attacker 7 hit me → attacker swings (Attack1).
+        w.apply(&msg(pk::ATTACK_ACTOR, pkt(|p| { p.u8(b'Y').u16(7).u16(4).u8(0); })));
+        // Broadcast: attacker 12 → swings (Attack1).
+        w.apply(&msg(pk::ATTACK_ACTOR, pkt(|p| { p.u8(b'X').u16(12).u16(8); })));
+        assert_eq!(
+            w.pending_combat_sounds,
+            vec![(9, SPEECH_HIT1), (7, SPEECH_ATTACK1), (12, SPEECH_ATTACK1)]
+        );
+
+        // Death of the known actor 50 → death cry; an unknown rid queues nothing.
+        w.apply(&msg(pk::ACTOR_DEAD, pkt(|p| { p.u16(50); })));
+        w.apply(&msg(pk::ACTOR_DEAD, pkt(|p| { p.u16(999); })));
+        assert_eq!(w.pending_combat_sounds.last(), Some(&(50, SPEECH_DEATH)));
+        assert_eq!(w.pending_combat_sounds.iter().filter(|(r, _)| *r == 999).count(), 0);
     }
 
     #[test]

--- a/client-rs/crates/rcce-data/src/actors.rs
+++ b/client-rs/crates/rcce-data/src/actors.rs
@@ -11,7 +11,7 @@ use std::collections::HashMap;
 
 use crate::reader::{BlitzReader, ReadError};
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Default)]
 pub struct ActorTemplate {
     pub id: u16,
     pub race: String,
@@ -34,6 +34,12 @@ pub struct ActorTemplate {
     pub female_face_ids: [u16; 5],
     pub male_body_ids: [u16; 5],
     pub female_body_ids: [u16; 5],
+    /// Per-gender speech/voice sound ids (`MSpeechIDs`/`FSpeechIDs`, 16 slots
+    /// each: Greet1/2, Bye1/2, Attack1/2, Hit1/2, RequestHelp, Death, Footstep×2,
+    /// …). `65535` = no sound for that slot. Indexed by the `Speech_*` constants
+    /// (Actors.bb:12-23). The client plays Attack/Hit/Death on combat events.
+    pub male_speech: [u16; 16],
+    pub female_speech: [u16; 16],
     /// Template gender mode: 0 = player-selectable (the P_NewActor wire then
     /// carries a gender byte), 1 = male-only, 2 = female-only.
     pub genders: u8,
@@ -73,6 +79,25 @@ impl ActorCatalog {
             Some(m)
         }
     }
+
+    /// Voice sound id for actor `id`'s `gender` (`0` male → `MSpeechIDs`, else
+    /// female → `FSpeechIDs`, matching `Actors3D.bb:790`) at `Speech_*` `slot`.
+    /// `None` if the template is unknown, the slot is out of range, or the slot is
+    /// unset (`65535`). Mirrors `mesh_for`'s soft-fail.
+    pub fn speech_id(&self, id: u16, gender: u8, slot: usize) -> Option<u16> {
+        let t = self.templates.get(&id)?;
+        let arr = if gender == 0 { &t.male_speech } else { &t.female_speech };
+        arr.get(slot).copied().filter(|&s| s != 65535)
+    }
+}
+
+/// `Speech_*` voice-slot indices into a template's speech arrays (Actors.bb:12-23).
+pub mod speech {
+    pub const ATTACK1: usize = 4;
+    pub const ATTACK2: usize = 5;
+    pub const HIT1: usize = 6;
+    pub const HIT2: usize = 7;
+    pub const DEATH: usize = 9;
 }
 
 fn parse_record(r: &mut BlitzReader) -> Result<ActorTemplate, ReadError> {
@@ -108,9 +133,14 @@ fn parse_record(r: &mut BlitzReader) -> Result<ActorTemplate, ReadError> {
     let female_face_ids = read5(r)?;
     let male_body_ids = read5(r)?;
     let female_body_ids = read5(r)?;
-    // Speech: MSpeech(16) + FSpeech(16) = 32 shorts.
-    for _ in 0..32 {
-        r.read_short()?;
+    // Speech: MSpeech(16) + FSpeech(16) = 32 shorts (voice sound ids, 65535=none).
+    let mut male_speech = [0u16; 16];
+    for slot in &mut male_speech {
+        *slot = r.read_short_u()?;
+    }
+    let mut female_speech = [0u16; 16];
+    for slot in &mut female_speech {
+        *slot = r.read_short_u()?;
     }
     let _blood_tex = r.read_short()?;
     // Attributes[40] × (Value + Maximum) = 80 shorts.
@@ -149,7 +179,35 @@ fn parse_record(r: &mut BlitzReader) -> Result<ActorTemplate, ReadError> {
         female_face_ids,
         male_body_ids,
         female_body_ids,
+        male_speech,
+        female_speech,
         genders,
         playable,
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn speech_id_resolves_per_gender_and_soft_fails() {
+        let mut t = ActorTemplate { id: 3, ..Default::default() };
+        t.male_speech[speech::ATTACK1] = 100;
+        t.male_speech[speech::DEATH] = 105;
+        t.female_speech[speech::ATTACK1] = 200;
+        t.female_speech[speech::HIT1] = 65535; // explicitly "no sound"
+        let mut cat = ActorCatalog::default();
+        cat.templates.insert(3, t);
+
+        // gender 0 → male array; gender 1 (and anything non-zero) → female array.
+        assert_eq!(cat.speech_id(3, 0, speech::ATTACK1), Some(100));
+        assert_eq!(cat.speech_id(3, 0, speech::DEATH), Some(105));
+        assert_eq!(cat.speech_id(3, 1, speech::ATTACK1), Some(200));
+        // 65535 sentinel → None (no sound for that slot).
+        assert_eq!(cat.speech_id(3, 1, speech::HIT1), None);
+        // Unknown template → None; out-of-range slot → None (no panic).
+        assert_eq!(cat.speech_id(99, 0, speech::ATTACK1), None);
+        assert_eq!(cat.speech_id(3, 0, 999), None);
+    }
 }


### PR DESCRIPTION
## What

The Blitz client plays each actor's gender-appropriate voice on combat events — the attacker grunts `Speech_Attack`, the victim `Speech_Hit` (`ClientNet.bb:1122/1166`), and a dying actor cries `Speech_Death` (`:1094`), all via `PlayActorSound` (`Actors3D.bb:790`). The Rust client's combat handlers produced only *visual* feedback (floaters, swing anims, death pose) — **combat was silent**. This closes that parity gap and honors the authored voice data the parser was throwing away.

## How

- **rcce-data**: the `Actors.dat` parser read and **discarded** the 32 per-template speech shorts; now it retains them (`male_speech`/`female_speech: [u16;16]`) and adds `ActorCatalog::speech_id(id, gender, slot)` (0 male → MSpeech, else female → FSpeech; `65535`/unknown/out-of-range → `None`). Byte-offset preserved (32 `read_short` → 32 `read_short_u` = identical consumption), so every field after speech parses unchanged.
- **rcce-client**: the handlers can't resolve the sound id (speech ids live in the AssetStore template, not `World`), so `on_attack_actor`/`on_actor_dead` queue `(runtime_id, Speech_* slot)` intents into a new `pending_combat_sounds`; the App drains them, resolves per actor template+gender via `speech_id` + `sound_path_by_id`, and plays one-shot.

**Fail-safe by construction**: every step soft-fails to silence (unknown actor / unset slot / no sound file), so the default project — which ships **no** combat voice files — is silent, exactly like the engine's `If Result < 65535` gate; a customised project with authored voices gets full parity. Same honor-the-authored-data pattern as FixedAttributes (#469) / Suns (#480).

## Verification

- `cargo test -p rcce-data -p rcce-net -p rcce-render -p rcce-client --locked` — green. Release build clean.
- **Unit tests**: `speech_id` resolver (gender select, `65535`/unknown/out-of-range soft-fail); `combat_voice_sound_intents` (feeds 'H'/'Y'/broadcast `P_AttackActor` + `P_ActorDead`, asserts the correct `(rid, slot)` intents queue, and that an unknown-rid death queues nothing).
- **Live world shot** confirms the actor template parse + render is intact after the speech-field change (two actors render with correct appearance/gender).
- The audible playback itself is unverifiable on starter content (no voice files ship) — like the empty hit-anim ranges — but the intent + resolution logic is fully tested and silent-safe.

## Follow-up
Local-player Attack/Hit voice (needs the local player's template+gender); Attack1/Attack2 + Hit1/Hit2 variant selection (currently the base slot); 3D positional attenuation (consistent with the existing 2D P_Sound path).

🤖 Generated with [Claude Code](https://claude.com/claude-code)