### PR TITLE
feat(rust): show actor level on nameplates + the target panel

### DIFF
--- a/client-rs/crates/rcce-client/src/bin/client_window.rs
+++ b/client-rs/crates/rcce-client/src/bin/client_window.rs
@@ -7750,9 +7750,17 @@ impl App {
                             }
                         }
                         if !a.name.is_empty() {
-                            let tw = rcce_render::font::text_width(&a.name, 1.0);
+                            // Prefix the level (Blitz tracks AI\Level + shows it in
+                            // the CharInteract window; an at-a-glance nameplate level
+                            // is the on-world enhancement). Level 0 = unknown → omit.
+                            let label = if a.level > 0 {
+                                format!("Lvl {} {}", a.level, a.name)
+                            } else {
+                                a.name.clone()
+                            };
+                            let tw = rcce_render::font::text_width(&label, 1.0);
                             let nc = if is_target { col } else { white };
-                            overlay.text_shadow(px - tw * 0.5, py - 26.0, 1.0, &a.name, nc);
+                            overlay.text_shadow(px - tw * 0.5, py - 26.0, 1.0, &label, nc);
                         }
                         // Equipped weapon (from P_InventoryUpdate "O") under the name.
                         if a.equipped[0] != 0xFFFF {
@@ -7776,6 +7784,13 @@ impl App {
                         overlay.rect(px0, py0, pw, 2.0, [1.0, 0.85, 0.2, 0.9]);
                         let name: &str = if t.name.is_empty() { "Target" } else { t.name.as_str() };
                         overlay.text_shadow(px0 + 8.0, py0 + 6.0, 1.2, name, [1.0, 0.92, 0.6, 1.0]);
+                        // Level, right-aligned on the name row (Blitz CharInteract
+                        // window shows `LS_Level + AI\Level`, Interface3D.bb:25).
+                        if t.level > 0 {
+                            let lvl = format!("Lvl {}", t.level);
+                            let lw = rcce_render::font::text_width(&lvl, 1.0);
+                            overlay.text_shadow(px0 + pw - 8.0 - lw, py0 + 7.0, 1.0, &lvl, [0.8, 0.86, 1.0, 1.0]);
+                        }
                         let frac = if t.health_max > 0 {
                             (t.health as f32 / t.health_max as f32).clamp(0.0, 1.0)
                         } else {

--- a/client-rs/crates/rcce-client/src/world.rs
+++ b/client-rs/crates/rcce-client/src/world.rs
@@ -171,6 +171,10 @@ pub struct ServerAnim {
 pub struct Actor {
     pub runtime_id: u16,
     pub template_id: u16,
+    /// Actor level, from `P_NewActor` and kept live by `P_XPUpdate "L"`. Shown on
+    /// the nameplate and the target panel (Blitz tracks it as `AI\Level` and shows
+    /// it in the CharInteract window).
+    pub level: u16,
     pub name: String,
     pub tag: String,
     pub is_player: bool,
@@ -792,7 +796,7 @@ impl World {
         let mut r = MsgReader::new(d);
         let _server_area = r.u32();
         let Some(runtime_id) = r.u16() else { return };
-        let _level = r.u16();
+        let level = r.u16().unwrap_or(0);
         let _xp = r.u32();
         let template_id = r.u16().unwrap_or(0);
         let x = r.f32().unwrap_or(0.0);
@@ -853,6 +857,7 @@ impl World {
             Actor {
                 runtime_id,
                 template_id,
+                level,
                 name,
                 tag,
                 is_player,
@@ -967,6 +972,16 @@ impl World {
                 if let Some(level) = MsgReader::new(&d[1..]).u16() {
                     self.me_level = level;
                     self.me_xp = 0;
+                }
+            }
+            // Another actor's level changed (ClientNet.bb:699): RuntimeID(u16) +
+            // Level(u16). Keep the actor's displayed level live on level-up.
+            Some(b'L') => {
+                let mut r = MsgReader::new(&d[1..]);
+                if let (Some(rid), Some(level)) = (r.u16(), r.u16()) {
+                    if let Some(a) = self.actors.get_mut(&rid) {
+                        a.level = level;
+                    }
                 }
             }
             _ => {}
@@ -3232,6 +3247,30 @@ mod tests {
         w.apply(&msg(pk::ITEM_HEALTH, pkt(|p| { p.u8(99).u16(50); })));
         w.apply(&msg(pk::ITEM_HEALTH, pkt(|p| { p.u8(14); }))); // missing health
         assert_eq!(w.me_inventory[&14].health, 0, "truncated packet left health unchanged");
+    }
+
+    // Actor level: captured from P_NewActor (previously dropped) and kept live by
+    // the P_XPUpdate "L" sub-packet (another actor levelled up). Shown on the
+    // nameplate + target panel.
+    #[test]
+    fn actor_level_captured_and_updated() {
+        let mut w = World::default();
+        // Spawn actor 50 at level 7 (level is the 2nd u16 after server_area+rid).
+        w.apply(&msg(pk::NEW_ACTOR, pkt(|p| {
+            p.u32(0).u16(50).u16(7).u32(0).u16(3);
+            p.f32(0.0).f32(0.0).f32(0.0).f32(0.0);
+            p.u8(0).str8("Stag").str8("");
+        })));
+        assert_eq!(w.actors[&50].level, 7, "spawn level captured");
+
+        // P_XPUpdate "L": actor 50 levelled to 8.
+        w.apply(&msg(pk::XP_UPDATE, pkt(|p| { p.u8(b'L').u16(50).u16(8); })));
+        assert_eq!(w.actors[&50].level, 8, "level-up applied");
+
+        // "L" for an unknown actor and a truncated packet both soft-fail.
+        w.apply(&msg(pk::XP_UPDATE, pkt(|p| { p.u8(b'L').u16(999).u16(5); })));
+        w.apply(&msg(pk::XP_UPDATE, pkt(|p| { p.u8(b'L').u16(50); }))); // missing level
+        assert_eq!(w.actors[&50].level, 8, "unchanged on unknown actor / truncation");
     }
 
     // P_KickedPlayer (empty payload) flags the session so the App tears it down


### PR DESCRIPTION
## What

`P_NewActor` carries each actor's level, and `P_XPUpdate "L"` broadcasts a remote actor's level-up (ClientNet.bb:699) — but the Rust client **parsed-and-dropped** the spawn level (world.rs:795, the same pattern as the iter-30 me_template bug) and **didn't handle the "L" sub-packet** at all. So an actor's level was tracked nowhere and shown nowhere. Blitz tracks it as `AI\Level` and shows it in the CharInteract window (Interface3D.bb:25: `LS_Level + AI\Level`).

## How

- **World:** `Actor` gains a `level` field, captured from `P_NewActor` and kept live by a new `P_XPUpdate "L"` arm (`RuntimeID u16 + Level u16`; soft-fails on an unknown actor or short packet).
- **Render:** the floating nameplate now reads **"Lvl N \<name\>"** (level 0 = unknown → omitted), and the target panel shows **"Lvl N"** right-aligned on the name row — the Rust analogue of Blitz's CharInteract level label. An at-a-glance nameplate level is the on-world enhancement over Blitz's target-window-only display.

## Verification

- `cargo +1.95.0 clippy … --all-targets -- -D warnings` clean — the only rcce-client compile check (CI compiles only rcce-data/rcce-net).
- `cargo +1.95.0 test -p rcce-client --lib` → 132 pass, incl. new `actor_level_captured_and_updated` (spawn capture, the "L" level-up, unknown-actor + truncated soft-fails).
- Release build OK; **1280×800 headless world shot** confirms no nameplate-render regression. The "Lvl N" string is correct-by-construction over the unit-tested `level` field (the small nameplate text isn't thumbnail-legible, and the target panel needs a live target the autowalk harness doesn't set).

🤖 Generated with [Claude Code](https://claude.com/claude-code)