### PR TITLE
rust-client: dynamic particle emitters (P_CreateEmitter)

### DIFF
--- a/client-rs/crates/rcce-client/src/assets.rs
+++ b/client-rs/crates/rcce-client/src/assets.rs
@@ -506,6 +506,15 @@ impl AssetStore {
     /// (`Actors3D.bb:45`): `0.05 × LoadedMeshScales[mesh] × Actor.Scale`.
     /// Positions stay in raw world units. Falls back to `0.05` if a stored
     /// scale is non-positive.
+    /// Load a particle-emitter config by name from `Data/Emitter Configs/<name>.rpc`.
+    /// Used by the zone-emitter load and by `P_CreateEmitter` (dynamic emitters).
+    /// `None` if the file is missing or unparseable (caller soft-fails).
+    pub fn emitter_config(&self, name: &str) -> Option<rcce_data::EmitterConfig> {
+        let path = self.data_root.join("Emitter Configs").join(format!("{name}.rpc"));
+        let bytes = std::fs::read(path).ok()?;
+        rcce_data::EmitterConfig::parse(&bytes).ok()
+    }
+
     /// The template's AI hostility (`Actors.dat` Aggressiveness): 0 passive,
     /// 1 defensive, 2 always-attacks, 3 non-combatant. Defaults to 0 (passive)
     /// for an unknown template. Drives the nameplate hostility colour.

--- a/client-rs/crates/rcce-client/src/bin/client_window.rs
+++ b/client-rs/crates/rcce-client/src/bin/client_window.rs
@@ -2119,7 +2119,11 @@ fn register_gui_textures(overlay: &mut rcce_render::Overlay, device: &wgpu::Devi
 
 #[allow(clippy::type_complexity)]
 /// A live emitter + its resolved billboard texture, simulated per frame.
-type ZoneEmitter = (rcce_client::particles::Emitter, Option<rcce_data::Image>);
+/// A live particle emitter in the sim: the emitter, its billboard texture, and an
+/// optional remaining lifetime in milliseconds. `None` = a permanent zone emitter
+/// (from the area file); `Some(ms)` = a finite server-spawned `P_CreateEmitter`
+/// effect that stops + is dropped when the timer runs out.
+type ZoneEmitter = (rcce_client::particles::Emitter, Option<rcce_data::Image>, Option<f32>);
 
 type ZoneStatic = (
     [f32; 3],
@@ -2248,7 +2252,7 @@ fn particle_batches(
     // Softness vs Blitz: scale particle alpha (RCCE_PARTICLE_GAIN, default 0.6).
     let gain = std::env::var("RCCE_PARTICLE_GAIN").ok().and_then(|s| s.parse().ok()).unwrap_or(0.6_f32);
     let mut batches = Vec::with_capacity(emitters.len());
-    for (e, tex) in emitters.iter_mut() {
+    for (e, tex, _life) in emitters.iter_mut() {
         e.update(delta);
         let mut verts = Vec::new();
         e.billboards(right, up, gain, &mut verts);
@@ -2776,7 +2780,7 @@ fn load_zone_static(store: &mut AssetStore, view: &mut WorldView, gfx: &Gfx, dat
         let Ok(config) = rcce_data::EmitterConfig::parse(&bytes) else { continue };
         let tex = store.texture_path(em.tex_id).and_then(|p| rcce_data::texture::load(&p));
         let seed = 0x9E3779B97F4A7C15u64.wrapping_mul(ei as u64 + 1) ^ (em.pos[0].to_bits() as u64);
-        emitters.push((rcce_client::particles::Emitter::new(config, em.tex_id, em.pos, em.rot, seed), tex));
+        emitters.push((rcce_client::particles::Emitter::new(config, em.tex_id, em.pos, em.rot, seed), tex, None));
     }
     if !emitters.is_empty() {
         println!("[client-window] zone '{zone}': {} particle emitter(s)", emitters.len());
@@ -4933,10 +4937,24 @@ impl App {
     /// Advance every emitter and upload this frame's billboards (preview path —
     /// no other `self` borrow is live, so a `&mut self` method is fine).
     fn tick_particles(&mut self, eye: [f32; 3], target: [f32; 3], dt: f32) {
+        // Age finite (P_CreateEmitter) emitters: count their lifetime down and
+        // stop them spawning when it elapses (live particles then taper off).
+        let dt_ms = dt * 1000.0;
+        for (e, _, life) in self.emitters.iter_mut() {
+            if let Some(ms) = life {
+                *ms -= dt_ms;
+                if *ms <= 0.0 {
+                    e.stop();
+                }
+            }
+        }
         let batches = particle_batches(&mut self.emitters, eye, target, dt);
         if let (Some(gfx), Some(view)) = (self.gfx.as_ref(), self.view.as_mut()) {
             view.set_particles(&gfx.device, &gfx.queue, &batches);
         }
+        // Drop stopped emitters whose particles have all died (permanent zone
+        // emitters, life == None, are kept).
+        self.emitters.retain(|(e, _, life)| life.is_none() || !e.is_done());
     }
 
     /// Headless zone preview (`RCCE_VIEWZONE`): render the startup-loaded gameplay
@@ -5147,7 +5165,7 @@ impl App {
         // plume, then build this frame's billboards facing the preview camera.
         if !self.emitters.is_empty() {
             for _ in 0..180 {
-                for (e, _) in self.emitters.iter_mut() {
+                for (e, _, _) in self.emitters.iter_mut() {
                     e.update(1.0);
                 }
             }
@@ -6216,6 +6234,29 @@ impl App {
                             },
                         );
                     }
+                }
+            }
+            // Server-spawned particle emitters (P_CreateEmitter): World validated
+            // the config name + queued a PendingEmitter; resolve the .rpc config +
+            // billboard texture via the store (which World can't reach) and build a
+            // FINITE emitter (Some(lifetime_ms)) so tick aging stops + reaps it.
+            // A missing/unparseable config or texture soft-fails to no emitter.
+            if !net.world.pending_emitters.is_empty() {
+                let reqs: Vec<rcce_client::world::PendingEmitter> =
+                    net.world.pending_emitters.drain(..).collect();
+                for req in reqs {
+                    let Some(config) = store.emitter_config(&req.name) else { continue };
+                    let tex = store
+                        .texture_path(req.tex_id)
+                        .and_then(|p| rcce_data::texture::load(&p));
+                    let seed = 0x9E3779B97F4A7C15u64
+                        ^ (req.pos[0].to_bits() as u64)
+                        ^ ((req.pos[2].to_bits() as u64) << 1);
+                    let emitter = rcce_client::particles::Emitter::new(
+                        config, req.tex_id, req.pos, [0.0, 0.0, 0.0], seed,
+                    );
+                    self.emitters
+                        .push((emitter, tex, Some(req.lifetime_ms as f32)));
                 }
             }
             net.world.tick_server_anims(proj_dt, moving);
@@ -7609,6 +7650,18 @@ impl App {
         // Particles: advance the sim + upload this frame's camera-facing billboards.
         // `&mut self.emitters` is disjoint from the live gfx/view/store borrows.
         let pdt = (elapsed - self.prev_elapsed).clamp(0.0, 0.1);
+        // Age finite (P_CreateEmitter) emitters: count their lifetime down and stop
+        // them spawning when it elapses (live particles then taper off). Permanent
+        // zone emitters (life == None) are unaffected.
+        let pdt_ms = pdt * 1000.0;
+        for (e, _, life) in self.emitters.iter_mut() {
+            if let Some(ms) = life {
+                *ms -= pdt_ms;
+                if *ms <= 0.0 {
+                    e.stop();
+                }
+            }
+        }
         let mut pbatches = particle_batches(&mut self.emitters, eye, cam_target, pdt);
         // Projectiles: a depth-correct glowing orb + motion trail, appended as an
         // additive particle batch (so terrain/scenery occludes them) — replaces the
@@ -7624,6 +7677,9 @@ impl App {
             }
         }
         view.set_particles(&gfx.device, &gfx.queue, &pbatches);
+        // Reap finite emitters that have stopped and whose particles have all died
+        // (permanent zone emitters, life == None, are kept). Disjoint field borrow.
+        self.emitters.retain(|(e, _, life)| life.is_none() || !e.is_done());
         view.render(
             &gfx.device,
             &gfx.queue,

--- a/client-rs/crates/rcce-client/src/particles.rs
+++ b/client-rs/crates/rcce-client/src/particles.rs
@@ -61,6 +61,10 @@ pub struct Emitter {
     particles: Vec<Particle>,
     to_spawn: i32,
     rng: Rng,
+    /// When true, no new particles spawn (live ones still age out). Used by
+    /// finite-lifetime dynamic emitters (`P_CreateEmitter`) once their time is up,
+    /// so the effect tapers off instead of vanishing mid-puff.
+    stopped: bool,
 }
 
 fn rot_basis(deg: [f32; 3]) -> [[f32; 3]; 3] {
@@ -95,7 +99,19 @@ impl Emitter {
             particles,
             to_spawn: 0,
             rng: Rng(seed | 1),
+            stopped: false,
         }
+    }
+
+    /// Stop spawning new particles; live ones keep ageing until they expire.
+    pub fn stop(&mut self) {
+        self.stopped = true;
+    }
+
+    /// True once the emitter is stopped and all its particles have died — the
+    /// caller can then drop it.
+    pub fn is_done(&self) -> bool {
+        self.stopped && !self.particles.iter().any(|p| p.in_use)
     }
 
     fn spawn(&mut self, i: usize) {
@@ -163,7 +179,12 @@ impl Emitter {
     /// Advance the sim by `delta` Blitz-frames.
     pub fn update(&mut self, delta: f32) {
         let c = &self.config;
-        self.to_spawn = (c.particles_per_frame as f32 * delta).ceil() as i32;
+        // A stopped emitter spawns nothing; live particles below still age + fade.
+        self.to_spawn = if self.stopped {
+            0
+        } else {
+            (c.particles_per_frame as f32 * delta).ceil() as i32
+        };
         let (fm, force_shaping) = (c.force_mod, c.force_shaping);
         for i in 0..self.particles.len() {
             if self.particles[i].in_use {
@@ -269,6 +290,23 @@ mod tests {
             e.update(1.0);
         }
         assert_eq!(e.particles.iter().filter(|p| p.in_use).count(), 0);
+    }
+
+    // A stopped emitter spawns no new particles but lets live ones finish, then
+    // reports `is_done` so a finite dynamic emitter can be dropped.
+    #[test]
+    fn stop_lets_particles_finish_then_is_done() {
+        let mut e = Emitter::new(cfg(), 0, [0.0; 3], [0.0; 3], 9);
+        e.update(1.0);
+        assert!(e.particles.iter().any(|p| p.in_use), "spawned some");
+        e.stop();
+        assert!(!e.is_done(), "not done while particles live");
+        // Once stopped, no fresh spawns even though particles_per_frame is high.
+        for _ in 0..40 {
+            e.update(1.0);
+        }
+        assert_eq!(e.particles.iter().filter(|p| p.in_use).count(), 0, "all aged out, none respawned");
+        assert!(e.is_done(), "done after stop + all particles dead");
     }
 
     #[test]

--- a/client-rs/crates/rcce-client/src/world.rs
+++ b/client-rs/crates/rcce-client/src/world.rs
@@ -151,6 +151,21 @@ pub struct CombatEvent {
     pub damage_type: u8,
 }
 
+/// A server-spawned particle emitter request (`P_CreateEmitter`), resolved by the
+/// App against the AssetStore (`.rpc` config + texture).
+#[derive(Debug, Clone, PartialEq)]
+pub struct PendingEmitter {
+    /// Billboard texture catalog id.
+    pub tex_id: u16,
+    /// Lifetime in milliseconds (the emitter stops spawning after this).
+    pub lifetime_ms: u32,
+    /// World spawn position.
+    pub pos: [f32; 3],
+    /// Emitter config name (indexes `Data/Emitter Configs/<name>.rpc`). Validated
+    /// against path traversal at the receive site.
+    pub name: String,
+}
+
 /// A server-commanded animation override (`P_AnimateActor`). Blitz `Animate`
 /// mode 3 plays the clip once from the start, holds its last frame, and only
 /// reverts when the actor next moves — so we track time **since the clip began**
@@ -377,6 +392,11 @@ pub struct World {
     /// below death) instead of locomotion; `tick_server_anims` expires it after the
     /// clip's natural length, reverting to idle/walk (Blitz mode-3 plays once).
     pub server_anims: HashMap<u16, ServerAnim>,
+    /// Server-spawned particle emitters (`P_CreateEmitter`): the App drains these,
+    /// loads each one's `.rpc` config + texture (which live in the AssetStore), and
+    /// adds a finite-lifetime emitter to the live particle sim. Mirrors Blitz
+    /// `ScriptedEmitter` (ClientNet.bb:772).
+    pub pending_emitters: Vec<PendingEmitter>,
     /// The local player's inventory, keyed by slot (0..13 equipment, 14..45
     /// backpack). Seeded from the P_FetchCharacter sheet, then kept live by
     /// P_InventoryUpdate G/T/H/R. BTreeMap so the panel iterates in slot order.
@@ -746,6 +766,7 @@ impl World {
             pk::REPOSITION_ACTOR => self.on_reposition_actor(&m.data),
             pk::ANIMATE_ACTOR => self.on_animate_actor(&m.data),
             pk::ITEM_HEALTH => self.on_item_health(&m.data),
+            pk::CREATE_EMITTER => self.on_create_emitter(&m.data),
             // The server kicked us (admin/ban/dup-login). Flag it; the App tears
             // down the session and returns to the login screen. Empty payload.
             pk::KICKED_PLAYER => self.kicked = true,
@@ -1862,6 +1883,42 @@ impl World {
             a.dest_z = a.z;
         }
         self.pending_anims.push((rid, name));
+    }
+
+    /// `P_CreateEmitter` (ClientNet.bb:772): the server spawns a particle emitter —
+    /// a spell/ability/script visual. Layout: TexID(u16) · Time(u32, ms lifetime) ·
+    /// RuntimeID(u16, attach target) · X·Y·Z(f32) · ConfigName(string-to-end). We
+    /// queue the request; the App loads the `.rpc` config + texture and adds a
+    /// finite emitter to the sim.
+    ///
+    /// The config name is validated against path traversal exactly as Blitz does
+    /// (ClientNet.bb:785-797): a hostile server could otherwise pass `..\..\x` to
+    /// escape `Data/Emitter Configs`. Reject empty / >240 chars, any byte outside
+    /// printable ASCII, `:` `/` `\`, or a `..` substring. Soft-fails (queues
+    /// nothing) on a bad name or short packet. (RuntimeID/attachment is parsed but
+    /// not yet applied — first slice uses the spawn position; following the actor
+    /// is a deferred follow-up.)
+    fn on_create_emitter(&mut self, d: &[u8]) {
+        let mut r = MsgReader::new(d);
+        let (Some(tex_id), Some(lifetime_ms), Some(_rid)) = (r.u16(), r.u32(), r.u16()) else {
+            return;
+        };
+        let (Some(x), Some(y), Some(z)) = (r.f32(), r.f32(), r.f32()) else {
+            return;
+        };
+        let name = String::from_utf8_lossy(r.rest()).into_owned();
+        if name.is_empty() || name.len() > 240 || name.contains("..") {
+            return;
+        }
+        if name.bytes().any(|b| !(32..=126).contains(&b) || b == b':' || b == b'/' || b == b'\\') {
+            return;
+        }
+        self.pending_emitters.push(PendingEmitter {
+            tex_id,
+            lifetime_ms,
+            pos: [x, y, z],
+            name,
+        });
     }
 
     /// `P_ItemHealth` (ClientNet.bb:249): the server reports a durability change
@@ -3158,6 +3215,28 @@ mod tests {
         w.server_anims.insert(60, ServerAnim { name: "Bow".into(), elapsed: 0.0, duration: 0.1 });
         w.tick_server_anims(0.5, false);
         assert!(w.server_anims.contains_key(&60), "held pose survives a pinned (idle) dest");
+    }
+
+    // P_CreateEmitter queues a (tex, lifetime, pos, name) intent for the App to
+    // resolve into a live particle emitter. The config name is validated against
+    // path traversal; bad names + short packets soft-fail.
+    #[test]
+    fn create_emitter_queues_and_validates() {
+        let mut w = World::default();
+        // Valid: tex 5, 2000ms, rid 0, pos (10,1,20), config "fire".
+        w.apply(&msg(pk::CREATE_EMITTER, pkt(|p| { p.u16(5).u32(2000).u16(0).f32(10.0).f32(1.0).f32(20.0).raw(b"fire"); })));
+        assert_eq!(
+            w.pending_emitters,
+            vec![PendingEmitter { tex_id: 5, lifetime_ms: 2000, pos: [10.0, 1.0, 20.0], name: "fire".into() }]
+        );
+
+        // Path traversal (".."), a slash, an empty name, and a truncated packet
+        // all queue nothing.
+        w.apply(&msg(pk::CREATE_EMITTER, pkt(|p| { p.u16(5).u32(2000).u16(0).f32(0.0).f32(0.0).f32(0.0).raw(b"..\\evil"); })));
+        w.apply(&msg(pk::CREATE_EMITTER, pkt(|p| { p.u16(5).u32(2000).u16(0).f32(0.0).f32(0.0).f32(0.0).raw(b"a/b"); })));
+        w.apply(&msg(pk::CREATE_EMITTER, pkt(|p| { p.u16(5).u32(2000).u16(0).f32(0.0).f32(0.0).f32(0.0); })));
+        w.apply(&msg(pk::CREATE_EMITTER, pkt(|p| { p.u16(5).u32(2000).u16(0); })));
+        assert_eq!(w.pending_emitters.len(), 1, "only the valid emitter queued");
     }
 
     #[test]

--- a/client-rs/crates/rcce-net/src/lib.rs
+++ b/client-rs/crates/rcce-net/src/lib.rs
@@ -80,6 +80,7 @@ pub mod packet_id {
     pub const ITEM_SCRIPT: u8 = 43;
     pub const EAT_ITEM: u8 = 44;
     pub const ITEM_HEALTH: u8 = 45;
+    pub const CREATE_EMITTER: u8 = 28;
     pub const ANIMATE_ACTOR: u8 = 30;
     pub const APPEARANCE_UPDATE: u8 = 39;
     pub const JUMP: u8 = 46;


### PR DESCRIPTION
## What

Teaches the Rust client to spawn **server-driven particle emitters** in response to `P_CreateEmitter` (packet 28). Until now the Rust client only rendered the *static* zone emitters baked into an area's scenery; the engine's runtime-spawned effects (a cast spell's burst, a scripted campfire, an environmental puff) were dropped on the floor. This wires them through end to end.

## How

- **rcce-net**: add `pk::CREATE_EMITTER = 28`.
- **World::on_create_emitter** decodes the payload — `TexID u16 · lifetime u32 ms · attach-RID u16 · X·Y·Z f32 · config-name to end` (per `ClientNet.bb:772`) — into a `PendingEmitter` the app drains each frame. The config name is **validated against path traversal** exactly like `ClientNet.bb:785-797` (reject empty / len>240 / control bytes / `:` / `/` / `\` / `..`) so a hostile server can't escape `Data\Emitter Configs`. Truncated payloads soft-fail (return) — no panic on wire input.
- **Emitter** gains a `stop()` / `is_done()` lifecycle: a finite emitter stops spawning when its lifetime elapses, then is reaped once its live particles have all died.
- **Render loop** builds a finite `Emitter` (`Some(lifetime_ms)`) per request, resolving the `.rpc` config (new `AssetStore::emitter_config`) + billboard texture via the store, ages them down each frame, and reaps the dead ones. `ZoneEmitter` is now `(Emitter, tex, Option<f32>)` where `None` = permanent zone emitter (unchanged behavior), `Some` = finite runtime emitter.

The attach-to-actor RID is parsed but ignored in this slice (world-anchored position only) — see follow-ups.

## Verification

- `cargo clippy … -D warnings` clean; `cargo test` 128 client tests + new `create_emitter_queues_and_validates` (valid→queued; `..`/slash/empty/truncated→rejected) and `stop_lets_particles_finish_then_is_done` pass.
- Release build + headless 1280x800 dusk shot: world renders, **11 Plains zone emitters still load** (no regression from the tuple change), no crash. `P_CreateEmitter` is server-triggered so the dynamic path is covered by unit tests + correct-by-construction.

## Follow-up slices (deferred)
- Actor-attachment (emitter follows the attach-RID actor).
- `P_FreeEmitter` (server-commanded early stop by handle).
- `P_LoadEmitterConfig` (server pushes a config the client lacks on disk).

🤖 Generated with [Claude Code](https://claude.com/claude-code)