### PR TITLE
feat(rust): colour NPC nameplates by hostility (aggressiveness), like Blitz

### DIFF
--- a/client-rs/crates/rcce-client/src/assets.rs
+++ b/client-rs/crates/rcce-client/src/assets.rs
@@ -506,6 +506,13 @@ impl AssetStore {
     /// (`Actors3D.bb:45`): `0.05 × LoadedMeshScales[mesh] × Actor.Scale`.
     /// Positions stay in raw world units. Falls back to `0.05` if a stored
     /// scale is non-positive.
+    /// The template's AI hostility (`Actors.dat` Aggressiveness): 0 passive,
+    /// 1 defensive, 2 always-attacks, 3 non-combatant. Defaults to 0 (passive)
+    /// for an unknown template. Drives the nameplate hostility colour.
+    pub fn actor_aggressiveness(&self, template_id: u16) -> u8 {
+        self.actors.templates.get(&template_id).map(|t| t.aggressiveness).unwrap_or(0)
+    }
+
     pub fn actor_render_scale(&self, template_id: u16, gender: u8) -> Option<f32> {
         let mesh_id = self.actors.mesh_for(template_id, gender)?;
         let mesh = self.meshes.get(mesh_id)?;

--- a/client-rs/crates/rcce-client/src/bin/client_window.rs
+++ b/client-rs/crates/rcce-client/src/bin/client_window.rs
@@ -1658,6 +1658,18 @@ fn damage_color(dtype: u8, alpha: f32) -> [f32; 4] {
     [r, g, b, alpha]
 }
 
+/// Nameplate colour for a non-player actor by its template hostility, so a player
+/// can read at a glance whether an NPC will attack — Blitz colours the nametag the
+/// same way (Actors3D.bb:546-559): non-combatant green, passive/defensive gold,
+/// always-attacks red.
+fn aggression_color(aggressiveness: u8) -> [f32; 4] {
+    match aggressiveness {
+        3 => [0.20, 0.85, 0.25, 1.0], // non-combatant — green
+        0 | 1 => [1.0, 0.86, 0.45, 1.0], // passive / defensive — gold
+        _ => [0.90, 0.30, 0.30, 1.0], // always attacks (2) — red
+    }
+}
+
 /// A GPU-skinned actor body: the source model (with bones), its textures, the
 /// animation frame, the column-major instance transform, and tint. The body's
 /// static mesh is uploaded once by [`WorldView::set_skinned`]; only the pose
@@ -7720,7 +7732,8 @@ impl App {
                         } else if a.is_player {
                             [0.4, 0.7, 1.0, 1.0]
                         } else {
-                            [0.9, 0.3, 0.3, 1.0]
+                            // NPC: colour by hostility (Blitz Actors3D.bb:546).
+                            aggression_color(store.actor_aggressiveness(a.template_id))
                         };
                         overlay.bar(px - 24.0, py - 14.0, 48.0, 5.0, frac, col);
                         if is_target {
@@ -9340,6 +9353,19 @@ fn main() {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    // NPC nameplate hostility colour: non-combatant (3) green, passive/defensive
+    // (0/1) gold, always-attacks (2, and any other value) red — mirrors Blitz's
+    // nametag colouring (Actors3D.bb:546-559).
+    #[test]
+    fn aggression_color_maps_hostility() {
+        assert_eq!(aggression_color(3), [0.20, 0.85, 0.25, 1.0]); // non-combatant
+        assert_eq!(aggression_color(0), aggression_color(1)); // passive == defensive
+        assert_eq!(aggression_color(0)[0], 1.0); // gold (high red+green)
+        let red = aggression_color(2);
+        assert!(red[0] > red[1] && red[0] > red[2], "always-attacks is red-dominant");
+        assert_eq!(aggression_color(99), red, "unknown aggressiveness defaults to red");
+    }
 
     // Non-blocking login moves the EnetTransport to a worker thread and back
     // through an mpsc channel, which requires `EnetTransport: Send` (a hand-

--- a/client-rs/crates/rcce-data/src/actors.rs
+++ b/client-rs/crates/rcce-data/src/actors.rs
@@ -45,6 +45,11 @@ pub struct ActorTemplate {
     pub genders: u8,
     /// Whether this template is a playable race (offered in character create).
     pub playable: bool,
+    /// AI hostility (`Actors.dat`): 0 = passive, 1 = defensive, 2 = always
+    /// attacks (the proactive hunters), 3 = non-combatant. Drives the nameplate
+    /// colour so a player can read an NPC's hostility at a glance (Blitz
+    /// Actors3D.bb:546-559).
+    pub aggressiveness: u8,
 }
 
 #[derive(Debug, Default, Clone)]
@@ -154,7 +159,7 @@ fn parse_record(r: &mut BlitzReader) -> Result<ActorTemplate, ReadError> {
     let genders = r.read_byte()?;
     let playable = r.read_byte()? != 0;
     let _rideable = r.read_byte()?;
-    let _aggressiveness = r.read_byte()?;
+    let aggressiveness = r.read_byte()?;
     let _aggressive_range = r.read_int()?;
     let _trade_mode = r.read_byte()?;
     let _environment = r.read_byte()?;
@@ -183,6 +188,7 @@ fn parse_record(r: &mut BlitzReader) -> Result<ActorTemplate, ReadError> {
         female_speech,
         genders,
         playable,
+        aggressiveness,
     })
 }
 


### PR DESCRIPTION
## What

Blitz colours an NPC's nametag by its AI **aggressiveness** so a player can read its hostility at a glance (Actors3D.bb:546-559): non-combatant **green**, passive/defensive **gold**, always-attacks **red**. The Rust client **parsed-and-dropped** the template's Aggressiveness byte (rcce-data/actors.rs:157, `_aggressiveness`) and coloured **every** NPC nameplate the same flat red — losing the hostility signal.

## How

- **rcce-data:** `ActorTemplate` gains an `aggressiveness: u8` field, captured from `Actors.dat` (was the dropped `_aggressiveness`; still a `read_byte` at the same offset, so the following fields are unaffected).
- **rcce-client:** `AssetStore::actor_aggressiveness(template_id)` accessor (defaults 0/passive for an unknown template); a new `aggression_color` helper maps `3→green`, `0|1→gold`, `2/else→red`; the nameplate's NPC colour branch now uses it instead of the flat red (players stay blue, the target override stays gold).

## Verification

- `cargo +1.95.0 clippy … --all-targets -- -D warnings` clean — the only rcce-client compile check (CI compiles only rcce-data/rcce-net).
- Tests pass incl. new `aggression_color_maps_hostility` (the 3 / 0|1 / 2 mapping + unknown→red default).
- Release build OK; **1280×800 daytime headless world shot** shows a non-combatant NPC's nameplate rendering **green** where the old flat scheme drew red — the hostility colouring works. (Distant nameplate text isn't thumbnail-legible, so the exact per-NPC colours are unit-tested + correct-by-construction.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)