### PR TITLE
fix(rust): render the local player's own body with its real race template

### DIFF
--- a/client-rs/crates/rcce-client/src/bin/client_window.rs
+++ b/client-rs/crates/rcce-client/src/bin/client_window.rs
@@ -6268,8 +6268,9 @@ impl App {
             let need_rebake = hash != self.last_dyn_hash;
             if self.gpu_skin || need_rebake {
                 let (models, textures, place, keys, skinned) = build_actors(
-                    store, &net.world, elapsed, self.gpu_skin, moving, run, 0, me_attack, me_jumping,
-                    me_jump_offset, self.first_person, me_fidget, self.height_field.as_ref(),
+                    store, &net.world, elapsed, self.gpu_skin, moving, run, net.world.me_actor_id,
+                    me_attack, me_jumping, me_jump_offset, self.first_person, me_fidget,
+                    self.height_field.as_ref(),
                 );
                 // GPU-skinned bodies (when enabled) — static mesh + pose uniform. Cheap;
                 // runs every frame so the body animates at display rate.

--- a/client-rs/crates/rcce-client/src/world.rs
+++ b/client-rs/crates/rcce-client/src/world.rs
@@ -231,6 +231,11 @@ pub struct World {
     /// Local player's buffered authoritative positions `[time, x, z]` for
     /// time-based render interpolation (see [`World::tick_movement`]).
     pub me_samples: Vec<[f32; 3]>,
+    /// Local player's actor template id (= race), from our own P_NewActor. The
+    /// in-world body mesh/scale/hair are resolved from this (like every other
+    /// actor); without it the local body fell back to template 0, rendering the
+    /// wrong race for any non-default-race character.
+    pub me_actor_id: u16,
     /// Local player's appearance (from our own P_NewActor).
     pub me_gender: u8,
     pub me_face_tex: u8,
@@ -779,6 +784,9 @@ impl World {
             self.me_render_z = z;
             self.me_render_init = true;
             self.me_samples.clear(); // fresh trail at spawn (snaps, then interpolates)
+            // Capture our own template (race) so the in-world body renders with
+            // the correct race mesh — the server sends it in our P_NewActor.
+            self.me_actor_id = template_id;
             self.me_gender = gender;
             self.me_face_tex = face_tex;
             self.me_body_tex = body_tex;
@@ -2127,6 +2135,30 @@ mod tests {
         // An 'R' for a handle that isn't in the world queues no toast.
         w.apply(&msg(pk::INVENTORY_UPDATE, pkt(|p| { p.u8(b'R').u32(999).u8(0); })));
         assert_eq!(w.pending_pickup_toasts.len(), 1, "no toast for an unknown handle");
+    }
+
+    // Our own P_NewActor (rid == my_runtime_id) carries our actor template
+    // (race); capture it into `me_actor_id` so the in-world body uses the right
+    // race mesh. Previously the template was dropped and the body fell back to 0.
+    #[test]
+    fn own_new_actor_captures_race_template() {
+        let mut w = World { my_runtime_id: 42, ..Default::default() };
+        assert_eq!(w.me_actor_id, 0, "defaults to 0 before our spawn packet");
+        // P_NewActor for ME (rid 42), template 7.
+        w.apply(&msg(pk::NEW_ACTOR, pkt(|p| {
+            p.u32(0).u16(42).u16(1).u32(0).u16(7); // area rid level xp template
+            p.f32(1.0).f32(2.0).f32(3.0).f32(0.5); // x y z yaw
+            p.u8(1).str8("MyChar"); // isPlayer name
+        })));
+        assert_eq!(w.me_actor_id, 7, "captured our race template from our own P_NewActor");
+        // Another actor's P_NewActor must NOT overwrite our template.
+        w.apply(&msg(pk::NEW_ACTOR, pkt(|p| {
+            p.u32(0).u16(50).u16(1).u32(0).u16(3);
+            p.f32(0.0).f32(0.0).f32(0.0).f32(0.0);
+            p.u8(0).str8("Stag");
+        })));
+        assert_eq!(w.me_actor_id, 7, "an NPC's template doesn't change ours");
+        assert_eq!(w.actors[&50].template_id, 3, "the NPC still records its own");
     }
 
     #[test]


### PR DESCRIPTION
## What
In-world, the local player's body was built with `me_template = 0` **hardcoded** (the in-world `build_actors` call), not the selected character's race. The body **mesh**, render **scale**, and **hair/beard** attachments are all resolved *from* the template (`store.actor_model(tmpl, gender)`, `actor_render_scale`, `actor_attachments`), so any character whose race template isn't 0 rendered as the **wrong race to itself** — other players saw it correctly (server-sent appearance), but the local player saw a default body.

## Root cause
`on_new_actor` already handles our **own** `P_NewActor` (the `runtime_id == my_runtime_id` branch sets `me_gender/face/body/hair/beard` from it) but **dropped** the `template_id` it had just parsed.

## Fix
Capture it into a new `World::me_actor_id` and pass it (not `0`) to the in-world `build_actors`. Because it's driven by our own spawn packet:
- works on **every** entry path (auto-login *and* char-select),
- re-syncs on a **zone warp** (the server re-sends our `P_NewActor`).

The menu/char-select 3D preview already passed the real `c.actor_id`, so this makes the in-world body consistent with it.

## Verification
- `cargo +1.95.0 clippy … --all-targets --locked -- -D warnings` → clean; `cargo +1.95.0 test -p rcce-client` → 116 pass, incl. new `own_new_actor_captures_race_template` (our P_NewActor sets `me_actor_id`; an NPC's doesn't overwrite it).
- Live 1280×800 in-world render of the Human starter character is **unchanged (no regression)** and consistent with its char-select preview.
- The *visible* race correction applies to non-default-race characters, which the all-Human starter project can't exhibit — the fix is correct-by-construction (Me now uses its server-sent template like every other actor).

Also unblocks the deferred local-player combat voice (which needs Me's template for `actor_speech_id`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)