### PR TITLE
fix(ci): kill the ItemsTest/chain-test exit-crash flake at its root — BlitzForge bump (#85 + #86)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -66,7 +66,7 @@ Always run from the repo root.
 ./test.sh ItemsTest        # same single-file substring filter as Windows
 ```
 
-`test.bat` / `test.sh` print a `[RUN ]` / `[PASS]` / `[FAIL]` marker per file and an end-of-run `Ran N files: P passed, F failed.` summary with a bulleted list of any failing files. CI still calls the runner with no args and only checks the exit code, so the default behavior is unchanged. The positional substring filter is the documented way to reproduce the known intermittent `ItemsTest.bb` flake locally without re-running the whole suite — see the **Known intermittent flake** note under [CI](#ci-githubworkflowsciyml) below.
+`test.bat` / `test.sh` print a `[RUN ]` / `[PASS]` / `[FAIL]` marker per file and an end-of-run `Ran N files: P passed, F failed.` summary with a bulleted list of any failing files. CI still calls the runner with no args and only checks the exit code, so the default behavior is unchanged. The positional substring filter remains handy for looping a single file (it's how the historical `ItemsTest.bb` exit-crash flake was reproduced and statistically verified fixed — see the **Historical intermittent flake** note under [CI](#ci-githubworkflowsciyml) below).
 
 After any change to a `.bb` file under `src/`, run `compile.bat -t` and confirm clean compile before committing. `Local`-shadowing-a-`Global`, missing field, wrong sigil — Strict mode catches all of these at compile time.
 
@@ -296,11 +296,7 @@ The compound rule: if the function reaches out to a resource the host owns (kern
 - Build step caches BlitzForge binaries keyed on the submodule SHA. Most PRs hit cache.
 - Test step runs every file under `src/Tests/` and exits 1 on first failure.
 - **Generator-staleness gate**: after the test step, CI runs `bash scripts/gen_packet_index.sh --check` and `bash scripts/gen_bvm_reference.sh --check`. Both auto-regenerate the two reference docs ([`docs/protocol/index.md`](docs/protocol/index.md), [`docs/bvm-reference.md`](docs/bvm-reference.md)) from source and exit non-zero if the committed file no longer matches. If you touch any of [`src/Modules/ServerNet.bb`](src/Modules/ServerNet.bb), [`src/Modules/ClientNet.bb`](src/Modules/ClientNet.bb), [`src/Modules/Packets.bb`](src/Modules/Packets.bb), [`src/Modules/RC_Standard_Invoker.bb`](src/Modules/RC_Standard_Invoker.bb), or [`src/Modules/ScriptingCommands.bb`](src/Modules/ScriptingCommands.bb), rerun the two generators and commit the regenerated docs before pushing — CI will fail with a diff message otherwise.
-- **Known intermittent flake**: `ItemsTest.bb` sometimes fails with `Stack overflow!` for unrelated PRs. If a PR's CI fails *only* with that error and your change doesn't touch items/inventory/serialization, retry via close + reopen of the PR:
-  ```bash
-  gh pr close <N> && sleep 3 && gh pr reopen <N>
-  ```
-  Two retries is plenty; if it still fails, investigate.
+- **Historical intermittent flake — FIXED (2026-06-09)**: `ItemsTest.bb` / `OnlinePlayerChainTest.bb` used to crash intermittently at exit (`Stack overflow!` / `Memory access violation`) on unrelated PRs, with a documented close-and-reopen retry ritual. Root cause was in the BlitzForge compiler, not the tests: `deleteVars()` codegen emitted a GC release for program **globals** through an **uninitialized** `Decl::offset` frame displacement, so main's epilogue performed a wild `[ebp+garbage]` read (harmless when the stale value was 0, an access violation otherwise). Fixed in blitz-forge PRs [#85](https://github.com/RydeTec/blitz-forge/pull/85)/[#86](https://github.com/RydeTec/blitz-forge/pull/86) (verified 0 failures in 300 runs of each test vs. a 2-12% baseline). If a similar intermittent native crash ever reappears, the runtime now prints the exception code, module-relative fault address, registers, a dump of the faulting generated-code image, and a symbolized stack walk — diagnose from that instead of retrying; the per-test sweep band-aids from PRs #313/#322 remain harmless.
 
 ### Git submodules
 


### PR DESCRIPTION
## Summary (non-technical)

Every PR in this repo has carried a ~5-7% chance of a spurious CI failure for months: `ItemsTest.bb` or `OnlinePlayerChainTest.bb` would crash *after all tests passed*, and the documented workaround was to close and reopen the PR to re-roll CI. The cause was never in those tests — it was a code-generation bug in the BlitzForge compiler. This PR bumps the submodule to the fixed compiler and retires the workaround from CLAUDE.md. CI failures mean something again.

## Root cause (in the compiler, fixed upstream)

[blitz-forge#86](https://github.com/RydeTec/blitz-forge/pull/86): `deleteVars()` emitted the GC release `__bbRelease([ebp + Decl::offset], type)` for **every** struct-typed decl in main's environ — including program **globals**, whose `Decl::offset` is never assigned by frame layout and was missing from the `Decl` constructor's initializer list (uninitialized memory). Main's epilogue therefore executed a wild `[ebp+garbage]` read: harmless when the stale heap value was 0 (most runs), an access violation otherwise (the historical "Stack overflow!" label was a separate, since-fixed mislabeling bug). GC on/off irrelevant — the wild read precedes the release, which is why the non-GC chain test crashed identically.

[blitz-forge#85](https://github.com/RydeTec/blitz-forge/pull/85) (also in this bump): two real `Delete Each` runtime defects found en route (captured-next invalidation that silently left chain remainders undeleted — deterministic 499/1000-survivor repro, now a regression test; GC reference_map desync on pool delete), plus permanent native-crash diagnostics (exception code, module-relative fault address, registers, generated-image hex dump, dbghelp-symbolized stack walk) — the instrumentation that made the root cause findable.

## Evidence

| | pre-fix | post-fix |
|---|---|---|
| ItemsTest | 2/100, 12/300 failed | **0/300** |
| OnlinePlayerChainTest | 12/100, 27/300 failed | **0/300** |

All pre-fix failures: `0xC0000005` at a stable program-relative offset in main's epilogue. At baseline rates ~6-12 and ~27-36 failures were expected across 300 runs; observing zero in both is p < 1e-8. Full investigation log: `compiler/BlitzForge/docs/notes/exit-teardown-crash.md`.

## This PR

- Submodule pointer → blitz-forge `af497fba` (develop, includes #85 + #86).
- CLAUDE.md: "Known intermittent flake" section rewritten as **Historical — FIXED**, retiring the close/reopen ritual and pointing future intermittent-crash diagnosis at the new runtime diagnostics. The #313/#322 per-test sweep band-aids stay (harmless).
- Local verification: full `compile.bat` (engine + tools) clean and `test.bat` 50/50 green against the fixed compiler.

Note: this PR's own CI run rebuilds BlitzForge (cache miss on the new submodule SHA) — expected to be slower than usual.

🤖 Generated with [Claude Code](https://claude.com/claude-code)