### PR TITLE
feat(rust): seed the quest log from the login character sheet (P_FetchCharacter "Q")

### DIFF
--- a/client-rs/crates/rcce-client/src/bin/client_window.rs
+++ b/client-rs/crates/rcce-client/src/bin/client_window.rs
@@ -3853,6 +3853,30 @@ impl App {
                     .collect();
                 world.known_spells.sort_by_key(|a| a.name.to_lowercase());
             }
+            // Seed the quest log from the login sheet's "Q" blocks. A returning
+            // player's existing quests arrive in the P_FetchCharacter stream at
+            // character-select, NOT as a live P_QuestLog "N" push, so without this
+            // the L panel showed "No quests available." until/unless the server
+            // happened to send a live update. Mirrors on_quest_log's "N" add:
+            // parse the raw status blob (RGB + completed marker + text) and dedup
+            // by name (case-insensitive), matching the live handler in world.rs.
+            if world.quests.is_empty() {
+                for (name, blob) in &s.quests {
+                    if name.is_empty()
+                        || world.quests.iter().any(|q| q.name.eq_ignore_ascii_case(name))
+                    {
+                        continue;
+                    }
+                    let (status, color, completed) =
+                        rcce_client::world::parse_quest_status(blob);
+                    world.quests.push(rcce_client::world::Quest {
+                        name: name.clone(),
+                        status,
+                        color,
+                        completed,
+                    });
+                }
+            }
         }
         // Load the persisted hotbar (P_ActionBarUpdate round-trip): resolve each
         // stored spell NAME back to its id via the sheet / known spells; item slots

--- a/client-rs/crates/rcce-client/src/fetch.rs
+++ b/client-rs/crates/rcce-client/src/fetch.rs
@@ -12,7 +12,10 @@
 //!   (sentinel 99) the slot is empty. May span multiple packets.
 //! - `"S"` — known spells: repeated level u16, id u16, thumbTex u16, recharge
 //!   u16, name str16, description str16, memorised u8.
-//! - `"Q"` — quest log (ignored here).
+//! - `"Q"` — quest log: repeated `nameLen u8 · name · statusLen u16 ·
+//!   statusBlob` (the status blob is raw RGB + optional completed marker +
+//!   text, parsed by `world::parse_quest_status` at seed time — not a UTF-8
+//!   string, so it is read as raw bytes).
 //! - `"F"` — terminator: questCount u16, spellCount u16.
 //!
 //! All multi-byte fields are little-endian (matches `MsgReader` and the live
@@ -65,6 +68,11 @@ pub struct CharacterSheet {
     pub attributes: Vec<(i16, i16)>,
     pub inventory: Vec<InvItem>,
     pub spells: Vec<SpellInfo>,
+    /// Quest log entries from the `"Q"` blocks: `(name, raw status blob)`. The
+    /// blob is parsed into a coloured status line + completed flag at seed time
+    /// via `world::parse_quest_status` (it carries non-text RGB bytes, so it is
+    /// kept raw here rather than lossily decoded to a `String`).
+    pub quests: Vec<(String, Vec<u8>)>,
     /// Set once the `"F"` terminator block is seen.
     pub done: bool,
 }
@@ -78,8 +86,9 @@ impl CharacterSheet {
             Some(b'C') if data.get(1) == Some(&b'1') => self.parse_stats(&data[2..]),
             Some(b'C') if data.get(1) == Some(&b'3') => self.parse_inventory(&data[2..]),
             Some(b'S') => self.parse_spells(&data[1..]),
+            Some(b'Q') => self.parse_quests(&data[1..]),
             Some(b'F') => self.done = true,
-            _ => {} // "Q" quests + anything else: ignored
+            _ => {} // anything else: ignored
         }
     }
 
@@ -138,6 +147,25 @@ impl CharacterSheet {
                 description,
                 memorised: mem != 0,
             });
