### PR TITLE
feat(rust): render server-driven floating numbers (P_FloatingNumber parity)

### DIFF
--- a/client-rs/crates/rcce-client/src/bin/client_window.rs
+++ b/client-rs/crates/rcce-client/src/bin/client_window.rs
@@ -6070,6 +6070,14 @@ impl App {
                 // Spawn floating damage numbers for any new combat hits, expire old.
                 self.floaters.ingest(&net.world.combat_events, elapsed);
             }
+            // Server-driven floating numbers (P_FloatingNumber): script-driven
+            // heal/text popups, always shown regardless of the combat-damage
+            // display style (they aren't combat damage). Drained unconditionally
+            // so the queue can't grow even when combat floaters are off.
+            for (rid, amount, c) in net.world.pending_floaters.drain(..) {
+                let col = [c[0] as f32 / 255.0, c[1] as f32 / 255.0, c[2] as f32 / 255.0];
+                self.floaters.spawn_value(rid, amount, col, elapsed);
+            }
             self.floaters.tick(elapsed);
             // Advance in-flight projectiles (PRJ-1). prev_elapsed is updated
             // later (weather), so this read gives the same per-frame dt.
@@ -7835,8 +7843,13 @@ impl App {
                     };
                     let Some(p) = pos else { continue };
                     if let Some((px, py)) = rcce_render::project(&vp, [p[0], p[1] + 6.5, p[2]], sw, sh) {
-                        let s = fl.damage.to_string();
-                        let col = damage_color(fl.damage_type, fl.alpha(elapsed));
+                        // Server floaters carry an explicit signed value + colour;
+                        // combat floaters show the damage in a damage-type colour.
+                        let a = fl.alpha(elapsed);
+                        let (s, col) = match (fl.value, fl.color) {
+                            (Some(v), Some(c)) => (v.to_string(), [c[0], c[1], c[2], a]),
+                            _ => (fl.damage.to_string(), damage_color(fl.damage_type, a)),
+                        };
                         let tw = rcce_render::font::text_width(&s, 1.5);
                         overlay.text_shadow(px - tw * 0.5, py - 30.0 - fl.rise(elapsed), 1.5, &s, col);
                     }

