### PR TITLE
feat(rust): show a "Picked up item: <name> (xN)" toast on loot (Blitz parity)

### DIFF
--- a/client-rs/crates/rcce-client/src/bin/client_window.rs
+++ b/client-rs/crates/rcce-client/src/bin/client_window.rs
@@ -6114,6 +6114,27 @@ impl App {
                 self.bubbles.insert(rid, (text, col, elapsed));
             }
             self.bubbles.retain(|_, (_, _, start)| elapsed - *start < 5.0);
+            // Item-pickup chat toast (parity, ClientNet.bb:1349/1351): a green
+            // "Picked up item: <name> (xN)" line when I loot a dropped item. The
+            // item NAME lives in the catalog (not World), so World queues a
+            // (item_id, amount) intent and we resolve name + localized prefix
+            // here. Drain into a local first to release the borrow.
+            let pickups: Vec<(u16, u16)> = net.world.pending_pickup_toasts.drain(..).collect();
+            for (item_id, amount) in pickups {
+                let name = store.item_name(item_id);
+                let line = {
+                    let prefix = net
+                        .world
+                        .language
+                        .get_or(rcce_data::language::ls::PICKED_UP_ITEM, "Picked up item:");
+                    if amount > 1 {
+                        format!("{prefix} {name} (x{amount})")
+                    } else {
+                        format!("{prefix} {name}")
+                    }
+                };
+                net.world.chat.push((line, [0.3, 1.0, 0.3, 1.0]));
+            }
             // Inbound sound (AUD-4/5: P_Sound/P_Speech) + mid-zone music switch
             // (AUD-1: P_Music). Drain the queued events to the audio engine —
             // one-shots play 2D for the alpha; the music switch replaces the

--- a/client-rs/crates/rcce-client/src/world.rs
+++ b/client-rs/crates/rcce-client/src/world.rs
@@ -348,6 +348,12 @@ pub struct World {
     /// template+gender, resolves via `ActorCatalog::speech_id`, and plays. Mirrors
     /// Blitz `PlayActorSound` on combat (ClientNet.bb:1094/1122/1166).
     pub pending_combat_sounds: Vec<(u16, u8)>,
+    /// `(item_id, amount)` of items the local player just picked up off the
+    /// ground (`P_InventoryUpdate "R"`). The App drains these, resolves the item
+    /// NAME (which lives in the AssetStore, not `World`) + the localized prefix,
+    /// and pushes a green "Picked up item: <name> (xN)" chat line — Blitz parity
+    /// (ClientNet.bb:1349/1351).
+    pub pending_pickup_toasts: Vec<(u16, u16)>,
     /// A pending mid-zone music switch (`P_Music`, AUD-1): the App applies it via
     /// `audio.set_music`, replacing the looping track. `None` when unchanged.
     pub pending_music: Option<u16>,
@@ -1142,6 +1148,9 @@ impl World {
                 let (Some(handle), Some(slot)) = (r.u32(), r.u8()) else { return };
                 if let Some(di) = self.dropped_items.remove(&handle) {
                     self.inv_add(slot, di.item_id, di.amount, di.health);
+                    // Queue the "Picked up item: <name> (xN)" toast (resolved +
+                    // localized App-side, since item names live in the catalog).
+                    self.pending_pickup_toasts.push((di.item_id, di.amount));
                 }
             }
             // Given an item: handle u32 + ItemID u16 + Amount u16. Place it in a
@@ -2089,6 +2098,35 @@ mod tests {
         w.apply(&msg(pk::ATTACK_ACTOR, pkt(|p| { p.u8(b'Y').u16(8).u16(6).u8(0); })));
         assert!(w.attack_anims.contains_key(&8));
         assert_eq!(w.combat_events.last().unwrap().damage, 5);
+    }
+
+    // Looting a dropped item ('R') moves it into inventory AND queues a
+    // (item_id, amount) pickup-toast intent for the App to resolve into the
+    // green "Picked up item: <name> (xN)" chat line — Blitz parity
+    // (ClientNet.bb:1349). An 'R' for an unknown handle queues nothing.
+    #[test]
+    fn pickup_queues_toast_intent() {
+        let mut w = World::default();
+        // 'D': a stack of 3 of item 77 drops in the world at handle 9 (header
+        // amount/x/y/z/handle, then the 83-byte ItemInstance: id u16 + 80 + health).
+        w.apply(&msg(pk::INVENTORY_UPDATE, pkt(|p| {
+            p.u8(b'D').u16(3).f32(1.0).f32(2.0).f32(3.0).u32(9);
+            p.u16(77);
+            for _ in 0..80 {
+                p.u8(0);
+            }
+            p.u8(100);
+        })));
+        assert!(w.dropped_items.contains_key(&9));
+
+        // 'R': I pick it up into backpack slot 14.
+        w.apply(&msg(pk::INVENTORY_UPDATE, pkt(|p| { p.u8(b'R').u32(9).u8(14); })));
+        assert!(!w.dropped_items.contains_key(&9), "removed from the world on pickup");
+        assert_eq!(w.pending_pickup_toasts, vec![(77, 3)], "queued (item_id, amount)");
+
+        // An 'R' for a handle that isn't in the world queues no toast.
+        w.apply(&msg(pk::INVENTORY_UPDATE, pkt(|p| { p.u8(b'R').u32(999).u8(0); })));
+        assert_eq!(w.pending_pickup_toasts.len(), 1, "no toast for an unknown handle");
     }
 
     #[test]

--- a/client-rs/crates/rcce-data/src/language.rs
+++ b/client-rs/crates/rcce-data/src/language.rs
@@ -23,6 +23,8 @@ pub mod ls {
     pub const XP_RECEIVED: usize = 61;
     /// `LS_YouKilled` (63) — prefix of the kill line: `"<this> <name>!"`.
     pub const YOU_KILLED: usize = 63;
+    /// `LS_PickedUpItem` (64) — prefix of the loot line: `"<this> <name> (xN)"`.
+    pub const PICKED_UP_ITEM: usize = 64;
 }
 
 /// The project's localizable string table, parsed from `Language.txt`. `Default`


### PR DESCRIPTION
## What
Looting a dropped item (`P_InventoryUpdate "R"`) moved it into the inventory but gave **no feedback**. Blitz prints a green "<LS_PickedUpItem> <name> (xN)" chat line on ground pickup (ClientNet.bb:1349/1351); the Rust client showed nothing. This adds the toast.

## How
Item **names** live in the catalog (AssetStore), not `World` — so, like the combat-sound intents, the `'R'` handler queues an `(item_id, amount)` intent (`pending_pickup_toasts`), and the App drains it each frame, resolving the name via `store.item_name` and the localized prefix via `World::lang` (`LS_PickedUpItem` = 64, "Picked up item:"), then pushes a green chat line. The `(xN)` suffix shows only for stacks > 1, matching Blitz.

## Scope (matches Blitz exactly)
Only the ground-pickup `'R'` path toasts. The `'G'` (script/NPC-given) path does **not** toast in Blitz either — verified — and is left unchanged. (No sibling gap.)

## Verification
- `cargo +1.95.0 clippy … --all-targets --locked -- -D warnings` → clean.
- `cargo +1.95.0 test -p rcce-data -p rcce-client` → green, incl. `pickup_queues_toast_intent` (a 'D' drop then an 'R' pickup queues `(item_id, amount)`; an 'R' for an unknown handle queues nothing). The App-side name/prefix resolution mirrors the proven `pending_combat_sounds` drain.
- Uses the localization infra (#494), so a translated `Language.txt` localizes the prefix; English default unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)