### PR TITLE
rust-client: projectile trail emitters (fireball/frost particle effects)

### DIFF
--- a/client-rs/crates/rcce-client/src/bin/client_window.rs
+++ b/client-rs/crates/rcce-client/src/bin/client_window.rs
@@ -2140,6 +2140,10 @@ struct ZoneEmitter {
     /// (the packet's X/Y/Z, which Blitz applies as a parent-local PositionEntity).
     /// Only meaningful when `attach` is `Some`; ignored for world-anchored emitters.
     offset: [f32; 3],
+    /// Projectile id this emitter follows each frame (the projectile's trailing
+    /// effect, e.g. a fireball's flame). `None` for zone/actor emitters. When the
+    /// projectile is gone the emitter is stopped (tapers) and reaped.
+    proj_id: Option<u32>,
 }
 
 type ZoneStatic = (
@@ -2835,6 +2839,7 @@ fn load_zone_static(store: &mut AssetStore, view: &mut WorldView, gfx: &Gfx, dat
             life: None,
             attach: None,
             offset: [0.0, 0.0, 0.0],
+            proj_id: None,
         });
     }
     if !emitters.is_empty() {
@@ -5264,6 +5269,9 @@ impl App {
                 tz: pos[2] + dir[2] * 100.0,
                 homing: false,
                 speed: 40.0,
+                id: 0,
+                emitter: String::new(),
+                emitter_tex: 0,
             };
             let mut batches = particle_batches(&mut self.emitters, eye, target, 1.0 / 60.0);
             let mut verts = Vec::new();
@@ -6344,6 +6352,7 @@ impl App {
                         life: Some(req.lifetime_ms as f32),
                         attach: req.attach,
                         offset: req.pos,
+                        proj_id: None,
                     });
                 }
             }
@@ -7211,6 +7220,11 @@ impl App {
                             tz: sz + fwd[1] * 200.0,
                             homing: false,
                             speed: 4.0,
+                            id: 1,
+                            // Trail the Fireball emitter so the effect is capturable
+                            // (RCCE_PROJTEST verification of the projectile-emitter path).
+                            emitter: "Fireball".to_string(),
+                            emitter_tex: 0,
                         });
                         let (sw, sh) = (gfx.config.width as f32, gfx.config.height as f32);
                         match rcce_render::project(&vp, [sx, sy_, sz], sw, sh) {
@@ -7774,6 +7788,43 @@ impl App {
                 }
             }
         }
+        // Projectile trail emitters: each projectile with a configured emitter
+        // (Emitter2$ from P_Projectile, e.g. "Fireball"/"Snow") gets one following
+        // particle emitter so it trails its distinctive effect — the dynamic-emitter
+        // system applied to projectiles. The plain glow still draws underneath.
+        if let Some(net) = self.net.as_ref() {
+            // Follow live projectiles; stop the emitter when its projectile is gone.
+            for ze in self.emitters.iter_mut() {
+                if let Some(pid) = ze.proj_id {
+                    match net.world.projectiles.iter().find(|p| p.id == pid) {
+                        Some(p) => ze.emitter.set_pos([p.x, p.y, p.z]),
+                        None => ze.emitter.stop(),
+                    }
+                }
+            }
+            // Spawn one emitter for each new projectile that has a config name.
+            for p in &net.world.projectiles {
+                if p.emitter.is_empty() || self.emitters.iter().any(|ze| ze.proj_id == Some(p.id)) {
+                    continue;
+                }
+                let Some(config) = store.emitter_config(&p.emitter) else { continue };
+                let tex = store
+                    .texture_path(p.emitter_tex)
+                    .and_then(|pp| rcce_data::texture::load(&pp));
+                let seed = 0x9E3779B97F4A7C15u64 ^ (p.id as u64);
+                let emitter = rcce_client::particles::Emitter::new(
+                    config, p.emitter_tex, [p.x, p.y, p.z], [0.0, 0.0, 0.0], seed,
+                );
+                self.emitters.push(ZoneEmitter {
+                    emitter,
+                    tex,
+                    life: None,
+                    attach: None,
+                    offset: [0.0; 3],
+                    proj_id: Some(p.id),
+                });
+            }
+        }
         let mut pbatches = particle_batches(&mut self.emitters, eye, cam_target, pdt);
         // Projectiles: a depth-correct glowing orb + motion trail, appended as an
         // additive particle batch (so terrain/scenery occludes them) — replaces the
