### PR TITLE
feat(rust): faithful mode-3 playback for server animations (play-from-start, hold, cancel-on-move)

### DIFF
--- a/client-rs/crates/rcce-client/src/bin/client_window.rs
+++ b/client-rs/crates/rcce-client/src/bin/client_window.rs
@@ -1733,9 +1733,10 @@ fn build_actors(
                     ClipPlay::HoldEnd => c.end as f32,
                     ClipPlay::Loop => clip_frame(c, fps, elapsed + rid as f32 * 0.13),
                     // Advance from frame 0 at the clip's native rate, clamping at the
-                    // last frame so the pose holds once it has played through.
+                    // last frame so the pose holds once it has played through. Guard
+                    // fps/speed like clip_frame so pathological data can't stall it.
                     ClipPlay::OnceFrom(t) => {
-                        (c.start as f32 + t * fps * c.speed).min(c.end as f32)
+                        (c.start as f32 + t * fps.max(0.001) * c.speed.max(0.001)).min(c.end as f32)
                     }
                 }),
             None => {

--- a/client-rs/crates/rcce-client/src/bin/client_window.rs
+++ b/client-rs/crates/rcce-client/src/bin/client_window.rs
@@ -1537,6 +1537,18 @@ enum CombatStep {
     Wait,
 }
 
+/// How an override clip advances when present, vs the looping locomotion default.
+#[derive(Clone, Copy)]
+enum ClipPlay {
+    /// Loop the clip on the global timeline (jump/attack swings).
+    Loop,
+    /// Pin the last frame statically (a death/corpse pose).
+    HoldEnd,
+    /// Play once from frame 0 given seconds-since-start, then hold the last frame
+    /// (a server-commanded emote/pose, `P_AnimateActor` mode 3).
+    OnceFrom(f32),
+}
+
 /// Combat animation clip names (ANIM-8), tried in order (exact match first, then
 /// substring). The shipped data labels them "Default attack"/"Death 1"; Hit
 /// ranges are empty so there's no hit-react clip.
@@ -1704,7 +1716,7 @@ fn build_actors(
                     rid: u16,
                     moving: bool,
                     running: bool,
-                    combat: Option<(&[&str], bool)>,
+                    combat: Option<(&[&str], ClipPlay)>,
                     pos: [f32; 3],
                     yaw: f32,
                     color: [f32; 3]| {
@@ -1714,10 +1726,18 @@ fn build_actors(
         // clips (this data's Hit ranges are [0..0]) are skipped; `hold` pins the
         // clip's last frame for a static corpse pose (ANIM-8).
         let frame = match combat {
-            Some((names, hold)) => store
+            Some((names, play)) => store
                 .actor_clip(tmpl, gender, names)
                 .filter(|c| c.end > c.start)
-                .map(|c| if hold { c.end as f32 } else { clip_frame(c, fps, elapsed + rid as f32 * 0.13) }),
+                .map(|c| match play {
+                    ClipPlay::HoldEnd => c.end as f32,
+                    ClipPlay::Loop => clip_frame(c, fps, elapsed + rid as f32 * 0.13),
+                    // Advance from frame 0 at the clip's native rate, clamping at the
+                    // last frame so the pose holds once it has played through.
+                    ClipPlay::OnceFrom(t) => {
+                        (c.start as f32 + t * fps * c.speed).min(c.end as f32)
+                    }
+                }),
             None => {
                 let names: &[&str] = if running {
                     &["Run"]
@@ -1863,18 +1883,18 @@ fn build_actors(
     // (ANIM-6) overrides only when nothing more important is playing.
     // A server-commanded animation on the local player (P_AnimateActor for our own
     // rid) overrides jump/attack/fidget, same as remote actors. Runtime name → a
-    // 1-element slice borrowing it for this build.
-    let me_server_anim = world.server_anims.get(&world.my_runtime_id).map(|s| s.name.as_str());
+    // 1-element slice borrowing it for this build; OnceFrom plays it from frame 0.
+    let me_server_anim = world.server_anims.get(&world.my_runtime_id);
     let me_sa_slot;
-    let me_combat = if let Some(name) = me_server_anim {
-        me_sa_slot = [name];
-        Some((&me_sa_slot[..], false))
+    let me_combat = if let Some(sa) = me_server_anim {
+        me_sa_slot = [sa.name.as_str()];
+        Some((&me_sa_slot[..], ClipPlay::OnceFrom(sa.elapsed)))
     } else if me_jumping {
-        Some((JUMP_CLIP, false))
+        Some((JUMP_CLIP, ClipPlay::Loop))
     } else if me_attack {
-        Some((ATTACK_CLIP, false))
+        Some((ATTACK_CLIP, ClipPlay::Loop))
     } else {
-        me_fidget.map(|f| (f, false))
+        me_fidget.map(|f| (f, ClipPlay::Loop))
     };
     if !hide_me {
         push(store, &mut models, &mut textures, &mut place, &mut keys, &mut skinned, me_template, world.me_gender, world.me_face_tex, world.me_body_tex, world.me_hair, world.me_beard, me_weapon, me_shield, weapon_override, world.my_runtime_id, me_moving, me_running, me_combat, [world.me_render_x, world.me_y + me_jump_offset, world.me_render_z], world.me_yaw, [0.85, 0.95, 0.85]);
@@ -1893,17 +1913,17 @@ fn build_actors(
         // explicit emote/pose and overrides locomotion, jump, and attack — but not
         // death. Priority: dead > server-anim > jump > attack > none. The clip name
         // is a runtime String, so build a 1-element slice borrowing it for this call.
-        let server_anim = world.server_anims.get(&a.runtime_id).map(|s| s.name.as_str());
+        let server_anim = world.server_anims.get(&a.runtime_id);
         let sa_slot;
         let combat = if !a.alive {
-            Some((death_clip(a.runtime_id), true))
-        } else if let Some(name) = server_anim {
-            sa_slot = [name];
-            Some((&sa_slot[..], false))
+            Some((death_clip(a.runtime_id), ClipPlay::HoldEnd))
+        } else if let Some(sa) = server_anim {
+            sa_slot = [sa.name.as_str()];
+            Some((&sa_slot[..], ClipPlay::OnceFrom(sa.elapsed)))
         } else if jump_left.is_some() {
-            Some((JUMP_CLIP, false))
+            Some((JUMP_CLIP, ClipPlay::Loop))
         } else if world.attack_anims.contains_key(&a.runtime_id) {
-            Some((ATTACK_CLIP, false))
+            Some((ATTACK_CLIP, ClipPlay::Loop))
         } else {
             None
         };
@@ -6170,12 +6190,16 @@ impl App {
                         let dur = (end - start) as f32 / (fps.max(0.001) * speed.max(0.001));
                         net.world.server_anims.insert(
                             rid,
-                            rcce_client::world::ServerAnim { name, remaining: dur.max(0.05) },
+                            rcce_client::world::ServerAnim {
+                                name,
+                                elapsed: 0.0,
+                                duration: dur.max(0.05),
+                            },
                         );
                     }
                 }
             }
-            net.world.tick_server_anims(proj_dt);
+            net.world.tick_server_anims(proj_dt, moving);
             if !self.grounded {
                 let (o, v, g) = jump_step(self.jump_offset, self.jump_vel);
                 self.jump_offset = o;

--- a/client-rs/crates/rcce-client/src/world.rs
+++ b/client-rs/crates/rcce-client/src/world.rs
@@ -151,12 +151,20 @@ pub struct CombatEvent {
     pub damage_type: u8,
 }
 
-/// A server-commanded animation override (`P_AnimateActor`): the clip name to
-/// play and how long it has left before reverting to locomotion.
+/// A server-commanded animation override (`P_AnimateActor`). Blitz `Animate`
+/// mode 3 plays the clip once from the start, holds its last frame, and only
+/// reverts when the actor next moves — so we track time **since the clip began**
+/// (to play it from frame 0, not a global-time phase) and its natural length.
 #[derive(Debug, Clone, PartialEq)]
 pub struct ServerAnim {
     pub name: String,
-    pub remaining: f32,
+    /// Seconds since the clip started; drives the play-once frame in `build_actors`
+    /// (clip start + elapsed·rate, clamped to the last frame = the held pose).
+    pub elapsed: f32,
+    /// The clip's natural play-once length in seconds. Until `elapsed` reaches it
+    /// the clip is still playing (movement can't cancel); after, the end pose holds
+    /// until the actor moves.
+    pub duration: f32,
 }
 
 #[derive(Debug, Clone, Default)]
@@ -1810,15 +1818,33 @@ impl World {
         self.pending_anims.push((rid, name));
     }
 
-    /// Tick down server-commanded animation timers, reverting expired overrides to
-    /// locomotion by dropping them from the map.
-    pub fn tick_server_anims(&mut self, dt: f32) {
+    /// Advance server-commanded animations and expire them the Blitz mode-3 way:
+    /// the clip always plays through once (movement can't interrupt it), then its
+    /// end pose holds until the actor next moves — at which point the override is
+    /// dropped and locomotion takes over. `me_moving` is the local player's current
+    /// movement intent; remote actors use their own dest-vs-position delta.
+    pub fn tick_server_anims(&mut self, dt: f32, me_moving: bool) {
         if self.server_anims.is_empty() {
             return;
         }
-        self.server_anims.retain(|_, sa| {
-            sa.remaining -= dt;
-            sa.remaining > 0.0
+        let actors = &self.actors;
+        let my_rid = self.my_runtime_id;
+        self.server_anims.retain(|&rid, sa| {
+            sa.elapsed += dt;
+            // Still playing the one-shot through → keep regardless of movement.
+            if sa.elapsed < sa.duration {
+                return true;
+            }
+            // Played out; hold the end pose until this actor moves.
+            let moving = if rid == my_rid {
+                me_moving
+            } else if let Some(a) = actors.get(&rid) {
+                let (dx, dz) = (a.dest_x - a.x, a.dest_z - a.z);
+                dx * dx + dz * dz > 1.0
+            } else {
+                true // actor gone → drop the override
+            };
+            !moving
         });
     }
 
@@ -3027,12 +3053,16 @@ mod tests {
         w.apply(&msg(pk::ANIMATE_ACTOR, pkt(|p| { p.u16(50).u8(0); })));
         assert_eq!(w.pending_anims.len(), 1, "truncated packet not queued");
 
-        // tick_server_anims counts an active override down and drops it on expiry.
-        w.server_anims.insert(50, ServerAnim { name: "Wave".into(), remaining: 0.5 });
-        w.tick_server_anims(0.3);
-        assert!((w.server_anims[&50].remaining - 0.2).abs() < 1e-6);
-        w.tick_server_anims(0.3);
-        assert!(w.server_anims.is_empty(), "expired override reverts to locomotion");
+        // Mode-3 lifecycle on the local player (rid 1): the clip plays through once
+        // (movement can't interrupt), then the end pose holds while idle and only
+        // reverts once the player moves.
+        w.server_anims.insert(1, ServerAnim { name: "Wave".into(), elapsed: 0.0, duration: 0.5 });
+        w.tick_server_anims(0.3, true); // mid-playthrough: movement is ignored
+        assert!(w.server_anims.contains_key(&1), "plays through even while moving");
+        w.tick_server_anims(0.3, false); // elapsed 0.6 > 0.5, idle → held
+        assert!(w.server_anims.contains_key(&1), "holds the end pose while idle");
+        w.tick_server_anims(0.1, true); // moving after the playthrough → cancel
+        assert!(w.server_anims.is_empty(), "movement cancels the held pose");
     }
 
     #[test]

--- a/client-rs/crates/rcce-client/src/world.rs
+++ b/client-rs/crates/rcce-client/src/world.rs
@@ -1815,6 +1815,16 @@ impl World {
         if name.is_empty() {
             return;
         }
+        // Pin a remote actor's destination to its current position, exactly as
+        // Blitz does on receipt (ClientNet.bb:727-728). Otherwise a stale dest
+        // left by the prior P_StandardUpdate (an actor that was walking when the
+        // emote was issued) reads as "still moving", and tick_server_anims would
+        // cancel the held end pose the instant the one-shot plays out. (Me isn't
+        // in `actors`; its movement-cancel uses the live `me_moving` intent.)
+        if let Some(a) = self.actors.get_mut(&rid) {
+            a.dest_x = a.x;
+            a.dest_z = a.z;
+        }
         self.pending_anims.push((rid, name));
     }
 
@@ -3063,6 +3073,25 @@ mod tests {
         assert!(w.server_anims.contains_key(&1), "holds the end pose while idle");
         w.tick_server_anims(0.1, true); // moving after the playthrough → cancel
         assert!(w.server_anims.is_empty(), "movement cancels the held pose");
+
+        // A remote actor that was WALKING when told to emote: on_animate_actor
+        // must pin dest=pos (Blitz ClientNet.bb:727-728) so its held end pose
+        // isn't cancelled by the stale far-away dest the moment the clip plays out.
+        w.apply(&msg(pk::NEW_ACTOR, pkt(|p| {
+            p.u32(0).u16(60).u16(1).u32(0).u16(3);
+            p.f32(10.0).f32(0.0).f32(20.0).f32(0.0);
+            p.u8(0).str8("Walker").str8("");
+        })));
+        w.actors.get_mut(&60).unwrap().dest_x = 999.0; // stale far dest (was walking)
+        w.actors.get_mut(&60).unwrap().dest_z = 999.0;
+        w.apply(&msg(pk::ANIMATE_ACTOR, pkt(|p| { p.u16(60).u8(0).f32(0.05).raw(b"Bow"); })));
+        assert_eq!(w.actors[&60].dest_x, 10.0, "dest pinned to pos on emote");
+        assert_eq!(w.actors[&60].dest_z, 20.0);
+        // Install the override and tick well past its duration while idle: the
+        // pinned dest now reads as not-moving, so the end pose holds.
+        w.server_anims.insert(60, ServerAnim { name: "Bow".into(), elapsed: 0.0, duration: 0.1 });
+        w.tick_server_anims(0.5, false);
+        assert!(w.server_anims.contains_key(&60), "held pose survives a pinned (idle) dest");
     }
 
     #[test]


### PR DESCRIPTION
## What

Refines the `P_AnimateActor` support from #508 to match Blitz's `Animate` **mode-3** semantics, and fixes a real bug introduced there: the emote was driven by `clip_frame(elapsed_global)`, so it **started at a pseudo-random phase** (global client time) instead of the clip's first frame, and it **looped** for ~one clip length before snapping back to idle.

Blitz mode 3 plays a clip **once from the start**, **holds** its last frame, and reverts only when the actor **next moves**. The Rust client now does the same.

## How

- `ServerAnim` tracks `elapsed` (seconds since the clip began) + the clip's natural `duration` instead of a bare countdown.
- New override mode `ClipPlay::OnceFrom(elapsed)` in `build_actors` advances the clip from frame 0 at its native rate and clamps at the last frame → plays through exactly once, then holds. (`ClipPlay::Loop`/`HoldEnd` replace the old `hold: bool` for jump/attack and death — **no behaviour change** for those.)
- `tick_server_anims` plays the one-shot fully through (movement can't interrupt it), then holds the end pose until the actor moves — the local player by its movement intent, remote actors by their dest-vs-position delta — then drops the override so locomotion resumes.

Result: short emotes (wave) play once cleanly from the start; **sustained poses (sit/kneel/sleep) hold** as authored (the gap the #508 reviewer flagged); and any actor that walks cancels its emote immediately (no frozen pose sliding around).

Speed is still played at the clip's data-native rate (Blitz's framerate-coupled `Animate` speed isn't faithfully reproducible) — unchanged from #508.

## Verification

- `cargo +1.95.0 clippy … --all-targets -- -D warnings` clean.
- `cargo +1.95.0 test -p rcce-client -p rcce-net --lib` → 129 pass; the server-anim test now exercises the **play-through → hold-while-idle → cancel-on-move** lifecycle.
- Release build OK; **1280×800 headless world shot** confirms no locomotion/idle regression from the `ClipPlay` refactor.
- The emote is server-triggered (the starter sends none during autowalk), so correct-by-construction + unit-tested.

Follow-up to #508 (the iter-35 reviewer's deferred mode-3 hold-vs-loop note).

🤖 Generated with [Claude Code](https://claude.com/claude-code)