### PR TITLE
Rust client: seat actors under building roofs on the floor, not the roof

### DIFF
--- a/client-rs/crates/rcce-client/src/bin/client_window.rs
+++ b/client-rs/crates/rcce-client/src/bin/client_window.rs
@@ -1776,6 +1776,12 @@ fn build_actors(
     let mut place = Vec::new();
     let mut keys: Vec<String> = Vec::new();
     let mut skinned: Vec<SkinnedActor> = Vec::new();
+    // Seat each actor on the ground surface nearest its authoritative Y, so a
+    // body standing under a building roof sits on the FLOOR, not the roof (the
+    // height field's near-horizontal triangles include both, and plain
+    // `height_at` returns the highest). RCCE_NOROOFFIX restores the old highest-
+    // surface seating for an A/B comparison. Read once per frame, not per actor.
+    let roof_fix = std::env::var_os("RCCE_NOROOFFIX").is_none();
 
     let push = |store: &mut AssetStore,
                     models: &mut Vec<Rc<B3dModel>>,
@@ -1857,7 +1863,13 @@ fn build_actors(
         // (model `min`) at the ground. Fall back to centring on the server Y when
         // no ground triangle is under the actor (e.g. mid-air / off-mesh).
         let half_h = (max[1] - min[1]) * 0.5;
-        let ground = height.and_then(|h| h.height_at(pos[0], pos[2]));
+        let ground = height.and_then(|h| {
+            if roof_fix {
+                h.height_at_near(pos[0], pos[2], pos[1])
+            } else {
+                h.height_at(pos[0], pos[2])
+            }
+        });
         let trans_y = match ground {
             // Inside a water plane, float the body at the surface (swim) instead
             // of on the submerged lakebed (the user's "I walk underwater" bug).
@@ -2955,6 +2967,21 @@ fn load_zone_static(store: &mut AssetStore, view: &mut WorldView, gfx: &Gfx, dat
         }
         rcce_client::terrain::HeightField::build(tris, 8.0)
     };
+
+    // Headless roof-seating diagnostic (RCCE_ROOFSCAN): at each building
+    // occluder centre, report the highest vs lowest ground surface. A large gap
+    // means floor + roof stack there — the spot to test the roof-seating fix.
+    if std::env::var_os("RCCE_ROOFSCAN").is_some() {
+        for (c, r) in &occluders {
+            let hi = height_field.height_at(c[0], c[2]);
+            let lo = height_field.lowest_at(c[0], c[2]);
+            if let (Some(hi), Some(lo)) = (hi, lo) {
+                if hi - lo > 3.0 {
+                    println!("[roofscan] building @({:.1},{:.1}) r{:.1}: highest={:.2} lowest={:.2} gap={:.2}", c[0], c[2], r, hi, lo, hi - lo);
+                }
+            }
+        }
+    }
 
     // Particle emitters: load each placement's .rpc config + billboard texture and
     // build a live emitter (simulated per frame in `tick_particles`).

--- a/client-rs/crates/rcce-client/src/terrain.rs
+++ b/client-rs/crates/rcce-client/src/terrain.rs
@@ -71,6 +71,31 @@ impl HeightField {
         best
     }
 
+    /// Ground Y at `(x, z)` on the surface NEAREST `ref_y`, or `None` if no
+    /// ground triangle covers it. Actor seating uses this with the actor's
+    /// authoritative Y so a character standing under a building roof sits on the
+    /// FLOOR (near its server Y) instead of the roof — `height_at` returns the
+    /// highest surface, which is the roof when floor + roof stack at one (x, z).
+    /// With a single surface (open terrain) this equals `height_at`.
+    pub fn height_at_near(&self, x: f32, z: f32, ref_y: f32) -> Option<f32> {
+        if let Some(y) = self.flat {
+            return Some(y);
+        }
+        let key = ((x / self.cell).floor() as i32, (z / self.cell).floor() as i32);
+        let ids = self.grid.get(&key)?;
+        let mut best: Option<f32> = None;
+        for &i in ids {
+            if let Some(y) = tri_height(&self.tris[i as usize], x, z) {
+                best = match best {
+                    // Keep the current best only if it's at least as close to ref_y.
+                    Some(b) if (b - ref_y).abs() <= (y - ref_y).abs() => Some(b),
+                    _ => Some(y),
+                };
+            }
+        }
+        best
+    }
+
     /// Lowest ground Y at `(x, z)`, or `None` if no ground triangle covers it.
     /// The set's rug is its lowest horizontal surface under the character (the
     /// ceiling vault / tables sit above it), so the menu seats the character on
@@ -130,6 +155,34 @@ mod tests {
         assert_eq!(hf.height_at(5.0, 5.0), Some(5.0));
         assert_eq!(hf.height_at(1.0, 9.0), Some(5.0));
         assert_eq!(hf.height_at(-1.0, 5.0), None); // off the quad
+    }
+
+    #[test]
+    fn height_at_near_picks_floor_under_roof() {
+        // A floor quad at y=0 and a roof quad at y=12, both over [0,10]×[0,10]
+        // (a building the player can walk under).
+        let quad = |y: f32| {
+            let v = |x: f32, z: f32| Vec3::new(x, y, z);
+            vec![
+                [v(0.0, 0.0), v(10.0, 0.0), v(10.0, 10.0)],
+                [v(0.0, 0.0), v(10.0, 10.0), v(0.0, 10.0)],
+            ]
+        };
+        let mut tris = quad(0.0);
+        tris.extend(quad(12.0));
+        let hf = HeightField::build(tris, 8.0);
+
+        // `height_at` returns the highest surface — the roof (the bug).
+        assert_eq!(hf.height_at(5.0, 5.0), Some(12.0));
+        // Seated near the floor's authoritative Y → picks the FLOOR.
+        assert_eq!(hf.height_at_near(5.0, 5.0, 1.0), Some(0.0));
+        // Standing on the roof (ref_y high) → picks the roof.
+        assert_eq!(hf.height_at_near(5.0, 5.0, 11.0), Some(12.0));
+        // Open terrain (single surface) → identical to height_at regardless of ref.
+        let flat = HeightField::build(quad(3.0), 8.0);
+        assert_eq!(flat.height_at_near(5.0, 5.0, -50.0), flat.height_at(5.0, 5.0));
+        // Off the quad → None.
+        assert_eq!(hf.height_at_near(-1.0, 5.0, 0.0), None);
     }
 
     #[test]


### PR DESCRIPTION
## What

Fixes user bug-list item **#9** (the last one): walking under a building's roof puts the character **on top of the roof** instead of underneath on the floor.

## Cause

The client height field (same family as the swim bug #8) gathers near-horizontal "ground" triangles from every non-foliage scenery mesh — which includes a building's near-horizontal **roof** — and `height_at` returns the **highest** surface at an (x, z). Where a floor and roof stack at one column, it returns the roof, so `build_actors` seats the body up there. (`lowest_at` exists for the menu's ceiling case, but picking the lowest would sink actors below raised floors / bridges.)

## Fix

New `HeightField::height_at_near(x, z, ref_y)` returns the ground surface **nearest a reference Y**; seat each actor using its own authoritative Y as the reference. The server keeps the actor on its actual level, so the surface closest to that Y is the one it's standing on. With a single surface (open terrain) this is identical to `height_at` — normal seating unchanged.

## Verify

- At a real building (Plains occluder centre -50.2,1.6: floor 0.08, roof 10.89) via `RCCE_SEATDIAG`: the body's seat drops from **10.89 (on the roof) → 0.09 (on the floor)**; the actor's authoritative Y 3.33 is nearer the floor.
- Unit test `height_at_near_picks_floor_under_roof` (floor-under-roof / standing-on-roof / single-surface == height_at / off-mesh).
- Two env-gated diagnostics added: `RCCE_ROOFSCAN` (lists buildings with stacked ground surfaces) and `RCCE_NOROOFFIX` (A/B). 133 client tests pass; clippy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)