### PR TITLE
rust-client: render projectile base (Emitter1) trail

### DIFF
--- a/client-rs/crates/rcce-client/src/bin/client_window.rs
+++ b/client-rs/crates/rcce-client/src/bin/client_window.rs
@@ -5272,6 +5272,8 @@ impl App {
                 id: 0,
                 emitter: String::new(),
                 emitter_tex: 0,
+                emitter1: String::new(),
+                emitter1_tex: 0,
             };
             let mut batches = particle_batches(&mut self.emitters, eye, target, 1.0 / 60.0);
             let mut verts = Vec::new();
@@ -7221,10 +7223,12 @@ impl App {
                             homing: false,
                             speed: 4.0,
                             id: 1,
-                            // Trail the Fireball emitter so the effect is capturable
-                            // (RCCE_PROJTEST verification of the projectile-emitter path).
+                            // Trail the Fireball + Default emitters so both are
+                            // capturable (RCCE_PROJTEST verification of the path).
                             emitter: "Fireball".to_string(),
                             emitter_tex: 0,
+                            emitter1: "Default".to_string(),
+                            emitter1_tex: 0,
                         });
                         let (sw, sh) = (gfx.config.width as f32, gfx.config.height as f32);
                         match rcce_render::project(&vp, [sx, sy_, sz], sw, sh) {
@@ -7802,27 +7806,35 @@ impl App {
                     }
                 }
             }
-            // Spawn one emitter for each new projectile that has a config name.
+            // Spawn the projectile's emitters once: Emitter1$ (base, e.g. "Default")
+            // + Emitter2$ (distinctive, e.g. "Fireball"), each a following ZoneEmitter
+            // (Blitz attaches both). Skipped once any emitter exists for this id.
             for p in &net.world.projectiles {
-                if p.emitter.is_empty() || self.emitters.iter().any(|ze| ze.proj_id == Some(p.id)) {
+                if self.emitters.iter().any(|ze| ze.proj_id == Some(p.id)) {
                     continue;
                 }
-                let Some(config) = store.emitter_config(&p.emitter) else { continue };
-                let tex = store
-                    .texture_path(p.emitter_tex)
-                    .and_then(|pp| rcce_data::texture::load(&pp));
-                let seed = 0x9E3779B97F4A7C15u64 ^ (p.id as u64);
-                let emitter = rcce_client::particles::Emitter::new(
-                    config, p.emitter_tex, [p.x, p.y, p.z], [0.0, 0.0, 0.0], seed,
-                );
-                self.emitters.push(ZoneEmitter {
-                    emitter,
-                    tex,
-                    life: None,
-                    attach: None,
-                    offset: [0.0; 3],
-                    proj_id: Some(p.id),
-                });
+                for (name, tex_id) in [(&p.emitter1, p.emitter1_tex), (&p.emitter, p.emitter_tex)] {
+                    if name.is_empty() {
+                        continue;
+                    }
+                    let Some(config) = store.emitter_config(name) else { continue };
+                    let tex = store
+                        .texture_path(tex_id)
+                        .and_then(|pp| rcce_data::texture::load(&pp));
+                    // Differentiate the two emitters' RNGs (id + tex + name length).
+                    let seed = 0x9E3779B97F4A7C15u64 ^ (p.id as u64) ^ (tex_id as u64) ^ (name.len() as u64);
+                    let emitter = rcce_client::particles::Emitter::new(
+                        config, tex_id, [p.x, p.y, p.z], [0.0, 0.0, 0.0], seed,
+                    );
+                    self.emitters.push(ZoneEmitter {
+                        emitter,
+                        tex,
+                        life: None,
+                        attach: None,
+                        offset: [0.0; 3],
+                        proj_id: Some(p.id),
+                    });
+                }
             }
         }
         let mut pbatches = particle_batches(&mut self.emitters, eye, cam_target, pdt);
@@ -9837,6 +9849,8 @@ mod tests {
             id: 0,
             emitter: String::new(),
             emitter_tex: 0,
+            emitter1: String::new(),
+            emitter1_tex: 0,
         };
         let mut out = Vec::new();
         projectile_billboards(std::slice::from_ref(&pr), [0.0, 10.0, -30.0], [0.0, 10.0, 0.0], &mut out);

