### PR TITLE
feat(tools): git-friendly project format — rcproject .dat↔JSON round-trip CLI (#32, phase 1)

### DIFF
--- a/tools/projectgen/README.md
+++ b/tools/projectgen/README.md
@@ -24,6 +24,48 @@ generated and round-trip-verified before it ever reaches the engine.
   asserts byte-for-byte equality. **Run this first, every iteration**, before trusting
   the codec to generate anything.
 - `add_spells.py` — iteration 1 content: adds the restorative starter spells.
+- `rcproject.py` — git-friendly project format ([Issue #32](https://github.com/RydeTec/rcce2/issues/32),
+  phase 1). Round-trips the gameplay `.dat` files to/from JSON so they diff and
+  merge in git; see below.
+
+## Git-friendly project format (`rcproject.py`)
+
+Projects store content as opaque binary `.dat` files, so two people editing the
+same catalog produce an **unmergeable binary conflict**. [Issue #32](https://github.com/RydeTec/rcce2/issues/32)
+("Make projects more git friendly") proposes keeping an editable, diffable
+representation in the tree and converting to `.dat` only at publish time. `rcproject.py`
+is phase 1 of that: a round-trip `.dat ↔ JSON` CLI built on the same byte-faithful
+`rcdata.py` codec `validate.py` proves.
+
+```sh
+python tools/projectgen/rcproject.py export data text/   # .dat -> .json   (decode for git)
+# ...edit/merge the JSON, then before running the server / publishing:
+python tools/projectgen/rcproject.py build  text/ data   # .json -> .dat   (the "obfuscation" form)
+python tools/projectgen/rcproject.py verify data         # prove the round-trip is byte-exact
+```
+
+- **`export`** decodes every supported `.dat` into pretty-printed, key-sorted JSON
+  (one `<name>.dat.json` mirroring the source path). The output is deterministic, so
+  re-exporting an unchanged project yields byte-identical text — `git diff` shows
+  exactly which records changed.
+- **`build`** re-encodes the JSON back to `.dat` (atomic temp-file + replace).
+- **`verify`** is the safety gate: for every supported file it decodes → serialises to
+  JSON → parses back → re-encodes and asserts the bytes equal the original (and that the
+  JSON is deterministic). Run it after editing the codec or before trusting a publish.
+
+**Scope (phase 1):** the symmetric value-codec formats — `Spells`, `Items`, `Actors`,
+`Projectiles`, `Factions`, server-side `Areas` (gameplay) and client-side `Areas`
+(visual). The `Meshes`/`Textures`/`Sounds` media databases are append-only index+blob
+structures (§ below) — rebuilding them from decoded entries would lose insertion-order /
+gap layout and change the bytes — so a git-friendly form for them is **deferred to phase 2**.
+`Server Data/Areas/Ownerships/*.dat` (a different format) and the legacy `Areas/ha.dat`
+stub are skipped, matching `validate.py`'s known-good set. Unrecognised `.dat` files are
+reported and left untouched.
+
+**Deferred (phase 2):** wiring `verify` into CI; a media-DB representation; optional
+compaction of the fixed-size area arrays (150 triggers / 2000 waypoints / 1000 spawns are
+serialised in full today — faithful and diffable, but verbose); a GUE/Loom export-on-save
+hook so authors never touch the CLI.
 
 ## The formats (verified against engine source)
 

--- a/tools/projectgen/rcproject.py
+++ b/tools/projectgen/rcproject.py
@@ -1,0 +1,189 @@
+#!/usr/bin/env python3
+"""rcproject -- git-friendly project format (Issue #32, phase 1).
+
+Projects store content as opaque binary `.dat` files, so two authors editing the
+same catalog produce an unmergeable binary conflict. This tool round-trips the
+gameplay `.dat` files to/from pretty-printed, key-sorted JSON so they diff and
+merge cleanly in git; the `.dat` stays the runtime / publish ("obfuscation")
+form, exactly as Issue #32 proposes.
+
+  rcproject export <project_dir> <text_dir>   # .dat -> .json   (decode for git)
+  rcproject build  <text_dir> <project_dir>   # .json -> .dat   (publish)
+  rcproject verify <project_dir>              # in-memory round-trip byte-check
+
+Built on the byte-faithful codec in `rcdata.py` (the same one `validate.py`
+proves). `verify` is the safety gate: it decodes every supported file, serialises
+it to JSON text, parses it back, re-encodes, and asserts the bytes are identical
+to the original -- so `export` then `build` is provably lossless before anyone
+trusts it.
+
+Scope (phase 1): the symmetric value-codec formats only -- Spells, Items, Actors,
+Projectiles, Factions, server-side Areas (gameplay) and client-side Areas
+(visual). The Meshes/Textures/Sounds media databases are append-only index+blob
+structures (not value codecs -- a rebuild from their decoded entries would lose
+insertion order / gap layout and change the bytes), so a git-friendly form for
+them is deferred to phase 2. Unrecognised `.dat` files are reported and left
+untouched, never silently mangled.
+"""
+import os
+import sys
+import json
+import glob
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+import rcdata
+
+# codec key -> (decode bytes->obj, encode obj->bytes)
+CODECS = {
+    'spells':      (rcdata.read_spells,      rcdata.write_spells),
+    'items':       (rcdata.read_items,       rcdata.write_items),
+    'actors':      (rcdata.read_actors,      rcdata.write_actors),
+    'projectiles': (rcdata.read_projectiles, rcdata.write_projectiles),
+    'factions':    (rcdata.read_factions,    rcdata.write_factions),
+    'server_area': (rcdata.read_server_area, rcdata.write_server_area),
+    'client_area': (rcdata.read_client_area, rcdata.write_client_area),
+}
+
+# Exact project-relative paths (forward slashes) for the single-file catalogs.
+_EXACT = {
+    'Server Data/Spells.dat':      'spells',
+    'Server Data/Items.dat':       'items',
+    'Server Data/Actors.dat':      'actors',
+    'Server Data/Projectiles.dat': 'projectiles',
+    'Server Data/Factions.dat':    'factions',
+}
+
+
+def classify(rel):
+    """Map a project-relative `.dat` path (forward slashes) to a codec key, or
+    None if it is not a supported format. Mirrors validate.py's known-good set:
+    gameplay areas live DIRECTLY under "Server Data/Areas" (not the Ownerships
+    subfolder, a different format); visual areas live directly under "Areas",
+    where `ha.dat` is a legacy pre-shadow-fields stub the codec can't read."""
+    if rel in _EXACT:
+        return _EXACT[rel]
+    parts = rel.split('/')
+    base = parts[-1].lower()
+    parent = '/'.join(parts[:-1])
+    if not base.endswith('.dat'):
+        return None
+    if parent == 'Server Data/Areas':
+        return 'server_area'
+    if parent == 'Areas' and base != 'ha.dat':
+        return 'client_area'
+    return None
+
+
+def discover(project_dir):
+    """Yield (relpath, codec_key) for every supported `.dat` under project_dir,
+    sorted for deterministic output."""
+    found = []
+    for p in glob.glob(os.path.join(project_dir, '**', '*.dat'), recursive=True):
+        rel = os.path.relpath(p, project_dir).replace(os.sep, '/')
+        key = classify(rel)
+        if key:
+            found.append((rel, key))
+    return sorted(found)
+
+
+def _dumps(obj):
+    """Deterministic JSON: sorted keys + stable indent + ascii-escaped, so the
+    latin-1 high bytes the codec uses serialise reproducibly and survive the
+    round-trip through `write_*` (which re-encodes via latin-1)."""
+    return json.dumps(obj, sort_keys=True, indent=2, ensure_ascii=True) + '\n'
+
+
+def _atomic_write(path, data):
+    """Temp-file + os.replace, per the projectgen atomic-write discipline -- a
+    failed/partial encode never clobbers an existing file."""
+    os.makedirs(os.path.dirname(path) or '.', exist_ok=True)
+    tmp = path + '.tmp'
+    with open(tmp, 'wb') as f:
+        f.write(data)
+    os.replace(tmp, path)
+
+
+def cmd_export(project_dir, text_dir):
+    files = discover(project_dir)
+    for rel, key in files:
+        read_fn, _ = CODECS[key]
+        with open(os.path.join(project_dir, rel), 'rb') as f:
+            raw = f.read()
+        obj = read_fn(raw)
+        out = os.path.join(text_dir, rel + '.json')
+        _atomic_write(out, _dumps(obj).encode('utf-8'))
+        print(f"  export {rel}  ({key})")
+    print(f"Exported {len(files)} file(s) to {text_dir}.")
+    return 0
+
+
+def cmd_build(text_dir, project_dir):
+    n = 0
+    for p in sorted(glob.glob(os.path.join(text_dir, '**', '*.dat.json'), recursive=True)):
+        rel_json = os.path.relpath(p, text_dir).replace(os.sep, '/')
+        rel = rel_json[:-len('.json')]
+        key = classify(rel)
+        if not key:
+            print(f"  skip   {rel_json} (unrecognised)")
+            continue
+        _, write_fn = CODECS[key]
+        with open(p, 'r', encoding='utf-8') as f:
+            obj = json.load(f)
+        _atomic_write(os.path.join(project_dir, rel), write_fn(obj))
+        print(f"  build  {rel}  ({key})")
+        n += 1
+    print(f"Built {n} .dat file(s) into {project_dir}.")
+    return 0
+
+
+def cmd_verify(project_dir):
+    files = discover(project_dir)
+    ok = True
+    for rel, key in files:
+        read_fn, write_fn = CODECS[key]
+        with open(os.path.join(project_dir, rel), 'rb') as f:
+            raw = f.read()
+        try:
+            obj = read_fn(raw)
+            text = _dumps(obj)                      # decode -> JSON text
+            rebuilt = write_fn(json.loads(text))    # parse -> encode
+            text2 = _dumps(read_fn(raw))            # determinism check
+        except Exception as e:                      # noqa: BLE001 -- report, don't crash the sweep
+            print(f"[FAIL] {rel} ({key}): {e!r}")
+            ok = False
+            continue
+        match = rebuilt == raw
+        det = text == text2
+        if not (match and det):
+            ok = False
+        notes = ''
+        if not match:
+            notes += f' [bytes differ: {len(raw)} in, {len(rebuilt)} out]'
+        if not det:
+            notes += ' [non-deterministic JSON]'
+        print(f"[{'PASS' if (match and det) else 'FAIL'}] {rel} ({key}){notes}")
+    print()
+    print(f"{'ALL' if ok else 'SOME'} round-trips {'passed' if ok else 'FAILED'} "
+          f"({len(files)} file(s)).")
+    return 0 if ok else 1
+
+
+USAGE = ("usage:\n"
+         "  rcproject export <project_dir> <text_dir>   # .dat -> .json\n"
+         "  rcproject build  <text_dir> <project_dir>   # .json -> .dat\n"
+         "  rcproject verify <project_dir>              # round-trip byte-check")
+
+
+def main(argv):
+    if len(argv) >= 2 and argv[1] == 'export' and len(argv) == 4:
+        return cmd_export(argv[2], argv[3])
+    if len(argv) >= 2 and argv[1] == 'build' and len(argv) == 4:
+        return cmd_build(argv[2], argv[3])
+    if len(argv) >= 2 and argv[1] == 'verify' and len(argv) == 3:
+        return cmd_verify(argv[2])
+    print(USAGE)
+    return 2
+
+
+if __name__ == '__main__':
+    sys.exit(main(sys.argv))


### PR DESCRIPTION
Phase 1 of [#32](https://github.com/RydeTec/rcce2/issues/32) ("Make projects more git friendly").

## Non-technical summary

Game projects store their content (spells, items, monsters, zones…) as binary `.dat` files. When two people edit the same file, git can't merge it — you get an unresolvable binary conflict. Issue #32 asks for a git-friendly representation that's converted back to `.dat` only at publish time. This PR delivers exactly that for the gameplay content: a tool that turns each `.dat` into readable, diffable JSON and back, with a built-in proof that the round-trip is byte-for-byte lossless.

## Technical summary

The expensive prerequisite — a byte-faithful codec for the formats — already existed in `tools/projectgen/rcdata.py` (the one `validate.py` proves). This adds `tools/projectgen/rcproject.py` on top:

```sh
rcproject export <project> <text>   # .dat -> pretty, key-sorted, deterministic JSON
rcproject build  <text> <project>   # JSON -> .dat  (atomic temp-file + replace)
rcproject verify <project>          # decode->JSON->parse->encode, assert bytes == original
```

- **`export`** mirrors the source layout as `<name>.dat.json`; output is deterministic (sorted keys, stable indent, ascii-escaped) so re-exporting an unchanged project is byte-identical text — `git diff` shows exactly which records changed.
- **`build`** re-encodes via the codec's `write_*`, atomic temp-file + `os.replace` per the projectgen atomic-write discipline.
- **`verify`** is the safety gate: full text round-trip per file, asserting byte-equality + JSON determinism.

**Scope (phase 1):** the symmetric value-codec formats — `Spells`, `Items`, `Actors`, `Projectiles`, `Factions`, server `Areas` (gameplay), client `Areas` (visual). The `Meshes`/`Textures`/`Sounds` **media DBs are append-only index+blob structures** — a rebuild from their decoded entries would lose insertion-order / gap layout and change the bytes — so they're **deferred to phase 2**. `Server Data/Areas/Ownerships/*.dat` (a different format) and the legacy `Areas/ha.dat` stub are skipped, mirroring `validate.py`'s known-good set. Unrecognised `.dat` files are reported, never mangled.

**No engine/`.bb` change**; the engine still reads `.dat` at runtime. Pure additive Python tooling under `tools/`.

## Acceptance criteria + test results (verified on the shipped `data/`)

- [x] **`verify data` exits 0** — all **14/14** supported files round-trip byte-exact AND deterministically (`Spells`, `Items`, `Actors`, `Projectiles`, `Factions`, 4 server areas, 5 client areas).
- [x] **`export` → `build` into a fresh tree** reproduces **14/14** `.dat` byte-identical to the originals.
- [x] **Field isolation** — editing one spell's `recharge` in the exported JSON and rebuilding changes **only** `Server Data/Spells.dat`, with exactly that value updated (8000 → 9234).
- [x] **Determinism** — two exports of the unchanged project produce byte-identical JSON (0 files differ).
- [x] Correct exclusions — `Areas/Ownerships/*.dat` and `Areas/ha.dat` are not touched; media DBs / other formats are skipped with a report.
- [x] README documents the `export`/`build`/`verify` workflow and the "text in git, `.dat` at publish" model.

The `verify` subcommand doubles as the regression test (runnable over real `data/`); the end-to-end export/build/edit checks above were run from a scratch script.

## Trade-offs, deferred follow-ups, remaining gap

- **Phase-2 follow-ups (documented in the README):** wiring `verify` into CI; a media-DB (Meshes/Textures/Sounds) representation; optional **compaction** of the fixed-size area arrays (150 triggers / 2000 waypoints / 1000 spawns are serialised in full today — faithful and diffable, but verbose); a GUE/Loom export-on-save hook so authors never touch the CLI.
- This does **not** flip the project's committed form to JSON yet — it's the tooling that *enables* that policy switch, not the switch itself (that's a repo-owner decision).
- Floats round-trip byte-exact because Python's `repr` is round-trip-exact for doubles and the codec's 32-bit `<f` widens/narrows losslessly; `verify` proves this empirically rather than by assertion.