### PR TITLE
perf(rust): tear down immediately on kick/loss instead of the ~1s graceful wait

### DIFF
--- a/client-rs/crates/enet-sys/src/transport.rs
+++ b/client-rs/crates/enet-sys/src/transport.rs
@@ -60,6 +60,27 @@ impl EnetTransport {
         !self.peer.is_null() && !self.host.is_null()
     }
 
+    /// Tear the connection down IMMEDIATELY, skipping the reliable-disconnect
+    /// handshake + up-to-~1s ack wait that `teardown` (Drop) performs. Use when
+    /// the connection is already gone — a server kick (it has already cleared our
+    /// session) or a dropped/timed-out peer — so the graceful wait would only
+    /// stall the UI for a disconnect the server has already done. Sends one
+    /// best-effort unreliable disconnect, frees the host, and nulls both handles,
+    /// so the later `Drop` runs `teardown` as a no-op (no double-free).
+    pub fn disconnect_immediate(&mut self) {
+        unsafe {
+            if !self.peer.is_null() {
+                enet_peer_disconnect_now(self.peer, 0);
+            }
+            if !self.host.is_null() {
+                enet_host_flush(self.host);
+                enet_host_destroy(self.host);
+            }
+        }
+        self.host = ptr::null_mut();
+        self.peer = ptr::null_mut();
+    }
+
     fn teardown(&mut self) {
         unsafe {
             if !self.peer.is_null() && !self.host.is_null() {

--- a/client-rs/crates/rcce-client/src/bin/client_window.rs
+++ b/client-rs/crates/rcce-client/src/bin/client_window.rs
@@ -6498,6 +6498,14 @@ impl App {
             .is_some_and(|n| n.world.kicked || !n.transport.is_connected());
         if lost {
             let kicked = self.net.as_ref().is_some_and(|n| n.world.kicked);
+            // The connection is already gone (server kick, or a dropped/timed-out
+            // peer), so tear it down immediately rather than letting `Drop` do the
+            // reliable-disconnect handshake + ~1s ack wait — the server has already
+            // cleared our session, so that wait would just freeze the kick→login
+            // transition. (Normal quit still does the graceful disconnect.)
+            if let Some(net) = self.net.as_mut() {
+                net.transport.disconnect_immediate();
+            }
             self.net = None;
             self.target = None;
             self.mode = Mode::Login;


### PR DESCRIPTION
## What

Completes the connection-loss handling from #511. When the client returns to the login screen after a **kick** (`P_KickedPlayer`) or a **dropped/timed-out peer**, dropping the `Net` session ran `EnetTransport`'s `Drop` teardown, which does a **reliable** disconnect handshake and pumps the host for **up to ~1s** waiting for the acknowledgement. But in both cases the connection is already gone — the server kicked us (it has already cleared our `LoggedOn` session) or the peer dropped — so that ~1s wait just **freezes the kick→login transition** for no benefit.

## How

- `EnetTransport::disconnect_immediate()`: one best-effort unreliable disconnect, free the host, **null both handles** (so the subsequent `Drop`→`teardown` is a no-op — no double-free).
- The App calls it in the connection-lost teardown before dropping the `Net`, so the return to the login screen is **instant**.

**Normal quit is unchanged:** `shutdown_net` (RCCE_SHOT/quit) and a normal `Drop` still do the graceful reliable disconnect, which the server needs to clear the session promptly so an immediate re-login isn't rejected with `'L'`. Only the already-lost path skips it.

## Verification

- `cargo +1.95.0 clippy … --all-targets -- -D warnings` clean — the only rcce-client compile check (CI compiles only rcce-data/rcce-net).
- rcce-client lib tests pass (126, no regression).
- Pure net-layer; the normal graceful-disconnect path is untouched, and the FFI teardown nulls both handles so `Drop` can't double-free. (The kick path isn't headlessly inducible — same as #511 — so this is correct-by-construction over the unchanged normal path + the new immediate teardown.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)