### PR TITLE
feat(rust): show the "experience points received!" XP toast (Blitz parity)

### DIFF
--- a/client-rs/crates/rcce-client/src/world.rs
+++ b/client-rs/crates/rcce-client/src/world.rs
@@ -853,6 +853,14 @@ impl World {
             Some(b'M') => {
                 if let Some(gain) = MsgReader::new(&d[1..]).i32() {
                     self.me_xp = self.me_xp.saturating_add(gain);
+                    // Blitz toast (ClientNet.bb:698): "<N> experience points
+                    // received!" in warm gold (255,225,100 → LS_XPReceived). Only
+                    // for a real positive gain, so a malformed/zero/negative 'M'
+                    // (the fuzz suite feeds these) shows no confusing message.
+                    if gain > 0 {
+                        self.chat
+                            .push((format!("{gain} experience points received!"), [1.0, 0.882, 0.392, 1.0]));
+                    }
                 }
             }
             Some(b'U') => {
@@ -2199,6 +2207,8 @@ mod tests {
         assert_eq!(w.me_xp_bar, 4);
         w.apply(&msg(pk::XP_UPDATE, pkt(|p| { p.u8(b'M').i32(150); })));
         assert_eq!(w.me_xp, 150);
+        // 'M' also pushes the Blitz "experience points received!" toast.
+        assert!(w.chat.iter().any(|(t, _)| t == "150 experience points received!"));
 
         // Gold: increase then decrease, clamped at 0.
         w.apply(&msg(pk::GOLD_CHANGE, pkt(|p| { p.u8(b'I').i32(100); })));
@@ -2243,6 +2253,34 @@ mod tests {
         // A truncated 'U' (no level bytes) is a safe no-op (soft-fail, no panic).
         w.apply(&msg(pk::XP_UPDATE, pkt(|p| { p.u8(b'U'); })));
         assert_eq!(w.me_level, 5, "truncated 'U' leaves the level unchanged");
+    }
+
+    // The 'M' XP toast (Blitz ClientNet.bb:698) only fires for a real positive
+    // gain — a 0 or negative gain (the malformed-input fuzzer feeds these) still
+    // updates me_xp but must not push a confusing "0 / -N ... received!" line.
+    #[test]
+    fn xp_received_toast_only_on_positive_gain() {
+        let mut w = World { my_runtime_id: 7, ..Default::default() };
+        w.apply(&msg(pk::XP_UPDATE, pkt(|p| { p.u8(b'M').i32(42); })));
+        assert_eq!(w.me_xp, 42);
+        assert_eq!(
+            w.chat.iter().filter(|(t, _)| t.contains("experience points received")).count(),
+            1,
+            "a positive gain pushes exactly one toast"
+        );
+        // Warm gold (255,225,100), matching Blitz Output(...,255,225,100).
+        let (_, col) = w.chat.iter().find(|(t, _)| t.contains("experience")).unwrap();
+        assert_eq!(*col, [1.0, 0.882, 0.392, 1.0]);
+
+        // Zero and negative gains update xp but push NO toast.
+        w.apply(&msg(pk::XP_UPDATE, pkt(|p| { p.u8(b'M').i32(0); })));
+        w.apply(&msg(pk::XP_UPDATE, pkt(|p| { p.u8(b'M').i32(-10); })));
+        assert_eq!(w.me_xp, 32, "xp still tracks the raw gain (42 + 0 - 10)");
+        assert_eq!(
+            w.chat.iter().filter(|(t, _)| t.contains("experience points received")).count(),
+            1,
+            "no extra toast for the 0 / negative gains"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## What
The Blitz client prints a warm-gold chat line on every XP gain — `Output(Str$(XP) + " " + LanguageString$(LS_XPReceived), 255,225,100)` (ClientNet.bb:698). The Rust client's `P_XPUpdate 'M'` handler updated `me_xp` but showed **nothing** — a frequent, player-facing parity gap.

This pushes `"<N> experience points received!"` in warm gold `[1.0, 0.882, 0.392, 1.0]` (= 255,225,100) to the existing `chat` log on a positive `'M'` gain.

## Faithfulness / design
- The string is the shipped `LS_XPReceived` (`data/Game Data/Language.txt`, filtered index 61 = "experience points received!"), hardcoded in English — **consistent with the client's existing all-strings-hardcoded design**. The sibling "You killed {name}!" combat line (world.rs:972) is `LS` index 63 handled the same way. A per-string `Language.txt` read would be inconsistent with the ~hundreds of other hardcoded strings; localizing **all** client strings via a `Language.txt` loader is noted as a deferred follow-up (the right factoring — do it once for everything, not per-string).
- Color matches Blitz exactly (255,225,100).

## Robustness
Gated on `gain > 0`, so a 0 / negative / malformed `'M'` (the iter-16 fuzz suite feeds these) still tracks `me_xp` but shows no confusing "0 / -N received" line.

## Verification
- `cargo +1.95.0 clippy … --all-targets --locked -- -D warnings` → clean (CI-exact toolchain).
- `cargo +1.95.0 test -p rcce-client` → green, incl. an inline assertion in the XP integration test + new `xp_received_toast_only_on_positive_gain` (asserts text, warm-gold color, and the positive-only gate).
- No new render path: the toast appends to the existing `chat` Vec whose render is already proven; the XP-gain trigger needs live combat (not feasible headless), so the pure unit test is the verification surface (same shape as the iter-15 chat-editing increment).

🤖 Generated with [Claude Code](https://claude.com/claude-code)