### PR TITLE
rust-client: honor Other.dat ViewMode (camera default + lock)

### DIFF
--- a/client-rs/crates/rcce-client/src/assets.rs
+++ b/client-rs/crates/rcce-client/src/assets.rs
@@ -222,6 +222,17 @@ impl AssetStore {
         self.other.nametags_hidden()
     }
 
+    /// Whether the camera starts in first-person (`Other.dat` ViewMode == 1).
+    pub fn default_first_person(&self) -> bool {
+        self.other.default_first_person()
+    }
+
+    /// Whether the first/third-person toggle key is allowed (`Other.dat` ViewMode
+    /// not locked to 1/3). See [`rcce_data::OtherConfig::view_toggle_allowed`].
+    pub fn view_toggle_allowed(&self) -> bool {
+        self.other.view_toggle_allowed()
+    }
+
     /// The project's name for a weapon damage-type index (`Damage.dat`), e.g.
     /// `3 -> "Fire"`. `None` when the table is absent or the slot is unnamed/out
     /// of range — the tooltip then omits the "(type)" suffix.

--- a/client-rs/crates/rcce-client/src/bin/client_window.rs
+++ b/client-rs/crates/rcce-client/src/bin/client_window.rs
@@ -2987,6 +2987,9 @@ impl ApplicationHandler for App {
                 self.login_user = name;
             }
         }
+        // Project camera default (Other.dat ViewMode): start first-person when the
+        // project requests first-only (1). ViewMode 2/3/absent start third-person.
+        self.first_person = store.default_first_person();
         self.store = Some(store);
         self.gfx = Some(gfx);
         self.view = Some(view);
@@ -3343,7 +3346,14 @@ impl ApplicationHandler for App {
                             self.target = next_target(self.target, &rids);
                         }
                         KeyCode::KeyK if pressed => self.show_spellbook = !self.show_spellbook,
-                        KeyCode::KeyV if pressed => self.first_person = !self.first_person, // CAM-4
+                        // CAM-4: toggle first/third-person — unless the project locks
+                        // the view (Other.dat ViewMode 1=first-only / 3=third-only).
+                        KeyCode::KeyV
+                            if pressed
+                                && self.store.as_ref().is_none_or(|s| s.view_toggle_allowed()) =>
+                        {
+                            self.first_person = !self.first_person
+                        }
                         KeyCode::KeyJ if pressed && self.grounded => {
                             // MOVE-7: jump only when grounded. Kick the vertical
                             // velocity, leave the ground, and tell the server

--- a/client-rs/crates/rcce-data/src/other.rs
+++ b/client-rs/crates/rcce-data/src/other.rs
@@ -54,6 +54,24 @@ impl OtherConfig {
     pub fn nametags_hidden(&self) -> bool {
         self.hide_nametags == 1
     }
+
+    /// Whether the camera should start in first-person. Blitz `ViewMode`: 1 =
+    /// first-person only (`If ViewMode = 1 Then CamMode = 1`, ClientLoaders.bb:41);
+    /// 2 = both (third-person default, toggleable); 3 = third-person only. So the
+    /// camera starts first-person ONLY for ViewMode 1.
+    pub fn default_first_person(&self) -> bool {
+        self.view_mode == 1
+    }
+
+    /// Whether the player may toggle first/third-person. Blitz flips `CamMode` on
+    /// the toggle key only `If ... And ViewMode = 2` (Interface3D.bb:466); ViewMode
+    /// 1 (first-only) and 3 (third-only) LOCK the camera. Expressed as "not locked to
+    /// a single mode" so an absent file (soft-failed to view_mode 0, which Blitz —
+    /// requiring the file — never has) leaves the toggle enabled rather than trapping
+    /// the player in third-person. For the real values 1/2/3 this equals `== 2`.
+    pub fn view_toggle_allowed(&self) -> bool {
+        self.view_mode != 1 && self.view_mode != 3
+    }
 }
 
 #[cfg(test)]
@@ -68,6 +86,18 @@ mod tests {
         assert!(!cfg(0).nametags_hidden(), "0 shows");
         assert!(!cfg(2).nametags_hidden(), "2 (the shipped default) shows");
         assert!(!cfg(255).nametags_hidden(), "any other value shows");
+    }
+
+    #[test]
+    fn view_mode_semantics() {
+        // Byte 2 = ViewMode. 1 = first-person only, 2 = both (default), 3 = third only.
+        let cfg = |vm: u8| OtherConfig::parse(&[0, 0, vm, 0, 0, 0, 0, 0, 0]);
+        assert!(cfg(1).default_first_person() && !cfg(1).view_toggle_allowed(), "1 = first-only, locked");
+        assert!(!cfg(2).default_first_person() && cfg(2).view_toggle_allowed(), "2 = third default, toggleable");
+        assert!(!cfg(3).default_first_person() && !cfg(3).view_toggle_allowed(), "3 = third-only, locked");
+        // Absent file (soft-failed to 0) → third-person start, but toggle stays
+        // ENABLED (don't trap the player; only an explicit 1/3 locks).
+        assert!(!cfg(0).default_first_person() && cfg(0).view_toggle_allowed());
     }
 
     #[test]


### PR DESCRIPTION
## What

The Rust client now honors the project's `ViewMode` from `Game Data/Other.dat` — the camera default + whether the first/third-person toggle is allowed. Continues the Other.dat honor-the-data work (#524 did HideNametags from the same parser).

Blitz `ViewMode`: **1** = first-person only (`If ViewMode = 1 Then CamMode = 1`, ClientLoaders.bb:41), **2** = both (third-person default, toggleable via `If … And ViewMode = 2`, Interface3D.bb:466), **3** = third-person only. The Rust previously always started third-person and always allowed the 'V' toggle.

## How

- **rcce-data**: `OtherConfig` gains `default_first_person()` (`ViewMode == 1`) and `view_toggle_allowed()` (`ViewMode != 1 && != 3`). The toggle accessor is phrased as "not locked to a single mode" so an **absent** Other.dat (soft-failed to ViewMode 0, which the file-requiring Blitz never has) keeps the toggle **enabled** rather than trapping the player in third-person; for the real values 1/2/3 it equals `== 2`.
- **rcce-client**: `AssetStore` exposes both; at store load `self.first_person = store.default_first_person()`, and the 'V' toggle is gated on `view_toggle_allowed()`.

The shipped default (ViewMode 2) starts third-person and stays toggleable → **no change** for the default project.

## Verification

`cargo clippy … -D warnings` clean; `cargo test` 63 rcce-data (new `view_mode_semantics` covers 1/2/3/0) + 48 client bin. Release build + **dual headless 1280x800 shot** (the camera mode is always visible, unlike actor overlays): default ViewMode 2 shows the **player body** (third-person); a temp ViewMode 1 starts with **no body, eye-level forward view** (first-person) — matching `If ViewMode = 1 Then CamMode = 1`. Other.dat restored after the shot.

## Follow-up
The remaining Other.dat field UseBubbles/BubblesRGB is **not** a simple render-loop gate (P_BubbleMessage script bubbles are ungated in Blitz; the `UseBubbles > 1` gate lives in the chat→bubble conversion, which the Rust doesn't implement yet) — deferred as a larger "player-chat speech bubbles" feature.

🤖 Generated with [Claude Code](https://claude.com/claude-code)