### PR TITLE
Rust client: optimistic local removal on item drop (fix drop desync)

### DIFF
--- a/client-rs/crates/rcce-client/src/bin/client_window.rs
+++ b/client-rs/crates/rcce-client/src/bin/client_window.rs
@@ -3346,13 +3346,8 @@ impl ApplicationHandler for App {
                                                 true,
                                             );
                                         }
-                                    } else if let Some(net) = self.net.as_mut() {
-                                        net.transport.send(
-                                            net.peer,
-                                            rcce_net::packet_id::INVENTORY_UPDATE,
-                                            &rcce_client::net::inv_drop_packet(slot, 1),
-                                            true,
-                                        );
+                                    } else {
+                                        self.send_drop(slot, 1);
                                     }
                                 }
                                 return;
@@ -4522,6 +4517,25 @@ impl App {
         }
     }
 
+    /// Drop `amount` from inventory `slot`: tell the server (P_InventoryUpdate
+    /// "D") AND optimistically remove it locally, mirroring Blitz `InventoryDrop`
+    /// (Inventories.bb:86, called with `TellServer=True`). The server broadcasts
+    /// the drop to everyone in the area but sends the *dropper* no "taken" echo,
+    /// so without the local removal the slot icon lingers and a subsequent pickup
+    /// lands in the next free slot — the "phantom duplicate" the user reported.
+    /// No-op if not connected.
+    fn send_drop(&mut self, slot: u8, amount: u16) {
+        if let Some(net) = self.net.as_mut() {
+            net.transport.send(
+                net.peer,
+                rcce_net::packet_id::INVENTORY_UPDATE,
+                &rcce_client::net::inv_drop_packet(slot, amount),
+                true,
+            );
+            net.world.inv_remove(slot, amount);
+        }
+    }
+
     /// Apply the open quantity prompt (Enter): stage the sell `(slot, qty)` or
     /// drop `qty` from the slot, then close the prompt.
     fn confirm_qty(&mut self) {
@@ -4533,9 +4547,7 @@ impl App {
                 self.pending_sells.push((p.slot, qty));
             }
             QtyAction::Drop => {
-                if let Some(net) = self.net.as_mut() {
-                    net.transport.send(net.peer, rcce_net::packet_id::INVENTORY_UPDATE, &rcce_client::net::inv_drop_packet(p.slot, qty), true);
-                }
+                self.send_drop(p.slot, qty);
             }
         }
     }
@@ -4726,14 +4738,7 @@ impl App {
                 if let Some(item_id) = item {
                     match action {
                         InvAction::Drop => {
-                            if let Some(net) = self.net.as_mut() {
-                                net.transport.send(
-                                    net.peer,
-                                    rcce_net::packet_id::INVENTORY_UPDATE,
-                                    &rcce_client::net::inv_drop_packet(slot, 1),
-                                    true,
-                                );
-                            }
+                            self.send_drop(slot, 1);
                         }
                         InvAction::Eat => {
                             // Faithful to Blitz UseItem (Interface3D.bb:4138-4216):
@@ -4821,14 +4826,9 @@ impl App {
                     true,
                 );
             }
-        } else if let Some(net) = self.net.as_mut() {
+        } else {
             // Plain click a backpack item → drop one.
-            net.transport.send(
-                net.peer,
-                rcce_net::packet_id::INVENTORY_UPDATE,
-                &rcce_client::net::inv_drop_packet(slot, 1),
-                true,
-            );
+            self.send_drop(slot, 1);
         }
     }
 
@@ -4914,17 +4914,15 @@ impl App {
             }
             ItemAction::DropAll => {
                 let amount = self.net.as_ref().and_then(|n| n.world.me_inventory.values().find(|it| it.slot == slot)).map(|it| it.amount.max(1)).unwrap_or(1);
-                if let Some(net) = self.net.as_mut() {
-                    net.transport.send(net.peer, rcce_net::packet_id::INVENTORY_UPDATE, &rcce_client::net::inv_drop_packet(slot, amount), true);
-                }
+                self.send_drop(slot, amount);
             }
             ItemAction::Drop => {
                 let amount = self.net.as_ref().and_then(|n| n.world.me_inventory.values().find(|it| it.slot == slot)).map(|it| it.amount.max(1)).unwrap_or(1);
                 if amount > 1 {
                     // Stack → ask how many to drop.
                     self.qty_prompt = Some(QtyPrompt { slot, item_id, max: amount, qty: 1, action: QtyAction::Drop });
-                } else if let Some(net) = self.net.as_mut() {
-                    net.transport.send(net.peer, rcce_net::packet_id::INVENTORY_UPDATE, &rcce_client::net::inv_drop_packet(slot, 1), true);
+                } else {
+                    self.send_drop(slot, 1);
                 }
             }
         }
