### PR TITLE
fix(server): clamp KnownSpells[] spell IDs at the character-load boundary

### DIFF
--- a/src/Modules/Actors.bb
+++ b/src/Modules/Actors.bb
@@ -503,6 +503,23 @@ Function ReadActorInstance.ActorInstance(Stream)
 	For i = 0 To 999
 		A\KnownSpells[i] = ReadShort(Stream)
 		A\SpellLevels[i] = ReadShort(Stream)
+		; KnownSpells[i] is a spell ID used directly as a SpellsList(...)
+		; index (Dim'd (65534), valid 0..65534). ReadShort can carry a
+		; corrupt/tampered Accounts.dat slot outside that range -- a
+		; negative value, or an unsigned read-back of one (e.g. 65535).
+		; Release builds emit no array-bounds check (debug-only), so
+		; SpellsList(OOB) reads garbage memory, casts it to a Spell handle,
+		; and crashes the SHARED server process on character-list send
+		; (ServerNet.bb P_FetchCharacter: the `If Sp <> Null` guard runs
+		; AFTER the OOB read). Zero both the id and its paired level so the
+		; slot is inert everywhere the `SpellLevels[i] > 0` gate is checked,
+		; mirroring the MemorisedSpells clamp just below and the ServerNet
+		; recovery branch. The two-sided test catches the OOB regardless of
+		; ReadShort's signedness.
+		If A\KnownSpells[i] < 0 Or A\KnownSpells[i] > 65534
+			A\KnownSpells[i] = 0
+			A\SpellLevels[i] = 0
+		EndIf
 	Next
 	For i = 0 To 9
 		A\MemorisedSpells[i] = ReadShort(Stream)

--- a/src/Tests/Modules/KnownSpellsLoadClampTest.bb
+++ b/src/Tests/Modules/KnownSpellsLoadClampTest.bb
@@ -1,0 +1,143 @@
+; Tests for the KnownSpells[] sanitisation in ReadActorInstance
+; (Modules/Actors.bb). The character load path reads 1000 (KnownSpells,
+; SpellLevels) pairs off disk via ReadShort and, as of the KnownSpells
+; load-clamp fix, zeroes any slot whose spell ID falls outside the valid
+; SpellsList index range before storing it.
+;
+; Why this matters: KnownSpells[i] is used DIRECTLY as a SpellsList(...)
+; index. SpellsList is Dim'd (65534) -> valid indices 0..65534. ReadShort
+; returns a value a corrupt or tampered Accounts.dat can push out of that
+; range -- a negative ID, or (if ReadShort reads unsigned) a value like
+; 65535. BlitzForge emits array-bounds checks only in debug builds; the
+; shipped release Server.exe does NOT, so SpellsList(OOB) reads garbage
+; memory, casts it to a Spell handle, and crashes the shared server
+; process when P_FetchCharacter (ServerNet.bb) dereferences it on
+; character-list send. The `If Sp <> Null` guard there runs AFTER the OOB
+; read, so it cannot save us -- the clamp has to happen at the load
+; boundary. The sibling MemorisedSpells field two lines below already
+; clamps for exactly this OOB reason; KnownSpells was the missed slot.
+;
+; What this pins: the load-site clamp zeroes BOTH the id and its paired
+; level for an out-of-range slot (making it inert under every
+; `SpellLevels[i] > 0` gate), while a legitimate saved (id, level) pair
+; survives unchanged. The two-sided test (< 0 Or > 65534) neutralises the
+; OOB regardless of whether ReadShort is signed or unsigned -- the
+; ReadShort-round-trip cases below assert that directly.
+;
+; Actors.bb itself can't be Included into a test build (it pulls in the
+; Items / world graph). Per the established pattern (ActorLoadFloatClampTest.bb,
+; ClampFloatTest.bb), replicate the load-site logic verbatim and the
+; ReadShort round-trip (PeekShort after a PokeShort = ReadShort after a
+; WriteShort against the save stream). A refactor that changes the clamp
+; range must update the production copy and this duplicate -- the trigger
+; to refresh this test.
+;
+; NOT Strict: matches the non-Strict production module and ActorLoadFloatClampTest.bb.
+
+Const SpellsListMaxIndex = 65534
+
+; Replicated load-site clamp from Actors.bb ReadActorInstance. Production
+; applies this inline to A\KnownSpells[i] / A\SpellLevels[i]; here it writes
+; the clamped result into globals (Blitz can't return two values). True if
+; the slot was already valid, False if it was zeroed.
+Global ClampedId%, ClampedLevel%
+Function ClampKnownSpellSlot%(rawId, rawLevel)
+	ClampedId = rawId
+	ClampedLevel = rawLevel
+	If ClampedId < 0 Or ClampedId > SpellsListMaxIndex
+		ClampedId = 0
+		ClampedLevel = 0
+		Return False
+	EndIf
+	Return True
+End Function
+
+; Round-trip a short through a 2-byte Bank exactly as WriteShort/ReadShort
+; do against the save stream, returning the read-back value. A negative
+; saved ID survives this round-trip as an out-of-range value (either signed
+; -N or its unsigned read-back), which is precisely why the clamp has to
+; happen AFTER the read.
+Function RoundTripShort%(v)
+	Local b = CreateBank(2)
+	PokeShort(b, 0, v)
+	Local out = PeekShort(b, 0)
+	FreeBank(b)
+	Return out
+End Function
+
+
+; A legitimate (id, level) pair inside the valid range passes through the
+; clamp unchanged -- the fix must not disturb real spellbooks.
+Test testValidSlotPassesThrough()
+	Assert(ClampKnownSpellSlot(1, 4) = True)
+	Assert(ClampedId = 1)
+	Assert(ClampedLevel = 4)
+
+	Assert(ClampKnownSpellSlot(500, 7) = True)
+	Assert(ClampedId = 500)
+	Assert(ClampedLevel = 7)
+
+	; The maximum valid SpellsList index is accepted (inclusive boundary).
+	Assert(ClampKnownSpellSlot(SpellsListMaxIndex, 1) = True)
+	Assert(ClampedId = SpellsListMaxIndex)
+	Assert(ClampedLevel = 1)
+
+	; The largest value a SIGNED ReadShort can produce (32767) is still in
+	; range, so it passes -- only negatives / >65534 are OOB.
+	Assert(ClampKnownSpellSlot(32767, 9) = True)
+	Assert(ClampedId = 32767)
+	Assert(ClampedLevel = 9)
+End Test
+
+; An already-empty slot (id 0, level 0) is valid and untouched.
+Test testEmptySlotUnchanged()
+	Assert(ClampKnownSpellSlot(0, 0) = True)
+	Assert(ClampedId = 0)
+	Assert(ClampedLevel = 0)
+End Test
+
+; A negative spell ID (the core OOB case) zeroes the slot -- both the id and
+; its paired level -- so it is skipped by every SpellLevels>0 gate and never
+; reaches SpellsList(...).
+Test testNegativeIdZeroesSlot()
+	Assert(ClampKnownSpellSlot(-1, 3) = False)
+	Assert(ClampedId = 0)
+	Assert(ClampedLevel = 0)
+
+	; The most-negative ReadShort value.
+	Assert(ClampKnownSpellSlot(-32768, 5) = False)
+	Assert(ClampedId = 0)
+	Assert(ClampedLevel = 0)
+End Test
+
+; A value above the SpellsList ceiling (e.g. an unsigned read-back of a
+; negative, or a future wider field) also zeroes the slot.
+Test testAboveCeilingZeroesSlot()
+	Assert(ClampKnownSpellSlot(65535, 2) = False)
+	Assert(ClampedId = 0)
+	Assert(ClampedLevel = 0)
+
+	Assert(ClampKnownSpellSlot(70000, 1) = False)
+	Assert(ClampedId = 0)
+	Assert(ClampedLevel = 0)
+End Test
+
+; Load-contract: a poisoned ID written to disk survives the WriteShort/
+; ReadShort round-trip as an out-of-range value, and the load-site clamp
+; rejects whatever comes back -- proving the threat is real post-
+; serialisation and the clamp neutralises it regardless of ReadShort's
+; signedness. A valid ID survives the same round-trip and stays valid.
+Test testLoadedNegativeIdIsRejected()
+	; -1 round-trips to either -1 (signed) or 65535 (unsigned); both are OOB.
+	Local loadedBad = RoundTripShort(-1)
+	Assert(ClampKnownSpellSlot(loadedBad, 6) = False)
+	Assert(ClampedId = 0)
+	Assert(ClampedLevel = 0)
+
+	; A legitimate ID survives the round-trip intact and passes the clamp.
+	Local loadedGood = RoundTripShort(42)
+	Assert(loadedGood = 42)
+	Assert(ClampKnownSpellSlot(loadedGood, 8) = True)
+	Assert(ClampedId = 42)
+	Assert(ClampedLevel = 8)
+End Test


### PR DESCRIPTION
## Non-technical summary

A corrupt or tampered character-save file could **crash the entire game server** the moment that character's owner enters the world — taking everyone else offline with them. The crash came from a saved spell-ID that fell outside the valid range being used to look up a spell without a range check. This PR sanitises those IDs as they're loaded, so a bad save quietly drops the offending spell slot instead of crashing the shared server.

## Technical summary

`ReadActorInstance` (`Actors.bb`) loaded each saved `KnownSpells[i]` via `ReadShort` and used it **directly** as a `SpellsList(...)` index. `SpellsList` is `Dim`'d `(65534)` (valid `0..65534`), but `ReadShort` can carry an out-of-range value from a corrupt/tampered `Accounts.dat` — a negative ID, or its unsigned read-back (empirically confirmed: `PeekShort(-1)` returns `65535`). Per the repo's own doctrine, **BlitzForge emits array-bounds checks only in debug builds**; the shipped release `Server.exe` does not, so `SpellsList(OOB)` reads garbage memory, casts it to a `Spell` handle, and crashes the shared server process on character-list send (`ServerNet.bb` `P_FetchCharacter` — whose `If Sp <> Null` guard runs *after* the OOB read, so it can't help).

The fix clamps at the load boundary: an out-of-range `KnownSpells[i]` zeroes both it and its paired `SpellLevels[i]`, making the slot inert under every `SpellLevels[i] > 0` gate so it never reaches `SpellsList(...)`. This:
- **mirrors the `MemorisedSpells` clamp two lines below** (`Actors.bb:515-516`), added for *exactly this OOB reason* — `KnownSpells` was the one slot that sweep missed;
- **covers every downstream consumer at once** (`DeleteSpell`, `ScriptingCommands`, `Interface3D`), all of which index `SpellsList(KnownSpells[...])`;
- uses a **two-sided** test (`< 0 Or > 65534`) so it catches the OOB regardless of `ReadShort`'s signedness.

Engine-only change to `ReadActorInstance`; no wire/packet/BVM/dispatch change → **no generator regen**. This is the "audit EVERY deserialization boundary" doctrine (cf. the position-float load-clamp) finding a genuinely missed slot.

## Acceptance criteria + test results

New `src/Tests/Modules/KnownSpellsLoadClampTest.bb` (mirrors `ActorLoadFloatClampTest.bb`):
- [x] A negative ID (`-1`, `-32768`) zeroes **both** the id and its paired level.
- [x] An above-ceiling ID (`65535`, `70000`) zeroes both.
- [x] A valid `(id, level)` pair (`1/4`, `500/7`, `65534/1`, `32767/9`) passes through unchanged; an empty slot (`0/0`) is untouched.
- [x] Load-contract round-trip: a saved `-1` survives `WriteShort`/`ReadShort` as an out-of-range `65535` and the clamp rejects it; a valid `42` survives intact.
- [x] **Non-tautological** — verified by mutation (dropping the `> 65534` branch makes the suite fail), then restored.
- [x] Full `compile.bat` clean across all 5 engine targets + 7 tools (`Actors.bb` is widely shared).
- [x] Full `test.bat` green — **49/49**.

## Trade-offs, deferred follow-ups, remaining gap

- **Threat model is defense-in-depth.** `Accounts.dat` is server-side (not client-writable), so the trigger is a corrupt/bit-rotted/partial write or a hand-edit — the same model the position-float and `MemorisedSpells` clamps already defend against. Per the soft-fail doctrine, save-file data must not crash the shared process.
- The per-consumer guards in `Interface3D.bb` are now belt-and-suspenders; removing them is separate churn, intentionally not done here.
- **Top deferred follow-up:** an author-facing RSL scripting-language guide (`docs/scripting/language.md`) — a real, off-theme onboarding-DevEx gap serving the 2.0.0 milestone. Also still queued: the player-to-player trade-commit dupe/gold regression test.