### PR TITLE
fix(areas): lock media databases only after the area file opens

### DIFF
--- a/src/Modules/AreaLoader.bb
+++ b/src/Modules/AreaLoader.bb
@@ -144,12 +144,18 @@ Function LoadAreaData(Name$, CameraEN, DisplayItems = False, UpdateRottNet = Fal
 	; RottNet update
 	Local RNUpdateTime% = MilliSecs()
 	
-	LockMeshes()
-	LockTextures()
-
-	; Open file
+	; Open file. The Lock calls come AFTER this check: LockMeshes/LockTextures
+	; (Media.bb) each open a database file and stash the handle in a Global;
+	; locking before the missing-file early return leaked both handles on
+	; every failed load (the next Lock call overwrites the Global without
+	; closing the old handle). With the order below, the early return holds
+	; no locks and the success path pairs with UnlockMeshes/UnlockTextures
+	; at the end of this function.
 	F = ReadFile("Data\Areas\" + Name$ + ".dat")
 	If F = 0 Then Return False
+
+	LockMeshes()
+	LockTextures()
 
 		; Loading screen
 		LoadingTexID = ReadShort(F)

--- a/src/Modules/ClientAreasTE.bb
+++ b/src/Modules/ClientAreasTE.bb
@@ -117,12 +117,15 @@ Function LoadArea(Name$, CameraEN, DisplayItems = False, UpdateRottNet = False)
 	RNUpdateTime = MilliSecs()
 	Local PLoadMusic%, CLoadMusic%
 
-	LockMeshes()
-	LockTextures()
-
-	; Open file
+	; Open file. Lock AFTER the missing-file check (matching AreaLoader.bb):
+	; locking first leaked both Media.bb lock handles on every failed load,
+	; since the next Lock call overwrites the handle Global without closing
+	; the old one. The early return below holds no locks.
 	F = ReadFile("Data\Areas\" + Name$ + ".dat")
 	If F = 0 Then Return False
+
+	LockMeshes()
+	LockTextures()
 
 		; Loading screen
 		LoadingTexID = ReadShort(F)

--- a/src/Modules/ClientAreas_FE.bb
+++ b/src/Modules/ClientAreas_FE.bb
@@ -258,12 +258,15 @@ Function LoadArea(Name$, CameraEN, DisplayItems = False, UpdateRottNet = False)
 	FadeOutTexture = LoadTexture("Data\Textures\Shadows\fade.png", 59)	
 	ShadowFade FadeOutTexture
 		
-	LockMeshes()
-	LockTextures()
-	
-	; Open file
+	; Open file. Lock AFTER the missing-file check (matching AreaLoader.bb):
+	; locking first leaked both Media.bb lock handles on every failed load,
+	; since the next Lock call overwrites the handle Global without closing
+	; the old one. The early return below holds no locks.
 	F = ReadFile("Data\Areas\" + Name$ + ".dat")
 	If F = 0 Then Return False
+
+	LockMeshes()
+	LockTextures()
 
 		; Loading screen
 		LoadingTexID = ReadShort(F)

--- a/src/Modules/Loom/ZoneViewport.bb
+++ b/src/Modules/Loom/ZoneViewport.bb
@@ -291,11 +291,12 @@ Function Loom_SetWorldMode(zoneHandle, enable)
     If enable = True
         If VPWorldLoaded = True Then Loom_UnloadWorld()
         ; Pre-check the visual data file rather than letting LoadAreaData's
-        ; missing-file Return False handle it: the loader's early return
-        ; happens after LockMeshes/LockTextures, leaking the two lock file
-        ; handles per attempt (pre-existing in AreaLoader, also reachable
-        ; from GUE). The common Loom case -- toggling world view on a
-        ; gameplay-only zone -- shouldn't pay that. (Review finding on #551.)
+        ; missing-file Return False handle it, so the common Loom case --
+        ; toggling world view on a gameplay-only zone -- gets the specific
+        ; "no visual zone data" toast instead of a generic load failure.
+        ; (Originally this also dodged a lock-handle leak in the loader's
+        ; early return -- review finding on #551 -- but AreaLoader now
+        ; locks only after the ReadFile check, so that's no longer a factor.)
         If FileType("Data\Areas\" + Ar\Name$ + ".dat") <> 1
             Toast_Show("No visual zone data (Data\Areas\" + Ar\Name$ + ".dat)", "warning")
             WriteLog(LoomLog, "ZoneViewport: no visual .dat for " + Ar\Name$ + " -- staying schematic")


### PR DESCRIPTION
## Why

`LoadAreaData` ([AreaLoader.bb](https://github.com/RydeTec/rcce2/blob/develop/src/Modules/AreaLoader.bb)) and the `LoadArea` forks in `ClientAreas_FE.bb` (Client target) and `ClientAreasTE.bb` (RC Terrain Editor target) all called `LockMeshes()` / `LockTextures()` **before** the `ReadFile("Data\Areas\<name>.dat")` success check. On a missing area file, the `If F = 0 Then Return False` early return leaked both lock file handles: Media.bb's Lock helpers stash the `OpenFile` handle in a Global, so the **next** Lock call overwrites the Global without closing the old handle — the orphaned handle is never recoverable for the life of the process.

Reachable from GUE's `LoadArea` wrapper (ClientAreas.bb delegates straight to `LoadAreaData`), and previously from Loom's world-mode toggle until the `FileType` pre-check landed in #553 (which called this leak out as a pre-existing upstream issue).

## What

- Move the two Lock calls **below** the ReadFile success check in all three files. The early return now holds no locks; on the success path the locks still pair with `UnlockMeshes()` / `UnlockTextures()` after `CloseFile` at the end of each function. Verified by grep that there is **no other `Return`** inside the lock-held span of any of the three functions.
- Update the now-stale rationale comment on Loom's `FileType` pre-check in `ZoneViewport.bb` — the pre-check stays (it produces the specific 'no visual zone data' toast), but it no longer needs to dodge the loader leak.

## Testing

- Full `.\compile.bat` (no `-t`): all five engine targets + all tools compile clean (the forks live in the Client and RC Terrain Editor targets).
- `.\test.bat`: **Ran 50 files: 50 passed, 0 failed.**
- No generator-gated files touched (no ServerNet/ClientNet/Packets/Invoker/ScriptingCommands), so no doc regen needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)