### PR TITLE
rust-client: player-chat speech bubbles over the speaker

### DIFF
--- a/client-rs/crates/rcce-client/src/assets.rs
+++ b/client-rs/crates/rcce-client/src/assets.rs
@@ -233,6 +233,17 @@ impl AssetStore {
         self.other.view_toggle_allowed()
     }
 
+    /// Whether player-chat speech bubbles are shown (`Other.dat` UseBubbles > 1).
+    pub fn bubbles_enabled(&self) -> bool {
+        self.other.bubbles_enabled()
+    }
+
+    /// The project's chat-bubble text colour (`Other.dat` BubblesR/G/B; readable
+    /// warm-white fallback when unset). See [`rcce_data::OtherConfig::bubble_color`].
+    pub fn bubble_color(&self) -> [f32; 4] {
+        self.other.bubble_color()
+    }
+
     /// The project's name for a weapon damage-type index (`Damage.dat`), e.g.
     /// `3 -> "Fire"`. `None` when the table is absent or the slot is unnamed/out
     /// of range — the tooltip then omits the "(type)" suffix.

--- a/client-rs/crates/rcce-client/src/bin/client_window.rs
+++ b/client-rs/crates/rcce-client/src/bin/client_window.rs
@@ -3630,6 +3630,10 @@ impl App {
             // Which attribute slot is Health for this project (default 0);
             // P_StatUpdate reports HP under this slot.
             health_stat: store.health_stat(),
+            // Player-chat speech bubbles (Other.dat UseBubbles/BubblesRGB). `me_name`
+            // is captured from our own P_NewActor below (in the world_packets apply).
+            bubbles_enabled: store.bubbles_enabled(),
+            bubble_color: store.bubble_color(),
             ..Default::default()
         };
         for m in &outcome.world_packets {

--- a/client-rs/crates/rcce-client/src/world.rs
+++ b/client-rs/crates/rcce-client/src/world.rs
@@ -304,6 +304,16 @@ pub struct World {
     /// threaded in at enter-world. Empty (the `Default`) → chat strings use
     /// their hardcoded-English fallback. See [`World::lang`].
     pub language: rcce_data::Language,
+    /// Player-chat speech bubbles (`Other.dat` UseBubbles > 1), threaded in at
+    /// enter-world. When true, a plain say (`"<Name> text"`) shows as a bubble over
+    /// the speaker in addition to the chat log.
+    pub bubbles_enabled: bool,
+    /// Chat-bubble text colour for other players (`Other.dat` BubblesR/G/B; readable
+    /// fallback when unset). The local player's own bubble is always blue.
+    pub bubble_color: [f32; 4],
+    /// The local player's character name, for matching their own `"<Name>"` say to
+    /// `my_runtime_id` (so it bubbles over Me in blue). Empty until enter-world.
+    pub me_name: String,
     pub zone: Zone,
     /// Other actors keyed by runtime id (excludes the local player).
     pub actors: HashMap<u16, Actor>,
@@ -882,6 +892,8 @@ impl World {
             self.me_beard = beard;
             self.me_health = health;
             self.me_health_max = health_max;
+            // Our own name, so a "<Name>" say bubbles over Me (CHAT bubbles).
+            self.me_name = name;
             return; // don't list ourselves among "other actors"
         }
         self.actors.insert(
@@ -1510,9 +1522,42 @@ impl World {
         if text.starts_with("<<") {
             color = [0.0, 0.5, 1.0, 1.0]; // local player's own line
         }
+        // Player-chat speech bubble: a plain say arrives as "<Name> text" with NO
+        // colour-code prefix (`d[0] == '<'`, ServerNet.bb:708). Colour-prefixed
+        // yells/guild/etc. (250..=254) are NOT bubbled — matching Blitz, where only
+        // the "Normal" branch bubbles (ClientNet.bb:1237). Shown over the speaker
+        // when the project enables bubbles (UseBubbles > 1); the log line still shows.
+        if self.bubbles_enabled && d[0] == b'<' {
+            if let Some(bubble) = self.chat_bubble_for(&text) {
+                self.pending_bubbles.push(bubble);
+            }
+        }
         if !text.is_empty() {
             self.chat.push((text, color));
         }
+    }
+
+    /// Resolve a plain say `"<Name> text"` to a bubble `(runtime id, message, colour)`
+    /// when the speaker is a known actor (or the local player). `None` when the format
+    /// doesn't match or the name is unknown — the say then only hits the chat log. The
+    /// local player's own line bubbles over `my_runtime_id` in blue (Blitz `If AI = Me`);
+    /// others use the project's bubble colour.
+    fn chat_bubble_for(&self, text: &str) -> Option<(u16, String, [f32; 4])> {
+        let rest = text.strip_prefix('<')?;
+        let close = rest.find('>')?;
+        let name = &rest[..close];
+        if name.is_empty() {
+            return None;
+        }
+        let msg = rest[close + 1..].trim_start().to_string();
+        if msg.is_empty() {
+            return None;
+        }
+        if !self.me_name.is_empty() && name == self.me_name {
+            return Some((self.my_runtime_id, msg, [0.0, 0.5, 1.0, 1.0]));
+        }
+        let rid = self.actors.values().find(|a| a.name == name).map(|a| a.runtime_id)?;
+        Some((rid, msg, self.bubble_color))
     }
 
     /// Handle an inbound `P_Dialog` (NPC dialog). Builds/updates `self.dialog`
@@ -2727,6 +2772,45 @@ mod tests {
         assert_eq!(*rid, 9);
         assert_eq!(text, "Hello!");
         assert_eq!(*col, [0.0, 1.0, 0.0, 1.0]);
+    }
+
+    // A plain say "<Name> text" (no colour-code prefix) becomes a speech bubble over
+    // the speaker when the project enables bubbles — over Me in blue, others in the
+    // project colour. Colour-prefixed messages, unknown names, and disabled bubbles
+    // produce none. The chat log line always appears.
+    #[test]
+    fn plain_say_makes_a_bubble() {
+        let mut w = World {
+            my_runtime_id: 1,
+            bubbles_enabled: true,
+            bubble_color: [0.5, 0.5, 0.5, 1.0],
+            me_name: "Hero".into(),
+            ..Default::default()
+        };
+        w.actors.insert(7, Actor { runtime_id: 7, name: "Stag".into(), alive: true, ..Default::default() });
+
+        // Another player's say → bubble over actor 7 in the project colour, + log line.
+        w.on_chat(b"<Stag> hello there");
+        assert_eq!(w.pending_bubbles.last(), Some(&(7u16, "hello there".to_string(), [0.5, 0.5, 0.5, 1.0])));
+        assert!(w.chat.iter().any(|(t, _)| t.contains("hello there")), "still logged");
+
+        // My own say → bubble over me (rid 1) in blue.
+        w.on_chat(b"<Hero> hi");
+        assert_eq!(w.pending_bubbles.last(), Some(&(1u16, "hi".to_string(), [0.0, 0.5, 1.0, 1.0])));
+
+        let n = w.pending_bubbles.len();
+        // Unknown speaker → no bubble.
+        w.on_chat(b"<Ghost> boo");
+        // A colour-prefixed yell (253) is NOT bubbled even with a valid "<Stag>".
+        let mut yell = vec![253u8];
+        yell.extend_from_slice(b"<Stag> YELL");
+        w.on_chat(&yell);
+        assert_eq!(w.pending_bubbles.len(), n, "unknown name + colour-prefixed → no bubble");
+
+        // Disabled → no bubble.
+        w.bubbles_enabled = false;
+        w.on_chat(b"<Stag> quiet");
+        assert_eq!(w.pending_bubbles.len(), n, "disabled → no bubble");
     }
 
     #[test]

--- a/client-rs/crates/rcce-data/src/other.rs
+++ b/client-rs/crates/rcce-data/src/other.rs
@@ -122,9 +122,11 @@ mod tests {
 
     #[test]
     fn bubble_semantics() {
-        // Byte 5 = UseBubbles (>1 enables); bytes 6-8 = BubblesR/G/B.
+        // Full record layout: HideNametags, DisableCollisions, ViewMode, ServerPort
+        // (i32 = 4 bytes!), RequireMemorise, UseBubbles, BubblesR/G/B. So UseBubbles
+        // is byte index 8 and the colour is bytes 9-11.
         let with = |ub: u8, rgb: [u8; 3]| {
-            OtherConfig::parse(&[0, 0, 2, 0, 0, 0, ub, rgb[0], rgb[1], rgb[2]])
+            OtherConfig::parse(&[0, 0, 2, 0, 0, 0, 0, 0, ub, rgb[0], rgb[1], rgb[2]])
         };
         assert!(with(2, [10, 20, 30]).bubbles_enabled(), "2 enables");
         assert!(!with(1, [10, 20, 30]).bubbles_enabled(), "1 disables");

--- a/client-rs/crates/rcce-data/src/other.rs
+++ b/client-rs/crates/rcce-data/src/other.rs
@@ -63,6 +63,26 @@ impl OtherConfig {
         self.view_mode == 1
     }
 
+    /// Whether player-chat speech bubbles are shown. Blitz turns a plain say
+    /// (`"<Name> text"`) into a bubble over the speaker only `If ... And UseBubbles
+    /// > 1` (ClientNet.bb:1237). The shipped default is 2 (enabled).
+    pub fn bubbles_enabled(&self) -> bool {
+        self.use_bubbles > 1
+    }
+
+    /// The project's chat-bubble text colour (`BubblesR/G/B`), as RGBA 0..1. When
+    /// the project leaves it unset (all zero — incl. the truncated default file that
+    /// omits these bytes), fall back to a readable warm white instead of invisible
+    /// black on the dark bubble background. (Blitz uses the raw bytes; this keeps
+    /// the default project's bubbles legible — a genuine improvement.)
+    pub fn bubble_color(&self) -> [f32; 4] {
+        let [r, g, b] = self.bubbles_rgb;
+        if r == 0 && g == 0 && b == 0 {
+            return [0.95, 0.95, 0.85, 1.0];
+        }
+        [r as f32 / 255.0, g as f32 / 255.0, b as f32 / 255.0, 1.0]
+    }
+
     /// Whether the player may toggle first/third-person. Blitz flips `CamMode` on
     /// the toggle key only `If ... And ViewMode = 2` (Interface3D.bb:466); ViewMode
     /// 1 (first-only) and 3 (third-only) LOCK the camera. Expressed as "not locked to
@@ -98,6 +118,22 @@ mod tests {
         // Absent file (soft-failed to 0) → third-person start, but toggle stays
         // ENABLED (don't trap the player; only an explicit 1/3 locks).
         assert!(!cfg(0).default_first_person() && cfg(0).view_toggle_allowed());
+    }
+
+    #[test]
+    fn bubble_semantics() {
+        // Byte 5 = UseBubbles (>1 enables); bytes 6-8 = BubblesR/G/B.
+        let with = |ub: u8, rgb: [u8; 3]| {
+            OtherConfig::parse(&[0, 0, 2, 0, 0, 0, ub, rgb[0], rgb[1], rgb[2]])
+        };
+        assert!(with(2, [10, 20, 30]).bubbles_enabled(), "2 enables");
+        assert!(!with(1, [10, 20, 30]).bubbles_enabled(), "1 disables");
+        assert!(!with(0, [0, 0, 0]).bubbles_enabled(), "0 disables");
+        // Set colour is honored.
+        let c = with(2, [255, 128, 0]).bubble_color();
+        assert!((c[0] - 1.0).abs() < 1e-6 && (c[1] - 0.502).abs() < 0.01 && c[2] == 0.0);
+        // Unset (all-zero / truncated) colour falls back to a readable warm white.
+        assert_eq!(with(2, [0, 0, 0]).bubble_color(), [0.95, 0.95, 0.85, 1.0]);
     }
 
     #[test]


### PR DESCRIPTION
## What

Player chat now shows as a **speech bubble over the speaker**, not just a log line — the core MMO feel the Rust client was missing. When another player (or you) says something, a bubble appears over their head, matching Blitz (`ClientNet.bb:1237`). Wires the last two `Other.dat` fields (UseBubbles + BubblesRGB) from the #524 parser.

## How

A plain say arrives as `"<Name> text"` with **no colour-code prefix** (`ServerNet.bb:708`; colour-prefixed yells/guild/GM use a 250–254 byte and are NOT bubbled — matching Blitz's "Normal" branch). `World::on_chat` now, when `d[0] == '<'` and the project enables bubbles (UseBubbles > 1):
- parses `<Name>`, resolves the speaker — by name in `actors`, or `my_runtime_id` when it's the local player's own name (captured from our `P_NewActor`) — and pushes a bubble,
- **blue** for me (Blitz `If AI = Me`), the project's **BubblesRGB** colour for others (with a readable warm-white fallback when unset — the default file omits those bytes, so raw is invisible black),
- reusing the **existing** `P_BubbleMessage` render path (already anchors a bubble over any actor incl. me).

The chat **log line still appears** (a small improvement — Blitz drops it when bubbling). Unknown name / disabled / colour-prefixed → no bubble, only the log (no regression).

## Verification

`cargo clippy … -D warnings` clean; `cargo test` 130 client lib (new `plain_say_makes_a_bubble`: other player → project colour + log; me → blue; unknown / colour-prefixed / disabled → none) + rcce-data `bubble_semantics` (enable thresholds, set/unset colour). **No render shot:** the new logic is a wire handler (unit-tested); the bubble **render is pre-existing and unchanged** (RCCE_BUBBLETEST-verified in prior work, anchors over any rid). Player chat isn't headless-inducible (needs a second player chatting), so the end-to-end path is unit-test + correct-by-construction.

## Follow-up
The `OtherConfig` arc is now complete (HideNametags #524, ViewMode #525, UseBubbles/BubblesRGB here). Blitz drops the chat-log line when bubbling; we keep it — revisit if a project wants the Blitz-exact behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)