### PR TITLE
rust-client: seed HUD vitals (health/mana) from login sheet — fixes /1 bars

### DIFF
--- a/client-rs/crates/rcce-client/src/bin/client_window.rs
+++ b/client-rs/crates/rcce-client/src/bin/client_window.rs
@@ -3669,6 +3669,21 @@ impl App {
             world.me_level = s.level;
             world.me_xp = s.xp as i32;
             world.me_reputation = s.reputation as i32;
+            // Seed the live attribute values + MAXes from the sheet so the HUD
+            // vitals bars (Health/Energy) show real numbers immediately. Without
+            // this, me_attributes was empty and me_health_max 0 at login, so every
+            // bar rendered "value/1" (the max defaulted to 1) until a P_StatUpdate
+            // "M" max-update arrived — which often never came. A later value-update
+            // ("A") preserves the seeded max (on_stat_update only writes e.0).
+            for (i, &(v, m)) in s.attributes.iter().take(40).enumerate() {
+                world.me_attributes.insert(i as u8, (v, m));
+            }
+            // Mirror the Health slot onto me_health/me_health_max (the Health bar +
+            // target panel read these), matching on_stat_update's health mirror.
+            if let Some(&(hv, hm)) = s.attributes.get(world.health_stat as usize) {
+                world.me_health = hv;
+                world.me_health_max = hm;
+            }
             // Populate the spellbook's known-spell list from the login sheet.
             // Login spells arrive via P_FetchCharacter, NOT P_KnownSpellUpdate, so
             // without this the spellbook was EMPTY at login for any character that


### PR DESCRIPTION
## What (user-reported bug)

The HUD vitals bars rendered `value/1` — "0/1" (black) for Health, "49/1" for Mana after a cast, "500/1" after death — so you couldn't read your real HP/mana. Now both bars show real numbers with correct maxes immediately on login.

## Root cause

`enter_outcome` seeded gold/level/xp/reputation from the character sheet but **not** the attribute values or their **maxes**. So `me_attributes` was empty and `me_health_max` 0 at login, and `vitals_value` fell back to `max(1) = 1` (the `/1` denominator) until a `P_StatUpdate "M"` max-update arrived — which often never did (value updates only set `e.0`).

## Fix

Seed `me_attributes` from `sheet.attributes` (which already carries `(value, max)` per slot, up to 40) and mirror the Health slot onto `me_health`/`me_health_max`. A later `"A"` value-update preserves the seeded max (`on_stat_update` only writes `e.0`), so the max sticks.

## Verification

`cargo clippy … -D warnings` clean; `cargo test` exit 0 (the `vitals_value` helper is already unit-tested). Release build + login shot: the HUD now shows **two bars with real values** — Mana `50/100` (half-full blue), Health bar full — vs the previous `0/1`/`49/1`. (Health reads `10000/1000` = the server's actual data, the known max-HP-1000 content anomaly, not a client bug — the client now correctly displays the authoritative values.)

First of a batch of user-reported HUD/UX issues; subsequent fixes (text word-wrap, drop-item desync, spell icons, water tiling, camera occlusion, swim-on-surface) follow in later PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)