### PR TITLE
feat(rust): show an actor's tag as a "<Tag>" nameplate line (Blitz parity)

### DIFF
--- a/client-rs/crates/rcce-client/src/bin/client_window.rs
+++ b/client-rs/crates/rcce-client/src/bin/client_window.rs
@@ -7775,11 +7775,21 @@ impl App {
                             let nc = if is_target { col } else { white };
                             overlay.text_shadow(px - tw * 0.5, py - 26.0, 1.0, &label, nc);
                         }
-                        // Equipped weapon (from P_InventoryUpdate "O") under the name.
+                        // Role/guild tag, shown above the name as "<Tag>" — Blitz
+                        // draws it as a second nametag line (Actors3D.bb:562). Rows
+                        // stack upward: name, tag, then the equipped weapon.
+                        let mut row_y = py - 38.0;
+                        if !a.tag.is_empty() {
+                            let tag = format!("<{}>", a.tag);
+                            let tw = rcce_render::font::text_width(&tag, 1.0);
+                            overlay.text_shadow(px - tw * 0.5, row_y, 1.0, &tag, [0.78, 0.86, 1.0, 1.0]);
+                            row_y -= 12.0;
+                        }
+                        // Equipped weapon (from P_InventoryUpdate "O").
                         if a.equipped[0] != 0xFFFF {
                             let wname = store.item_name(a.equipped[0]);
                             let tw = rcce_render::font::text_width(&wname, 1.0);
-                            overlay.text_shadow(px - tw * 0.5, py - 38.0, 1.0, &wname, [0.85, 0.85, 0.7, 1.0]);
+                            overlay.text_shadow(px - tw * 0.5, row_y, 1.0, &wname, [0.85, 0.85, 0.7, 1.0]);
                         }
                     }
                 }


### PR DESCRIPTION
## What

Blitz draws an actor's **Tag** (a short role/guild/title label — e.g. set by `BVM_SetTag` or the world editor) as a second nametag line under the name: `<Tag>` (Actors3D.bb:562). The Rust client parsed the tag into `Actor.tag` (and tested it) but never displayed it.

## How

The nameplate now stacks upward: name, then `<Tag>` (when non-empty), then the equipped-weapon label above that. Light-blue tint, centred like the other rows. No new data or logic — `Actor.tag` is already parsed from `P_NewActor` and covered by the existing `on_new_actor` test; this is purely the display.

## Verification

- `cargo +1.95.0 clippy … --all-targets -- -D warnings` clean.
- rcce-client lib tests pass (126, no regression).
- Release build OK; **1280×800 daytime headless world shot** confirms no nameplate regression.
- The starter project tags no NPC by default (`BVM_SetTag` is used by the manual `Spawn_Test` script — `data/Server Data/Scripts/Spawn_Test.rsl` does `SetTag(NPC, "Tag Test")`), so the `<Tag>` row is correct-by-construction over the unit-tested tag field — it renders when content provides a tag, exactly as Blitz.

🤖 Generated with [Claude Code](https://claude.com/claude-code)