### PR TITLE
docs(rust): correct XP-toast gate rationale (reviewer #488 follow-up)

### DIFF
--- a/client-rs/crates/rcce-client/src/world.rs
+++ b/client-rs/crates/rcce-client/src/world.rs
@@ -854,9 +854,16 @@ impl World {
                 if let Some(gain) = MsgReader::new(&d[1..]).i32() {
                     self.me_xp = self.me_xp.saturating_add(gain);
                     // Blitz toast (ClientNet.bb:698): "<N> experience points
-                    // received!" in warm gold (255,225,100 → LS_XPReceived). Only
-                    // for a real positive gain, so a malformed/zero/negative 'M'
-                    // (the fuzz suite feeds these) shows no confusing message.
+                    // received!" in warm gold (255,225,100 → LS_XPReceived).
+                    // DELIBERATE deviation from Blitz (which prints it for ANY
+                    // value): gate on a positive gain. The server legitimately
+                    // sends gain==0 as normal traffic — party-split integer
+                    // division `PartyXP = XP / Members` is 0 when XP < Members
+                    // (GameServer.bb:80→106), and BVM_GIVEXP passes any value
+                    // through — so Blitz spams "0 experience points received!" on
+                    // small-kill party splits. Suppressing the zero/penalty toast
+                    // is a quieter, genuine improvement; me_xp itself still tracks
+                    // every gain (the saturating_add above is unconditional).
                     if gain > 0 {
                         self.chat
                             .push((format!("{gain} experience points received!"), [1.0, 0.882, 0.392, 1.0]));


### PR DESCRIPTION
## What
Follow-up to #488. The fresh-context reviewer flagged that the audit comment on the `gain > 0` XP-toast gate was **misleading** — it implied only "malformed/fuzz" packets are non-positive.

In fact the server sends `gain == 0` as **normal traffic**:
- **Party-split integer division** — `PartyXP = XP / Members` yields 0 when a small kill's XP is split across in-area party members (`GameServer.bb:80`→`:106` reaches the `RNID > 0 → "M"` send).
- **`BVM_GIVEXP`** passes any script-supplied value through (so 0 or a penalty is possible).

Blitz prints "0 experience points received!" in those cases. Suppressing that noise is a **deliberate, quieter improvement** over Blitz — not fuzz defense. This corrects the comment to document the deviation honestly.

## Scope
Comment-only. No behavior change, no test change. `me_xp` accounting stays unconditional (`saturating_add` runs for every gain). The `gain > 0` gate (and the reviewer's APPROVE of the behavior) is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)