### PR TITLE
Rust client: highlight the selected inventory slot

### DIFF
--- a/client-rs/crates/rcce-client/src/bin/client_window.rs
+++ b/client-rs/crates/rcce-client/src/bin/client_window.rs
@@ -7795,6 +7795,7 @@ impl App {
                         net.world.me_inventory.insert(15, InvItem { slot: 15, item_id: 2, amount: 3, health: 100 });
                     }
                     self.show_inventory = true;
+                    self.last_inv_slot = Some(14); // select a slot so the highlight is capturable
                     // Stage a buy (offer 1) + a sell (slot 14) so the basket /
                     // net-gold / Confirm button are capturable.
                     self.pending_buys = vec![1];
@@ -9164,9 +9165,22 @@ impl App {
                             };
                             overlay.rect(bx, bgy, bw, bh, bg);
                         }
+                        // Selection highlight (SEL): a bright border on the slot the
+                        // player last clicked. The user reported that clicking an
+                        // inventory item gave no visual feedback before the Drop/Eat
+                        // buttons act on it. Drawn under the icon (icons are inset).
+                        if self.last_inv_slot == Some(i as u8) {
+                            let t = (bw.min(bh) * 0.08).clamp(1.5, 3.0);
+                            let hl = [1.0, 0.88, 0.35, 0.95];
+                            overlay.rect(bx, bgy, bw, t, hl); // top
+                            overlay.rect(bx, bgy + bh - t, bw, t, hl); // bottom
+                            overlay.rect(bx, bgy, t, bh, hl); // left
+                            overlay.rect(bx + bw - t, bgy, t, bh, hl); // right
+                        }
                         // Empty equipment slots show their Blitz placeholder ICON
                         // (Hat/Chest/Ring/…), dimmed, so you can see what goes where —
-                        // like Blitz. Slot 0 ("Weapon") has no icon → name fallback.
+                        // like Blitz. Each slot 0..13 has a placeholder (slot 0 =
+                        // Weapon.bmp); occupied slots draw the item icon below.
                         if equip && !occupied {
                             let name = rcce_data::equip_slot_name(i as u8);
                             let key = name.map(|n| format!("gui:slot:{n}"));


### PR DESCRIPTION
## What

Closes the still-open part of the iter-61 play-test report. Alongside the drop-item desync (fixed in #533), the user noted: *"I click an item in inventory and there is no highlight."* The drop logic was fixed, but the missing **visual feedback** was not — `last_inv_slot` was tracked (the Drop/Eat buttons act on it) yet never drawn, so the player couldn't see which slot was selected.

## Change

- Draw a bright border around the slot matching `last_inv_slot` in the inventory grid, under the item icon (icons are inset, so they're not covered). Border thickness scales with slot size.
- Fixes a stale comment the reviewer flagged after #534: slot 0 ("Weapon") now has a placeholder icon (`gui:slot:Weapon`), so the old "slot 0 has no icon → name fallback" note was wrong.

## Verify

`RCCE_VENDORTEST` (now also selects slot 14): the screenshot shows the selected slot with a yellow border while its neighbours have none. 52 client tests pass; clippy `-D warnings` clean.

## Note

This iteration's recon also confirmed the renderer is feature-complete and runs at ~105 fps (frustum + shadow culling, MSAA 4×, aniso 8×, bloom, shadows+PCF, GPU skinning already present), so there was no high-confidence perf win; and foliage wind-sway — the most appealing visual upgrade — would require a vertex-layout/draw restructuring (foliage shares the solid pipeline via alpha-to-coverage), too big for one clean increment. This user-reported UX gap was the higher-confidence pick.

🤖 Generated with [Claude Code](https://claude.com/claude-code)