### PR TITLE
fix(rust): restore login-probe first-reply intent (post-#485 follow-up)

### DIFF
--- a/client-rs/crates/rcenet-ffi-probe/src/bin/login_probe.rs
+++ b/client-rs/crates/rcenet-ffi-probe/src/bin/login_probe.rs
@@ -58,7 +58,10 @@ fn main() {
         w.str8(UNAME).str8(&md5).u8(EMAIL.len() as u8).raw(&encrypt_email(EMAIL));
         t.send(peer, pk::CREATE_ACCOUNT, w.as_slice(), true);
         let resp = pump(&mut t, 1500);
-        let r = resp.iter().find(|m| m.connection == peer);
+        // Single-peer probe: take the first reply. (The dead `|| true` predicate
+        // this replaced made `.find` unconditional; `m.connection` isn't a
+        // reliable equal-to-`peer` key across the FFI boundary, so don't filter.)
+        let r = resp.first();
         match r.map(sentinel) {
             Some('Y') => println!("[login] CreateAccount: created"),
             Some('N') => println!("[login] CreateAccount: already exists / refused (ok)"),


### PR DESCRIPTION
## What
Follow-up to #485. That PR cleared a dead `|| true` from the login-probe's `resp.iter().find(|m| m.connection == peer || true)`. Dropping `|| true` left a **live** filter `m.connection == peer` — a behavior change, not the no-op the original commit claimed. `m.connection` isn't a dependable equal-to-`peer` key across the RCEnet FFI boundary (this repo has prior pointer-vs-id history, cf. #462), so the filter can return `None` where the original always returned the first message.

The original intent was just "grab the first reply" on this single-peer probe. This restores that explicitly with `resp.first()` — provably the same value the `|| true` find produced, lint-clean, no surprise.

## Why
A fresh-context reviewer of #485 flagged this as the one genuine semantic change in that PR (everything else was bit-/borrow-verified equivalent). Closing it out faithfully.

## Scope / verification
`rcenet-ffi-probe` is an i686-only diagnostic, not built or tested by CI. Verified by inspection: `resp.first()` and `resp.iter().find(..)` both yield `Option<&RecvMessage>`, so `r.map(sentinel)` is unchanged. No shipping code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)