+        }
+    }
+
+    /// Parse a `"Q"` quest-log block: repeated `nameLen u8 · name · statusLen
+    /// u16 · statusBlob`. The status blob is kept raw (it holds RGB bytes the
+    /// `world::parse_quest_status` reader needs); empty-name entries are
+    /// skipped. Bounded at 500 (the server caps the log at 500 — ServerNet.bb).
+    /// Mirrors the live `on_quest_log` "N" wire shape (world.rs).
+    fn parse_quests(&mut self, body: &[u8]) {
+        let mut r = MsgReader::new(body);
+        while let Some(name) = r.str8() {
+            let Some(n) = r.u16() else { break };
+            let Some(blob) = r.bytes(n as usize) else { break };
+            if self.quests.len() >= 500 {
+                break;
+            }
+            if !name.is_empty() {
+                self.quests.push((name, blob.to_vec()));
+            }
         }
     }
 }
@@ -223,6 +251,88 @@ mod tests {
         assert_eq!(s.spells[1].name, "Heal");
         assert_eq!(s.spells[1].description, "");
         assert!(!s.spells[1].memorised);
+    }
+
+    /// Build one Q-block entry: `nameLen u8 · name · statusLen u16 · blob`.
+    fn quest_entry(w: &mut MsgWriter, name: &str, blob: &[u8]) {
+        w.u8(name.len() as u8).raw(name.as_bytes());
+        w.u16(blob.len() as u16).raw(blob);
+    }
+
+    #[test]
+    fn parse_q_quests() {
+        // Two quests: an in-progress one and a completed one. The status blob is
+        // RGB(3) + optional 254 completed-marker + text, exactly as the server
+        // packs it and as world::parse_quest_status decodes it.
+        let mut w = MsgWriter::new();
+        w.raw(b"Q");
+        quest_entry(&mut w, "Find the Sword", &{
+            let mut b = vec![255u8, 255, 64];
+            b.extend_from_slice(b"Search the ruins.");
+            b
+        });
+        quest_entry(&mut w, "Greet the Mayor", &{
+            let mut b = vec![128u8, 255, 128, 254];
+            b.extend_from_slice(b"Done.");
+            b
+        });
+        let mut s = CharacterSheet::default();
+        s.apply_packet(w.as_slice());
+        assert_eq!(s.quests.len(), 2);
+        assert_eq!(s.quests[0].0, "Find the Sword");
+        assert_eq!(s.quests[1].0, "Greet the Mayor");
+        // The raw blob round-trips through world::parse_quest_status correctly.
+        let (text0, color0, done0) = crate::world::parse_quest_status(&s.quests[0].1);
+        assert_eq!(text0, "Search the ruins.");
+        assert_eq!(color0, [1.0, 1.0, 64.0 / 255.0, 1.0]);
+        assert!(!done0);
+        let (text1, _c1, done1) = crate::world::parse_quest_status(&s.quests[1].1);
+        assert_eq!(text1, "Done.");
+        assert!(done1);
+    }
+
+    #[test]
+    fn parse_q_multi_packet_accumulates() {
+        let mut s = CharacterSheet::default();
+        let mut a = MsgWriter::new();
+        a.raw(b"Q");
+        quest_entry(&mut a, "Quest A", b"\x80\x80\x80status a");
+        s.apply_packet(a.as_slice());
+        let mut b = MsgWriter::new();
+        b.raw(b"Q");
+        quest_entry(&mut b, "Quest B", b"\x80\x80\x80status b");
+        s.apply_packet(b.as_slice());
+        assert_eq!(s.quests.len(), 2);
+    }
+
+    #[test]
+    fn parse_q_truncated_does_not_panic_and_keeps_prefix() {
+        // First entry complete; second entry's status is truncated (claims 50
+        // bytes, supplies 3). The parser keeps the good prefix and stops without
+        // panicking — the bounded-walk soft-fail discipline.
+        let mut w = MsgWriter::new();
+        w.raw(b"Q");
+        quest_entry(&mut w, "Good", b"\xff\xff\xfftext");
+        w.u8("Bad".len() as u8).raw(b"Bad");
+        w.u16(50).raw(b"abc"); // statusLen says 50, only 3 present
+        let mut s = CharacterSheet::default();
+        s.apply_packet(w.as_slice());
+        assert_eq!(s.quests.len(), 1);
+        assert_eq!(s.quests[0].0, "Good");
+    }
+
+    #[test]
+    fn parse_q_empty_name_skipped() {
+        // A zero-length name entry is consumed (cursor stays aligned) but not
+        // stored, matching on_quest_log's `!name.is_empty()` guard.
+        let mut w = MsgWriter::new();
+        w.raw(b"Q");
+        quest_entry(&mut w, "", b"\xff\xff\xffignored");
+        quest_entry(&mut w, "Real", b"\xff\xff\xffkept");
+        let mut s = CharacterSheet::default();
+        s.apply_packet(w.as_slice());
+        assert_eq!(s.quests.len(), 1);
+        assert_eq!(s.quests[0].0, "Real");
     }
 
     #[test]


