### PR TITLE
fix(editors): declare collision-type constants in GUE, Terrain Editor, Gubbin Tool

### DIFF
--- a/src/GUE.bb
+++ b/src/GUE.bb
@@ -6,6 +6,22 @@ Global LogMode = 1; (0 = standard logging, 1 = debug mode)
 
 ChangeDir RootDir$
 
+; Collision types (mirrors Client.bb). GUE.bb never declared these even though
+; AreaLoader.bb (scenery Collides branches), Actors3D.bb (EntityType C_Actor /
+; C_ActorTri1 / C_ActorTri2) and GUE.bb's own undo-restore path reference them.
+; Under non-Strict Blitz an undeclared identifier silently reads as 0, so every
+; `If Collides = C_Sphere` compared against 0 and the pick-mode/radius/box
+; setup never ran as intended. Must be declared BEFORE the module Includes.
+Const C_None      = 0
+Const C_Sphere    = 1
+Const C_Box       = 2
+Const C_Triangle  = 3
+Const C_Actor     = 4
+Const C_Player    = 5
+Const C_Cam       = 6
+Const C_ActorTri1 = 7
+Const C_ActorTri2 = 8
+
 ; Includes --------------------------------------------------------------------------------------------------------------------------
 
 Include "Modules\Path.bb"

--- a/src/Tools/Gubbin Tool.bb
+++ b/src/Tools/Gubbin Tool.bb
@@ -10,6 +10,20 @@ Global AH_AppB$ = "RCSTD", AH_Loca$ = "..\New Game\"
 ;Include "AntiHack.bb"
 Const testing=True
 
+; Collision types (mirrors Client.bb). Never declared in this target even
+; though Actors3D.bb sets EntityType with C_Actor / C_ActorTri1 / C_ActorTri2;
+; under non-Strict Blitz they silently read as 0. Declared before the module
+; Includes so the EntityType calls use the intended values.
+Const C_None      = 0
+Const C_Sphere    = 1
+Const C_Box       = 2
+Const C_Triangle  = 3
+Const C_Actor     = 4
+Const C_Player    = 5
+Const C_Cam       = 6
+Const C_ActorTri1 = 7
+Const C_ActorTri2 = 8
+
 ; Includes
 Include "Modules\Spells.bb"
 Include "Modules\Language.bb"

--- a/src/Tools/RC Terrain Editor.bb
+++ b/src/Tools/RC Terrain Editor.bb
@@ -96,6 +96,20 @@ Const max_brush_size=80
 Dim GUI_HANDLE_TEMPORARY_IMAGE(6)
 thispath$=CurrentDir()
 
+; Collision types (mirrors Client.bb). Never declared in this target even
+; though ClientAreasTE.bb's LoadArea/ChunkTerrain reference C_Sphere /
+; C_Triangle / C_Box; under non-Strict Blitz they silently read as 0. Declared
+; before the module Includes so the comparisons work as written.
+Const C_None      = 0
+Const C_Sphere    = 1
+Const C_Box       = 2
+Const C_Triangle  = 3
+Const C_Actor     = 4
+Const C_Player    = 5
+Const C_Cam       = 6
+Const C_ActorTri1 = 7
+Const C_ActorTri2 = 8
+
 	;Include "modules\encrypt_b3d.bb"
 Include "modules\rcenet.bb"
 Include "modules\language.bb"


### PR DESCRIPTION
## Why

The collision-type constants `C_None`..`C_ActorTri2` are declared only in [src/Client.bb:101-110](https://github.com/RydeTec/rcce2/blob/develop/src/Client.bb#L101-L110), but three other compile targets include code that references them. Under non-Strict Blitz an undeclared identifier silently reads as **0** (the documented trap from PRs #323/#324), so every reference in those targets has been comparing against / passing 0 since the code was written.

## Affected targets

| Target | References | Effect of the bug |
|---|---|---|
| **GUE.exe** | `AreaLoader.bb:439-452` (zone-load scenery), `GUE.bb` undo-restore scenery path (~9435), `Actors3D.bb:494-497` | `If Collides = C_Sphere` compared against 0, so the sphere branch ran for **non-colliding** scenery (0 = 0) and the triangle/box branches **never** ran — EntityPickMode/EntityRadius/EntityBox were set on exactly the wrong entities at zone load. Actors3D's `EntityType` calls passed 0 instead of 4/7/8. |
| **RC Terrain Editor.exe** | `ClientAreasTE.bb:361-374` (LoadArea) + `ChunkTerrain` | Currently **dead code** — the TE only ever calls `LoadAreaTE` (line 1647), never `LoadArea`. Fixed for correctness/future-proofing. |
| **Gubbin Tool.exe** | `Actors3D.bb:494-497` | `EntityType` calls passed 0 instead of `C_Actor`/`C_ActorTri1`/`C_ActorTri2`. |

(Loom.exe is **not** affected: it includes neither AreaLoader.bb nor Actors3D.bb and references none of the constants. Interface3D.bb:3838 is Client-only — Client.bb declares them.)

## Fix

Declare the full Client.bb constant block at program scope in each root `.bb`, before the module Includes, with a comment explaining the trap. Full block (not just the three referenced) so the same trap can't recur if a target later includes more Client-shared modules.

## Behavior change — verified inert

GUE zone loads now set `EntityPickMode`/`EntityRadius`/`EntityBox` per the scenery's real Collides value for the first time (and stop setting sphere pick mode on Collides=0 scenery). Verified this is safe:

- **No collision response change:** no editor target registers `Collisions()` pairs — those live only in `ClientLoaders.bb` (Client-only). `EntityType` values without registered pairs are inert, so the corrected Actors3D/terrain/ColBox EntityType values change nothing observable in the editors.
- **No picking change in GUE:** every `CameraPick` site in GUE.bb (2418, 2460, 2741, 2803, 2881, 2939, 2965, 2993, 3029, 3063, 3106) is immediately preceded by `UpdateZonePickModes(...)` (GUE.bb:8342), which recomputes pick mode on **all** scenery/terrain/water/etc. per the current edit view — so the corrected load-time pick modes are overwritten before any pick happens.
- **Save round-trip unaffected:** zone load sets `EntityType(S\EN, Collides)` from the file-read *variable* (not the constants), and the save/properties-UI paths read it back via `GetEntityType` (GUE.bb:8098/8664, ClientAreas.bb:194) — correct before and after this change.

## Testing

- Full `.\compile.bat` (no `-t`): all 5 engine targets + all tools compile clean.
- `.\test.bat`: **Ran 50 files: 50 passed, 0 failed.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)