### PR TITLE
rust-client: blood-spurt emitter on combat hits

### DIFF
--- a/client-rs/crates/rcce-client/src/assets.rs
+++ b/client-rs/crates/rcce-client/src/assets.rs
@@ -575,6 +575,18 @@ impl AssetStore {
         self.actors.templates.get(&template_id).map(|t| t.aggressiveness).unwrap_or(0)
     }
 
+    /// The template's blood-spurt texture id (`Actors.dat` BloodTexID), or `None`
+    /// when the race has no blood (id <= 0). When present, a connecting combat hit
+    /// spawns a `Blood.rpc` emitter textured with this id (Blitz ClientNet.bb:1136).
+    pub fn actor_blood_tex(&self, template_id: u16) -> Option<u16> {
+        self.actors
+            .templates
+            .get(&template_id)
+            .map(|t| t.blood_tex)
+            .filter(|&b| b > 0)
+            .map(|b| b as u16)
+    }
+
     pub fn actor_render_scale(&self, template_id: u16, gender: u8) -> Option<f32> {
         let mesh_id = self.actors.mesh_for(template_id, gender)?;
         let mesh = self.meshes.get(mesh_id)?;

--- a/client-rs/crates/rcce-client/src/bin/client_window.rs
+++ b/client-rs/crates/rcce-client/src/bin/client_window.rs
@@ -345,6 +345,9 @@ struct App {
     /// the floaters' `consumed` cursor) so each hit makes exactly one chat line.
     damage_info_style: u8,
     combat_chat_consumed: usize,
+    /// Append-only cursor into `combat_events` for spawning blood-spurt emitters
+    /// (one per new connecting hit). Mirrors `combat_chat_consumed`.
+    combat_blood_consumed: usize,
     /// Audio output (zone music). `None` when there's no audio device.
     audio: Option<rcce_client::audio::Audio>,
     /// Character sheet (gold/level/inventory/spells) from login's P_FetchCharacter.
@@ -561,6 +564,7 @@ impl App {
             floaters: rcce_client::floaters::Floaters::new(),
             damage_info_style: 3,
             combat_chat_consumed: 0,
+            combat_blood_consumed: 0,
             audio: rcce_client::audio::Audio::new(),
             sheet: None,
             show_inventory: false,
@@ -6237,6 +6241,48 @@ impl App {
                 // Spawn floating damage numbers for any new combat hits, expire old.
                 self.floaters.ingest(&net.world.combat_events, elapsed);
             }
+            // Blood spurt (CBT): a connecting hit (damage > 0) spawns a finite
+            // Blood.rpc emitter at the struck actor, textured with its race's
+            // BloodTexID — Blitz ClientNet.bb:1136/1168. Independent of the
+            // damage-info display style. Soft-fails (no blood) for a race with
+            // BloodTexID 0, a missing Blood.rpc, or an unknown target actor.
+            {
+                let total = net.world.combat_events.len();
+                if self.combat_blood_consumed > total {
+                    self.combat_blood_consumed = 0;
+                }
+                for i in self.combat_blood_consumed..total {
+                    let ev = net.world.combat_events[i];
+                    if ev.damage == 0 {
+                        continue; // a miss/parry draws no blood
+                    }
+                    let (tmpl, pos) = if ev.target == net.world.my_runtime_id {
+                        (net.world.me_actor_id, [net.world.me_render_x, net.world.me_y + 3.0, net.world.me_render_z])
+                    } else if let Some(a) = net.world.actors.get(&ev.target) {
+                        (a.template_id, [a.render_x, a.y + 3.0, a.render_z])
+                    } else {
+                        continue;
+                    };
+                    let (Some(tex_id), Some(config)) = (store.actor_blood_tex(tmpl), store.emitter_config("Blood")) else {
+                        continue;
+                    };
+                    let tex = store.texture_path(tex_id).and_then(|p| rcce_data::texture::load(&p));
+                    if std::env::var_os("RCCE_BLOODTEST").is_some() {
+                        println!("[blood] spawned at {pos:?} tex {tex_id} (tex loaded: {})", tex.is_some());
+                    }
+                    let seed = 0x9E3779B97F4A7C15u64 ^ (i as u64) ^ (ev.target as u64);
+                    let emitter = rcce_client::particles::Emitter::new(config, tex_id, pos, [0.0, 0.0, 0.0], seed);
+                    self.emitters.push(ZoneEmitter {
+                        emitter,
+                        tex,
+                        life: Some(700.0), // a brief spurt, then taper + reap
+                        attach: None,
+                        offset: [0.0; 3],
+                        proj_id: None,
+                    });
+                }
+                self.combat_blood_consumed = total;
+            }
             // Server-driven floating numbers (P_FloatingNumber): script-driven
             // heal/text popups, always shown regardless of the combat-damage
             // display style (they aren't combat damage). Drained unconditionally
@@ -7085,6 +7131,31 @@ impl App {
             }
         }
         // Headless script-input + progress-bar self-test (TGT-8): inject a
+        // Headless blood-spurt self-test (CBT): inject one connecting hit on Me so
+        // the Blood.rpc emitter spawns over the player (always framable). No-op unless
+        // RCCE_BLOODTEST=<frame> set. Logs Me's resolved BloodTexID so a no-show can
+        // be distinguished (race BloodTexID 0 = latent) from a render fault.
+        if let Ok(bv) = std::env::var("RCCE_BLOODTEST") {
+            if let Ok(at) = bv.parse::<u64>() {
+                if self.frames == at {
+                    if let Some(net) = self.net.as_mut() {
+                        let me = net.world.my_runtime_id;
+                        let tmpl = net.world.me_actor_id;
+                        net.world.combat_events.push(rcce_client::world::CombatEvent {
+                            target: me,
+                            attacker: me,
+                            damage: 10,
+                            damage_type: 0,
+                        });
+                        println!(
+                            "[bloodtest] frame {} injected hit on me (tmpl {tmpl}, BloodTexID {:?})",
+                            self.frames,
+                            store.actor_blood_tex(tmpl)
+                        );
+                    }
+                }
+            }
+        }
         // Headless remote-attack self-test (CBT-3): make the nearest actor play
         // its attack swing so it's capturable without a hostile NPC. No-op unless
         // RCCE_REMOTEATTACK=<frame> set.

--- a/client-rs/crates/rcce-data/src/actors.rs
+++ b/client-rs/crates/rcce-data/src/actors.rs
@@ -50,6 +50,10 @@ pub struct ActorTemplate {
     /// colour so a player can read an NPC's hostility at a glance (Blitz
     /// Actors3D.bb:546-559).
     pub aggressiveness: u8,
+    /// Blood-spurt texture id (`Actors.dat` BloodTexID). When > 0, Blitz spawns a
+    /// `Blood.rpc` particle emitter (textured with this id) at the actor on a
+    /// connecting combat hit (ClientNet.bb:1136/1168). 0 = no blood for this race.
+    pub blood_tex: i16,
 }
 
 #[derive(Debug, Default, Clone)]
@@ -147,7 +151,7 @@ fn parse_record(r: &mut BlitzReader) -> Result<ActorTemplate, ReadError> {
     for slot in &mut female_speech {
         *slot = r.read_short_u()?;
     }
-    let _blood_tex = r.read_short()?;
+    let blood_tex = r.read_short()?;
     // Attributes[40] × (Value + Maximum) = 80 shorts.
     for _ in 0..80 {
         r.read_short()?;
@@ -189,6 +193,7 @@ fn parse_record(r: &mut BlitzReader) -> Result<ActorTemplate, ReadError> {
         genders,
         playable,
         aggressiveness,
+        blood_tex,
     })
 }
 
@@ -215,5 +220,13 @@ mod tests {
         // Unknown template → None; out-of-range slot → None (no panic).
         assert_eq!(cat.speech_id(99, 0, speech::ATTACK1), None);
         assert_eq!(cat.speech_id(3, 0, 999), None);
+    }
+
+    #[test]
+    fn blood_tex_defaults_to_none() {
+        // Captured from Actors.dat; default 0 = no blood (the gate is `> 0`).
+        assert_eq!(ActorTemplate::default().blood_tex, 0);
+        let t = ActorTemplate { id: 5, blood_tex: 42, ..Default::default() };
+        assert_eq!(t.blood_tex, 42);
     }
 }


### PR DESCRIPTION
## What

A connecting combat hit now spawns a **blood spurt** (a `Blood.rpc` particle emitter at the struck actor), textured with that race's `BloodTexID` — matching Blitz (`ClientNet.bb:1136` when I hit someone, `:1168` when I'm hit). The Rust showed no blood on hits. Combat-feedback VFX, reusing the particle system (iters 46-48 / projectile emitters #527).

## How

- **Capture (was dropped):** `Actors.dat` `BloodTexID` (the dropped `_blood_tex`) is captured onto `ActorTemplate.blood_tex` (offset-preserving) + a new `AssetStore::actor_blood_tex(template_id)` accessor (`> 0` → Some, else None — Blitz's `If BloodTexID > 0` gate).
- **Render:** a new `combat_blood_consumed` cursor over `combat_events` spawns one finite `Blood.rpc` emitter per new connecting hit (damage > 0), at the target's position (Me → my render pos; else the actor's), via the existing finite-emitter path (life ~700ms, taper + reap). Independent of the damage-info display style. Soft-fails to no blood for a race with `BloodTexID 0`, a missing `Blood.rpc`, or an unknown target.

## Verification

`cargo clippy … -D warnings` clean; `cargo test` (exit 0) + `blood_tex_defaults_to_none`. Release build + `RCCE_BLOODTEST` (injects a hit on Me, always framable) **definitively logs**: `[blood] spawned at [-36.66, 6.33, -67.70] tex 12 (tex loaded: true)` — confirming the end-to-end path runs (the **default race has BloodTexID 12, so this is non-latent**), the emitter is created at the player's head with the race texture loaded, and renders via the triple-verified finite-emitter path (#518/#527). The spurt is **sparse by design** (`Blood.rpc`: max 30, ~1 particle/frame — a few droplets, not a cloud), so it's subtle at the downscaled headless resolution; the log is the definitive spawn proof. (The `[blood]` log is gated behind `RCCE_BLOODTEST` — no production output.)

## Follow-up (deferred)
- Orient the spurt away from the attacker (Blitz `PointEntity` + `MoveEntity`) — currently world-anchored at the hit point (the emitter's own config velocity still spreads the droplets).

🤖 Generated with [Claude Code](https://claude.com/claude-code)