### PR TITLE
fix(rust): keep CharSelect roster panel above the buttons at tall/4:3 aspects

### DIFF
--- a/client-rs/crates/rcce-client/src/bin/client_window.rs
+++ b/client-rs/crates/rcce-client/src/bin/client_window.rs
@@ -5724,9 +5724,16 @@ impl App {
         // layout (the 3D character fills the open right area). Only CharSelect
         // reaches here — the other modes draw + return above.
         let pw = (sw * 0.30).clamp(300.0, 520.0);
-        let ph = sh * 0.66;
         let px = sw * 0.025;
         let py = sh * 0.17;
+        // Clamp the panel height so its bottom-anchored content (the last roster
+        // rows, the select/delete message at `py+ph-30`, the creation box at
+        // `py+ph-96`) stays ABOVE the centred button row (`wy + wh*0.87`). The
+        // panel is anchored to SCREEN fractions while the buttons are anchored to
+        // the centred window, so on tall / 4:3 windows (e.g. 1280x1024) the
+        // unclamped `sh*0.66` bottom slides into the button band and draws under
+        // the Start/Create/Delete/Cancel buttons.
+        let ph = (sh * 0.66).min((wy + wh * 0.87) - py - 12.0).max(160.0);
         overlay.rect(px, py, pw, ph, [0.05, 0.06, 0.10, 0.86]);
         overlay.rect(px, py, pw, 2.5, [0.45, 0.5, 0.65, 0.95]);
         overlay.rect(px, py + ph - 2.5, pw, 2.5, [0.45, 0.5, 0.65, 0.95]);


### PR DESCRIPTION
## What
Follow-up to #498 (the menu button/text overlap fix). A fresh-context reviewer flagged a *remaining* aspect-ratio overlap: the CharSelect roster panel is anchored to **screen fractions** (`py = sh*0.17`, `ph = sh*0.66`) while the action buttons are anchored to the **centred window** (`wy + wh*0.87`). At tall / 4:3 windows (e.g. **1280×1024**), the panel's screen-fraction bottom slides into the window-anchored button band, so the last roster rows, the select/delete message (`py+ph-30`), and the creation box (`py+ph-96`) render **under** the Start/Create/Delete/Cancel buttons.

## Fix
Clamp the panel height to end above the button row at every aspect:
```rust
ph = (sh*0.66).min((wy + wh*0.87) - py - 12.0).max(160.0)
```
At the 1280×800 default and 1280×720 this only trims ~20px (the panel already sat ~10px into the buttons *translucently*, with no text in that band) → no visible regression. At 1280×1024 the panel and all its content now clear the buttons.

## Verification (live render)
Captured CharSelect at **1280×1024** (the previously-broken 4:3 case → now clear), **1280×800** (default → no regression), **1280×720** (→ no regression). `cargo +1.95.0 clippy … --all-targets -- -D warnings` clean; `cargo +1.95.0 test -p rcce-client` → 114 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)