--- a/client-rs/crates/rcce-client/src/bin/overlay_test.rs
+++ b/client-rs/crates/rcce-client/src/bin/overlay_test.rs
@@ -84,7 +84,7 @@ fn main() {
     let samples: [(u16, u8, f32); 4] =
         [(120, 0, 0.0), (45, 1, 0.4), (310, 2, 0.8), (7, 5, 1.1)];
     for (i, (dmg, dt, age)) in samples.iter().enumerate() {
-        let fl = rcce_client::floaters::Floater { rid: 0, damage: *dmg, damage_type: *dt, t0: 0.0 };
+        let fl = rcce_client::floaters::Floater { rid: 0, damage: *dmg, damage_type: *dt, t0: 0.0, value: None, color: None };
         let c = palette[*dt as usize % 6];
         let base_x = 300.0 + i as f32 * 78.0;
         overlay.text_shadow(base_x, 190.0 - fl.rise(*age), 1.5, &dmg.to_string(), [c[0], c[1], c[2], fl.alpha(*age)]);

--- a/client-rs/crates/rcce-client/src/floaters.rs
+++ b/client-rs/crates/rcce-client/src/floaters.rs
@@ -12,7 +12,14 @@ pub const LIFETIME: f32 = 1.2;
 /// How far (world-ish px applied at draw time) a number rises over its life.
 pub const RISE: f32 = 38.0;
 
-/// One on-screen damage number, anchored to a target actor by runtime id.
+/// One on-screen floating number, anchored to a target actor by runtime id.
+///
+/// Two flavours share the same rise/fade/expiry machinery:
+/// - **Combat damage** (the default): `value`/`color` are `None`; the draw shows
+///   `damage` styled by `damage_type` (see `damage_color`).
+/// - **Server-driven** (`P_FloatingNumber` / `BVM_CreateFloatingNumber`): `value`
+///   is the signed amount the server sent and `color` is the server's explicit
+///   RGB. The draw shows `value` in `color`, ignoring `damage`/`damage_type`.
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub struct Floater {
     pub rid: u16,
@@ -20,6 +27,12 @@ pub struct Floater {
     pub damage_type: u8,
     /// Wall-clock (seconds since client start) when it spawned.
     pub t0: f32,
+    /// `Some` for a server-driven floater: the signed amount to display (can be
+    /// negative, unlike `damage`). `None` ⇒ a combat floater showing `damage`.
+    pub value: Option<i32>,
+    /// `Some` for a server-driven floater: explicit RGB (0..1). `None` ⇒ a combat
+    /// floater coloured by `damage_type`.
+    pub color: Option<[f32; 3]>,
 }
 
 impl Floater {
@@ -70,9 +83,27 @@ impl Floaters {
                 damage: e.damage,
                 damage_type: e.damage_type,
                 t0: now,
+                value: None,
+                color: None,
             });
         }
         self.consumed = events.len();
+    }
+
+    /// Spawn a server-driven floating number (`P_FloatingNumber`): a signed
+    /// `value` in an explicit `color`, anchored over actor `rid`, rising and
+    /// fading on the same timeline as a combat number. Independent of the
+    /// `consumed` cursor — these are pushed directly, not drained from the
+    /// combat log.
+    pub fn spawn_value(&mut self, rid: u16, value: i32, color: [f32; 3], now: f32) {
+        self.items.push(Floater {
+            rid,
+            damage: 0,
+            damage_type: 0,
+            t0: now,
+            value: Some(value),
+            color: Some(color),
+        });
     }
 
     /// Drop floaters older than [`LIFETIME`].
@@ -130,12 +161,35 @@ mod tests {
 
     #[test]
     fn alpha_and_rise_progress() {
-        let fl = Floater { rid: 1, damage: 5, damage_type: 0, t0: 0.0 };
+        let fl = Floater { rid: 1, damage: 5, damage_type: 0, t0: 0.0, value: None, color: None };
         assert_eq!(fl.alpha(0.0), 1.0); // fresh = opaque
         assert!(fl.rise(LIFETIME) >= RISE - 0.001); // fully risen at end
         assert!(fl.alpha(LIFETIME) <= 0.001); // faded out at end
         // Monotonic rise.
         assert!(fl.rise(LIFETIME * 0.25) < fl.rise(LIFETIME * 0.75));
+    }
+
+    #[test]
+    fn server_value_floater_coexists_with_combat() {
+        let mut f = Floaters::new();
+        // A combat hit and a server-driven number live side by side, both on the
+        // same rise/fade timeline but distinguished by `value`/`color`.
+        f.ingest(&[ev(7, 10)], 0.0);
+        f.spawn_value(7, -250, [0.0, 1.0, 0.0], 0.0); // a green heal "-250"
+        assert_eq!(f.len(), 2);
+        let combat = f.iter().find(|x| x.value.is_none()).unwrap();
+        assert_eq!(combat.damage, 10);
+        let server = f.iter().find(|x| x.value.is_some()).unwrap();
+        assert_eq!(server.value, Some(-250));
+        assert_eq!(server.color, Some([0.0, 1.0, 0.0]));
+        assert_eq!(server.rid, 7);
+        // Server floaters do NOT advance the combat-event cursor, so a later
+        // combat ingest still fires.
+        f.ingest(&[ev(7, 10), ev(8, 4)], 0.5);
+        assert_eq!(f.len(), 3);
+        // Both flavours expire on the same timeline (last one spawned at t=0.5).
+        f.tick(0.5 + LIFETIME + 0.01);
+        assert_eq!(f.len(), 0);
     }
 
     #[test]

--- a/client-rs/crates/rcce-client/src/world.rs
+++ b/client-rs/crates/rcce-client/src/world.rs
@@ -287,6 +287,13 @@ pub struct World {
     pub me_attributes: HashMap<u8, (i16, i16)>,
     /// Recent combat hits (from P_AttackActor).
     pub combat_events: Vec<CombatEvent>,
+    /// Server-driven floating numbers (`P_FloatingNumber` /
+    /// `BVM_CreateFloatingNumber`): `(rid, amount, [r,g,b])`. The App drains these
+    /// into the floater system with the server's explicit colour — these are the
+    /// script-driven popups (heals, custom text) the client can't compute itself,
+    /// distinct from the locally-derived combat-damage floaters. Mirrors Blitz
+    /// `CreateFloatingNumber` (ClientNet.bb:213).
+    pub pending_floaters: Vec<(u16, i32, [u8; 3])>,
     /// Items dropped in the world (P_InventoryUpdate "D"), keyed by the
     /// server's DroppedItem handle. Removed on pickup ("P"/"R").
     pub dropped_items: HashMap<u32, DroppedItem>,
@@ -696,6 +703,7 @@ impl World {
             pk::PARTY_UPDATE => self.on_party_update(&m.data),
             pk::JUMP => self.on_jump(&m.data),
             pk::FETCH_ACTORS => self.on_fetch_actors(&m.data),
+            pk::FLOATING_NUMBER => self.on_floating_number(&m.data),
             _ => {}
         }
     }
@@ -1608,6 +1616,21 @@ impl World {
         }
     }
 
+    /// `P_FloatingNumber` (ClientNet.bb:205): RuntimeID(u16) · Amount(i32) ·
+    /// R(u8) · G(u8) · B(u8). A script-driven floating number (heal popups,
+    /// custom text) broadcast to everyone in the zone. We queue the intent; the
+    /// App anchors it over the actor and animates it with the floater system.
+    /// Soft-fail: a short/garbled packet queues nothing (no panic, no crash).
+    fn on_floating_number(&mut self, d: &[u8]) {
+        let mut r = MsgReader::new(d);
+        let (Some(rid), Some(amount), Some(cr), Some(cg), Some(cb)) =
+            (r.u16(), r.i32(), r.u8(), r.u8(), r.u8())
+        else {
+            return;
+        };
+        self.pending_floaters.push((rid, amount, [cr, cg, cb]));
+    }
+
     /// Tick down remote jump-anim timers, dropping any that have elapsed.
     pub fn tick_jumps(&mut self, dt: f32) {
         if self.jumps.is_empty() {
@@ -2166,6 +2189,25 @@ mod tests {
         // 'Y' raw 6 (damage 5, a landed blow): NOW I cry out (Hit).
         w.apply(&msg(pk::ATTACK_ACTOR, pkt(|p| { p.u8(b'Y').u16(8).u16(6).u8(0); })));
         assert_eq!(w.pending_self_sounds, vec![SPEECH_HIT1], "I cry out only on a connecting blow");
+    }
+
+    // P_FloatingNumber (script-driven, BVM_CreateFloatingNumber): RuntimeID u16,
+    // signed Amount i32, then R/G/B u8. Queues a (rid, amount, [r,g,b]) intent for
+    // the App to anchor + animate. A short/garbled packet queues nothing.
+    #[test]
+    fn floating_number_queues_intent() {
+        let mut w = World::default();
+        // A green heal "+250" over actor 7.
+        w.apply(&msg(pk::FLOATING_NUMBER, pkt(|p| { p.u16(7).i32(250).u8(0).u8(255).u8(0); })));
+        assert_eq!(w.pending_floaters, vec![(7, 250, [0, 255, 0])]);
+
+        // A negative amount (signed i32 round-trips) in red over actor 12.
+        w.apply(&msg(pk::FLOATING_NUMBER, pkt(|p| { p.u16(12).i32(-40).u8(255).u8(0).u8(0); })));
+        assert_eq!(w.pending_floaters.last(), Some(&(12, -40, [255, 0, 0])));
+
+        // A truncated packet (missing the colour bytes) queues nothing more.
+        w.apply(&msg(pk::FLOATING_NUMBER, pkt(|p| { p.u16(9).i32(5); })));
+        assert_eq!(w.pending_floaters.len(), 2, "truncated packet soft-fails");
     }
 
     // Looting a dropped item ('R') moves it into inventory AND queues a

--- a/client-rs/crates/rcce-net/src/lib.rs
+++ b/client-rs/crates/rcce-net/src/lib.rs
@@ -80,6 +80,7 @@ pub mod packet_id {
     pub const ITEM_SCRIPT: u8 = 43;
     pub const EAT_ITEM: u8 = 44;
     pub const JUMP: u8 = 46;
+    pub const FLOATING_NUMBER: u8 = 48;
     pub const PROGRESS_BAR: u8 = 51;
     pub const BUBBLE_MESSAGE: u8 = 52;
     pub const SCRIPT_INPUT: u8 = 53;


### PR DESCRIPTION
## What

The Rust client now renders **server-driven floating numbers** (`P_FloatingNumber` / `BVM_CreateFloatingNumber`, ClientNet.bb:205) — a signed amount in an explicit RGB colour floating over an actor, broadcast zone-wide. These are the **script-driven** popups (heal numbers, custom combat text, etc.), distinct from the combat-damage numbers the client computes locally from `P_AttackActor`. The Rust client previously dropped `P_FloatingNumber` entirely, so any content script calling `CreateFloatingNumber` was invisible.

## How

- **rcce-net:** `pk::FLOATING_NUMBER = 48`.
- **World:** `on_floating_number` parses `RuntimeID(u16) · Amount(i32) · R/G/B(u8)` and queues a `(rid, amount, [r,g,b])` intent. Soft-fails to nothing on a short/garbled packet (no panic).
- **floaters::Floater** gains optional `value: Option<i32>` + `color: Option<[f32;3]>`; `spawn_value` puts a server floater on the **same** rise/fade/expiry timeline as combat numbers, independent of the combat-event cursor.
- **App:** drains `pending_floaters` each frame **unconditionally** (so the queue can't grow even when combat floaters are disabled by `DamageInfoStyle`), and the draw path shows the server `value`+`color`, falling back to `damage`+`damage_type` styling for combat floaters. Combat-floater rendering is **byte-identical** to before (the fallback arm reproduces the old two lines exactly).

## Verification

- `cargo +1.95.0 clippy … --all-targets -- -D warnings` clean.
- `cargo +1.95.0 test -p rcce-client -p rcce-net --lib` → 126 pass, incl. new `floating_number_queues_intent` (signed amount round-trips; truncated packet soft-fails) and `server_value_floater_coexists_with_combat` (a server number and a combat hit share the timeline; server floaters don't advance the combat cursor).
- Release build OK; **1280×800 headless world shot** confirms no combat-floater/HUD regression.
- The server floater itself is script-triggered (the starter project sends none during autowalk), so the feature is correct-by-construction + unit-tested — same posture as the combat-voice increments.

🤖 Generated with [Claude Code](https://claude.com/claude-code)