### PR TITLE
fix(rust): close stale interaction windows on a zone change

### DIFF
--- a/client-rs/crates/rcce-client/src/world.rs
+++ b/client-rs/crates/rcce-client/src/world.rs
@@ -695,6 +695,18 @@ impl World {
         // A zone change invalidates the old actor set (the server re-announces
         // everyone via P_NewActor for the new zone).
         self.actors.clear();
+        // Close any interaction window tied to an entity in the OLD zone — you
+        // can't trade with / talk to / answer a script prompt from an NPC or
+        // partner you just warped away from. The server cancels these
+        // server-side on warp, but the local panel lingers if the warp packet
+        // races (or precedes) the close, leaving a stale window. (Reviewer-
+        // flagged for trades on #477/#479; dialog + script_input are the same
+        // class.) World/projectile state is NOT cleared here — like actors, the
+        // server re-announces/re-simulates it for the new zone.
+        self.current_trade = None;
+        self.player_trade = None;
+        self.dialog = None;
+        self.script_input = None;
         self.zone = Zone {
             area_id,
             name,
@@ -2182,6 +2194,34 @@ mod tests {
         p.u16(50);
         w.apply(&msg(pk::ACTOR_GONE, p.into_bytes()));
         assert!(w.actors.is_empty());
+    }
+
+    // A zone change must close every interaction window tied to an old-zone
+    // entity (trade / dialog / script prompt). You can't trade with / talk to /
+    // answer a prompt from an NPC or partner you just warped away from, so a
+    // lingering panel is stale. Reviewer-flagged for trades (#477/#479); dialog
+    // + script_input are the same class.
+    #[test]
+    fn change_area_closes_stale_interaction_windows() {
+        let mut w = World { my_runtime_id: 1, ..Default::default() };
+        w.current_trade = Some(crate::trade::TradeWindow {
+            kind: crate::trade::TradeKind::Player,
+            offers: vec![],
+        });
+        w.player_trade = Some(crate::trade::PlayerTrade::default());
+        w.dialog = Some(Dialog::default());
+        w.script_input = Some(ScriptInput::default());
+
+        let mut p = MsgWriter::new();
+        p.f32(0.0).f32(0.0).f32(0.0).f32(0.0);
+        p.u8(0).u16(200).u32(9).u8(0).str8("NewZone");
+        w.apply(&msg(pk::CHANGE_AREA, p.into_bytes()));
+
+        assert_eq!(w.zone.name, "NewZone", "zone changed");
+        assert!(w.current_trade.is_none(), "vendor/trade window closed on warp");
+        assert!(w.player_trade.is_none(), "player trade closed on warp");
+        assert!(w.dialog.is_none(), "NPC dialog closed on warp");
+        assert!(w.script_input.is_none(), "script prompt closed on warp");
     }
 
     /// Build a payload (the builders return `&mut Self`, so chaining


### PR DESCRIPTION
## What
`World::on_change_area` cleared the actor set (the server re-announces actors for the new zone) but left every open **interaction window** tied to an old-zone entity: a vendor/player trade, an NPC dialog, a scripted text prompt. After a mid-interaction warp the panel lingers as a stale window — you can't trade with / talk to / answer a prompt from an NPC or partner you just left.

This clears `current_trade`, `player_trade`, `dialog`, and `script_input` in `on_change_area`.

## Why / scope
- The server cancels these server-side on warp, but the local panel survives if the `P_ChangeArea` packet races (or precedes) the close — leaving a stale window.
- Reviewer-flagged for **trades** on #477 / #479; `dialog` and `script_input` are the same "stale NPC-interaction panel" class, so this closes the whole category rather than a partial trades-only fix.
- **World/projectile state is deliberately NOT cleared here** — like actors (`actors.clear()` already present), the server re-announces/re-simulates dropped items, projectiles, etc. for the new zone. The principle: clear client-side *interaction windows* tied to a specific old-zone entity; let the server re-send world state.

## Verification
- `cargo +1.95.0 clippy … --all-targets --locked -- -D warnings` → clean (CI-exact toolchain).
- `cargo +1.95.0 test -p rcce-client` → green, incl. `change_area_closes_stale_interaction_windows` (sets all four windows → applies `P_ChangeArea` → asserts each is `None` and the zone changed).
- Pure-logic change in `World`; no render path touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)