### PR TITLE
feat(rust): localize client chat strings from Language.txt

### DIFF
--- a/client-rs/crates/rcce-client/src/assets.rs
+++ b/client-rs/crates/rcce-client/src/assets.rs
@@ -42,6 +42,9 @@ pub struct AssetStore {
     /// Project sun/moon directional lights from `Game Data/Suns.dat`. `None` when
     /// absent → the renderer uses a neutral white sun. See `sun_light`.
     suns: Option<rcce_data::Suns>,
+    /// Localizable client strings from `Game Data/Language.txt`. Empty when the
+    /// file is absent → callers fall back to hardcoded English. See `language`.
+    language: rcce_data::Language,
     cache: HashMap<u16, Option<Rc<B3dModel>>>,
     /// Memoised decoded actor skins, keyed by appearance, so per-frame actor
     /// rebuilds don't re-read + re-decode the skin files from disk.
@@ -162,6 +165,11 @@ impl AssetStore {
         let suns = std::fs::read(data_root.join("Game Data/Suns.dat"))
             .ok()
             .and_then(|b| rcce_data::Suns::parse(&b).ok());
+        // Localizable client strings (Language.txt is UTF-8/ASCII text, not a
+        // .dat). Absent / unreadable → empty table → hardcoded-English fallback.
+        let language = std::fs::read_to_string(data_root.join("Game Data/Language.txt"))
+            .map(|t| rcce_data::Language::parse(&t))
+            .unwrap_or_default();
         Ok(Self {
             data_root,
             actors,
@@ -176,6 +184,7 @@ impl AssetStore {
             attribute_names,
             fixed_attributes,
             suns,
+            language,
             cache: HashMap::new(),
             actor_tex_cache: HashMap::new(),
         })
@@ -187,6 +196,14 @@ impl AssetStore {
     /// shipped default project (Health = slot 0).
     pub fn health_stat(&self) -> u8 {
         self.fixed_attributes.and_then(|f| f.health).unwrap_or(0)
+    }
+
+    /// The project's localizable string table (`Game Data/Language.txt`), for
+    /// threading into `World` at enter-world so chat strings honor the project's
+    /// translation. Empty when the file is absent → callers fall back to
+    /// hardcoded English. Cloned (a few KB of small strings, once per login).
+    pub fn language(&self) -> rcce_data::Language {
+        self.language.clone()
     }
 
     /// The project's active directional sun colour at `minutes` (game-minutes

--- a/client-rs/crates/rcce-client/src/bin/client_window.rs
+++ b/client-rs/crates/rcce-client/src/bin/client_window.rs
@@ -3485,6 +3485,9 @@ impl App {
         let mut world = World {
             my_runtime_id: outcome.runtime_id,
             template_genders: store.template_genders(),
+            // Localizable chat strings (Language.txt) — empty unless the project
+            // ships a translation, in which case toasts honor it.
+            language: store.language(),
             // Which attribute slot is Health for this project (default 0);
             // P_StatUpdate reports HP under this slot.
             health_stat: store.health_stat(),

--- a/client-rs/crates/rcce-client/src/world.rs
+++ b/client-rs/crates/rcce-client/src/world.rs
@@ -249,6 +249,10 @@ pub struct World {
     /// whether the wire carries a gender byte (only when mode == 0). Empty map
     /// ⇒ assume 0 (byte present), the players-and-most-NPCs default.
     pub template_genders: HashMap<u16, u8>,
+    /// The project's localizable string table (`Game Data/Language.txt`),
+    /// threaded in at enter-world. Empty (the `Default`) → chat strings use
+    /// their hardcoded-English fallback. See [`World::lang`].
+    pub language: rcce_data::Language,
     pub zone: Zone,
     /// Other actors keyed by runtime id (excludes the local player).
     pub actors: HashMap<u16, Actor>,
@@ -846,6 +850,14 @@ impl World {
         }
     }
 
+    /// A localizable client string by `LS_*` index, or the hardcoded English
+    /// `default` when the project ships no `Language.txt` (or leaves the entry
+    /// blank). Lets chat strings honor a project's translation while the default
+    /// project (English) renders byte-identically.
+    fn lang<'a>(&'a self, idx: usize, default: &'a str) -> &'a str {
+        self.language.get_or(idx, default)
+    }
+
     /// `P_XPUpdate` (ClientNet.bb:689):
     ///   `'B'` + barLevel(u8)  — XP bar position.
     ///   `'M'` + xpGain(i32)   — XP points received (added to total).
@@ -877,8 +889,11 @@ impl World {
                     // is a quieter, genuine improvement; me_xp itself still tracks
                     // every gain (the saturating_add above is unconditional).
                     if gain > 0 {
-                        self.chat
-                            .push((format!("{gain} experience points received!"), [1.0, 0.882, 0.392, 1.0]));
+                        let msg = format!(
+                            "{gain} {}",
+                            self.lang(rcce_data::language::ls::XP_RECEIVED, "experience points received!")
+                        );
+                        self.chat.push((msg, [1.0, 0.882, 0.392, 1.0]));
                     }
                 }
             }
@@ -996,7 +1011,11 @@ impl World {
             self.pending_combat_sounds.push((rid, SPEECH_DEATH));
         }
         if killer == Some(self.my_runtime_id) {
-            self.chat.push((format!("You killed {name}!"), [0.3, 1.0, 0.3, 1.0]));
+            // Blitz: `LanguageString$(LS_YouKilled) + " " + Name$ + "!"` (green,
+            // ClientNet.bb:1091) → "You killed: <name>!". The default keeps the
+            // colon to match Blitz (the prior hardcoded line dropped it).
+            let msg = format!("{} {name}!", self.lang(rcce_data::language::ls::YOU_KILLED, "You killed:"));
+            self.chat.push((msg, [0.3, 1.0, 0.3, 1.0]));
         }
     }
 
@@ -1895,18 +1914,19 @@ mod tests {
         w.actors.insert(9, Actor { runtime_id: 9, name: "Goblin".into(), alive: true, ..Default::default() });
         w.actors.insert(8, Actor { runtime_id: 8, alive: true, ..Default::default() }); // unnamed
 
-        // I (rid 1) killed the Goblin (rid 9): green "You killed Goblin!".
+        // I (rid 1) killed the Goblin (rid 9): green "You killed: Goblin!"
+        // (LS_YouKilled = "You killed:", matching Blitz ClientNet.bb:1091).
         let mut k = MsgWriter::new();
         k.u16(9).u16(1);
         w.apply(&msg(pk::ACTOR_DEAD, k.into_bytes()));
         assert!(!w.actors[&9].alive);
-        assert_eq!(w.chat.last().unwrap().0, "You killed Goblin!");
+        assert_eq!(w.chat.last().unwrap().0, "You killed: Goblin!");
 
         // Unnamed actor killed by me → fallback name.
         let mut k2 = MsgWriter::new();
         k2.u16(8).u16(1);
         w.apply(&msg(pk::ACTOR_DEAD, k2.into_bytes()));
-        assert_eq!(w.chat.last().unwrap().0, "You killed Someone!");
+        assert_eq!(w.chat.last().unwrap().0, "You killed: Someone!");
 
         // A death I didn't cause (killer 7 ≠ me) → marked dead, no chat line.
         w.actors.insert(5, Actor { runtime_id: 5, name: "Rat".into(), alive: true, ..Default::default() });
@@ -1923,6 +1943,33 @@ mod tests {
         let before2 = w.chat.len();
         w.apply(&msg(pk::ACTOR_DEAD, k4.into_bytes()));
         assert_eq!(w.chat.len(), before2);
+    }
+
+    // The XP + kill chat toasts honor a project's translated `Language.txt`
+    // (the "customizable nature" goal). With no language set they use the
+    // hardcoded English (covered by the other toast tests); here a translated
+    // table flows through `World::lang` into the rendered strings.
+    #[test]
+    fn chat_toasts_honor_translated_language() {
+        use rcce_data::language::ls;
+        // A table where only the two LS indices we use are translated (parse
+        // skips blanks, so fill 0..64 with placeholders to keep the indices).
+        let mut lines: Vec<String> = (0..64).map(|i| format!("s{i}")).collect();
+        lines[ls::XP_RECEIVED] = "Erfahrungspunkte erhalten!".into();
+        lines[ls::YOU_KILLED] = "Du hast getoetet:".into();
+        let language = rcce_data::Language::parse(&lines.join("\n"));
+        assert_eq!(language.get(ls::XP_RECEIVED), Some("Erfahrungspunkte erhalten!"));
+
+        let mut w = World { my_runtime_id: 1, language, ..Default::default() };
+
+        // XP gain → "<N> <translated>".
+        w.apply(&msg(pk::XP_UPDATE, pkt(|p| { p.u8(b'M').i32(7); })));
+        assert_eq!(w.chat.last().unwrap().0, "7 Erfahrungspunkte erhalten!");
+
+        // Kill → "<translated> <name>!".
+        w.actors.insert(9, Actor { runtime_id: 9, name: "Goblin".into(), alive: true, ..Default::default() });
+        w.apply(&msg(pk::ACTOR_DEAD, pkt(|p| { p.u16(9).u16(1); })));
+        assert_eq!(w.chat.last().unwrap().0, "Du hast getoetet: Goblin!");
     }
 
     #[test]

--- a/client-rs/crates/rcce-data/src/language.rs
+++ b/client-rs/crates/rcce-data/src/language.rs
@@ -1,0 +1,133 @@
+//! `Game Data/Language.txt` — the client's localizable string table.
+//!
+//! The Blitz client loads this in `Language.bb::LoadLanguage` (:282-318): each
+//! line is `Trim$`-ed; blank lines and comment-only lines (`;` as the first
+//! char) are skipped; an inline `;` truncates the line to the text before it;
+//! the surviving lines are the string constants in declaration order, indexed
+//! 0-based by the `LS_*` constants in `Language.bb`. A project translates the
+//! game purely by editing this file — so honoring it lets the Rust client show
+//! the project's authored strings instead of hardcoded English (the "respect
+//! the engine's customizable nature" goal), with the hardcoded English as a
+//! soft fallback when the file (or a given index) is absent.
+//!
+//! Note: this loader is for client **display** strings. Blitz additionally
+//! upper-cases the `LS_SCKick..LS_SCSeason` slash-command-name range (190..219)
+//! at load so server chat dispatch matches case-insensitively; that's a
+//! server-side concern with no effect on the display strings the client renders,
+//! so it is intentionally not replicated here.
+
+/// Selected `LS_*` indices (from `src/Modules/Language.bb`) the Rust client
+/// resolves. Add more as strings are localized.
+pub mod ls {
+    /// `LS_XPReceived` (61) — appended after the XP number: `"<N> <this>"`.
+    pub const XP_RECEIVED: usize = 61;
+    /// `LS_YouKilled` (63) — prefix of the kill line: `"<this> <name>!"`.
+    pub const YOU_KILLED: usize = 63;
+}
+
+/// The project's localizable string table, parsed from `Language.txt`. `Default`
+/// is the empty table (every `get` → `None`), so a `World`/store without the
+/// file simply falls back to hardcoded English.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct Language {
+    strings: Vec<String>,
+}
+
+impl Language {
+    /// Parse `Language.txt`, mirroring `Language.bb::LoadLanguage` exactly:
+    /// `Trim$` each line; skip blanks and comment-only lines (`;` first); strip
+    /// an inline comment to the text before the `;` (NOT re-trimmed, matching
+    /// Blitz `Left$`); collect the rest in order (0-indexed per the `LS_*`
+    /// constants).
+    pub fn parse(text: &str) -> Language {
+        let mut strings = Vec::new();
+        for raw in text.lines() {
+            let line = raw.trim();
+            if line.is_empty() {
+                continue;
+            }
+            match line.find(';') {
+                Some(0) => continue,                              // comment-only line
+                Some(pos) => strings.push(line[..pos].to_string()), // strip inline comment (no re-trim)
+                None => strings.push(line.to_string()),
+            }
+        }
+        Language { strings }
+    }
+
+    /// The string at `LS_*` index `idx`, or `None` when out of range or empty
+    /// (the caller then uses its hardcoded English default).
+    pub fn get(&self, idx: usize) -> Option<&str> {
+        self.strings.get(idx).map(String::as_str).filter(|s| !s.is_empty())
+    }
+
+    /// The string at `idx`, or `default` (owned) when absent — the common
+    /// "localize with an English fallback" call.
+    pub fn get_or<'a>(&'a self, idx: usize, default: &'a str) -> &'a str {
+        self.get(idx).unwrap_or(default)
+    }
+
+    /// Number of parsed string constants.
+    pub fn len(&self) -> usize {
+        self.strings.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.strings.is_empty()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_skips_comments_and_blanks_and_is_zero_indexed() {
+        // Mirrors the real Language.txt header: comment lines, blanks, then the
+        // first real string at index 0.
+        let txt = "; header comment\n\
+                   ; another\n\
+                   \n\
+                   ; section\n\
+                   \n\
+                   Status: Connecting to server...\n\
+                   Current File Progress:\n";
+        let lang = Language::parse(txt);
+        assert_eq!(lang.len(), 2);
+        assert_eq!(lang.get(0), Some("Status: Connecting to server..."));
+        assert_eq!(lang.get(1), Some("Current File Progress:"));
+        assert_eq!(lang.get(2), None, "out of range → None");
+    }
+
+    #[test]
+    fn inline_comment_stripped_not_retrimmed() {
+        // Blitz `Left$(s, Pos-1)` keeps the text before `;` WITHOUT re-trimming,
+        // so a space before the inline `;` survives. A leading-`;` line is
+        // dropped entirely.
+        let lang = Language::parse("Hello ; trailing comment\n;dropped\nWorld\n");
+        assert_eq!(lang.get(0), Some("Hello ")); // trailing space preserved
+        assert_eq!(lang.get(1), Some("World"));
+        assert_eq!(lang.len(), 2);
+    }
+
+    #[test]
+    fn leading_whitespace_trimmed_then_comment_checked() {
+        // `Trim$` runs before the comment check, so an indented comment is still
+        // a comment, and an indented string is trimmed.
+        let lang = Language::parse("   ; indented comment\n   indented value\n");
+        assert_eq!(lang.len(), 1);
+        assert_eq!(lang.get(0), Some("indented value"));
+    }
+
+    #[test]
+    fn empty_and_default_fall_back() {
+        let lang = Language::default();
+        assert!(lang.is_empty());
+        assert_eq!(lang.get(61), None);
+        assert_eq!(lang.get_or(61, "experience points received!"), "experience points received!");
+        // A present, non-empty entry wins over the default.
+        let lang = Language::parse("a\nb\n");
+        assert_eq!(lang.get_or(1, "fallback"), "b");
+        assert_eq!(lang.get_or(9, "fallback"), "fallback");
+    }
+}

--- a/client-rs/crates/rcce-data/src/lib.rs
+++ b/client-rs/crates/rcce-data/src/lib.rs
@@ -16,6 +16,7 @@ pub mod catalog;
 pub mod fixed_attributes;
 pub mod interface;
 pub mod items;
+pub mod language;
 pub mod money;
 pub mod reader;
 pub mod suns;
@@ -36,6 +37,7 @@ pub use fixed_attributes::FixedAttributes;
 pub use suns::{Sun, Suns};
 pub use items::{equip_slot, equip_slot_name, ItemCatalog, ItemDef};
 pub use interface::{IComp, InterfaceLayout};
+pub use language::Language;
 pub use money::MoneyConfig;
 pub use reader::{BlitzReader, ReadError};
 


### PR DESCRIPTION
## What
The client hardcoded its English chat strings; the Blitz engine reads them from `Game Data/Language.txt` (`Language.bb::LoadLanguage`), which a project edits to **translate the game**. Honoring it is the "respect the engine's customizable nature" goal — with the hardcoded English kept as a soft fallback so the default (English) project renders unchanged.

## Pieces
- **`rcce-data::language`** — a faithful parser of `Language.txt`, mirroring `LoadLanguage` *exactly*: `Trim$` each line; skip blanks and comment-only lines (`;` first); strip an inline comment to the text before `;` (**not** re-trimmed, matching Blitz `Left$`); collect the rest 0-indexed per the `LS_*` constants. `ls::` consts for the indices used; `get` / `get_or` with an English fallback.
  - The `190..219` slash-command-name upper-casing in `LoadLanguage` is a *server* chat-dispatch concern with no effect on the display strings the client renders — intentionally not replicated (documented).
- **`AssetStore`**: loads `Game Data/Language.txt` (UTF-8 text; absent/unreadable → empty table → English fallback) + a `language()` accessor; threaded into `World` at enter-world exactly like `template_genders` / `health_stat`.
- **`World::lang(idx, default)`** resolves a string; the XP toast and the kill toast now flow through it.

## Parity fix (bundled)
The kill toast also gains a fix: Blitz is `LanguageString$(LS_YouKilled) + " " + Name$ + "!"` = **"You killed: \<name\>!"** (ClientNet.bb:1091, `LS_YouKilled` = "You killed:"). The prior hardcoded Rust line dropped the colon.

## Verification
- `cargo +1.95.0 clippy … --all-targets --locked -- -D warnings` → clean.
- `cargo +1.95.0 test -p rcce-data -p rcce-client` → green: 4 parser cases (comment/blank skipping, inline-comment strip without re-trim, indent handling, empty/default fallback) + `chat_toasts_honor_translated_language` (a German `Language` table flows through to both toasts). The two existing kill-message asserts updated for the restored colon.
- Default (no/English `Language.txt`) renders byte-identically (soft fallback); pure-logic, no render path.

Follow-up: the helper makes localizing each remaining hardcoded client string a one-liner — a natural batch follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)