### PR TITLE
feat(rust): return to the login screen on disconnect/kick instead of freezing

### DIFF
--- a/client-rs/crates/enet-sys/src/transport.rs
+++ b/client-rs/crates/enet-sys/src/transport.rs
@@ -52,6 +52,14 @@ impl EnetTransport {
         }
     }
 
+    /// Whether the connection is still live. The ENet `DISCONNECT` event (server
+    /// kick/shutdown/timeout, or network loss) nulls `peer` during `poll`, so a
+    /// `false` here is the signal the App uses to tear the world session down and
+    /// return to the login screen instead of freezing in a dead session.
+    pub fn is_connected(&self) -> bool {
+        !self.peer.is_null() && !self.host.is_null()
+    }
+
     fn teardown(&mut self) {
         unsafe {
             if !self.peer.is_null() && !self.host.is_null() {

--- a/client-rs/crates/rcce-client/src/bin/client_window.rs
+++ b/client-rs/crates/rcce-client/src/bin/client_window.rs
@@ -6474,6 +6474,27 @@ impl App {
             cam_me_yaw = net.world.me_yaw.to_radians(); // degrees -> radians for the FP camera
             following = true;
         }
+        // Connection lost — the server kicked us (P_KickedPlayer) or the ENet peer
+        // dropped (server shutdown / timeout / network loss, nulled in poll()).
+        // Tear the world session down and return to the login screen with a
+        // message instead of freezing in a dead session (Blitz: RCE_Disconnect +
+        // OnLostConnection). The `World` lives inside `Net`, so dropping `net`
+        // releases the whole session; a fresh login rebuilds it.
+        let lost = self
+            .net
+            .as_ref()
+            .is_some_and(|n| n.world.kicked || !n.transport.is_connected());
+        if lost {
+            let kicked = self.net.as_ref().is_some_and(|n| n.world.kicked);
+            self.net = None;
+            self.target = None;
+            self.mode = Mode::Login;
+            self.login_msg = if kicked {
+                "You were kicked from the server.".to_string()
+            } else {
+                "Connection to the server was lost.".to_string()
+            };
+        }
         if did_send {
             self.last_move = Instant::now();
         }

--- a/client-rs/crates/rcce-client/src/world.rs
+++ b/client-rs/crates/rcce-client/src/world.rs
@@ -230,6 +230,10 @@ pub struct Zone {
 #[derive(Debug, Default)]
 pub struct World {
     pub my_runtime_id: u16,
+    /// Set when the server sends `P_KickedPlayer` — the App tears the world
+    /// session down and returns to the login screen with a "kicked" message
+    /// (Blitz: `RCE_Disconnect` + `OnLostConnection`, ClientNet.bb:1780).
+    pub kicked: bool,
     pub me_x: f32,
     pub me_y: f32,
     pub me_z: f32,
@@ -735,6 +739,9 @@ impl World {
             pk::REPOSITION_ACTOR => self.on_reposition_actor(&m.data),
             pk::ANIMATE_ACTOR => self.on_animate_actor(&m.data),
             pk::ITEM_HEALTH => self.on_item_health(&m.data),
+            // The server kicked us (admin/ban/dup-login). Flag it; the App tears
+            // down the session and returns to the login screen. Empty payload.
+            pk::KICKED_PLAYER => self.kicked = true,
             _ => {}
         }
     }
@@ -3225,6 +3232,16 @@ mod tests {
         w.apply(&msg(pk::ITEM_HEALTH, pkt(|p| { p.u8(99).u16(50); })));
         w.apply(&msg(pk::ITEM_HEALTH, pkt(|p| { p.u8(14); }))); // missing health
         assert_eq!(w.me_inventory[&14].health, 0, "truncated packet left health unchanged");
+    }
+
+    // P_KickedPlayer (empty payload) flags the session so the App tears it down
+    // and returns to the login screen instead of freezing.
+    #[test]
+    fn kicked_player_sets_flag() {
+        let mut w = World::default();
+        assert!(!w.kicked);
+        w.apply(&msg(pk::KICKED_PLAYER, pkt(|_p| {})));
+        assert!(w.kicked, "P_KickedPlayer flags the session for teardown");
     }
 
     #[test]

--- a/client-rs/crates/rcce-net/src/lib.rs
+++ b/client-rs/crates/rcce-net/src/lib.rs
@@ -88,6 +88,7 @@ pub mod packet_id {
     pub const PROGRESS_BAR: u8 = 51;
     pub const BUBBLE_MESSAGE: u8 = 52;
     pub const SCRIPT_INPUT: u8 = 53;
+    pub const KICKED_PLAYER: u8 = 60;
     pub const EXAMINE: u8 = 61;
     pub const TRADE: u8 = 62;
 }


### PR DESCRIPTION
## What

When the server **kicked** the player (`P_KickedPlayer`) or the **ENet peer dropped** (server shutdown / timeout / network loss), the Rust client silently **froze in a dead world session** — the transport handled `ENET_EVENT_TYPE_DISCONNECT` by nulling its peer but never surfaced it, and `P_KickedPlayer` wasn't handled at all. The client kept rendering the last-known world and sending into the void, with no notification and no way back to the menu. Blitz instead does `RCE_Disconnect` + `OnLostConnection` (ClientNet.bb:1780).

## How

- **enet-sys:** `EnetTransport::is_connected()` exposes whether the peer is still live (`poll()` already nulls it on `DISCONNECT`).
- **rcce-net:** `pk::KICKED_PLAYER = 60`.
- **World:** a `kicked` flag set on `P_KickedPlayer` (empty payload).
- **App:** after the in-world update, if `world.kicked` or `!transport.is_connected()`, drop the `Net` session (the `World` lives inside it, so this releases everything), clear the target, switch to `Mode::Login`, and set `login_msg` to a kick / connection-lost message. A fresh login rebuilds the session — the same path used at startup.

## Verification

- `cargo +1.95.0 clippy … --all-targets -- -D warnings` clean — the only rcce-client compile check (CI compiles only rcce-data/rcce-net).
- `cargo +1.95.0 test -p rcce-client -p rcce-net --lib` → 131 pass, incl. new `kicked_player_sets_flag`.
- Release build OK; **1280×800 no-regression world shot** confirms normal play is unaffected (the teardown only fires on kick/loss).
- The teardown reuses the **known-good Login render + `login_msg`** mechanism (the same screen shown at startup and on "Connection failed").
- **Honest limitation:** the end-to-end disconnect→Login transition isn't headlessly inducible in-window — an ungraceful server kill only triggers ENet's default disconnect-on-timeout (~30s, unchanged from Blitz) after the screenshot frame, and an admin kick can't be triggered from the test harness. The `P_KickedPlayer` path is unit-tested and fires immediately; a graceful server-side disconnect surfaces the `DISCONNECT` event promptly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)