### PR TITLE
feat(rust): respect the area's per-scenery cast_shadow flag in the shadow pass

### DIFF
--- a/client-rs/crates/rcce-client/src/bin/actor_render.rs
+++ b/client-rs/crates/rcce-client/src/bin/actor_render.rs
@@ -158,6 +158,7 @@ fn main() {
             rot: r,
             scale: s,
             color: [1.0, 1.0, 1.0],
+            cast_shadow: true,
         })
         .collect();
 

--- a/client-rs/crates/rcce-client/src/bin/client_window.rs
+++ b/client-rs/crates/rcce-client/src/bin/client_window.rs
@@ -2568,7 +2568,7 @@ fn load_zone_static(store: &mut AssetStore, view: &mut WorldView, gfx: &Gfx, dat
                 s.mesh_id, s.pos[0], s.pos[1], s.pos[2], s.rot[0], s.rot[1], s.rot[2], s.scale[0], s.scale[1], s.scale[2]
             );
         }
-        place.push((idx, s.pos, rot, s.scale));
+        place.push((idx, s.pos, rot, s.scale, s.cast_shadow));
         for k in 0..3 {
             min[k] = min[k].min(s.pos[k]);
             max[k] = max[k].max(s.pos[k]);
@@ -2608,7 +2608,7 @@ fn load_zone_static(store: &mut AssetStore, view: &mut WorldView, gfx: &Gfx, dat
         textures.push(vec![tex]);
         lightmaps.push(vec![detail]);
         let rot = [t.rot[0].to_radians(), -t.rot[1].to_radians(), t.rot[2].to_radians()];
-        place.push((idx, t.pos, rot, t.scale));
+        place.push((idx, t.pos, rot, t.scale, true)); // terrain always casts
         // Expand the zone bounds (camera framing / centre) to the terrain footprint.
         let n = t.grid as f32;
         for [cx, cz] in [[0.0, 0.0], [n, 0.0], [0.0, n], [n, n]] {
@@ -2646,7 +2646,7 @@ fn load_zone_static(store: &mut AssetStore, view: &mut WorldView, gfx: &Gfx, dat
     }
     let instances: Vec<SceneInstance> = place
         .iter()
-        .map(|&(idx, pos, rot, scale)| SceneInstance {
+        .map(|&(idx, pos, rot, scale, cast_shadow)| SceneInstance {
             model: &models[idx],
             textures: &textures[idx],
             lightmaps: &lightmaps[idx],
@@ -2654,6 +2654,7 @@ fn load_zone_static(store: &mut AssetStore, view: &mut WorldView, gfx: &Gfx, dat
             rot,
             scale,
             color: [1.0, 1.0, 1.0],
+            cast_shadow,
         })
         .collect();
     view.set_scene(&gfx.device, &gfx.queue, &instances, min[1]);
@@ -2708,7 +2709,7 @@ fn load_zone_static(store: &mut AssetStore, view: &mut WorldView, gfx: &Gfx, dat
     // shortens when it would pass through one of these, so the camera doesn't
     // end up inside a building.
     let mut occluders: Vec<([f32; 3], f32)> = Vec::new();
-    for &(idx, pos, _rot, scale) in &place {
+    for &(idx, pos, _rot, scale, _) in &place {
         let model = &models[idx];
         let foliage = model.meshes.iter().any(|m| m.texture_flag & 4 != 0);
         if foliage {
@@ -2744,7 +2745,7 @@ fn load_zone_static(store: &mut AssetStore, view: &mut WorldView, gfx: &Gfx, dat
     let height_field = {
         use glam::{Mat3, Mat4, Vec3};
         let mut tris: Vec<[Vec3; 3]> = Vec::new();
-        for &(idx, pos, rot, scale) in &place {
+        for &(idx, pos, rot, scale, _) in &place {
             let model = &models[idx];
             let nrot = Mat3::from_mat4(
                 Mat4::from_rotation_y(rot[1]) * Mat4::from_rotation_x(rot[0]) * Mat4::from_rotation_z(rot[2]),
@@ -4998,6 +4999,7 @@ impl App {
                         rot: [0.0, 0.0, 0.0],
                         scale: [w.scale_x, 1.0, w.scale_z],
                         color: [1.0, 1.0, 1.0],
+                        cast_shadow: true,
                     })
                     .collect();
                 view.set_water(&gfx.device, &gfx.queue, &instances);
@@ -5098,6 +5100,7 @@ impl App {
                         rot: [0.0, 0.0, 0.0],
                         scale: [1.0, 1.0, 1.0],
                         color: [0.8, 0.4, 0.4],
+                        cast_shadow: true,
                     }];
                     view.set_dynamic(&gfx.device, &gfx.queue, &inst, &["testbox".to_string()]);
                 }
@@ -5134,6 +5137,7 @@ impl App {
                     rot: [0.0, 0.0, 0.0],
                     scale: [s, s, s],
                     color: [1.0, 1.0, 1.0],
+                    cast_shadow: true,
                 }];
                 view.set_dynamic(&gfx.device, &gfx.queue, &inst, &["loot:preview".to_string()]);
             }
@@ -5344,6 +5348,7 @@ impl App {
                             rot: [0.0, 0.0, 0.0],
                             scale: [s, s, s],
                             color: [1.0, 1.0, 1.0],
+                            cast_shadow: true,
                         };
                         // NAN ground_y: skip the green terrain ground plane — the
                         // set carries its own floor; the plane only showed as a
@@ -5435,6 +5440,7 @@ impl App {
                         rot: r,
                         scale: s,
                         color,
+                        cast_shadow: true,
                     })
                     .collect();
                 view.set_dynamic(&gfx.device, &gfx.queue, &instances, &keys);
@@ -6414,6 +6420,7 @@ impl App {
                             rot: r,
                             scale: s,
                             color,
+                            cast_shadow: true,
                         })
                         .collect();
                     // Dropped loot (DROP-1): render each item's world mesh (its `mmesh`)
@@ -6455,6 +6462,7 @@ impl App {
                             rot: [0.0, 0.0, 0.0],
                             scale: [*s, *s, *s],
                             color: [1.0, 1.0, 1.0],
+                            cast_shadow: true,
                         });
                         keys.push(key.clone());
                     }
@@ -6548,6 +6556,7 @@ impl App {
                     rot: [0.0, 0.0, 0.0],
                     scale: [w.scale_x, 1.0, w.scale_z],
                     color: [1.0, 1.0, 1.0],
+                    cast_shadow: true,
                 })
                 .collect();
             view.set_water(&gfx.device, &gfx.queue, &instances);

--- a/client-rs/crates/rcce-client/src/bin/zone_render.rs
+++ b/client-rs/crates/rcce-client/src/bin/zone_render.rs
@@ -120,6 +120,7 @@ fn main() {
             rot,
             scale,
             color: [1.0, 1.0, 1.0],
+            cast_shadow: true,
         })
         .collect();
 

--- a/client-rs/crates/rcce-client/src/main.rs
+++ b/client-rs/crates/rcce-client/src/main.rs
@@ -265,6 +265,7 @@ fn main() {
             rot,
             scale,
             color,
+            cast_shadow: true,
         })
         .collect();
 

--- a/client-rs/crates/rcce-data/src/area.rs
+++ b/client-rs/crates/rcce-data/src/area.rs
@@ -25,6 +25,10 @@ pub struct SceneryPlacement {
     pub scale: [f32; 3],
     /// Optional retexture id (texture catalog), 65535/none if unused.
     pub texture_id: u16,
+    /// Authored "casts a shadow" flag (`Areas.dat`). When false the renderer
+    /// should skip this scenery in the shadow-caster pass — respecting the
+    /// content author's intent (e.g. ground foliage that shouldn't cast).
+    pub cast_shadow: bool,
 }
 
 /// Zone environment/atmosphere from the area header — what the renderer needs
@@ -203,7 +207,7 @@ impl AreaScenery {
             let _collides = r.read_byte()?;
             let _lightmap = r.read_string(260)?;
             let _rcte = r.read_string(260)?;
-            let _cast_shadow = r.read_byte()?;
+            let cast_shadow = r.read_byte()? != 0;
             let _receive_shadow = r.read_byte()?;
             let _render_range = r.read_byte()?;
             sceneries.push(SceneryPlacement {
@@ -212,6 +216,7 @@ impl AreaScenery {
                 rot,
                 scale,
                 texture_id,
+                cast_shadow,
             });
         }
 
@@ -321,6 +326,32 @@ impl AreaScenery {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    // One synthetic scenery record exercises the per-object cast_shadow flag
+    // parse (used by the renderer to skip no-cast scenery in the shadow pass).
+    #[test]
+    fn scenery_cast_shadow_flag() {
+        let mut d = vec![0u8; SCENERY_COUNT_OFFSET]; // zeroed 41-byte header
+        d.extend_from_slice(&1u16.to_le_bytes()); // scenery count = 1
+        d.extend_from_slice(&7u16.to_le_bytes()); // mesh_id
+        for _ in 0..9 {
+            d.extend_from_slice(&0.0f32.to_le_bytes()); // pos + rot + scale
+        }
+        d.push(0); // anim_mode
+        d.push(0); // scenery_id
+        d.extend_from_slice(&65535u16.to_le_bytes()); // texture_id (none)
+        d.push(0); // catch_rain
+        d.push(0); // collides
+        d.extend_from_slice(&0i32.to_le_bytes()); // lightmap (empty string)
+        d.extend_from_slice(&0i32.to_le_bytes()); // rcte (empty string)
+        d.push(0); // cast_shadow = false  ← the field under test
+        d.push(1); // receive_shadow
+        d.push(0); // render_range
+        let a = AreaScenery::parse(&d).unwrap();
+        assert_eq!(a.sceneries.len(), 1);
+        assert_eq!(a.sceneries[0].mesh_id, 7);
+        assert!(!a.sceneries[0].cast_shadow, "cast_shadow byte 0 → false");
+    }
 
     fn approx(a: [f32; 3], b: [f32; 3]) -> bool {
         (0..3).all(|i| (a[i] - b[i]).abs() < 1e-4)

--- a/client-rs/crates/rcce-render/src/gpu.rs
+++ b/client-rs/crates/rcce-render/src/gpu.rs
@@ -1864,6 +1864,10 @@ pub struct Drawable {
     /// orthographic shadow box. Cheap to compute (once at bake time for statics).
     pub center: [f32; 3],
     pub radius: f32,
+    /// Whether this drawable contributes to the shadow-caster pass. Carried from
+    /// its source `SceneInstance.cast_shadow` so scenery the area author flagged
+    /// no-cast is still rendered but doesn't cast a shadow.
+    pub casts_shadow: bool,
 }
 
 /// World-space bounding sphere of `mesh` after the instance transform — the same
@@ -2013,7 +2017,7 @@ pub fn build_actor_drawables_cached(
                 .or_insert_with(|| Rc::new(pipeline.texture_bind(device, queue, tex)))
                 .clone();
             let (center, radius) = mesh_world_bounds(nrot, scale, trans, mesh);
-            drawables.push(Drawable { vbuf, ibuf, n_idx, tex_bind, alpha: mesh_is_alpha_overlay(mesh), center, radius });
+            drawables.push(Drawable { vbuf, ibuf, n_idx, tex_bind, alpha: mesh_is_alpha_overlay(mesh), center, radius, casts_shadow: inst.cast_shadow });
         }
     }
     drawables
@@ -2064,6 +2068,7 @@ pub fn build_drawables(
             alpha: false,
             center: gc.into(),
             radius: gr,
+            casts_shadow: true,
         });
     }
     drawables
@@ -2103,6 +2108,7 @@ fn build_instance_drawables(
                 alpha: mesh_is_alpha_overlay(mesh),
                 center,
                 radius,
+                casts_shadow: inst.cast_shadow,
             });
         }
     }