### PR DESCRIPTION
## Non-technical summary

In the Rust client, a returning player who had quests in progress saw an empty quest log ("No quests available.") right after logging in — their quests only reappeared if the server happened to send a live update. This PR seeds the quest log from the data the server already sends at character-select, so the L panel shows your in-progress quests immediately, matching the original Blitz client.

## Technical summary

The quest panel renders `world.quests`, populated **only** by live `P_QuestLog` "N"/"U"/"D" packets that arrive mid-session. The server already delivers the existing quest log at login inside the `P_FetchCharacter` "Q" sub-packets (`ServerNet.bb` ~2672), and the Blitz client parses them (`MainMenu.bb` ~1961) — but the Rust client's `CharacterSheet::apply_packet` discarded the "Q" block (`_ => {}`).

- **`fetch.rs`** — add `quests: Vec<(String, Vec<u8>)>` to `CharacterSheet` and a `parse_quests` for the "Q" wire shape (`nameLen u8 · name · statusLen u16 · statusBlob`), bounded at 500 (the server's cap), empty names skipped. The status blob is kept **raw**: it carries non-text RGB bytes that `world::parse_quest_status` reads, so it's read via `bytes()`, not lossily decoded as a `str16` string.
- **`client_window.rs` `enter_outcome`** — after the existing sheet seeding (gold/level/inventory/spells), build `world::Quest` from each "Q" entry via the already-unit-tested `parse_quest_status`, deduped by name (case-insensitive) — mirroring `on_quest_log`'s "N" add in `world.rs` exactly.

**No server, wire, or Blitz-client change.** The data was already on the wire; the consuming UI panel and the `parse_quest_status` helper already existed. This is login-path only — a parse bug degrades to the prior behavior (empty list).

## Acceptance criteria + test results

New `fetch.rs` unit tests (run + clippy-gated by CI under `-p rcce-client`):
- [x] `parse_q_quests` — parses two quests (in-progress + completed); each raw blob round-trips through `parse_quest_status` with the correct colour and completed flag.
- [x] `parse_q_multi_packet_accumulates` — quests split across two "Q" packets accumulate (the server splits the block at ~700 bytes).
- [x] `parse_q_truncated_does_not_panic_and_keeps_prefix` — a status blob that claims more bytes than present keeps the good prefix and stops without panicking (bounded soft-fail).
- [x] `parse_q_empty_name_skipped` — a zero-length-name entry is consumed (cursor stays aligned) but not stored, matching `on_quest_log`'s `!name.is_empty()` guard.
- [x] Existing `character_sheet_apply_packet_never_panics` fuzz test still green — `parse_quests` soft-fails on arbitrary bytes.
- [x] `cargo test -p rcce-client --locked` and `cargo clippy -p rcce-client --all-targets -- -D warnings` both clean locally; binary (`client_window`) builds.

The seeding in `enter_outcome` is a ~12-line mirror of the unit-tested `on_quest_log` "N" branch + the unit-tested `parse_quest_status`; `enter_outcome` lives in the binary so it isn't directly unit-testable, but every piece it composes is covered.

## Trade-offs, deferred follow-ups, remaining gap

- **Scope:** only seeds the existing list panel. Quest-objective detail UI / a quest-tracker HUD is out of scope.
- The `if world.quests.is_empty()` guard mirrors the sibling `known_spells` seed guard — at login the live updates haven't arrived yet, so it's belt-and-suspenders consistency.
- Deferred (unrelated): an author-facing RSL scripting-language guide; the player-to-player trade-commit dupe/gold test.