### PR TITLE
fix(areas): stop LoadAreaData clobbering its zone-name param with a mesh path

### DIFF
--- a/src/Modules/AreaLoader.bb
+++ b/src/Modules/AreaLoader.bb
@@ -232,9 +232,13 @@ Function LoadAreaData(Name$, CameraEN, DisplayItems = False, UpdateRottNet = Fal
 			
 		; Nasty hack to disable decryption on RCTE terrains in a subfolder DISABLED terrains are no longer encrypted so no need to keep code.
 			NoDecrypt = False
-			Name$ = Upper$(GetMeshName$(S\MeshID))
-			;If Instr(Name$, "RCTE\") = 1 Or Instr(Name$, "RCTE/") = 1
-			;	If Instr(Name$, "\", 6) > 0 Or Instr(Name$, "/", 6) > 0 Then NoDecrypt = True
+			; Distinct local: assigning to Name$ here clobbered the zone-name
+			; parameter, so the soft-fail logs below reported a mesh path.
+			; (meshName$ is taken -- Blitz identifiers are case-insensitive
+			; and GetMeshNameClean$ overwrites it inside the BUMPED branch.)
+			MeshPath$ = Upper$(GetMeshName$(S\MeshID))
+			;If Instr(MeshPath$, "RCTE\") = 1 Or Instr(MeshPath$, "RCTE/") = 1
+			;	If Instr(MeshPath$, "\", 6) > 0 Or Instr(MeshPath$, "/", 6) > 0 Then NoDecrypt = True
 			;EndIf
 			
 			; Load the mesh
@@ -246,7 +250,7 @@ Function LoadAreaData(Name$, CameraEN, DisplayItems = False, UpdateRottNet = Fal
 			S\ScaleX# = ReadFloat#(F) : S\ScaleY# = ReadFloat#(F) : S\ScaleZ# = ReadFloat#(F)
 		
 			; is it a bump mesh? [BUMP]
-         If Instr(Name$, "BUMPED\") Then
+         If Instr(MeshPath$, "BUMPED\") Then
         	 meshName$ = GetMeshNameClean$(S\MeshID)
         	 bumpMap = LoadTexture("Data\Meshes\"+meshName$+"_NORMAL.jpg")
 			 ;TextureCoords(colorMap, 1)
@@ -310,11 +314,11 @@ Function LoadAreaData(Name$, CameraEN, DisplayItems = False, UpdateRottNet = Fal
 				ScaleEntity S\EN, S\ScaleX#, S\ScaleY#, S\ScaleZ#
 				
 				;Dynamic Lighting
-				S\ENName=Left(Lower(GetFilename$(Name$)), 2)
+				S\ENName=Left(Lower(GetFilename$(MeshPath$)), 2)
 				S\LightID=0
-				S\ENLight=Lower(GetFilename$(Name$))
-				S\ENWF=Lower(GetFilename$(Name$))
-				S\ENFM=Lower(GetFilename$(Name$))
+				S\ENLight=Lower(GetFilename$(MeshPath$))
+				S\ENWF=Lower(GetFilename$(MeshPath$))
+				S\ENFM=Lower(GetFilename$(MeshPath$))
 								
 				If Left$(S\ENLight$, 6) = "light_" ;And S\LightID=0 And EntityDistance# (S\EN,Me\EN)<=10.0
 					
@@ -356,8 +360,8 @@ Function LoadAreaData(Name$, CameraEN, DisplayItems = False, UpdateRottNet = Fal
 				
 				; Chunking for dungeons etc.
 				If DisplayItems = False
-					Name$ = Upper$(GetMeshName$(S\MeshID))
-					If Instr(Name$, "RCDUNGEON\") Or Instr(Name$, "CUSTOMCHUNK\")
+					MeshPath$ = Upper$(GetMeshName$(S\MeshID))
+					If Instr(MeshPath$, "RCDUNGEON\") Or Instr(MeshPath$, "CUSTOMCHUNK\")
 						RotateMesh(S\EN, Pitch#, Yaw#, Roll#)
 						ScaleEntity(S\EN, S\ScaleX#, S\ScaleY#, S\ScaleZ#)
 						ChunkTerrain(S\EN, 3, 3, 3, X#, Y#, Z#)
@@ -375,7 +379,7 @@ Function LoadAreaData(Name$, CameraEN, DisplayItems = False, UpdateRottNet = Fal
 				EndIf
 
 				; Retexturing
-           ; If Instr(Name$, "BUMPED\") Then
+           ; If Instr(MeshPath$, "BUMPED\") Then
         ;	    colorMap = LoadTexture ("Data\Meshes\"+meshName$+"_DIMMER.jpg")
 		;		;TextureCoords(colorMap, 1)
 		;		EntityTexture S\EN, colorMap, 0, 0
@@ -385,7 +389,7 @@ Function LoadAreaData(Name$, CameraEN, DisplayItems = False, UpdateRottNet = Fal
         ;	    If S\TextureID < 65535 Then EntityTexture S\EN, GetTexture(S\TextureID)
          ;   EndIf
 
-			If Instr(Name$, "BUMPED\") Then
+			If Instr(MeshPath$, "BUMPED\") Then
         	    colorMap = LoadTexture ("Data\Meshes\"+meshName$+"_SPEC.jpg")
 				;TextureCoords(colorMap, 1)
 				EntityTexture S\EN, colorMap, 0, 0
@@ -395,7 +399,7 @@ Function LoadAreaData(Name$, CameraEN, DisplayItems = False, UpdateRottNet = Fal
         	    If S\TextureID < 65535 Then EntityTexture S\EN, GetTexture(S\TextureID)
             EndIf
 
-			If Instr(Name$, "BUMPED\") Then
+			If Instr(MeshPath$, "BUMPED\") Then
         	    colorMap = LoadTexture ("Data\Meshes\"+meshName$+"_COLOR.jpg")
 				;TextureCoords(colorMap, 1)
 				EntityTexture S\EN, colorMap, 0, 2
@@ -407,7 +411,7 @@ Function LoadAreaData(Name$, CameraEN, DisplayItems = False, UpdateRottNet = Fal
 
 
 			;Glow models
-	;		If Instr(Name$, "GLOWMODELS\") Then
+	;		If Instr(MeshPath$, "GLOWMODELS\") Then
     ;    	    colorMap = LoadTexture ("Data\Meshes\"+meshName$+"_GLOW.jpg")
 	;			;TextureCoords(colorMap, 1)
 	;			EntityTexture S\EN, colorMap, 0, 4


### PR DESCRIPTION
## What

`LoadAreaData` ([AreaLoader.bb:142](src/Modules/AreaLoader.bb#L142)) reused the `Name$` **parameter** — the zone name — as scratch for `Upper$(GetMeshName$(...))` inside the scenery loop. Two soft-fail logs read `Name$` afterward to report which zone dropped a scenery/emitter:

- `LoadArea: scenery MeshID ... not found ... (zone: " + Name$ + ")"`
- `LoadArea: emitter config '...' could not load ... (zone: " + Name$ + ")"`

By the time those logs run, `Name$` holds the last scenery's mesh path, not the zone — so the diagnostics printed the wrong thing on exactly the corrupted-area-data path they exist to surface.

## Fix

Introduce a distinct `MeshPath$` local for every mesh-path reuse (the NoDecrypt hack, BUMPED normal/spec/color retexture, dynamic-lighting filename extraction, dungeon-chunk detection, and the commented DIMMER/GLOWMODELS blocks for consistency). `Name$` now means only the zone name — at the signature, the `ReadFile`, and the two `(zone: ...)` logs.

`MeshPath$` is a fresh name chosen to avoid the existing `meshName$` (Blitz identifiers are case-insensitive, and `GetMeshNameClean$` overwrites `meshName$` inside the BUMPED branch). Non-Strict file, so no `Local` declaration is required.

## Notes for reviewer

- Pure local-variable rename. No signature or behavioral change beyond the two log strings now reporting the correct zone.
- Verified: `AreaLoaderGooeyFreeTest.bb` — which `Include`s the full `AreaLoader.bb` body with inline stubs — compiles clean and passes via `blitzcc -t`. `AreaLoader.bb` is included only by `GUE.bb` (engine target), not by the Tools.