### PR TITLE
feat(rust): play server-commanded animations (P_AnimateActor emotes/poses)

### DIFF
--- a/client-rs/crates/rcce-client/src/bin/client_window.rs
+++ b/client-rs/crates/rcce-client/src/bin/client_window.rs
@@ -1704,7 +1704,7 @@ fn build_actors(
                     rid: u16,
                     moving: bool,
                     running: bool,
-                    combat: Option<(&'static [&'static str], bool)>,
+                    combat: Option<(&[&str], bool)>,
                     pos: [f32; 3],
                     yaw: f32,
                     color: [f32; 3]| {
@@ -1861,7 +1861,15 @@ fn build_actors(
     // Jump (ANIM-7) overrides the attack clip; the offset lifts the body (MOVE-7).
     // In first-person (CAM-4) the own body is hidden entirely. An idle fidget
     // (ANIM-6) overrides only when nothing more important is playing.
-    let me_combat = if me_jumping {
+    // A server-commanded animation on the local player (P_AnimateActor for our own
+    // rid) overrides jump/attack/fidget, same as remote actors. Runtime name → a
+    // 1-element slice borrowing it for this build.
+    let me_server_anim = world.server_anims.get(&world.my_runtime_id).map(|s| s.name.as_str());
+    let me_sa_slot;
+    let me_combat = if let Some(name) = me_server_anim {
+        me_sa_slot = [name];
+        Some((&me_sa_slot[..], false))
+    } else if me_jumping {
         Some((JUMP_CLIP, false))
     } else if me_attack {
         Some((ATTACK_CLIP, false))
@@ -1881,10 +1889,17 @@ fn build_actors(
         // remote actor mid-attack (P_AttackActor → world.attack_anims) plays its
         // swing clip (CBT-3).
         let jump_left = world.jumps.get(&a.runtime_id).copied();
-        // CBT-3: a remote actor mid-attack (P_AttackActor 'Y'/broadcast) plays its
-        // swing clip. Priority: dead > jump > attack > none.
+        // A server-commanded animation (P_AnimateActor → world.server_anims) is an
+        // explicit emote/pose and overrides locomotion, jump, and attack — but not
+        // death. Priority: dead > server-anim > jump > attack > none. The clip name
+        // is a runtime String, so build a 1-element slice borrowing it for this call.
+        let server_anim = world.server_anims.get(&a.runtime_id).map(|s| s.name.as_str());
+        let sa_slot;
         let combat = if !a.alive {
             Some((death_clip(a.runtime_id), true))
+        } else if let Some(name) = server_anim {
+            sa_slot = [name];
+            Some((&sa_slot[..], false))
         } else if jump_left.is_some() {
             Some((JUMP_CLIP, false))
         } else if world.attack_anims.contains_key(&a.runtime_id) {
@@ -1939,7 +1954,12 @@ fn dyn_hash(world: &World, elapsed: f32, me_moving: bool, me_running: bool, me_a
         }
         // Remote attack-swing presence (CBT-3) so the swing shows under the throttle.
         world.attack_anims.contains_key(&rid).hash(&mut h);
+        // Server-commanded animation presence (P_AnimateActor) so the emote
+        // appears/reverts crisply rather than waiting on the elapsed term.
+        world.server_anims.contains_key(&rid).hash(&mut h);
     }
+    // The local player's own server-commanded animation.
+    world.server_anims.contains_key(&world.my_runtime_id).hash(&mut h);
     // Dropped loot (DROP-1): hash the set of item handles + ids so the 3D ground
     // meshes rebuild when loot is dropped or picked up (positions are fixed at drop).
     let mut loot: Vec<u32> = world.dropped_items.keys().copied().collect();
@@ -6120,6 +6140,42 @@ impl App {
             net.world.tick_jumps(proj_dt);
             // Remote attack-swing timers (CBT-3).
             net.world.tick_attack_anims(proj_dt);
+            // Server-commanded animations (P_AnimateActor): resolve each queued
+            // intent's clip + natural duration via the store (which World can't
+            // reach), install a timed override, then tick the active ones down so
+            // they revert to locomotion when the clip has played out.
+            if !net.world.pending_anims.is_empty() {
+                let intents: Vec<(u16, String)> = net.world.pending_anims.drain(..).collect();
+                for (rid, name) in intents {
+                    let (tmpl, gender) = if rid == net.world.my_runtime_id {
+                        (net.world.me_actor_id, net.world.me_gender)
+                    } else if let Some(a) = net.world.actors.get(&rid) {
+                        (a.template_id, a.gender)
+                    } else {
+                        continue; // unknown actor → drop (Blitz `If A <> Null`)
+                    };
+                    // Resolve the named clip; an unknown name drops the command
+                    // (Blitz `If ID > -1`). Copy the clip dims out first so the
+                    // immutable actor_clip borrow ends before the &mut actor_model.
+                    let clip_dims = store
+                        .actor_clip(tmpl, gender, &[name.as_str()])
+                        .filter(|c| c.end > c.start)
+                        .map(|c| (c.start, c.end, c.speed));
+                    if let Some((start, end, speed)) = clip_dims {
+                        // Duration = clip frames / effective fps (data-native rate).
+                        let fps = store
+                            .actor_model(tmpl, gender)
+                            .and_then(|m| m.anim.map(|a| a.fps))
+                            .unwrap_or(15.0);
+                        let dur = (end - start) as f32 / (fps.max(0.001) * speed.max(0.001));
+                        net.world.server_anims.insert(
+                            rid,
+                            rcce_client::world::ServerAnim { name, remaining: dur.max(0.05) },
+                        );
+                    }
+                }
+            }
+            net.world.tick_server_anims(proj_dt);
             if !self.grounded {
                 let (o, v, g) = jump_step(self.jump_offset, self.jump_vel);
                 self.jump_offset = o;

--- a/client-rs/crates/rcce-client/src/world.rs
+++ b/client-rs/crates/rcce-client/src/world.rs
@@ -151,6 +151,14 @@ pub struct CombatEvent {
     pub damage_type: u8,
 }
 
+/// A server-commanded animation override (`P_AnimateActor`): the clip name to
+/// play and how long it has left before reverting to locomotion.
+#[derive(Debug, Clone, PartialEq)]
+pub struct ServerAnim {
+    pub name: String,
+    pub remaining: f32,
+}
+
 #[derive(Debug, Clone, Default)]
 pub struct Actor {
     pub runtime_id: u16,
@@ -339,6 +347,17 @@ pub struct World {
     /// `'Y'`/broadcast, ticked down each frame; while present the actor renders
     /// its attack clip in `build_actors`. (The local player uses `me_attack_until`.)
     pub attack_anims: HashMap<u16, f32>,
+    /// `(rid, anim_name)` server-commanded animation intents from `P_AnimateActor`
+    /// (emotes, scripted poses). The App drains these, resolves the named clip +
+    /// its duration via the AssetStore (which `World` can't reach), and installs a
+    /// timed override in `server_anims`. Mirrors Blitz `PlayAnimation(A, 3, …)`
+    /// (ClientNet.bb:726).
+    pub pending_anims: Vec<(u16, String)>,
+    /// Active server-commanded animations: rid → `(clip name, seconds left)`. While
+    /// present, `build_actors` plays the named clip on that actor (priority just
+    /// below death) instead of locomotion; `tick_server_anims` expires it after the
+    /// clip's natural length, reverting to idle/walk (Blitz mode-3 plays once).
+    pub server_anims: HashMap<u16, ServerAnim>,
     /// The local player's inventory, keyed by slot (0..13 equipment, 14..45
     /// backpack). Seeded from the P_FetchCharacter sheet, then kept live by
     /// P_InventoryUpdate G/T/H/R. BTreeMap so the panel iterates in slot order.
@@ -706,6 +725,7 @@ impl World {
             pk::FLOATING_NUMBER => self.on_floating_number(&m.data),
             pk::APPEARANCE_UPDATE => self.on_appearance_update(&m.data),
             pk::REPOSITION_ACTOR => self.on_reposition_actor(&m.data),
+            pk::ANIMATE_ACTOR => self.on_animate_actor(&m.data),
             _ => {}
         }
     }
@@ -1765,6 +1785,41 @@ impl World {
                 a.render_yaw = yaw;
             }
         }
+    }
+
+    /// `P_AnimateActor` (ClientNet.bb:713): the server commands an actor to play a
+    /// named animation — an emote or a scripted pose. Layout: RuntimeID(u16) ·
+    /// FixedSpeed(u8) · Speed(f32) · AnimName(string-to-end). We queue a
+    /// `(rid, name)` intent; the App resolves the clip + its natural duration via
+    /// the AssetStore (out of `World`'s reach) and installs a timed override.
+    ///
+    /// Speed/FixedSpeed are parsed (to reach the name) but not applied: Blitz's
+    /// playback rate is framerate-coupled (`Animate` advances N frames per render
+    /// tick), which can't be reproduced faithfully here, so the clip plays at its
+    /// data-native rate — the deterministic, sensible choice. Soft-fails on a
+    /// short packet or an empty name.
+    fn on_animate_actor(&mut self, d: &[u8]) {
+        let mut r = MsgReader::new(d);
+        let (Some(rid), Some(_fixed), Some(_speed)) = (r.u16(), r.u8(), r.f32()) else {
+            return;
+        };
+        let name = String::from_utf8_lossy(r.rest()).into_owned();
+        if name.is_empty() {
+            return;
+        }
+        self.pending_anims.push((rid, name));
+    }
+
+    /// Tick down server-commanded animation timers, reverting expired overrides to
+    /// locomotion by dropping them from the map.
+    pub fn tick_server_anims(&mut self, dt: f32) {
+        if self.server_anims.is_empty() {
+            return;
+        }
+        self.server_anims.retain(|_, sa| {
+            sa.remaining -= dt;
+            sa.remaining > 0.0
+        });
     }
 
     /// Tick down remote jump-anim timers, dropping any that have elapsed.
@@ -2951,6 +3006,33 @@ mod tests {
         w.apply(&msg(pk::REPOSITION_ACTOR, pkt(|p| { p.u8(b'M').u16(999).f32(1.0).f32(1.0).f32(1.0).u8(0); })));
         w.apply(&msg(pk::REPOSITION_ACTOR, pkt(|p| { p.u8(b'M').u16(50).f32(7.0); }))); // missing Y/Z
         assert_eq!(w.actors[&50].x, 120.0, "truncated packet left position unchanged");
+    }
+
+    // P_AnimateActor queues a (rid, name) intent for the App to resolve into a
+    // timed clip override; tick_server_anims expires active overrides. (The
+    // clip/duration resolution lives App-side — it needs the AssetStore — so this
+    // covers the wire parse + the expiry timer.)
+    #[test]
+    fn animate_actor_queues_intent_and_expires() {
+        let mut w = World { my_runtime_id: 1, ..Default::default() };
+        // rid 50, fixed-speed 0, speed 0.05, name "Wave" (string-to-end, no prefix).
+        w.apply(&msg(pk::ANIMATE_ACTOR, pkt(|p| { p.u16(50).u8(0).f32(0.05).raw(b"Wave"); })));
+        assert_eq!(w.pending_anims, vec![(50, "Wave".to_string())]);
+
+        // An empty name queues nothing (no clip to play).
+        w.apply(&msg(pk::ANIMATE_ACTOR, pkt(|p| { p.u16(50).u8(0).f32(0.05); })));
+        assert_eq!(w.pending_anims.len(), 1, "empty name not queued");
+
+        // A truncated packet (missing the speed f32) soft-fails.
+        w.apply(&msg(pk::ANIMATE_ACTOR, pkt(|p| { p.u16(50).u8(0); })));
+        assert_eq!(w.pending_anims.len(), 1, "truncated packet not queued");
+
+        // tick_server_anims counts an active override down and drops it on expiry.
+        w.server_anims.insert(50, ServerAnim { name: "Wave".into(), remaining: 0.5 });
+        w.tick_server_anims(0.3);
+        assert!((w.server_anims[&50].remaining - 0.2).abs() < 1e-6);
+        w.tick_server_anims(0.3);
+        assert!(w.server_anims.is_empty(), "expired override reverts to locomotion");
     }
 
     #[test]

--- a/client-rs/crates/rcce-net/src/lib.rs
+++ b/client-rs/crates/rcce-net/src/lib.rs
@@ -79,6 +79,7 @@ pub mod packet_id {
     pub const PARTY_UPDATE: u8 = 38;
     pub const ITEM_SCRIPT: u8 = 43;
     pub const EAT_ITEM: u8 = 44;
+    pub const ANIMATE_ACTOR: u8 = 30;
     pub const APPEARANCE_UPDATE: u8 = 39;
     pub const JUMP: u8 = 46;
     pub const FLOATING_NUMBER: u8 = 48;


### PR DESCRIPTION
## What

The Rust client now plays **server-commanded animations** (`P_AnimateActor`, ClientNet.bb:713) — emotes (wave, bow, dance), scripted poses, cutscene beats, all driven by `BVM_AnimateActor(actor, name$, speed#, fixed%)`. The client dropped the packet, so every server-driven animation was invisible; actors only ever played their locomotion/attack/jump clips.

## How

- **rcce-net:** `pk::ANIMATE_ACTOR = 30`.
- **World::on_animate_actor** parses `RuntimeID(u16) · FixedSpeed(u8) · Speed(f32) · AnimName(string-to-end)` and queues a `(rid, name)` intent.
- **App** drains each intent, resolves the named clip + its natural duration via the AssetStore (which `World` can't reach), and installs a timed override in `World::server_anims` (`rid -> {name, seconds left}`). An unknown actor or unresolvable clip name drops the command (Blitz `If A <> Null` / `If ID > -1`).
- **build_actors** plays the override clip on that actor (and the local player via the `me_*` path) at priority **dead > server-anim > jump > attack > locomotion**; **tick_server_anims** expires it after the clip's natural length, reverting to idle/walk (Blitz mode-3 plays once). `dyn_hash` folds in the override presence so the emote appears/reverts crisply.

The combat-override slot in `build_actors` was `&'static [&'static str]`; relaxed to `&[&str]` so a runtime clip name threads as a 1-element slice (the existing static clip constants still coerce).

## Deliberate scoping

`Speed`/`FixedSpeed` are parsed (to reach the name) but **not applied**: Blitz's playback rate is framerate-coupled (`Animate` advances N frames per render tick) and can't be reproduced faithfully here, so the clip plays at its **data-native rate** — the deterministic, sensible choice. Exact speed-scaling is a deferred refinement, not headlessly verifiable.

## Verification

- `cargo +1.95.0 clippy … --all-targets -- -D warnings` clean.
- `cargo +1.95.0 test -p rcce-client -p rcce-net --lib` → 129 pass, incl. new `animate_actor_queues_intent_and_expires` (wire parse, empty-name/truncated soft-fail, expiry timer).
- Release build OK; **1280×800 headless world shot** confirms no actor-animation regression (locomotion/idle render correctly with the modified `build_actors`).
- The emote is server-triggered (the starter sends none during autowalk), so correct-by-construction + unit-tested — same posture as the recent parity increments.

🤖 Generated with [Claude Code](https://claude.com/claude-code)