### PR TITLE
fix(rust): finish trade teardown when a warp interrupts a trade (#492 follow-up)

### DIFF
--- a/client-rs/crates/rcce-client/src/bin/client_window.rs
+++ b/client-rs/crates/rcce-client/src/bin/client_window.rs
@@ -5926,6 +5926,10 @@ impl App {
         let mut open_inventory_for_trade = false;
         if let Some(net) = self.net.as_mut() {
             let was_trading = net.world.current_trade.is_some();
+            // Capture (pre-apply) whether ANY trade was open, so that if this
+            // batch contains a P_ChangeArea warp we can finish the teardown the
+            // warp can't reach (server IsTrading flag + the App-side basket).
+            let trade_active_before = net.world.current_trade.is_some() || net.world.player_trade.is_some();
             for m in net.transport.poll() {
                 net.updates += 1;
                 net.world.apply(&m);
@@ -5978,6 +5982,25 @@ impl App {
                 // Mark loaded even if the area file was missing, so we don't
                 // retry the reload (and its disk I/O) every frame.
                 self.loaded_zone = zone;
+                // If the warp interrupted an open trade, finish the teardown the
+                // way an Esc-cancel does. `World::on_change_area` already closed
+                // the local window, but the server still has us flagged
+                // `IsTrading` (its `SetArea` doesn't reset it), and the staged
+                // vendor basket (App-side `pending_*`) would otherwise survive
+                // and resolve stale offer indices against the next vendor. Send
+                // the close (a no-op server-side if we're no longer trading —
+                // safe under the soft-fail packet doctrine) and discard the
+                // basket.
+                if trade_active_before {
+                    net.transport.send(
+                        net.peer,
+                        rcce_net::packet_id::OPEN_TRADING,
+                        &rcce_client::net::trade_close_packet(),
+                        true,
+                    );
+                    self.pending_buys.clear();
+                    self.pending_sells.clear();
+                }
             }
             // Flush any replies the apply() logic queued (e.g. the "GY" accept
             // when the server gives us an item).


### PR DESCRIPTION
## What
Follow-up to #492. The fresh-context reviewer found that clearing the trade *window* on a zone change is only half the teardown:

1. **Server desync** — the server keeps the player flagged `IsTrading` (vendor=1, player=4); its `SetArea` never resets it. The Esc-cancel path sends `trade_close_packet()` to reset it; the #492 warp-clear didn't.
2. **Stale vendor basket** — the App-side staged basket (`pending_buys` = offer indices, `pending_sells` = inv slots) survived the warp. Every *other* trade-teardown clears it; a later vendor would resolve the stale indices against its own offers → a cross-vendor mis-buy / stale-sell.

## Fix
Mirror the Esc-cancel teardown in the live-loop zone-change block: capture whether a trade was open **before** applying the packet batch, and on an *actual* warp send `OPEN_TRADING` + `trade_close_packet()` and discard the basket.

- The close is a **safe no-op server-side** if we're no longer trading (soft-fail packet doctrine — handlers don't `RuntimeError` on wire input).
- Gated on `trade_active_before` so a normal (non-warp) trade close or a warp with no trade open does nothing extra.

Both issues are low-probability (mid-trade warp) and pre-existing, surfaced by the #492 window-clear.

## Verification
- `cargo +1.95.0 clippy … --all-targets --locked -- -D warnings` → clean.
- `cargo +1.95.0 test -p rcce-client` → green.
- App live-loop logic mirroring the proven `EscLayer::Trade` teardown path (client_window.rs:3325-3338); no render path touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)