### PR TITLE
rust-client: weapon damage type in item tooltip (Damage.dat)

### DIFF
--- a/client-rs/crates/rcce-client/src/assets.rs
+++ b/client-rs/crates/rcce-client/src/assets.rs
@@ -39,6 +39,9 @@ pub struct AssetStore {
     /// `Game Data/Fixed Attributes.dat`. `None` when the file is absent (the
     /// `health_stat()` accessor then falls back to the index-0 default).
     fixed_attributes: Option<rcce_data::FixedAttributes>,
+    /// Project weapon damage-type names (`Server Data/Damage.dat`), for the
+    /// weapon tooltip. Empty when the file is absent (then no type is shown).
+    damage_types: rcce_data::DamageTypes,
     /// Project sun/moon directional lights from `Game Data/Suns.dat`. `None` when
     /// absent → the renderer uses a neutral white sun. See `sun_light`.
     suns: Option<rcce_data::Suns>,
@@ -161,6 +164,11 @@ impl AssetStore {
         let fixed_attributes = std::fs::read(data_root.join("Game Data/Fixed Attributes.dat"))
             .ok()
             .and_then(|b| rcce_data::FixedAttributes::parse(&b).ok());
+        // Project weapon damage-type names (Piercing/Fire/…), shown in the weapon
+        // tooltip. Absent/unreadable → empty table → no "(type)" suffix.
+        let damage_types = std::fs::read(data_root.join("Server Data/Damage.dat"))
+            .map(|b| rcce_data::DamageTypes::parse(&b))
+            .unwrap_or_default();
         // Project sun/moon directional light colours (warm day / cool night).
         let suns = std::fs::read(data_root.join("Game Data/Suns.dat"))
             .ok()
@@ -183,6 +191,7 @@ impl AssetStore {
             money,
             attribute_names,
             fixed_attributes,
+            damage_types,
             suns,
             language,
             cache: HashMap::new(),
@@ -196,6 +205,13 @@ impl AssetStore {
     /// shipped default project (Health = slot 0).
     pub fn health_stat(&self) -> u8 {
         self.fixed_attributes.and_then(|f| f.health).unwrap_or(0)
+    }
+
+    /// The project's name for a weapon damage-type index (`Damage.dat`), e.g.
+    /// `3 -> "Fire"`. `None` when the table is absent or the slot is unnamed/out
+    /// of range — the tooltip then omits the "(type)" suffix.
+    pub fn damage_type_name(&self, idx: i16) -> Option<&str> {
+        self.damage_types.name(idx)
     }
 
     /// The project's localizable string table (`Game Data/Language.txt`), for

--- a/client-rs/crates/rcce-client/src/bin/client_window.rs
+++ b/client-rs/crates/rcce-client/src/bin/client_window.rs
@@ -2254,6 +2254,17 @@ fn actor_world_pos(world: &rcce_client::world::World, rid: u16) -> Option<[f32; 
     world.actors.get(&rid).map(|a| [a.render_x, a.y, a.render_z])
 }
 
+/// The weapon-damage tooltip line, with the project's damage-type name appended
+/// when the weapon has a named type in `Damage.dat` (e.g. "Damage: 12 (Fire)"),
+/// else just "Damage: 12". Mirrors Blitz's `DamageTypes$(WeaponDamageType)` tooltip
+/// (Interface3D.bb:1949). Caller already gated on `weapon_damage > 0` (a weapon).
+fn weapon_damage_line(damage: i16, type_name: Option<&str>) -> String {
+    match type_name {
+        Some(t) => format!("Damage: {damage} ({t})"),
+        None => format!("Damage: {damage}"),
+    }
+}
+
 /// Whether a scripted (dynamic) emitter survives a zone change. Blitz frees every
 /// scripted emitter on a zone change EXCEPT those attached to the local player
 /// (ClientNet.bb:1679 `AttachedToPlayer = False` gate) — a player-attached aura
@@ -9198,7 +9209,7 @@ impl App {
                                         lines.push((sname.to_string(), [0.7, 1.0, 0.8, 1.0]));
                                     }
                                     if def.weapon_damage > 0 {
-                                        lines.push((format!("Damage: {}", def.weapon_damage), [1.0, 0.7, 0.6, 1.0]));
+                                        lines.push((weapon_damage_line(def.weapon_damage, store.damage_type_name(def.weapon_damage_type)), [1.0, 0.7, 0.6, 1.0]));
                                     }
                                     if def.armour_level > 0 {
                                         lines.push((format!("Armour: {}", def.armour_level), [0.7, 0.85, 1.0, 1.0]));
@@ -9234,7 +9245,7 @@ impl App {
                                 lines.push((store.item_name(item_id), white));
                                 if let Some(def) = store.item_def(item_id) {
                                     if def.weapon_damage > 0 {
-                                        lines.push((format!("Damage: {}", def.weapon_damage), [1.0, 0.7, 0.6, 1.0]));
+                                        lines.push((weapon_damage_line(def.weapon_damage, store.damage_type_name(def.weapon_damage_type)), [1.0, 0.7, 0.6, 1.0]));
                                     }
                                     if def.armour_level > 0 {
                                         lines.push((format!("Armour: {}", def.armour_level), accent));
@@ -9517,6 +9528,14 @@ fn main() {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    // The weapon tooltip appends the project's damage-type name when present
+    // ("Damage: 12 (Fire)"), else just the number (Damage.dat absent / unnamed slot).
+    #[test]
+    fn weapon_damage_line_appends_type() {
+        assert_eq!(weapon_damage_line(12, Some("Fire")), "Damage: 12 (Fire)");
+        assert_eq!(weapon_damage_line(12, None), "Damage: 12");
+    }
 
     // A zone change keeps only player-attached dynamic emitters (Blitz
     // ClientNet.bb:1679); world-anchored + NPC-attached effects are dropped, and

--- a/client-rs/crates/rcce-data/src/damage.rs
+++ b/client-rs/crates/rcce-data/src/damage.rs
@@ -1,0 +1,85 @@
+//! `Damage.dat` — the project's weapon damage-type names (`DamageTypes$`,
+//! `Items.bb:486 LoadDamageTypes`). The file is 20 bounded strings (a 4-byte LE
+//! length prefix + the bytes, i.e. `ReadBoundedString$(F, 256)`). A weapon's
+//! `weapon_damage_type` indexes this table; Blitz shows the resolved name in the
+//! weapon tooltip (`Interface3D.bb:1949`) and the combat damage output
+//! (`ClientNet.bb:1129`). The names are project-customizable, so the client must
+//! read them from disk rather than hard-code "Fire/Ice/…".
+
+use crate::reader::BlitzReader;
+
+/// The damage-type names from `Server Data/Damage.dat`, in file order (Blitz dims
+/// `DamageTypes$(19)` = 20 slots).
+#[derive(Debug, Clone, Default)]
+pub struct DamageTypes {
+    pub names: Vec<String>,
+}
+
+impl DamageTypes {
+    /// Parse a `Damage.dat`: up to 20 bounded strings. Stops cleanly at EOF / the
+    /// first unreadable entry, keeping what parsed — the same soft-fail posture as
+    /// the other catalog parsers (and `LoadDamageTypes`, which aborts on a short
+    /// read). Empty slots are kept so indices line up with the file.
+    pub fn parse(data: &[u8]) -> DamageTypes {
+        let mut r = BlitzReader::new(data);
+        let mut names = Vec::with_capacity(20);
+        for _ in 0..20 {
+            match r.read_string(256) {
+                Ok(s) => names.push(s),
+                Err(_) => break,
+            }
+        }
+        DamageTypes { names }
+    }
+
+    /// The damage-type name at `idx`, or `None` when out of range, negative, or an
+    /// unnamed (empty) slot — so a caller can skip the "(…)" suffix entirely.
+    pub fn name(&self, idx: i16) -> Option<&str> {
+        if idx < 0 {
+            return None;
+        }
+        self.names
+            .get(idx as usize)
+            .map(|s| s.as_str())
+            .filter(|s| !s.is_empty())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn bstr(s: &str) -> Vec<u8> {
+        let b = s.as_bytes();
+        let mut v = (b.len() as i32).to_le_bytes().to_vec();
+        v.extend_from_slice(b);
+        v
+    }
+
+    #[test]
+    fn parses_names_and_resolves_index() {
+        let mut d = Vec::new();
+        for s in ["Piercing", "Slashing", "Fire"] {
+            d.extend(bstr(s));
+        }
+        // Pad the remaining slots with empty strings (zero-length).
+        for _ in 3..20 {
+            d.extend((0i32).to_le_bytes());
+        }
+        let dt = DamageTypes::parse(&d);
+        assert_eq!(dt.name(0), Some("Piercing"));
+        assert_eq!(dt.name(2), Some("Fire"));
+        assert_eq!(dt.name(3), None, "empty slot → None");
+        assert_eq!(dt.name(99), None, "out of range → None");
+        assert_eq!(dt.name(-1), None, "negative → None");
+    }
+
+    #[test]
+    fn truncated_file_keeps_what_parsed() {
+        let mut d = bstr("Piercing");
+        d.extend_from_slice(&[0x05, 0x00]); // a truncated 4-byte length prefix
+        let dt = DamageTypes::parse(&d);
+        assert_eq!(dt.name(0), Some("Piercing"));
+        assert_eq!(dt.name(1), None);
+    }
+}

--- a/client-rs/crates/rcce-data/src/items.rs
+++ b/client-rs/crates/rcce-data/src/items.rs
@@ -37,6 +37,10 @@ pub struct ItemDef {
     pub mass: i16,
     /// Base melee/ranged damage for weapons (item_type 1), else 0.
     pub weapon_damage: i16,
+    /// Weapon damage-type index (item_type 1), into the project's `Damage.dat`
+    /// names (`DamageTypes$`, Items.bb:486). 0 for non-weapons. Blitz shows the
+    /// resolved name in the weapon tooltip + combat output (ClientNet.bb:1129).
+    pub weapon_damage_type: i16,
     /// Weapon type for weapons (item_type 1): 1 OneHand, 2 TwoHand, 3 Ranged
     /// (`Items.bb` `W_*`). 0 for non-weapons. Drives the ranged attack-range gate.
     pub weapon_wtype: i16,
@@ -103,6 +107,7 @@ impl ItemCatalog {
         // ItemType-conditional tail (Items.bb:378-404).
         let mut weapon_damage = 0i16;
         let mut weapon_wtype = 0i16;
+        let mut weapon_damage_type = 0i16;
         let mut weapon_range = 0.0f32;
         let mut armour_level = 0i16;
         let mut image_id = -1i16;
@@ -111,7 +116,7 @@ impl ItemCatalog {
                 // Weapon: damage, dtype, wtype, rangedProjectile (4×i16),
                 // range f32, rangedAnimation string.
                 weapon_damage = r.read_short()?; // damage
-                let _dtype = r.read_short()?; // damage type
+                weapon_damage_type = r.read_short()?; // damage type (index into Damage.dat)
                 weapon_wtype = r.read_short()?; // weapon type (W_Ranged = 3)
                 let _ranged_proj = r.read_short()?; // ranged projectile id
                 weapon_range = r.read_float()?; // reach in world units
@@ -141,6 +146,7 @@ impl ItemCatalog {
             stackable,
             mass,
             weapon_damage,
+            weapon_damage_type,
             weapon_wtype,
             weapon_range,
             armour_level,

--- a/client-rs/crates/rcce-data/src/lib.rs
+++ b/client-rs/crates/rcce-data/src/lib.rs
@@ -11,6 +11,7 @@ pub mod anim;
 pub mod area;
 pub mod attributes;
 pub mod b3d;
+pub mod damage;
 pub mod emitter;
 pub mod catalog;
 pub mod fixed_attributes;
@@ -27,6 +28,7 @@ pub use anim::{AnimClip, AnimSet, AnimSetCatalog};
 pub use area::{AreaEnv, AreaScenery, EmitterPlacement, SceneryPlacement, TerrainPatch, WaterPlane};
 pub use emitter::EmitterConfig;
 pub use b3d::{B3dAnim, B3dBone, B3dKey, B3dMesh, B3dModel};
+pub use damage::DamageTypes;
 pub use texture::Image;
 pub use catalog::{
     MeshCatalog, MeshEntry, MusicCatalog, MusicEntry, ParsedCatalog, SoundCatalog, SoundEntry,


### PR DESCRIPTION
## What

The weapon item tooltip now shows the **damage type** — `Damage: 12 (Fire)` instead of just `Damage: 12` — reading the project's customizable type names from `Server Data/Damage.dat`. This matches Blitz, which resolves `DamageTypes$(WeaponDamageType)` in the weapon tooltip (Interface3D.bb:1949) and combat output (ClientNet.bb:1129). The default project defines 11 types (Piercing/Slashing/Bashing/Fire/Ice/Poison/Electricity/Shadow/Divine/Wind/Magical), so this is **not latent**.

Honors the engine's customizable nature — the names come from the project's file, not hardcoded (same pattern as FixedAttributes #469, Suns #480, Language #525).

## How

- **rcce-data**: new `DamageTypes` parser (`Damage.dat` = 20 bounded strings, the format `LoadDamageTypes` reads at Items.bb:486) with `name(idx)` resolution (empty/oob/negative → `None`). Plus capture the previously-**dropped** `_dtype` field on `ItemDef` → `weapon_damage_type: i16`. **Offset-preserving** (`read_short` stays `read_short`), so `Items.dat` parsing is byte-identical.
- **rcce-client**: `AssetStore` loads `Damage.dat` (`damage_type_name` accessor); the weapon tooltip appends the resolved name via a small unit-tested `weapon_damage_line` helper, at both tooltip sites. Missing file / unnamed slot → bare `Damage: 12` (no empty parens).

## Verification

`cargo clippy … -D warnings` clean; `cargo test` 60 rcce-data (incl. 3 new: name resolution + truncated-file soft-fail) + 48 client-window bin (incl. `weapon_damage_line_appends_type`). **No render shot:** the change is a data parser + a hover-only tooltip line (no headless mouse-hover injection exists), and the render hot path + `Items.dat` field offsets are unchanged. Parser + helper are unit-tested; the tooltip line is correct-by-construction.

## Follow-up (deferred)
The **combat damage numbers** (P_AttackActor "H"/"Y", ClientNet.bb:1124-1157) also carry a damage-type byte that Blitz shows in the floating output — a natural next increment reusing this `damage_type_name` accessor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)