@@ -7789,9 +7840,11 @@ impl App {
             }
         }
         view.set_particles(&gfx.device, &gfx.queue, &pbatches);
-        // Reap finite emitters that have stopped and whose particles have all died
-        // (permanent zone emitters, life == None, are kept). Disjoint field borrow.
-        self.emitters.retain(|ze| ze.life.is_none() || !ze.emitter.is_done());
+        // Reap finite (P_CreateEmitter) + projectile-trail emitters that have stopped
+        // and whose particles have all died. Permanent zone emitters (life == None and
+        // not projectile-bound) are kept. Disjoint field borrow.
+        self.emitters
+            .retain(|ze| (ze.life.is_none() && ze.proj_id.is_none()) || !ze.emitter.is_done());
         view.render(
             &gfx.device,
             &gfx.queue,
@@ -9781,6 +9834,9 @@ mod tests {
             tz: 100.0, // flying toward +z
             homing: false,
             speed: 40.0,
+            id: 0,
+            emitter: String::new(),
+            emitter_tex: 0,
         };
         let mut out = Vec::new();
         projectile_billboards(std::slice::from_ref(&pr), [0.0, 10.0, -30.0], [0.0, 10.0, 0.0], &mut out);

--- a/client-rs/crates/rcce-client/src/world.rs
+++ b/client-rs/crates/rcce-client/src/world.rs
@@ -84,6 +84,14 @@ pub struct Projectile {
     pub homing: bool,
     /// World units per second.
     pub speed: f32,
+    /// Stable id assigned at spawn, so the App can keep one following particle
+    /// emitter per projectile across frames (the projectiles Vec has no key).
+    pub id: u32,
+    /// The projectile's particle-emitter config name (`Emitter2$` on the wire — the
+    /// distinctive effect, e.g. "Fireball"/"Snow"/"Flame"; Projectiles.dat) and its
+    /// billboard texture id (`TexID2`). Empty name → no emitter (the plain glow only).
+    pub emitter: String,
+    pub emitter_tex: u16,
 }
 
 /// A screen-flash effect (`P_ScreenFlash`, id 33): a full-screen colour that
@@ -375,6 +383,9 @@ pub struct World {
     pub next_pbar_handle: u32,
     /// In-flight projectiles (P_Projectile). See [`Projectile`].
     pub projectiles: Vec<Projectile>,
+    /// Monotonic id source for projectiles (so the App can track one following
+    /// particle emitter per projectile). Wraps; collisions are harmless (transient).
+    pub next_proj_id: u32,
     /// A pending screen flash (P_ScreenFlash), drained by the renderer.
     pub flash: Option<ScreenFlash>,
     /// Live known-spell list maintained by P_KnownSpellUpdate. See [`KnownSpell`].
@@ -1718,14 +1729,22 @@ impl World {
     /// ref ClientNet.bb:217-238.
     fn on_projectile(&mut self, d: &[u8]) {
         let mut r = MsgReader::new(d);
-        let (Some(src), Some(tgt), Some(_mesh), Some(_t1), Some(_t2), Some(homing), Some(spd)) =
+        let (Some(src), Some(tgt), Some(_mesh), Some(_t1), Some(tex2), Some(homing), Some(spd)) =
             (r.u16(), r.u16(), r.u16(), r.u16(), r.u16(), r.u8(), r.u8())
         else {
             return;
         };
+        // Emitter config names (GameServer.bb:261): Emitter1$ is length-prefixed
+        // (str8), Emitter2$ is the rest. We render Emitter2 (the distinctive effect,
+        // e.g. "Fireball"/"Snow") with TexID2; a soft-fail to "" keeps the plain glow.
+        let _emitter1 = r.str8().unwrap_or_default();
+        let emitter2: String = String::from_utf8_lossy(r.rest()).into_owned();
+        let emitter2 = emitter2.trim().to_string();
         let (Some(sp), Some(tp)) = (self.actor_pos(src), self.actor_pos(tgt)) else {
             return;
         };
+        let id = self.next_proj_id;
+        self.next_proj_id = self.next_proj_id.wrapping_add(1);
         // Blitz: Speed# = (serverSpeed/50)·2.0 units/frame@30fps → ·30 for /sec.
         let speed = (spd as f32 / 50.0) * 2.0 * 30.0;
         self.projectiles.push(Projectile {
@@ -1738,6 +1757,9 @@ impl World {
             tz: tp[2],
             homing: homing != 0,
             speed,
+            id,
+            emitter: emitter2,
+            emitter_tex: tex2,
         });
     }
 
@@ -2772,6 +2794,27 @@ mod tests {
         assert_eq!(*rid, 9);
         assert_eq!(text, "Hello!");
         assert_eq!(*col, [0.0, 1.0, 0.0, 1.0]);
+    }
+
+    // P_Projectile carries the projectile's emitter config names + tex ids after
+    // the fixed header; we capture Emitter2 ("Fireball") + TexID2 so the App can
+    // render the distinctive particle effect over the plain glow.
+    #[test]
+    fn projectile_captures_emitter() {
+        let mut w = World::default();
+        w.actors.insert(2, Actor { runtime_id: 2, alive: true, ..Default::default() });
+        w.actors.insert(3, Actor { runtime_id: 3, x: 10.0, alive: true, ..Default::default() });
+        // src=2 tgt=3 mesh=65535 tex1=0 tex2=7 homing=0 spd=65, Emitter1="Default", Emitter2="Fireball".
+        let mut p = MsgWriter::new();
+        p.u16(2).u16(3).u16(65535).u16(0).u16(7).u8(0).u8(65).str8("Default").raw(b"Fireball");
+        w.apply(&msg(pk::PROJECTILE, p.into_bytes()));
+        assert_eq!(w.projectiles.len(), 1);
+        assert_eq!(w.projectiles[0].emitter, "Fireball");
+        assert_eq!(w.projectiles[0].emitter_tex, 7);
+        // Each spawn gets a distinct id.
+        w.apply(&msg(pk::PROJECTILE, { let mut q = MsgWriter::new(); q.u16(2).u16(3).u16(65535).u16(0).u16(0).u8(0).u8(65).str8("").raw(b""); q.into_bytes() }));
+        assert_ne!(w.projectiles[0].id, w.projectiles[1].id);
+        assert_eq!(w.projectiles[1].emitter, "", "no emitter name → plain glow");
     }
 
     // A plain say "<Name> text" (no colour-code prefix) becomes a speech bubble over


### PR DESCRIPTION
## What

Projectiles now trail their **distinctive particle effect** — a fireball trails flame, a frost bolt trails snow, a lightning bolt trails flame — instead of every projectile rendering the same generic white glow. This is the dynamic-emitter system (P_CreateEmitter, iters 46-48) applied to projectiles, matching Blitz's `CreateProjectile`, which parents the projectile's `.rpc` emitter to it (ClientNet.bb:237). Non-latent: the default project's 4 projectiles (Fireball/Arrow/Frost Bolt/Lightning Bolt) all define emitters in `Projectiles.dat`.

## How

- **Capture (was dropped):** `P_Projectile` carries the emitter config names + tex ids after the fixed header (`GameServer.bb:261`: `Emitter1$` as str8, `Emitter2$` as the rest). `on_projectile` stopped reading after `speed`. Now it captures `Emitter2` (the distinctive effect) + `TexID2` onto `Projectile`, plus a monotonic id so the App can track one following emitter per projectile.
- **Render:** each frame, every projectile with a config gets one following `ZoneEmitter` (new `proj_id` field) created via the existing `EmitterConfig` path, `set_pos`'d to the projectile, and reaped (tapered) when the projectile is gone. The plain white glow still draws underneath — **additive-safe**: a missing/unloadable config falls back to glow-only, no regression.

## Verification

`cargo clippy … -D warnings` clean; `cargo test` (exit 0) — new `projectile_captures_emitter` (Emitter2 + TexID2 + distinct ids + empty→plain-glow). Release build + headless shot via `RCCE_PROJTEST` (now trails a Fireball): the projectile renders **orange** (the Fireball emitter's flame particles) over the white base glow (`projectile_glow_image` is pure white 255,255,255), confirming the emitter spawns + follows. Additive-safe + correct-by-construction (reuses the shot-verified particle path from #518).

## Follow-up (deferred)
- Also attach `Emitter1$` (the base trail; the default uses "Default" alongside the specific effect) — currently only `Emitter2$` (the distinctive one) renders.
- Projectile `MeshID` (all -1 in the default project, so latent) for projects that use mesh projectiles.

🤖 Generated with [Claude Code](https://claude.com/claude-code)