--- a/client-rs/crates/rcce-client/src/world.rs
+++ b/client-rs/crates/rcce-client/src/world.rs
@@ -92,6 +92,10 @@ pub struct Projectile {
     /// billboard texture id (`TexID2`). Empty name → no emitter (the plain glow only).
     pub emitter: String,
     pub emitter_tex: u16,
+    /// The projectile's base emitter (`Emitter1$`, e.g. "Default") + its texture
+    /// (`TexID1`), attached alongside `emitter` like Blitz. Empty → not rendered.
+    pub emitter1: String,
+    pub emitter1_tex: u16,
 }
 
 /// A screen-flash effect (`P_ScreenFlash`, id 33): a full-screen colour that
@@ -1729,15 +1733,16 @@ impl World {
     /// ref ClientNet.bb:217-238.
     fn on_projectile(&mut self, d: &[u8]) {
         let mut r = MsgReader::new(d);
-        let (Some(src), Some(tgt), Some(_mesh), Some(_t1), Some(tex2), Some(homing), Some(spd)) =
+        let (Some(src), Some(tgt), Some(_mesh), Some(tex1), Some(tex2), Some(homing), Some(spd)) =
             (r.u16(), r.u16(), r.u16(), r.u16(), r.u16(), r.u8(), r.u8())
         else {
             return;
         };
         // Emitter config names (GameServer.bb:261): Emitter1$ is length-prefixed
-        // (str8), Emitter2$ is the rest. We render Emitter2 (the distinctive effect,
-        // e.g. "Fireball"/"Snow") with TexID2; a soft-fail to "" keeps the plain glow.
-        let _emitter1 = r.str8().unwrap_or_default();
+        // (str8), Emitter2$ is the rest. Blitz attaches BOTH to the projectile —
+        // Emitter1$ (e.g. "Default", the base trail) with TexID1, Emitter2$ (the
+        // distinctive effect, e.g. "Fireball") with TexID2. Empty names → plain glow.
+        let emitter1 = r.str8().unwrap_or_default().trim().to_string();
         let emitter2: String = String::from_utf8_lossy(r.rest()).into_owned();
         let emitter2 = emitter2.trim().to_string();
         let (Some(sp), Some(tp)) = (self.actor_pos(src), self.actor_pos(tgt)) else {
@@ -1760,6 +1765,8 @@ impl World {
             id,
             emitter: emitter2,
             emitter_tex: tex2,
+            emitter1,
+            emitter1_tex: tex1,
         });
     }
 
@@ -2811,6 +2818,9 @@ mod tests {
         assert_eq!(w.projectiles.len(), 1);
         assert_eq!(w.projectiles[0].emitter, "Fireball");
         assert_eq!(w.projectiles[0].emitter_tex, 7);
+        // Emitter1$ ("Default") + TexID1 (0) are also captured (the base trail).
+        assert_eq!(w.projectiles[0].emitter1, "Default");
+        assert_eq!(w.projectiles[0].emitter1_tex, 0);
         // Each spawn gets a distinct id.
         w.apply(&msg(pk::PROJECTILE, { let mut q = MsgWriter::new(); q.u16(2).u16(3).u16(65535).u16(0).u16(0).u8(0).u8(65).str8("").raw(b""); q.into_bytes() }));
         assert_ne!(w.projectiles[0].id, w.projectiles[1].id);


### PR DESCRIPTION
## What

Follow-up to #527 (projectile trail emitters). Blitz attaches **both** of a projectile's emitters — `Emitter1$` (the base, e.g. "Default") and `Emitter2$` (the distinctive effect, e.g. "Fireball") — to the projectile (`CreateProjectile`, ClientNet.bb:238). #527 rendered only Emitter2; this adds the base trail.

## How

- **Capture (was dropped):** `on_projectile` now captures `Emitter1$` (str8) + `TexID1` (the previously-dropped `_emitter1`/`_t1`) onto `Projectile`.
- **Render:** the projectile-emitter spawn loop now creates a following `ZoneEmitter` for **both** configs (each via the same proven path from #527). The per-id guard runs once before creating both, so no duplicates; each empty/missing config soft-fails to skip. The follow/reap/glow logic is unchanged (handles all `proj_id` emitters uniformly).

## Verification

`cargo clippy … -D warnings` clean; `cargo test` (exit 0) — `projectile_captures_emitter` extended to assert **both** emitters + tex ids are captured. **No render shot:** this is an incremental 2nd-emitter addition via the *exact* path shot-verified in #527 (the orange-fireball night shot); the only change is iterating over both configs, the new "Default" base is subtle (wouldn't visibly differ from the #527 shot), and it's additive-safe (empty/missing → skip, glow always draws). Capture is unit-tested; render is correct-by-construction on the verified path.

This completes the projectile-emitter parity (both Blitz emitter slots now rendered).

🤖 Generated with [Claude Code](https://claude.com/claude-code)