### PR TITLE
rust-client: player-attached emitters survive a zone change

### DIFF
--- a/client-rs/crates/rcce-client/src/bin/client_window.rs
+++ b/client-rs/crates/rcce-client/src/bin/client_window.rs
@@ -2254,6 +2254,16 @@ fn actor_world_pos(world: &rcce_client::world::World, rid: u16) -> Option<[f32; 
     world.actors.get(&rid).map(|a| [a.render_x, a.y, a.render_z])
 }
 
+/// Whether a scripted (dynamic) emitter survives a zone change. Blitz frees every
+/// scripted emitter on a zone change EXCEPT those attached to the local player
+/// (ClientNet.bb:1679 `AttachedToPlayer = False` gate) — a player-attached aura
+/// follows the player across zones, while world/NPC-attached effects are dropped and
+/// replaced by the new zone's emitters. `my_rid` is the local player's RuntimeID
+/// (0 before entering the world → nothing is player-attached, so nothing survives).
+fn emitter_survives_zone_change(attach: Option<u16>, my_rid: u16) -> bool {
+    my_rid != 0 && attach == Some(my_rid)
+}
+
 /// Advance emitters by `dt` seconds and build their camera-facing billboard
 /// batches `(texture, additive?, verts)`. A free function so the in-world render
 /// can call it while holding `gfx`/`view` borrows of other `self` fields.
@@ -6104,7 +6114,17 @@ impl App {
                     self.ground_y = z.ground_y;
                     self.height_field = Some(z.height_field);
                     set_water_planes(z.waters, &mut self.water_planes, &mut self.water_texs);
-                    self.emitters = z.emitters;
+                    // Carry player-attached dynamic emitters across the zone change
+                    // (Blitz keeps `AttachedToPlayer` ones, ClientNet.bb:1679 — a
+                    // player aura follows them), then append the new zone's permanent
+                    // emitters. World/NPC-attached + world-anchored effects are dropped.
+                    let my_rid = net.world.my_runtime_id;
+                    let mut carried: Vec<ZoneEmitter> = std::mem::take(&mut self.emitters)
+                        .into_iter()
+                        .filter(|ze| emitter_survives_zone_change(ze.attach, my_rid))
+                        .collect();
+                    carried.extend(z.emitters);
+                    self.emitters = carried;
                     self.cam_occluders = z.occluders;
                     self.fog_color = z.env.fog_color;
                     self.fog_near = z.env.fog_near;
@@ -9497,6 +9517,18 @@ fn main() {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    // A zone change keeps only player-attached dynamic emitters (Blitz
+    // ClientNet.bb:1679); world-anchored + NPC-attached effects are dropped, and
+    // before the player is in-world (my_rid 0) nothing is player-attached.
+    #[test]
+    fn emitter_survives_zone_change_only_player_attached() {
+        let me = 1285u16;
+        assert!(emitter_survives_zone_change(Some(me), me), "my aura follows me");
+        assert!(!emitter_survives_zone_change(Some(99), me), "an NPC's emitter is dropped");
+        assert!(!emitter_survives_zone_change(None, me), "a world-anchored emitter is dropped");
+        assert!(!emitter_survives_zone_change(Some(0), 0), "before in-world, nothing survives");
+    }
 
     // NPC nameplate hostility colour: non-combatant (3) green, passive/defensive
     // (0/1) gold, always-attacks (2, and any other value) red — mirrors Blitz's


### PR DESCRIPTION
## What

Closes the dynamic-emitter parity arc. Blitz frees every scripted emitter on a zone change **except** those attached to the local player (`ClientNet.bb:1679`: `If SEm\AttachedToPlayer = False Then RP_FreeEmitter`) — a player aura/buff effect follows the player across zones, while world-anchored and NPC-attached effects are dropped and replaced by the new zone's emitters. The Rust reload (`self.emitters = z.emitters`) replaced the whole list, dropping player-attached ones too.

## How

The in-render zone-reload now carries over player-attached emitters (`attach == my RuntimeID`) before appending the new zone's permanent emitters:
```rust
let mut carried = take(&mut self.emitters).into_iter()
    .filter(|ze| emitter_survives_zone_change(ze.attach, my_rid)).collect();
carried.extend(z.emitters);
self.emitters = carried;
```
New pure predicate `emitter_survives_zone_change(attach, my_rid)` (player-attached only; `my_rid 0` before in-world → nothing survives) + unit test. The initial-load path (`enter_outcome`) is unchanged — there are no prior dynamic emitters at first entry.

## Recon result (why this closes the arc)

There is **no `P_FreeEmitter` or `P_LoadEmitterConfig` packet** — `P_CreateEmitter` (28) is the only emitter packet in `Packets.bb`. All emitter teardown is client-local: **lifetime expiry** (Environment3D.bb:247 — already implemented as the `life` countdown + taper + reap) and **this zone-change rule**. So the dynamic-emitter wire surface is now complete: create + attach + offset + lifetime + zone-change survival.

## Verification

`cargo clippy … -D warnings` clean; `cargo test` 129 lib + 47 bin green incl. new `emitter_survives_zone_change_only_player_attached`. **No render shot:** the change is confined to the zone-RELOAD branch (fires only on a server warp — not headless-inducible), and the initial-load + per-frame emitter render paths are unchanged, so a startup shot would exercise none of the new code. Predicate unit-tested; carry-over is correct-by-construction (filter + extend).

🤖 Generated with [Claude Code](https://claude.com/claude-code)