### PR TITLE
feat(rust): show target reputation (signed) in the target panel

### DIFF
--- a/client-rs/crates/rcce-client/src/bin/client_window.rs
+++ b/client-rs/crates/rcce-client/src/bin/client_window.rs
@@ -7777,7 +7777,7 @@ impl App {
                 // the target dies/zones (on_actor_dead clears self.target).
                 if let Some(rid) = target_rid {
                     if let Some(t) = net.world.actors.get(&rid).filter(|a| a.alive) {
-                        let (pw, ph) = (240.0f32, 48.0f32);
+                        let (pw, ph) = (240.0f32, 62.0f32);
                         let px0 = (sw - pw) * 0.5;
                         let py0 = 40.0;
                         overlay.rect(px0, py0, pw, ph, [0.0, 0.0, 0.0, 0.55]);
@@ -7800,6 +7800,18 @@ impl App {
                         let hp = format!("{} / {}", t.health.max(0), t.health_max.max(0));
                         let tw = rcce_render::font::text_width(&hp, 1.0);
                         overlay.text_shadow(px0 + pw * 0.5 - tw * 0.5, py0 + 29.0, 1.0, &hp, [1.0, 1.0, 1.0, 1.0]);
+                        // Reputation, bottom row (Blitz CharInteract: LS_Reputation +
+                        // AI\Reputation, Interface3D.bb:26). Signed; tinted by sign as
+                        // a readability nicety over Blitz's plain label.
+                        let rep = t.reputation;
+                        let rc = if rep < 0 {
+                            [1.0, 0.55, 0.5, 1.0]
+                        } else if rep > 0 {
+                            [0.6, 1.0, 0.6, 1.0]
+                        } else {
+                            [0.82, 0.82, 0.82, 1.0]
+                        };
+                        overlay.text_shadow(px0 + 8.0, py0 + 45.0, 1.0, &format!("Reputation: {rep}"), rc);
                     }
                 }
 

--- a/client-rs/crates/rcce-client/src/world.rs
+++ b/client-rs/crates/rcce-client/src/world.rs
@@ -1025,10 +1025,15 @@ impl World {
         if kind == b'R' {
             let mut r = MsgReader::new(&d[1..]);
             if let (Some(rid), Some(rep)) = (r.u16(), r.u16()) {
+                // Reinterpret the 16-bit field as signed (reputation can be
+                // negative) — mirrors RCE_SignedShortFromStr. The server broadcasts
+                // a player's reputation change to everyone in the zone (Server.bb
+                // UpdateReputation), so apply it to a remote actor too, keeping the
+                // target panel live (Blitz ClientNet.bb:1014 sets it for any rid).
                 if rid == self.my_runtime_id {
-                    // Reinterpret the 16-bit field as signed (reputation can be
-                    // negative), then widen — mirrors RCE_SignedShortFromStr.
                     self.me_reputation = rep as i16 as i32;
+                } else if let Some(a) = self.actors.get_mut(&rid) {
+                    a.reputation = rep as i16;
                 }
             }
             return;
@@ -2890,9 +2895,21 @@ mod tests {
         assert_eq!(w.me_reputation, -30, "negative reputation sign-extends");
         w.apply(&msg(pk::STAT_UPDATE, pkt(|p| { p.u8(b'R').u16(7).u16(450); })));
         assert_eq!(w.me_reputation, 450, "positive reputation");
-        // Another actor's reputation ('R' for a non-self rid) does not touch mine.
+        // An 'R' for a non-self rid updates THAT actor's reputation (the server
+        // broadcasts a player's reputation change zone-wide) but never touches
+        // mine. An unknown rid is a harmless no-op.
+        w.apply(&msg(pk::NEW_ACTOR, pkt(|p| {
+            p.u32(0).u16(50).u16(1).u32(0).u16(3);
+            p.f32(0.0).f32(0.0).f32(0.0).f32(0.0);
+            p.u8(1).str8("Rival").str8("");
+            p.u8(0).u16(100); // gender byte + spawn reputation 100
+        })));
+        assert_eq!(w.actors[&50].reputation, 100);
         w.apply(&msg(pk::STAT_UPDATE, pkt(|p| { p.u8(b'R').u16(50).u16((-9i16) as u16); })));
+        assert_eq!(w.actors[&50].reputation, -9, "remote actor reputation updates (signed)");
         assert_eq!(w.me_reputation, 450, "other actors' reputation leaves mine unchanged");
+        w.apply(&msg(pk::STAT_UPDATE, pkt(|p| { p.u8(b'R').u16(999).u16(5); }))); // unknown rid
+        assert_eq!(w.me_reputation, 450);
         // The 'R' layout (no attr byte) must not be misparsed as an attribute.
         assert!(w.me_attributes.is_empty(), "'R' does not write an attribute slot");
     }

--- a/client-rs/crates/rcce-client/src/world.rs
+++ b/client-rs/crates/rcce-client/src/world.rs
@@ -175,6 +175,9 @@ pub struct Actor {
     /// the nameplate and the target panel (Blitz tracks it as `AI\Level` and shows
     /// it in the CharInteract window).
     pub level: u16,
+    /// Actor reputation (signed; from `P_NewActor`). Shown in the target panel —
+    /// Blitz's CharInteract window shows `LS_Reputation + AI\Reputation`.
+    pub reputation: i16,
     pub name: String,
     pub tag: String,
     pub is_player: bool,
@@ -817,7 +820,11 @@ impl World {
         } else {
             0
         };
-        let _reputation = r.u16(); // skip 2 bytes (value unused here)
+        // Reputation is a SIGNED short on the wire (Blitz reads it via
+        // RCE_SignedShortFromStr, Actors.bb:1170) — a hostile-faction actor can be
+        // negative. Cast u16→i16 to sign-extend; reading it unsigned would show a
+        // huge positive for any negative reputation.
+        let reputation = r.u16().unwrap_or(0) as i16;
         let clamp4 = |v: Option<u16>| v.unwrap_or(0).min(4) as u8;
         let face_tex = clamp4(r.u16());
         let hair = clamp4(r.u16());
@@ -858,6 +865,7 @@ impl World {
                 runtime_id,
                 template_id,
                 level,
+                reputation,
                 name,
                 tag,
                 is_player,
@@ -3271,6 +3279,33 @@ mod tests {
         w.apply(&msg(pk::XP_UPDATE, pkt(|p| { p.u8(b'L').u16(999).u16(5); })));
         w.apply(&msg(pk::XP_UPDATE, pkt(|p| { p.u8(b'L').u16(50); }))); // missing level
         assert_eq!(w.actors[&50].level, 8, "unchanged on unknown actor / truncation");
+    }
+
+    // Actor reputation is captured from P_NewActor as a SIGNED short (a
+    // hostile-faction actor can be negative). Shown in the target panel.
+    #[test]
+    fn actor_reputation_signed_capture() {
+        let mut w = World::default();
+        // template 3 is mode 0 (selectable) → a gender byte precedes reputation.
+        // Negative reputation: -10000 = 0xD8F0 as the u16 wire bits.
+        w.apply(&msg(pk::NEW_ACTOR, pkt(|p| {
+            p.u32(0).u16(50).u16(1).u32(0).u16(3);
+            p.f32(0.0).f32(0.0).f32(0.0).f32(0.0);
+            p.u8(0).str8("Wolf").str8("");
+            p.u8(0); // gender byte (mode 0)
+            p.u16(0xD8F0); // reputation -10000
+        })));
+        assert_eq!(w.actors[&50].reputation, -10000, "negative reputation sign-extended");
+
+        // Positive reputation round-trips unchanged.
+        w.apply(&msg(pk::NEW_ACTOR, pkt(|p| {
+            p.u32(0).u16(51).u16(1).u32(0).u16(3);
+            p.f32(0.0).f32(0.0).f32(0.0).f32(0.0);
+            p.u8(0).str8("Guard").str8("");
+            p.u8(0);
+            p.u16(250);
+        })));
+        assert_eq!(w.actors[&51].reputation, 250);
     }
 
     // P_KickedPlayer (empty payload) flags the session so the App tears it down


### PR DESCRIPTION
## What

Completes the CharInteract-window parity started with the level display (#512). `P_NewActor` carries each actor's reputation as a **signed** short (Blitz reads it via `RCE_SignedShortFromStr` — a hostile-faction actor can be negative), but the Rust client **parsed-and-dropped** it (world.rs:820, "value unused here") so it was shown nowhere. Blitz's CharInteract window shows `LS_Reputation + AI\Reputation` (Interface3D.bb:26). (Faction — the other CharInteract field — is **not** in `P_NewActor`'s wire format, so it stays out of scope.)

## How

- **World:** `Actor` gains a `reputation: i16` field, captured from `P_NewActor` by casting the u16 wire bits to `i16` to **sign-extend** (reading it unsigned, as the dropped `_reputation` did, would show a huge positive for any negative value). Reading it `i16` vs `u16` consumes the same 2 bytes, so the following face/hair/body/beard offsets are unchanged.
- **Render:** the target panel grows one row and shows **"Reputation: N"**, tinted by sign (red < 0, green > 0, grey = 0) — a small readability nicety over Blitz's plain label.

## Verification

- `cargo +1.95.0 clippy … --all-targets -- -D warnings` clean — the only rcce-client compile check (CI compiles only rcce-data/rcce-net).
- `cargo +1.95.0 test -p rcce-client --lib` → 133 pass, incl. new `actor_reputation_signed_capture` (a negative −10000 sign-extend + a positive 250).
- Release build OK; **1280×800 headless world shot** confirms no render regression. The panel row itself isn't headlessly reachable (gated on a live target the autowalk harness doesn't set) and the render-pipeline is untouched, so the "Reputation: N" string is correct-by-construction over the unit-tested signed field.

🤖 Generated with [Claude Code](https://claude.com/claude-code)