### PR TITLE
docs(tools): correct the media-DB gap-provenance claim (review finding on #555)

### DIFF
--- a/tools/projectgen/README.md
+++ b/tools/projectgen/README.md
@@ -62,11 +62,14 @@ python tools/projectgen/rcproject.py verify data         # prove the round-trip 
 `Areas/ha.dat` stub are skipped, matching `validate.py`'s known-good set.
 
 **Scope (phase 2):** the four media databases — `Game Data/Meshes.dat`, `Textures.dat`,
-`Sounds.dat`, `Music.dat`. These are append-only index+blob structures, not value codecs
-(a 65,535-slot offset index + records in insertion order; deletions leave dead spans),
-so their JSON form captures three things: the sparse `entries` map (what humans diff),
+`Sounds.dat`, `Music.dat`. These are index+blob structures, not value codecs
+(a 65,535-slot offset index + records in insertion order), so their JSON form captures
+three things: the sparse `entries` map (what humans diff),
 the insertion `order` (ids sorted by blob offset — enough to re-derive every offset),
-and any dead `gaps` (hex-encoded). Rebuild is byte-identical; the ~262 KB zero-heavy
+and any dead `gaps` (hex-encoded — note the engine itself never produces these:
+`Remove*FromDatabase` compacts via a full rewrite, so gaps only appear in
+crash-interrupted or hand-edited files, which the codec preserves faithfully
+instead of corrupting). Rebuild is byte-identical; the ~262 KB zero-heavy
 index serialises to a few KB of JSON. The actual assets are loose files and were always
 git-friendly — these indexes were the merge-conflict magnets (every asset import by any
 author rewrote the same opaque quarter-megabyte binary). Note `Music.dat` records are a

--- a/tools/projectgen/rcdata.py
+++ b/tools/projectgen/rcdata.py
@@ -638,13 +638,23 @@ def read_sounds(data):   return MediaDB(data, SOUND).entries()
 #
 # Byte-faithful round-trip form for the index+blob databases. The .dat is NOT
 # a value codec: record bytes live at the offsets the index points to, in
-# insertion order, and Remove*FromDatabase leaves dead (unreferenced) spans
-# behind rather than compacting. The JSON form therefore captures three
-# things: the decoded records (sparse id -> fields map, the part humans diff
-# and merge), the insertion ORDER (ids sorted by blob offset -- appends are
-# strictly increasing, so order reconstructs every offset), and any GAP spans
+# insertion order. The JSON form therefore captures three things: the decoded
+# records (sparse id -> fields map, the part humans diff and merge), the
+# insertion ORDER (ids sorted by blob offset -- appends are strictly
+# increasing, so order reconstructs every offset), and any GAP spans
 # (hex-encoded, keyed by the id whose record follows them; trailing gaps use
 # before=None). Rebuilding replays order/gaps and re-derives each index slot.
+#
+# Engine fact (verified against Media.bb:120/186/242/298): Remove*FromDatabase
+# does NOT leave dead spans -- every Remove* rereads the survivors and
+# rewrites the file compacted in ascending-ID order via CreateDatabase, and
+# the Add* duplicate-scan walks the blob sequentially, so a gapped file is
+# not a state the engine itself produces or can safely append to. The gap
+# mechanism here is a strict fidelity superset: it preserves the bytes of
+# crash-interrupted, legacy, or hand-edited files instead of corrupting them.
+# Corollary for diff readers: an engine-side DELETE rewrites the whole blob
+# (order + every offset change), so it shows as a large JSON diff, not a
+# one-slot change.
 
 def mediadb_to_obj(raw, kind):
     db = MediaDB(raw, kind)

--- a/tools/projectgen/rcproject.py
+++ b/tools/projectgen/rcproject.py
@@ -22,10 +22,12 @@ Projectiles, Factions, server-side Areas (gameplay) and client-side Areas
 (visual).
 
 Scope (phase 2): the four media databases (Game Data/Meshes.dat, Textures.dat,
-Sounds.dat, Music.dat). These are append-only index+blob structures, not value
-codecs, so their JSON form additionally captures insertion ORDER (ids sorted by
-blob offset) and any dead GAP spans left by Remove*FromDatabase (hex-encoded) --
-enough to rebuild the bytes identically. The actual assets are loose files and
+Sounds.dat, Music.dat). These are index+blob structures, not value codecs, so
+their JSON form additionally captures insertion ORDER (ids sorted by blob
+offset) and any dead GAP spans (hex-encoded) -- enough to rebuild the bytes
+identically. (The engine itself never produces gaps -- Remove*FromDatabase
+compacts via a full rewrite -- the gap mechanism preserves crash-interrupted
+or hand-edited files faithfully instead of corrupting them.) The actual assets are loose files and
 already git-friendly; only these quarter-megabyte indexes used to be guaranteed
 merge conflicts on every asset import.
 

--- a/tools/projectgen/test_mediadb_roundtrip.py
+++ b/tools/projectgen/test_mediadb_roundtrip.py
@@ -109,8 +109,11 @@ def build_synthetic(kind, placements):
 
 
 def zero_slot(raw, slot_id):
-    """Simulate RemoveFromDatabase the way the engine does: zero the index
-    slot, leave the record bytes in place as a dead span."""
+    """Zero an index slot, leaving the record bytes in place as a dead span.
+    NOTE: this is NOT what the engine's Remove*FromDatabase does -- those
+    compact via a full rewrite (Media.bb). A dead span models a
+    crash-interrupted or hand-edited file, which the gap mechanism must
+    preserve byte-faithfully rather than corrupt."""
     b = bytearray(raw)
     struct.pack_into('<i', b, slot_id * 4, 0)
     return bytes(b)
@@ -162,8 +165,10 @@ def check_sparsity():
 
 
 def check_mid_gap_roundtrip():
-    """3a. SYNTHETIC GAP: three records, middle one deleted engine-style
-    (index slot zeroed, bytes left as a dead span between live records).
+    """3a. SYNTHETIC GAP: three records, the middle one's slot zeroed
+    (a crash-interrupted / hand-edited state -- the engine's own Remove*
+    compacts instead; see zero_slot note) leaving a dead span between
+    live records.
     Round-trip must reproduce the dead bytes exactly."""
     placements = [
         (5,  rec_bytes(rcdata.SOUND, is_3d=1, name='Sounds\\step1.wav')),


### PR DESCRIPTION
The [#555](https://github.com/RydeTec/rcce2/pull/555) quality-gate review verified the phase-2 format claims against `Media.bb` and caught one that is **false**: "`Remove*FromDatabase` leaves dead spans". In fact all four `Remove*` functions reread the survivors and rewrite the file **compacted in ascending-ID order** via `CreateDatabase` (Media.bb:120/186/242/298) — and the `Add*` duplicate-scan walks the blob sequentially, so a gapped file isn't a state the engine produces or can safely append to.

The gap mechanism itself is correct and stays: it's a strict fidelity superset that preserves crash-interrupted/legacy/hand-edited files byte-faithfully instead of corrupting them (and it was exercised by the acceptance fixtures). This PR fixes the claim everywhere it appeared (rcdata.py comment block, rcproject.py docstring, README, test fixture docstrings) and records the practical corollary: an engine-side **delete** rewrites the whole blob, so it shows as a large JSON diff, not a one-slot change.

Docs/comments only — no code behavior changes. 10/10 acceptance tests + 18-file `verify` re-run green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)