### PR TITLE
fix(rust): stop menu instruction text overlapping the skinned buttons

### DIFF
--- a/client-rs/crates/rcce-client/src/bin/client_window.rs
+++ b/client-rs/crates/rcce-client/src/bin/client_window.rs
@@ -5704,8 +5704,12 @@ impl App {
             if !self.login_msg.is_empty() {
                 overlay.text(fx, y, 1.05, &self.login_msg, [1.0, 0.7, 0.5, 1.0]);
             }
+            // Flow the server line right under the fields/message — NOT at
+            // `wy + wh*0.88`, which collides with the BQuit button (`0.84..0.95`)
+            // at the 16:10 default window (the old position only cleared at the
+            // 16:9 smoke-test aspect).
             let srv = format!("server {}:{}", self.host, self.port);
-            overlay.text(fx, wy + wh * 0.88, 0.9, &srv, [0.5, 0.55, 0.65, 0.85]);
+            overlay.text(fx, y + 22.0, 0.9, &srv, [0.5, 0.55, 0.65, 0.85]);
             let hint = "Tab switch field   Enter login   F1 sound options   Esc quit";
             overlay.text(sw * 0.5 - hint.len() as f32 * 9.0 * 0.5, wy + wh + 12.0, 1.0, hint, [0.6, 0.66, 0.8, 0.9]);
             return;
@@ -5773,7 +5777,12 @@ impl App {
                 } else {
                     "Up/Down select   Enter play   C create   Del delete   Esc back"
                 };
-                overlay.text(sw * 0.5 - hint.len() as f32 * 9.0 * 0.5, py + ph + 14.0, 1.0, hint, [0.6, 0.66, 0.8, 0.9]);
+                // Anchor the hint just below the BUTTON ROW (`wy + wh*0.87..0.97`,
+                // the centred window), NOT `py + ph + 14` (the roster panel) — the
+                // two anchors collide at the 16:10 default window, drawing the hint
+                // on top of the Start/Create/Delete/Cancel buttons. `wy + wh` sits
+                // below the buttons at every aspect.
+                overlay.text(sw * 0.5 - hint.len() as f32 * 9.0 * 0.5, wy + wh + 6.0, 1.0, hint, [0.6, 0.66, 0.8, 0.9]);
             }
             Mode::InWorld => {}
         }


### PR DESCRIPTION
## What (user-reported)
On the **Login** and **CharSelect** screens the instruction text was drawn **on top of the skinned action buttons**.

## Root cause
The text and the buttons were anchored to **different reference frames** that only happened to clear each other at the 16:9 aspect we always used for smoke-test screenshots (**1280×720**) — but the interactive window defaults to **1280×800** (16:10, `client_window.rs:2762`), where they collide:

- **Login:** the "server host:port" line sat at `wy + wh*0.88`, inside the **BQuit** button band (`0.84..0.95`). Now it flows just under the fields (`y + 22`), above the buttons.
- **CharSelect:** the keyboard hint sat at `py + ph + 14` (anchored to the roster **panel**), landing on the **Start/Create/Delete/Cancel** button row (anchored to the centred **window**, `wy + wh*0.87..0.97`). Now it's anchored to the same window (`wy + wh + 6`), so it sits just below the buttons.

Both anchors are now relative to the same frame as the buttons, so they clear at **every aspect**.

## This is also the "smoke-test improvements that didn't reach the client" issue
It wasn't a code-path divergence — it was a **verification-size gap**. Every menu screenshot we took pinned 1280×720; the client runs 1280×800. The overlap was invisible to our checks. **Menu/HUD layout must be verified at the 1280×800 default going forward.**

## Verification (live render)
- **Login** + **CharSelect** captured at **both 1280×800 and 1280×720** → instruction text clears the buttons at both; no new overlap.
- In-world **HUD** spot-checked at 1280×800 → unaffected (fractional Interface.dat coords).
- `cargo +1.95.0 clippy … --all-targets --locked -- -D warnings` → clean; `cargo +1.95.0 test -p rcce-client` → 114 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)