### PR TITLE
rust-client: apply actor-local offset for attached emitters (#519 follow-up)

### DIFF
--- a/client-rs/crates/rcce-client/src/bin/client_window.rs
+++ b/client-rs/crates/rcce-client/src/bin/client_window.rs
@@ -2131,6 +2131,10 @@ struct ZoneEmitter {
     /// `None` = world-anchored at a fixed position. When the actor leaves the zone
     /// or dies the emitter is stopped (tapers + is reaped) rather than derefed.
     attach: Option<u16>,
+    /// Actor-local spawn offset added to the attached actor's position each frame
+    /// (the packet's X/Y/Z, which Blitz applies as a parent-local PositionEntity).
+    /// Only meaningful when `attach` is `Some`; ignored for world-anchored emitters.
+    offset: [f32; 3],
 }
 
 type ZoneStatic = (
@@ -2239,9 +2243,6 @@ fn test_box_model(skinned: bool) -> B3dModel {
 /// tiling density is the lone cosmetic unknown until verified against a real
 /// terrain (current rcce2 zones ship none). Winding is irrelevant (backface cull
 /// is off).
-/// Advance emitters by `dt` seconds and build their camera-facing billboard
-/// batches `(texture, additive?, verts)`. A free function so the in-world render
-/// can call it while holding `gfx`/`view` borrows of other `self` fields.
 /// Interpolated world position of an actor by RuntimeID, for an attached emitter
 /// to follow. Returns `None` when the actor isn't present (left the zone, despawned,
 /// or not yet spawned) — the caller then stops the emitter instead of derefing a
@@ -2253,6 +2254,9 @@ fn actor_world_pos(world: &rcce_client::world::World, rid: u16) -> Option<[f32; 
     world.actors.get(&rid).map(|a| [a.render_x, a.y, a.render_z])
 }
 
+/// Advance emitters by `dt` seconds and build their camera-facing billboard
+/// batches `(texture, additive?, verts)`. A free function so the in-world render
+/// can call it while holding `gfx`/`view` borrows of other `self` fields.
 fn particle_batches(
     emitters: &mut [ZoneEmitter],
     eye: [f32; 3],
@@ -2804,6 +2808,7 @@ fn load_zone_static(store: &mut AssetStore, view: &mut WorldView, gfx: &Gfx, dat
             tex,
             life: None,
             attach: None,
+            offset: [0.0, 0.0, 0.0],
         });
     }
     if !emitters.is_empty() {
@@ -6287,6 +6292,7 @@ impl App {
                         tex,
                         life: Some(req.lifetime_ms as f32),
                         attach: req.attach,
+                        offset: req.pos,
                     });
                 }
             }
@@ -7703,7 +7709,15 @@ impl App {
             for ze in self.emitters.iter_mut() {
                 if let Some(rid) = ze.attach {
                     match actor_world_pos(&net.world, rid) {
-                        Some(pos) => ze.emitter.set_pos(pos),
+                        // Add the actor-local offset (Blitz parents then sets a local
+                        // PositionEntity). World-space add (no actor-yaw rotation) —
+                        // exact for vertical/zero offsets; yaw-rotating a horizontal
+                        // offset is a deferred fidelity follow-up.
+                        Some(pos) => ze.emitter.set_pos([
+                            pos[0] + ze.offset[0],
+                            pos[1] + ze.offset[1],
+                            pos[2] + ze.offset[2],
+                        ]),
                         None => ze.emitter.stop(),
                     }
                 }

--- a/client-rs/crates/rcce-client/src/world.rs
+++ b/client-rs/crates/rcce-client/src/world.rs
@@ -1899,9 +1899,9 @@ impl World {
     /// (ClientNet.bb:785-797): a hostile server could otherwise pass `..\..\x` to
     /// escape `Data/Emitter Configs`. Reject empty / >240 chars, any byte outside
     /// printable ASCII, `:` `/` `\`, or a `..` substring. Soft-fails (queues
-    /// nothing) on a bad name or short packet. (RuntimeID/attachment is parsed but
-    /// not yet applied — first slice uses the spawn position; following the actor
-    /// is a deferred follow-up.)
+    /// nothing) on a bad name or short packet. A non-zero RuntimeID attaches the
+    /// emitter to that actor (`pos` is then an actor-local offset it follows each
+    /// frame); RuntimeID 0 = world-anchored (`pos` absolute).
     fn on_create_emitter(&mut self, d: &[u8]) {
         let mut r = MsgReader::new(d);
         let (Some(tex_id), Some(lifetime_ms), Some(rid)) = (r.u16(), r.u32(), r.u16()) else {


### PR DESCRIPTION
Reviewer follow-up to #519. The attach-follow loop set an attached emitter to the **bare actor position**, discarding the packet's X/Y/Z. But Blitz parents the emitter then sets a **local** `PositionEntity` (ClientNet.bb:816) — i.e. X/Y/Z is an actor-relative offset (`ScriptingCommands.bb:1740`: *"Emitter offsets are actor-relative"*). So an above-head / aura offset like `(0,50,0)` rendered at the actor's **feet**.

## Fix
- Capture the offset on `ZoneEmitter { offset: [f32;3] }` (from `PendingEmitter.pos`, which for an attached emitter is the local offset) and add it to the actor's position each frame.
- World-space add, **no actor-yaw rotation** — exact for vertical/zero offsets (the common case: head/aura/feet effects); yaw-rotating a *horizontal* offset stays a deferred fidelity follow-up (kept out to avoid a hard-to-verify-headless handedness bug).
- World-anchored emitters (`attach: None`) are unaffected — the follow loop is skipped, so their rendering is byte-identical.
- Cleared two stale doc comments the reviewer flagged: the `on_create_emitter` "attachment not yet applied" note (it is now), and the `particle_batches` doc that got separated from its function.

## Verification
`cargo clippy … -D warnings` clean; `cargo test` 129 lib + 46 bin green. No new render shot: the change is gated on `attach.is_some()`, which is never true for the zone (area-file) emitters, so the world-anchored render path is provably identical to the #519 no-regression shot. The attach offset is server-triggered → unit-test + correct-by-construction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)