@@ -7748,6 +7746,33 @@ impl App {
                         ],
                     });
                     println!("[itemmenu] frame {} opened item menu over slot 14", self.frames);
+                }
+            }
+        }
+        // Headless drop self-test: inject two backpack items (slots 14, 15) + open
+        // the inventory, then DROP slot 14 via the real send_drop path. After the
+        // drop, slot 14 must be EMPTY (the icon disappears) and slot 15 untouched —
+        // proving the optimistic local removal that the user's "icon stays after
+        // Drop / phantom duplicate on pickup" bug was missing. No-op unless
+        // RCCE_DROPTEST=<frame> is set; capture a frame or two later.
+        if let Ok(dt) = std::env::var("RCCE_DROPTEST") {
+            if let Ok(at) = dt.parse::<u64>() {
+                if self.frames == at {
+                    use rcce_client::fetch::InvItem;
+                    self.show_inventory = true;
+                    // Inline the send_drop logic via the disjoint `self.net` field
+                    // (gfx/view/store are already borrowed in this render scope, so
+                    // a `&mut self` method call isn't possible here).
+                    if let Some(net) = self.net.as_mut() {
+                        net.world.me_inventory.insert(14, InvItem { slot: 14, item_id: 1, amount: 1, health: 100 });
+                        net.world.me_inventory.insert(15, InvItem { slot: 15, item_id: 2, amount: 3, health: 100 });
+                        let before = net.world.me_inventory.contains_key(&14);
+                        net.transport.send(net.peer, rcce_net::packet_id::INVENTORY_UPDATE, &rcce_client::net::inv_drop_packet(14, 1), true);
+                        net.world.inv_remove(14, 1);
+                        let after = net.world.me_inventory.contains_key(&14);
+                        let s15 = net.world.me_inventory.get(&15).map(|it| it.amount);
+                        println!("[droptest] frame {} slot14 before={before} after={after} slot15_amount={s15:?}", self.frames);
+                    }
                 }
             }
         }

--- a/client-rs/crates/rcce-client/src/world.rs
+++ b/client-rs/crates/rcce-client/src/world.rs
@@ -1333,12 +1333,7 @@ impl World {
             Some(b'T') => {
                 let mut r = MsgReader::new(&d[1..]);
                 let (Some(slot), Some(amount)) = (r.u8(), r.u16()) else { return };
-                if let Some(it) = self.me_inventory.get_mut(&slot) {
-                    it.amount = it.amount.saturating_sub(amount);
-                    if it.amount == 0 {
-                        self.me_inventory.remove(&slot);
-                    }
-                }
+                self.inv_remove(slot, amount);
             }
             // Equipped-gear update for an actor: rid u16 + weapon/shield/chest/
             // hat item ids (u16 each, 65535 = none) + 6 gubbin bytes (ignored).
@@ -1377,6 +1372,21 @@ impl World {
             e.health = health;
         } else {
             *e = crate::fetch::InvItem { slot, item_id, amount, health };
+        }
+    }
+
+    /// Remove up to `amount` from inventory `slot`, deleting the entry when the
+    /// stack reaches zero. Mirrors the local side of Blitz `InventoryDrop`
+    /// (Inventories.bb:86) and the inbound "T" (taken) handler — the server
+    /// sends no "taken" echo to the *dropper*, so the client must remove its own
+    /// dropped item locally or the slot icon lingers (and a later pickup phantom-
+    /// duplicates into the next free slot).
+    pub fn inv_remove(&mut self, slot: u8, amount: u16) {
+        if let Some(it) = self.me_inventory.get_mut(&slot) {
+            it.amount = it.amount.saturating_sub(amount);
+            if it.amount == 0 {
+                self.me_inventory.remove(&slot);
+            }
         }
     }
 
