### PR TITLE
feat(rust): additive overlay pipeline + additive bright screen flashes

### DIFF
--- a/client-rs/crates/rcce-client/src/bin/client_window.rs
+++ b/client-rs/crates/rcce-client/src/bin/client_window.rs
@@ -1071,6 +1071,15 @@ fn lightning_fires(storm: bool, now: f32, next: f32) -> bool {
     storm && now >= next
 }
 
+/// Whether a screen flash of this colour should render ADDITIVELY (a light
+/// burst that brightens the scene) rather than alpha-blended. A bright flash
+/// (white lightning, a spell burst — Rec.709 luminance > 0.5) is light; a dark
+/// flash (a red damage vignette, a fade) is not — and additive black is a
+/// no-op, so a dark flash MUST stay alpha. Pure — unit-tested.
+fn flash_is_additive(color: [f32; 3]) -> bool {
+    0.2126 * color[0] + 0.7152 * color[1] + 0.0722 * color[2] > 0.5
+}
+
 /// A text-field edit operation (chat line). Mirrors the keys the Blitz Gooey
 /// text field handles (`Gooey.bb:4734-4796`).
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -7099,12 +7108,16 @@ impl App {
             if let Ok(at) = fv.parse::<u64>() {
                 if self.frames == at {
                     if let Some(net) = self.net.as_mut() {
+                        // Bright white → exercises the ADDITIVE flash path (the
+                        // luminance split sends this through rect_add), so a
+                        // headless capture during the flash shows the scene
+                        // brightening like a light burst.
                         net.world.flash = Some(rcce_client::world::ScreenFlash {
-                            color: [1.0, 0.1, 0.1],
+                            color: [1.0, 1.0, 1.0],
                             alpha: 0.6,
                             length: 3.0,
                         });
-                        println!("[flashtest] frame {} red flash", self.frames);
+                        println!("[flashtest] frame {} bright (additive) flash", self.frames);
                     }
                 }
             }
@@ -8960,12 +8973,22 @@ impl App {
             }
 
             // Screen flash (ENV-6): a full-screen colour fading out over its
-            // length, drawn on top of the whole HUD.
+            // length, drawn on top of the whole HUD. A BRIGHT flash (lightning,
+            // spell burst) is a light event → render it ADDITIVELY so it
+            // brightens the scene like real light, instead of the old alpha wash
+            // that flattened everything toward the flash colour. A DARK flash
+            // (e.g. a red damage vignette, a fade) stays alpha-blended — additive
+            // black would be a no-op. Split by Rec.709 luminance.
             if let Some((f, start)) = self.flash {
                 let t = (elapsed - start) / f.length;
                 if t < 1.0 {
                     let a = f.alpha * (1.0 - t).max(0.0);
-                    overlay.rect(0.0, 0.0, sw, sh, [f.color[0], f.color[1], f.color[2], a]);
+                    let rgba = [f.color[0], f.color[1], f.color[2], a];
+                    if flash_is_additive(f.color) {
+                        overlay.rect_add(0.0, 0.0, sw, sh, rgba);
+                    } else {
+                        overlay.rect(0.0, 0.0, sw, sh, rgba);
+                    }
                 } else {
                     self.flash = None;
                 }
@@ -9952,5 +9975,21 @@ mod tests {
         // Equidistant-ish but closer to B; and a far point → None.
         assert_eq!(actor_at(700.0, 500.0, &actors, &vp, sw, sh, 60.0), Some(20));
         assert_eq!(actor_at(500.0, 100.0, &actors, &vp, sw, sh, 32.0), None);
+    }
+
+    // Bright flashes (white lightning, spell bursts) render additively; dark
+    // flashes (a red damage vignette, a fade) must stay alpha-blended — additive
+    // black is a no-op, so misrouting a dark flash would make it vanish.
+    #[test]
+    fn flash_additive_only_when_bright() {
+        assert!(flash_is_additive([1.0, 1.0, 1.0]), "white lightning is a light burst");
+        assert!(flash_is_additive([0.9, 0.9, 0.6]), "bright warm flash is additive");
+        assert!(!flash_is_additive([1.0, 0.1, 0.1]), "red damage flash stays alpha (lum ~0.29)");
+        assert!(!flash_is_additive([0.0, 0.0, 0.0]), "a fade-to-black must NOT be additive");
+        assert!(!flash_is_additive([0.2, 0.2, 0.2]), "a dim flash stays alpha");
+        // Pure green is bright enough (lum 0.7152 > 0.5) → additive.
+        assert!(flash_is_additive([0.0, 1.0, 0.0]));
+        // Pure blue is dim (lum 0.0722) → alpha.
+        assert!(!flash_is_additive([0.0, 0.0, 1.0]));
     }
 }

--- a/client-rs/crates/rcce-render/src/overlay.rs
+++ b/client-rs/crates/rcce-render/src/overlay.rs
@@ -111,8 +111,13 @@ struct VsOut { @builtin(position) clip: vec4<f32>, @location(0) uv: vec2<f32>, @
 /// follows call order — a coloured rect drawn after a textured quad sits on top
 /// of it (lets slot numbers / cooldown shading layer over a slot texture).
 enum Cmd {
-    /// Filled rect: x, y, w, h, RGBA.
+    /// Filled rect: x, y, w, h, RGBA (alpha-blended).
     Rect(f32, f32, f32, f32, [f32; 4]),
+    /// Additive filled rect: x, y, w, h, RGBA. Adds `rgb*a` to the framebuffer
+    /// (a light burst) instead of alpha-blending toward the colour. Used for
+    /// bright screen flashes (lightning, spell bursts) so they brighten the
+    /// scene like real light. Same vertex format as `Rect`.
+    RectAdd(f32, f32, f32, f32, [f32; 4]),
     /// Textured quad: x, y, w, h, uv (u0,v0,u1,v1), tint, texture key.
     Tex(f32, f32, f32, f32, [f32; 4], [f32; 4], String),
 }
@@ -121,6 +126,8 @@ enum Cmd {
 /// interleaving coloured and textured runs in submission order.
 pub struct Overlay {
     pipeline: wgpu::RenderPipeline,
+    /// Same as `pipeline` but additive-blended (for bright screen flashes).
+    pipeline_add: wgpu::RenderPipeline,
     cmds: Vec<Cmd>,
     // Textured-quad layer (GUI icons, the XP bar, item icons).
     tex_pipeline: wgpu::RenderPipeline,
@@ -160,6 +167,51 @@ impl Overlay {
                 targets: &[Some(wgpu::ColorTargetState {
                     format: color_format,
                     blend: Some(wgpu::BlendState::ALPHA_BLENDING),
+                    write_mask: wgpu::ColorWrites::ALL,
+                })],
+            }),
+            primitive: wgpu::PrimitiveState::default(),
+            depth_stencil: None,
+            multisample: wgpu::MultisampleState::default(),
+            multiview: None,
+            cache: None,
+        });
+        // Additive variant of the coloured pipeline (same shader + vertex layout,
+        // additive blend): output = dst + src.rgb * src.a. A bright screen flash
+        // drawn through this ADDS light instead of washing the scene toward the
+        // flash colour. (A dark flash must NOT use this — additive black is a
+        // no-op; the caller picks the pipeline by flash luminance.)
+        let pipeline_add = device.create_render_pipeline(&wgpu::RenderPipelineDescriptor {
+            label: Some("overlay-add"),
+            layout: Some(&layout),
+            vertex: wgpu::VertexState {
+                module: &shader,
+                entry_point: "vs",
+                compilation_options: Default::default(),
+                buffers: &[wgpu::VertexBufferLayout {
+                    array_stride: std::mem::size_of::<V2>() as u64,
+                    step_mode: wgpu::VertexStepMode::Vertex,
+                    attributes: &wgpu::vertex_attr_array![0 => Float32x2, 1 => Float32x4],
+                }],
+            },
+            fragment: Some(wgpu::FragmentState {
+                module: &shader,
+                entry_point: "fs",
+                compilation_options: Default::default(),
+                targets: &[Some(wgpu::ColorTargetState {
+                    format: color_format,
+                    blend: Some(wgpu::BlendState {
+                        color: wgpu::BlendComponent {
+                            src_factor: wgpu::BlendFactor::SrcAlpha,
+                            dst_factor: wgpu::BlendFactor::One,
+                            operation: wgpu::BlendOperation::Add,
+                        },
+                        alpha: wgpu::BlendComponent {
+                            src_factor: wgpu::BlendFactor::One,
+                            dst_factor: wgpu::BlendFactor::One,
+                            operation: wgpu::BlendOperation::Add,
+                        },
+                    }),
                     write_mask: wgpu::ColorWrites::ALL,
                 })],
             }),
@@ -241,6 +293,7 @@ impl Overlay {
 
         Overlay {
             pipeline,
+            pipeline_add,
             cmds: Vec::new(),
             tex_pipeline,
             tex_layout,
@@ -326,6 +379,14 @@ impl Overlay {
         self.cmds.push(Cmd::Rect(x, y, w, h, color));
     }
 
+    /// Queue an ADDITIVE filled rectangle: adds `rgb * a` to the framebuffer
+    /// instead of alpha-blending. Use for a bright light burst (a white
+    /// lightning / spell flash) so it brightens the scene. Do NOT use for a
+    /// dark flash (additive black is a no-op — use `rect`).
+    pub fn rect_add(&mut self, x: f32, y: f32, w: f32, h: f32, color: [f32; 4]) {
+        self.cmds.push(Cmd::RectAdd(x, y, w, h, color));
+    }
+
     /// Draw `s` as 8×8 bitmap glyphs (one quad per lit pixel) at `scale` px per
     /// font pixel, top-left at `(x, y)`. Newlines advance a line.
     pub fn text(&mut self, x: f32, y: f32, scale: f32, s: &str, color: [f32; 4]) {
@@ -386,6 +447,7 @@ impl Overlay {
         // A run is a contiguous range of vertices of one kind, drawn together.
         enum Run {
             Colored { start: u32, count: u32 },
+            ColoredAdd { start: u32, count: u32 },
             Textured { key: String, start: u32, count: u32 },
         }
         let mut cverts: Vec<V2> = Vec::new();
@@ -407,6 +469,22 @@ impl Overlay {
                     match runs.last_mut() {
                         Some(Run::Colored { count, .. }) => *count += 6,
                         _ => runs.push(Run::Colored { start, count: 6 }),
+                    }
+                }
+                Cmd::RectAdd(x, y, w, h, c) => {
+                    // Same vertex buffer as Rect (identical V2 layout); only the
+                    // pipeline (blend) differs at replay time.
+                    let start = cverts.len() as u32;
+                    let tl = to_ndc(*x, *y);
+                    let tr = to_ndc(*x + *w, *y);
+                    let br = to_ndc(*x + *w, *y + *h);
+                    let bl = to_ndc(*x, *y + *h);
+                    for p in [tl, tr, br, tl, br, bl] {
+                        cverts.push(V2 { pos: p, color: *c });
+                    }
+                    match runs.last_mut() {
+                        Some(Run::ColoredAdd { count, .. }) => *count += 6,
+                        _ => runs.push(Run::ColoredAdd { start, count: 6 }),
                     }
                 }
                 Cmd::Tex(x, y, w, h, uv, c, key) => {
@@ -461,6 +539,12 @@ impl Overlay {
                 match run {
                     Run::Colored { start, count } => {
                         rp.set_pipeline(&self.pipeline);
+                        rp.set_vertex_buffer(0, cvbuf.slice(..));
+                        rp.draw(*start..(*start + *count), 0..1);
+                    }
+                    Run::ColoredAdd { start, count } => {
+                        // Same coloured vertex buffer, additive pipeline.
+                        rp.set_pipeline(&self.pipeline_add);
                         rp.set_vertex_buffer(0, cvbuf.slice(..));
                         rp.draw(*start..(*start + *count), 0..1);
                     }


### PR DESCRIPTION
## What
A screen flash (lightning, spell burst) is a **light event**, but the client drew it as a full-screen *alpha* rect (`overlay.rect(0,0,w,h,[color,a])`) — which washes the scene toward the flash color (a flat whiteout that loses contrast), not how light behaves. Now a **bright** flash brightens the scene like a real light burst.

## Render infra (`overlay.rs`)
Adds an additive-blended variant of the colored pipeline — `pipeline_add` (blend `dst + src.rgb*src.a`), `Cmd::RectAdd`, `Run::ColoredAdd`, and a `rect_add()` method. Additive rects share the same `V2` vertex buffer as `rect`; only the pipeline differs at replay, and **z-order (submission order) is preserved**. (This is also groundwork an eventual screen-space lens flare needs — though that wants the *textured* pipeline, a later follow-up.)

## Application (`client_window.rs`)
The screen-flash draw routes by **Rec.709 luminance** via the pure, unit-tested `flash_is_additive(color)`:
- **Bright** flash (white lightning, spell burst, lum > 0.5) → `rect_add` (floods light).
- **Dark** flash (red damage vignette, fade-to-black) → `rect` (alpha).

The split is **load-bearing**: additive black is a no-op, so routing a fade-to-black additively would make it vanish. `RCCE_FLASHTEST` now injects a bright white flash so the additive path is exercised headlessly.

## Verification
- `cargo +1.95.0 clippy … --all-targets --locked -- -D warnings` → clean (CI-exact toolchain).
- `cargo +1.95.0 test -p rcce-render -p rcce-client` → green, incl. `flash_additive_only_when_bright` (white/bright→additive; red/black/dim→alpha).
- **Live render** (`RCCE_FLASHTEST` white flash): the scene is flooded with light during the flash vs the normal baseline — the additive light-burst effect, validated headlessly. (Render change → live render is the validation.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)