### PR TITLE
rust-client: honor Other.dat HideNametags option

### DIFF
--- a/client-rs/crates/rcce-client/src/assets.rs
+++ b/client-rs/crates/rcce-client/src/assets.rs
@@ -42,6 +42,9 @@ pub struct AssetStore {
     /// Project weapon damage-type names (`Server Data/Damage.dat`), for the
     /// weapon tooltip. Empty when the file is absent (then no type is shown).
     damage_types: rcce_data::DamageTypes,
+    /// Project client-display options (`Game Data/Other.dat`): nametag visibility,
+    /// view mode, chat-bubble options. Default (all-zero) when the file is absent.
+    other: rcce_data::OtherConfig,
     /// Project sun/moon directional lights from `Game Data/Suns.dat`. `None` when
     /// absent → the renderer uses a neutral white sun. See `sun_light`.
     suns: Option<rcce_data::Suns>,
@@ -169,6 +172,11 @@ impl AssetStore {
         let damage_types = std::fs::read(data_root.join("Server Data/Damage.dat"))
             .map(|b| rcce_data::DamageTypes::parse(&b))
             .unwrap_or_default();
+        // Project client-display options (nametag visibility, view mode, bubbles).
+        // Absent/short → all-zero defaults (Blitz ReadByte-past-EOF semantics).
+        let other = std::fs::read(data_root.join("Game Data/Other.dat"))
+            .map(|b| rcce_data::OtherConfig::parse(&b))
+            .unwrap_or_default();
         // Project sun/moon directional light colours (warm day / cool night).
         let suns = std::fs::read(data_root.join("Game Data/Suns.dat"))
             .ok()
@@ -192,6 +200,7 @@ impl AssetStore {
             attribute_names,
             fixed_attributes,
             damage_types,
+            other,
             suns,
             language,
             cache: HashMap::new(),
@@ -205,6 +214,12 @@ impl AssetStore {
     /// shipped default project (Health = slot 0).
     pub fn health_stat(&self) -> u8 {
         self.fixed_attributes.and_then(|f| f.health).unwrap_or(0)
+    }
+
+    /// Whether the project hides actor nametags (the floating name/tag text) —
+    /// `Other.dat` HideNametags == 1 (Actors3D.bb:508). Health bars are unaffected.
+    pub fn nametags_hidden(&self) -> bool {
+        self.other.nametags_hidden()
     }
 
     /// The project's name for a weapon damage-type index (`Damage.dat`), e.g.

--- a/client-rs/crates/rcce-client/src/bin/client_window.rs
+++ b/client-rs/crates/rcce-client/src/bin/client_window.rs
@@ -7877,6 +7877,10 @@ impl App {
             }
 
             if let Some(net) = self.net.as_ref() {
+                // Project-configurable: hide the floating nametag text (name/tag/
+                // weapon) when Other.dat HideNametags == 1 (Actors3D.bb:508). The
+                // health bar + target reticle stay — Blitz gates only the nametag.
+                let nametags_hidden = store.nametags_hidden();
                 for a in net.world.actors.values() {
                     if !a.alive {
                         continue;
@@ -7933,7 +7937,7 @@ impl App {
                                 }
                             }
                         }
-                        if !a.name.is_empty() {
+                        if !nametags_hidden && !a.name.is_empty() {
                             // Prefix the level (Blitz tracks AI\Level + shows it in
                             // the CharInteract window; an at-a-glance nameplate level
                             // is the on-world enhancement). Level 0 = unknown → omit.
@@ -7950,14 +7954,14 @@ impl App {
                         // draws it as a second nametag line (Actors3D.bb:562). Rows
                         // stack upward: name, tag, then the equipped weapon.
                         let mut row_y = py - 38.0;
-                        if !a.tag.is_empty() {
+                        if !nametags_hidden && !a.tag.is_empty() {
                             let tag = format!("<{}>", a.tag);
                             let tw = rcce_render::font::text_width(&tag, 1.0);
                             overlay.text_shadow(px - tw * 0.5, row_y, 1.0, &tag, [0.78, 0.86, 1.0, 1.0]);
                             row_y -= 12.0;
                         }
                         // Equipped weapon (from P_InventoryUpdate "O").
-                        if a.equipped[0] != 0xFFFF {
+                        if !nametags_hidden && a.equipped[0] != 0xFFFF {
                             let wname = store.item_name(a.equipped[0]);
                             let tw = rcce_render::font::text_width(&wname, 1.0);
                             overlay.text_shadow(px - tw * 0.5, row_y, 1.0, &wname, [0.85, 0.85, 0.7, 1.0]);

--- a/client-rs/crates/rcce-data/src/lib.rs
+++ b/client-rs/crates/rcce-data/src/lib.rs
@@ -19,6 +19,7 @@ pub mod interface;
 pub mod items;
 pub mod language;
 pub mod money;
+pub mod other;
 pub mod reader;
 pub mod suns;
 pub mod texture;
@@ -41,6 +42,7 @@ pub use items::{equip_slot, equip_slot_name, ItemCatalog, ItemDef};
 pub use interface::{IComp, InterfaceLayout};
 pub use language::Language;
 pub use money::MoneyConfig;
+pub use other::OtherConfig;
 pub use reader::{BlitzReader, ReadError};
 
 #[cfg(test)]

--- a/client-rs/crates/rcce-data/src/other.rs
+++ b/client-rs/crates/rcce-data/src/other.rs
@@ -1,0 +1,95 @@
+//! `Game Data/Other.dat` — project client-display options the launcher writes and
+//! the Blitz client reads at startup (`ClientLoaders.bb:28-40`). Layout (all little
+//! -endian, `ReadByte`/`ReadInt`): HideNametags u8 · DisableCollisions u8 · ViewMode
+//! u8 · ServerPort i32 · RequireMemorise u8 · UseBubbles u8 · BubblesR/G/B u8.
+//!
+//! Blitz `ReadByte`/`ReadInt` past EOF return 0, and the shipped default file is
+//! truncated (9 bytes — no Bubbles RGB), so each field defaults to 0 when absent —
+//! matching the engine exactly.
+
+use crate::reader::BlitzReader;
+
+/// Parsed `Other.dat`. Fields are the raw bytes; the semantic accessors apply the
+/// engine's comparison rules (e.g. nametags hide only on the exact value 1).
+#[derive(Debug, Clone, Copy, Default)]
+pub struct OtherConfig {
+    pub hide_nametags: u8,
+    pub disable_collisions: u8,
+    pub view_mode: u8,
+    pub server_port: i32,
+    pub require_memorise: u8,
+    pub use_bubbles: u8,
+    pub bubbles_rgb: [u8; 3],
+}
+
+impl OtherConfig {
+    /// Read the fields in order, each defaulting to 0 past EOF (Blitz `ReadByte`/
+    /// `ReadInt` semantics) so a short/absent file yields engine-default behaviour.
+    pub fn parse(data: &[u8]) -> OtherConfig {
+        let mut r = BlitzReader::new(data);
+        let hide_nametags = r.read_byte().unwrap_or(0);
+        let disable_collisions = r.read_byte().unwrap_or(0);
+        let view_mode = r.read_byte().unwrap_or(0);
+        let server_port = r.read_int().unwrap_or(0);
+        let require_memorise = r.read_byte().unwrap_or(0);
+        let use_bubbles = r.read_byte().unwrap_or(0);
+        let rr = r.read_byte().unwrap_or(0);
+        let gg = r.read_byte().unwrap_or(0);
+        let bb = r.read_byte().unwrap_or(0);
+        OtherConfig {
+            hide_nametags,
+            disable_collisions,
+            view_mode,
+            server_port,
+            require_memorise,
+            use_bubbles,
+            bubbles_rgb: [rr, gg, bb],
+        }
+    }
+
+    /// Whether actor nametags (the floating name + tag text) should be hidden. Blitz
+    /// gates nametag creation on `If HideNametags <> 1` (Actors3D.bb:508), so they
+    /// are hidden ONLY for the exact value 1 — any other value (incl. the default 2)
+    /// shows them.
+    pub fn nametags_hidden(&self) -> bool {
+        self.hide_nametags == 1
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn nametags_hidden_only_on_exact_one() {
+        // Byte 0 = HideNametags. Only the exact value 1 hides (Blitz `<> 1`).
+        let cfg = |b: u8| OtherConfig::parse(&[b, 0, 2, 0, 0, 0, 0, 1, 0, 0, 0, 0]);
+        assert!(cfg(1).nametags_hidden(), "1 hides");
+        assert!(!cfg(0).nametags_hidden(), "0 shows");
+        assert!(!cfg(2).nametags_hidden(), "2 (the shipped default) shows");
+        assert!(!cfg(255).nametags_hidden(), "any other value shows");
+    }
+
+    #[test]
+    fn parses_full_record_and_truncation() {
+        // HideNametags 1, DisableCollisions 0, ViewMode 3, ServerPort 25000,
+        // RequireMemorise 1, UseBubbles 2, Bubbles 10/20/30.
+        let mut d = vec![1u8, 0, 3];
+        d.extend_from_slice(&25000i32.to_le_bytes());
+        d.extend_from_slice(&[1, 2, 10, 20, 30]);
+        let c = OtherConfig::parse(&d);
+        assert_eq!(c.hide_nametags, 1);
+        assert_eq!(c.view_mode, 3);
+        assert_eq!(c.server_port, 25000);
+        assert_eq!(c.use_bubbles, 2);
+        assert_eq!(c.bubbles_rgb, [10, 20, 30]);
+        // The shipped default is 9 bytes (no Bubbles RGB) — those default to 0.
+        let short = OtherConfig::parse(&d[..9]);
+        assert_eq!(short.use_bubbles, 2);
+        assert_eq!(short.bubbles_rgb, [0, 0, 0]);
+        // Empty file → all zero (no panic).
+        let empty = OtherConfig::parse(&[]);
+        assert_eq!(empty.hide_nametags, 0);
+        assert_eq!(empty.server_port, 0);
+    }
+}


### PR DESCRIPTION
## What

The Rust client now honors the project's `HideNametags` option from `Game Data/Other.dat`. When set to 1, floating actor nametags (name + level, `<tag>`, equipped-weapon line) are not drawn — matching Blitz, which gates `CreateActorNametag` on `If HideNametags <> 1` (Actors3D.bb:508). Another honor-the-data customization win (the Rust previously always drew nametags, ignoring the project's choice).

## How

- **rcce-data**: new `OtherConfig` parser for the whole `Other.dat` record (HideNametags u8 · DisableCollisions u8 · ViewMode u8 · ServerPort i32 · RequireMemorise u8 · UseBubbles u8 · BubblesR/G/B u8). Each field defaults to 0 past EOF — matching Blitz `ReadByte`/`ReadInt` semantics and the shipped 9-byte file (which omits Bubbles RGB). `nametags_hidden()` = `HideNametags == 1` (only the exact value 1 hides, per Blitz's `<> 1`).
- **rcce-client**: `AssetStore` loads `Other.dat` (`nametags_hidden` accessor); the nameplate render gates the name/tag/weapon **text** on `!nametags_hidden`. The **health bar + target reticle stay** — Blitz draws those separately, not under HideNametags.

The struct also captures ViewMode / UseBubbles / Bubbles RGB for future increments (camera default, chat-bubble enable + colour), but this PR wires only HideNametags.

## Verification

`cargo clippy … -D warnings` clean; `cargo test` 62 rcce-data (2 new `OtherConfig` tests: exact-1 hide semantics, full-record + truncation + empty) + 48 client bin. Release build + headless 1280x800 shots confirm **no regression** (world + HUD render intact with the default `HideNametags=2`). The shipped Plains NPCs spawn far from the player's start and weren't framable headlessly, so the *hide* path is unit-test + correct-by-construction verified (the gate is `if !nametags_hidden && !a.name.is_empty()`); the default value (2 ≠ 1) leaves the default project visually unchanged.

## Follow-up (deferred, struct ready)
`ViewMode` (default camera mode), `UseBubbles` (chat-bubble enable), `BubblesR/G/B` (bubble colour) — all parsed into `OtherConfig`, just not yet applied.

🤖 Generated with [Claude Code](https://claude.com/claude-code)