@@ -3636,5 +3646,31 @@ mod tests {
         // A change for a different area is ignored.
         w.apply(&msg(pk::WEATHER_CHANGE, pkt(|p| { p.u32(99).u8(2); })));
         assert_eq!(w.zone.weather, 1);
+    }
+
+    // Optimistic drop removal: the server sends the dropper no "taken" echo, so
+    // the client must remove its own dropped item locally (Blitz InventoryDrop).
+    // Without this the slot icon lingered and a pickup phantom-duplicated.
+    #[test]
+    fn inv_remove_decrements_and_clears_slot() {
+        use crate::fetch::InvItem;
+        let mut w = World::default();
+        w.me_inventory.insert(14, InvItem { slot: 14, item_id: 7, amount: 5, health: 100 });
+
+        // Partial drop from a stack: amount drops, the entry stays.
+        w.inv_remove(14, 2);
+        assert_eq!(w.me_inventory.get(&14).map(|it| it.amount), Some(3));
+
+        // Dropping the rest clears the slot entirely (no lingering ghost icon),
+        // freeing it for a subsequent pickup so nothing phantom-duplicates.
+        w.inv_remove(14, 3);
+        assert!(!w.me_inventory.contains_key(&14));
+        assert_eq!(w.inv_free_slot(7), Some(14), "freed slot is reused, not skipped");
+
+        // Over-drop and dropping an empty slot are safe (saturating, no panic).
+        w.me_inventory.insert(20, InvItem { slot: 20, item_id: 9, amount: 1, health: 100 });
+        w.inv_remove(20, 99);
+        assert!(!w.me_inventory.contains_key(&20));
+        w.inv_remove(20, 1); // already gone — no-op
     }
 }


### PR DESCRIPTION
## What

Fixes user bug-list item **#3 (drop desync)**: clicking Drop did nothing visible — the item icon stayed in its slot — and picking the item back up with E added a **phantom duplicate** in the next slot while the original icon stayed stuck/non-interactive.

## Root cause

A client/server contract gap the Blitz client compensates for but the Rust client didn't:
- On a drop, the server (`ServerNet.bb:1671`, `Case "D"`) removes the item server-side and broadcasts the on-floor `"D"` to **everyone in the area including the dropper** — but sends the dropper **no `"T"` (taken) echo**.
- The Blitz client removes the item from its **own** inventory locally the instant it sends the drop: `InventoryDrop(Me, slot, amount, TellServer=True)` (`Inventories.bb:86`) decrements/clears locally *and* sends.
- The Rust client only sent the packet and waited for an echo that never came → the slot icon lingered.
- The **phantom duplicate** is the same root cause: the ghost slot stayed "occupied", so the next pickup routed to the next free slot, leaving two icons (one real, one dead).

## Fix

- New `World::inv_remove(slot, amount)` — the local side of `InventoryDrop` (decrement, delete the entry at zero). The inbound `"T"` handler now reuses it (identical logic).
- New `send_drop(slot, amount)` App helper: send the packet **and** `inv_remove` locally.
- All five drop call sites route through it: context-menu Drop / DropAll, qty-prompt Drop, the Drop button, plain-click drop, number-key drop.

## Verify

- `RCCE_DROPTEST` self-test logs `slot14 before=true after=false slot15_amount=Some(3)` — the dropped slot empties; adjacent slots untouched.
- Unit test `inv_remove_decrements_and_clears_slot`: partial/full/over-drop + confirms the freed slot is reused (no phantom duplicate).
- 51 client tests pass; clippy `-D warnings` clean.

## Follow-up noted

The "click an item → no highlight" selection-feedback polish (same bug report) is a separate cosmetic concern, left for a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)