--- a/client-rs/crates/rcce-render/src/scene.rs
+++ b/client-rs/crates/rcce-render/src/scene.rs
@@ -30,6 +30,11 @@ pub struct SceneInstance<'a> {
     /// Fallback/tint colour (multiplied with the texture; shows through where a
     /// mesh has no texture).
     pub color: [f32; 3],
+    /// Whether this instance casts a shadow (its drawables are drawn in the
+    /// shadow-caster pass). Terrain/actors pass `true`; scenery passes the area
+    /// file's authored per-object `cast_shadow` flag, so ground foliage flagged
+    /// no-cast doesn't litter the ground with shadows.
+    pub cast_shadow: bool,
 }
 
 /// Render the scene to a PNG with distance fog. `eye`/`target` define the

--- a/client-rs/crates/rcce-render/src/world_view.rs
+++ b/client-rs/crates/rcce-render/src/world_view.rs
@@ -603,6 +603,13 @@ impl WorldView {
             // shadow fs alpha-tests so cut-out canopies cast their real shape.
             let (mut drawn, mut culled) = (0u32, 0u32);
             for d in self.statics.iter().chain(self.dynamics.iter()) {
+                // Respect the area's authored per-scenery cast-shadow flag: a
+                // no-cast object (e.g. ground foliage) is still rendered but
+                // contributes nothing to the shadow map.
+                if !d.casts_shadow {
+                    culled += 1;
+                    continue;
+                }
                 if !in_shadow_box(&d.center, d.radius) {
                     culled += 1;
                     continue;


### PR DESCRIPTION
## What

The shadow-caster pass drew **every** static (terrain + all scenery) into the shadow map, **ignoring** the area file's authored per-object `cast_shadow` flag. The starter **Plains** zone flags **249 of its 252** scenery objects (the ground foliage/grass tufts) as **no-cast** — but the Rust cast shadows from all 252, littering the ground with ~249 little grass shadows the content author had explicitly disabled.

## How

The flag was parsed-and-dropped (`_cast_shadow`, area.rs:210). Now:
- **rcce-data:** `SceneryPlacement` gains `cast_shadow: bool`, captured from `Areas.dat` (still a `read_byte` at the same offset — surrounding fields unaffected).
- **rcce-render:** `SceneInstance` gains `cast_shadow`; `build_drawables` carries it onto each `Drawable` (`casts_shadow`); the shadow pass **skips** a drawable whose `casts_shadow` is false (still rendered in the main pass — just no shadow).
- **rcce-client:** the live-zone scenery build threads each placement's flag through (terrain + actors + loot pass `true`; scenery passes the authored flag). All other `SceneInstance` sites (water, char-select preview, debug renderers) pass `true`.

Respecting the authored flag is parity with the engine's customizable intent, cleans the ground of 249 unwanted foliage shadows (clearly nicer up close), and is a shadow-pass perf micro-win (249 fewer caster draws/zone).

## Verification

- `cargo +1.95.0 clippy … --all-targets -- -D warnings` clean.
- Tests pass incl. new `area::scenery_cast_shadow_flag` (synthetic one-scenery record asserts `cast_shadow` parses) + rcce-client 126.
- Release build OK; **1280×800 daytime headless shot** shows the grass field rendering clean (no per-tuft shadows) while the player and the 3 authored casters still cast — no regression.
- A throwaway probe confirmed the real `Plains.dat` distribution: **252 scenery, 249 no-cast, 3 cast** — the payoff is real and large.

🤖 Generated with [Claude Code](https://claude.com/claude-code)