### PR TITLE
test(security): pin the script file-I/O path-traversal guard (BVM_ScriptPathIsSafe)

### DIFF
--- a/src/Tests/Modules/ScriptPathSafeTest.bb
+++ b/src/Tests/Modules/ScriptPathSafeTest.bb
@@ -1,0 +1,119 @@
+Strict
+EnableGC
+
+; Regression tests pinning BVM_ScriptPathIsSafe% -- the path-traversal floor
+; that keeps a non-privileged NPC script from escaping the RCScriptFiles$
+; sandbox via the script file-I/O BVMs (ScriptingCommands.bb:1913-1926).
+;
+; Why this guard is load-bearing: of the eight FS BVMs that route through it,
+; three -- BVM_READFILE, BVM_FILESIZE, BVM_FILETYPE -- DELIBERATELY run with
+; no BVM_RequirePrivileged() gate (read/stat are treated as non-mutating, so
+; any NPC's RightClick/Examine/ItemScript can call them). For those three,
+; BVM_ScriptPathIsSafe is the ONLY barrier between a hostile content script
+; and arbitrary host-file read/probe (e.g. ..\..\Server Data\Privileged
+; Scripts.dat, the running .exe, system configs). The other five FS BVMs
+; (DELETEFILE / WRITEFILE / OPENFILE / APPENDFILE / CREATEDIR) layer a
+; privilege gate on top, but the path check is the floor for all eight.
+; This invariant had zero test coverage; a refactor that "tidies" the ..
+; check or swaps Instr for a segment-splitter could silently re-open the
+; sandbox with no failing test.
+;
+; ScriptingCommands.bb can't be Included into a test build -- it pulls in the
+; whole actor / item / wire / scripting graph. Following the established
+; ClampFloatTest.bb / BVMPrivilegeGateTest.bb pattern, the function body is
+; replicated here CHARACTER-IDENTICAL to production (it is a pure string
+; predicate with no SI/Object/Handle dependencies, so no scaffolding is
+; needed). A refactor that changes the guard must update both copies; that
+; is the trigger to refresh this test.
+;
+; Blitz string-literal notes: Blitz does NOT process backslash escapes, so
+; "..\x" is literally dot-dot-backslash-x; embedded Chr$(0) is valid in a
+; length-prefixed Blitz string and Len/Asc see it.
+
+; --- Replicated production logic (ScriptingCommands.bb:1913-1926) ----------
+Function BVM_ScriptPathIsSafe%(Name$)
+	If Name$ = "" Then Return False
+	If Instr(Name$, "..") > 0 Then Return False
+	If Left$(Name$, 1) = "\" Or Left$(Name$, 1) = "/" Then Return False
+	; Drive letter "C:..." or any colon at position 2.
+	If Len(Name$) >= 2 And Mid$(Name$, 2, 1) = ":" Then Return False
+	; Reject control bytes / non-printable.
+	Local i, c
+	For i = 1 To Len(Name$)
+		c = Asc(Mid$(Name$, i, 1))
+		If c < 32 Or c = 127 Then Return False
+	Next
+	Return True
+End Function
+
+
+; Ordinary in-sandbox names are accepted. A mid-path separator (forward or
+; back slash) is allowed -- only a LEADING slash is an absolute-path marker.
+; Single dots and spaces are fine; only the ".." sequence is a traversal.
+Test testAcceptsOrdinaryNames()
+	Assert(BVM_ScriptPathIsSafe("player_log.txt") = True)
+	Assert(BVM_ScriptPathIsSafe("a") = True)
+	Assert(BVM_ScriptPathIsSafe("my.save") = True)
+	Assert(BVM_ScriptPathIsSafe("a.b.c") = True)
+	Assert(BVM_ScriptPathIsSafe("file with spaces.txt") = True)
+	Assert(BVM_ScriptPathIsSafe("subdir/data.dat") = True)
+	Assert(BVM_ScriptPathIsSafe("subdir\data.dat") = True)
+End Test
+
+; The empty string is rejected (production's first guard) -- an empty operand
+; would resolve to RCScriptFiles$ itself.
+Test testRejectsEmpty()
+	Assert(BVM_ScriptPathIsSafe("") = False)
+End Test
+
+; The core threat: any ".." sequence is rejected. This includes the bare
+; "..", traversal with either separator, and ".." nested mid-path. The guard
+; uses a SUBSTRING test (Instr), so "a..b" -- dots with no separator -- is
+; also rejected. That is deliberately strict; this test pins it so a future
+; switch to segment-aware matching is a conscious, reviewed change.
+Test testRejectsTraversal()
+	Assert(BVM_ScriptPathIsSafe("..") = False)
+	Assert(BVM_ScriptPathIsSafe("../etc/passwd") = False)
+	Assert(BVM_ScriptPathIsSafe("..\windows\system32") = False)
+	Assert(BVM_ScriptPathIsSafe("sub/../escape") = False)
+	Assert(BVM_ScriptPathIsSafe("foo\..\bar") = False)
+	Assert(BVM_ScriptPathIsSafe("foo/..") = False)
+	; Substring match -- dots without a separator are still rejected.
+	Assert(BVM_ScriptPathIsSafe("a..b") = False)
+End Test
+
+; A leading slash or backslash marks an absolute path and is rejected,
+; otherwise it would escape RCScriptFiles$ to a drive root / UNC path.
+Test testRejectsLeadingSlash()
+	Assert(BVM_ScriptPathIsSafe("/etc/passwd") = False)
+	Assert(BVM_ScriptPathIsSafe("\windows") = False)
+	Assert(BVM_ScriptPathIsSafe("\\server\share") = False)
+End Test
+
+; A colon at position 2 is a Windows drive letter ("C:\...") or drive-relative
+; path ("D:foo") and is rejected.
+Test testRejectsDriveLetter()
+	Assert(BVM_ScriptPathIsSafe("C:\Windows") = False)
+	Assert(BVM_ScriptPathIsSafe("D:foo") = False)
+	Assert(BVM_ScriptPathIsSafe("z:") = False)
+End Test
+
+; Control bytes (< 32) and DEL (127) are rejected anywhere in the name --
+; NUL-splicing and newline/CR injection into a host path are blocked. The
+; check scans every byte, so a control byte buried mid-string is caught too.
+Test testRejectsControlBytes()
+	Assert(BVM_ScriptPathIsSafe(Chr$(0)) = False)
+	Assert(BVM_ScriptPathIsSafe("file" + Chr$(0) + ".txt") = False)
+	Assert(BVM_ScriptPathIsSafe("line" + Chr$(10) + "two") = False)
+	Assert(BVM_ScriptPathIsSafe("cr" + Chr$(13)) = False)
+	Assert(BVM_ScriptPathIsSafe(Chr$(31)) = False)
+	Assert(BVM_ScriptPathIsSafe("del" + Chr$(127)) = False)
+End Test
+
+; A name made only of printable, in-range bytes at the boundary (space = 32,
+; '~' = 126) passes the control-byte scan -- confirms the scan boundary is
+; the documented one and isn't off-by-one rejecting valid printables.
+Test testAcceptsPrintableBoundary()
+	Assert(BVM_ScriptPathIsSafe(Chr$(32) + "x") = True)
+	Assert(BVM_ScriptPathIsSafe("x" + Chr$(126)) = True)
+End Test


### PR DESCRIPTION
## Non-technical summary

The game lets server-side content scripts (the things that run when you right-click an NPC, examine an item, etc.) read and write small data files — but only inside a sandboxed folder. A single guard function decides whether a requested filename is allowed or is a sneaky attempt to "escape" that folder (`..\..\somewhere\else`). That guard is the only thing standing between a malicious NPC script and reading arbitrary files on the server host, yet it had **no automated test**. This PR adds one, so a future code cleanup can't silently weaken the sandbox without CI catching it.

## Technical summary

`BVM_ScriptPathIsSafe%` (`ScriptingCommands.bb:1913-1926`) is the path-traversal floor for the eight script file-I/O BVMs. Three of those — `BVM_READFILE`, `BVM_FILESIZE`, `BVM_FILETYPE` — deliberately run **without** `BVM_RequirePrivileged()` (read/stat are treated as non-mutating, so any non-priv NPC script can call them). For those three the path check is the **sole** barrier against arbitrary host-file read/probe (`..\..\Server Data\Privileged Scripts.dat`, the running `.exe`, system configs). The guard had zero coverage.

New `src/Tests/Modules/ScriptPathSafeTest.bb` (Strict + EnableGC) replicates the guard **character-identical** to production (verified with `diff` — it's a pure string predicate with no SI/Object/Handle dependencies, so it needs none of the scaffolding `BVMPrivilegeGateTest.bb` uses) and asserts every branch. No production code changed; no dispatch-table or signature change, so **no generator regen**.

The banner documents two things in executable form: the verbatim-parity contract (change the guard → change both copies) and the non-obvious "READFILE/FILESIZE/FILETYPE are intentionally ungated, so this check is load-bearing" design fact.

## Acceptance criteria + test results

- [x] `test.bat ScriptPathSafe` → `[PASS]`; compiles Strict standalone, pulls in no network/world deps.
- [x] Covers all rejection classes — traversal (incl. the pinned strict-substring `"a..b"`), leading-slash/UNC absolute, drive-letter colon, control bytes (`<32`/`127`, including embedded), and empty — plus an accept set (ordinary names, mid-path separators, spaces, single dots, printable boundary 32/126).
- [x] Replicated body is character-identical to `ScriptingCommands.bb:1913-1926` (`diff` empty).
- [x] **Non-tautological**: a deliberate mutation (removing the `..` check) makes the suite fail (exit 1) — verified locally before restoring.
- [x] Full `test.bat` suite green — **48/48**.

## Trade-offs, deferred follow-ups, remaining gap

- This is a **characterization test of current behavior**, not a hardening change. It pins the guard as-is, including the deliberately-strict `Instr`-substring match that also rejects the innocuous `"a..b"`. If a future change wants segment-aware matching, this test is the trigger to make that a conscious, reviewed decision.
- Standard duplicated-logic maintenance burden (the banner mitigates, same as `ClampFloatTest.bb` / `InventoryStackClampTest.bb`).
- **Top deferred follow-up:** a regression test for the player-to-player **trade-commit** dupe/gold invariants in `ServerNet.bb` (the highest-stakes uncovered server path — item/gold duplication). It needs a careful dedicated iteration to replicate the multi-mock commit block faithfully.