### PR TITLE
fix(gfx): detect + auto-retry the random dead-surface boot — issue #40 instrumentation

### DIFF
--- a/scripts/gfxprobe_loop.ps1
+++ b/scripts/gfxprobe_loop.ps1
@@ -1,0 +1,54 @@
+# gfxprobe_loop.ps1 -- measure the incidence rate of issue #40 (random
+# dead-surface launch). Launches the given executable N times with
+# RCCE_GFXPROBE=exit: each run performs the boot render-sanity probe
+# (Modules\Graphics\RenderSanity.bb), writes PASS / RECOVERED n / FAIL to
+# gfxprobe_result.txt and exits immediately. The tally turns "random,
+# hard to replicate" into a number.
+#
+# Usage (from the repo root):
+#   powershell -ExecutionPolicy Bypass -File scripts\gfxprobe_loop.ps1 -Exe bin\Client.exe -Runs 100
+#
+# To test the ReShade hypothesis on issue #40, run once as-is and once
+# with bin\dxgi.dll temporarily renamed (which disables ReShade), then
+# compare the FAIL/RECOVERED counts.
+param(
+    [Parameter(Mandatory = $true)][string]$Exe,
+    [int]$Runs = 100,
+    [int]$TimeoutSec = 60
+)
+
+$exePath = Resolve-Path $Exe -ErrorAction Stop
+$workDir = Split-Path $exePath
+$resultFile = Join-Path $workDir "gfxprobe_result.txt"
+
+$tally = @{ "PASS" = 0; "RECOVERED" = 0; "FAIL" = 0; "NO-RESULT" = 0 }
+
+for ($i = 1; $i -le $Runs; $i++) {
+    if (Test-Path $resultFile) { Remove-Item $resultFile -Force }
+    $env:RCCE_GFXPROBE = "exit"
+    $p = Start-Process -FilePath $exePath -WorkingDirectory $workDir -PassThru
+    if (-not $p.WaitForExit($TimeoutSec * 1000)) {
+        $p.Kill()
+        Write-Output ("run {0}: TIMEOUT (killed)" -f $i)
+        $tally["NO-RESULT"]++
+        continue
+    }
+    if (Test-Path $resultFile) {
+        $line = (Get-Content $resultFile -TotalCount 1).Trim()
+        $key = ($line -split ' ')[0]
+        if (-not $tally.ContainsKey($key)) { $key = "NO-RESULT" }
+        $tally[$key]++
+        if ($key -ne "PASS") { Write-Output ("run {0}: {1}" -f $i, $line) }
+    } else {
+        $tally["NO-RESULT"]++
+        Write-Output ("run {0}: exited without writing a result" -f $i)
+    }
+}
+$env:RCCE_GFXPROBE = ""
+
+Write-Output ""
+Write-Output ("=== {0} runs of {1} ===" -f $Runs, (Split-Path $exePath -Leaf))
+Write-Output ("PASS      : {0}" -f $tally["PASS"])
+Write-Output ("RECOVERED : {0}  (probe failed, re-init cured it)" -f $tally["RECOVERED"])
+Write-Output ("FAIL      : {0}  (dead surfaces survived re-init)" -f $tally["FAIL"])
+Write-Output ("NO-RESULT : {0}  (crash/timeout before the probe)" -f $tally["NO-RESULT"])

--- a/src/Client.bb
+++ b/src/Client.bb
@@ -121,6 +121,7 @@ Global LootBagEN
 
 ; Includes --------------------------------------------------------------------------------------------------------------------------
 
+Include "Modules\Graphics\RenderSanity.bb" ; Issue #40 boot probe (dead-surface detection + bounded re-init)
 Include "Modules\Language.bb"              ; Language module (allows users to change string constants)
 Include "Modules\RottParticles.bb"         ; Particle system
 Include "Modules\RCEnet.bb"                ; Network library

--- a/src/GUE.bb
+++ b/src/GUE.bb
@@ -24,6 +24,7 @@ Const C_ActorTri2 = 8
 
 ; Includes --------------------------------------------------------------------------------------------------------------------------
 
+Include "Modules\Graphics\RenderSanity.bb" ; Issue #40 boot probe (dead-surface detection + bounded re-init)
 Include "Modules\Path.bb"
 Include "Modules\RCEnet.bb"
 Include "Modules\Media.bb"
@@ -118,12 +119,19 @@ If (GUE_width < 1280 And GUE_height< 960)
 EndIf
 WriteLog(GUELog, "Initialising windowed graphics mode")
 Graphics3D(GUE_width, GUE_height, 0, 2)
+; Issue #40 boot probe -- MUST run before FUI_Initialise: a probe-triggered
+; re-init re-issues Graphics3D, which would orphan any F-UI fonts/images
+; created beforehand. See Modules\Graphics\RenderSanity.bb.
+EnsureRenderSanity(GUE_width, GUE_height, 0, 2)
+If RenderSanityResult <> 0 Then WriteLog(GUELog, "RenderSanity (GUE boot): result " + RenderSanityResult + " -- issue #40 signature")
 FUI_Initialise(GUE_width, GUE_height, 0, 2, True, True, "Realm Crafter Community Edition -" + rcceVersion)
 SetBuffer(BackBuffer())
 
 ;FUI_RemoveBorder()
 
-AppTitle("RCCE 2")
+; Keep the probe's title-bar failure notice (the only OS-rendered,
+; always-visible text when surfaces are dead) instead of overwriting it.
+If RenderSanityResult >= 0 Then AppTitle("RCCE 2")
 Global DefaultLight = CreateLight()
 RotateEntity(DefaultLight, 30, 0, 0)
 AmbientLight(100, 100, 100)

--- a/src/Loom.bb
+++ b/src/Loom.bb
@@ -79,6 +79,7 @@ Global EnvironmentSaved = True
 //
 // Order matters for Type declarations -- mirror GUE.bb's order.
 // -----------------------------------------------------------------------------
+Include "Modules\Graphics\RenderSanity.bb" // Issue #40 boot probe (dead-surface detection + bounded re-init)
 Include "Modules\Path.bb"
 Include "Modules\RCEnet.bb"
 Include "Modules\Media.bb"
@@ -448,12 +449,18 @@ If (boot_width < 1280 And boot_height < 800)
 EndIf
 
 Graphics3D(boot_width, boot_height, 0, 2)
+// Issue #40 boot probe (dead-surface detection + bounded re-init); see
+// Modules\Graphics\RenderSanity.bb. Runs before anything creates surfaces.
+EnsureRenderSanity(Int(boot_width), Int(boot_height), 0, 2)
 SetBuffer(BackBuffer())
-AppTitle("Loom -- World Editor (Alpha) -- Realm Crafter " + rcceVersion$)
+// Keep the probe's title-bar failure notice (the only OS-rendered text
+// visible when every surface is dead) instead of overwriting it.
+If RenderSanityResult >= 0 Then AppTitle("Loom -- World Editor (Alpha) -- Realm Crafter " + rcceVersion$)
 
 // Log -- Data\Logs\Loom Log.txt (relative to project root, next to GUE's log).
 Global LoomLog = StartLog("Loom Log", False)
 WriteLog(LoomLog, "** Loom startup begins **", True, True)
+If RenderSanityResult <> 0 Then WriteLog(LoomLog, "RenderSanity (Loom boot): result " + RenderSanityResult + " -- issue #40 signature")
 WriteLog(LoomLog, "Resolution: " + Str(boot_width) + "x" + Str(boot_height))
 
 // Resolve project name from the working directory leaf.

--- a/src/Modules/ClientLoaders.bb
+++ b/src/Modules/ClientLoaders.bb
@@ -85,11 +85,15 @@ Function LoadGame()
 	Select FullScreen
 		Case 0
 			Graphics3D(Width, Height, Depth,2)
+			EnsureRenderSanity(Width, Height, Depth, 2)
 			Initext
 		Case 1
 			Graphics3D(Width, Height, Depth,1)
+			EnsureRenderSanity(Width, Height, Depth, 1)
 			Initext
 	End Select
+	; Issue #40 instrumentation (see Modules\Graphics\RenderSanity.bb).
+	If RenderSanityResult <> 0 Then WriteLog(MainLog, "RenderSanity (game boot): result " + RenderSanityResult + " -- issue #40 signature")
 			;multithreading cysis145 ???
 				;Local pointer1 = FunctionPointer()
 				;Goto skip1

--- a/src/Modules/Graphics/RCCEGraphics.bb
+++ b/src/Modules/Graphics/RCCEGraphics.bb
@@ -1,6 +1,7 @@
 Strict
 
 Include "Modules\Traits\Dim\ScaleTrait.bb"
+Include "Modules\Graphics\RenderSanity.bb" ; Issue #40 boot probe (dead-surface detection + bounded re-init)
 
 Type RCCEGraphics
     Field scale.ScaleTrait
@@ -18,6 +19,10 @@ Type RCCEGraphics
 
     Method init()
         Graphics3D(self\scale\x, self\scale\y, self\scale\z, self\mode)
+        ; Issue #40 boot probe -- dead-surface detection + bounded re-init,
+        ; run before any buffer state is cached. No log file exists on this
+        ; target; the probe sets an AppTitle notice on final failure.
+        EnsureRenderSanity(self\scale\x, self\scale\y, self\scale\z, self\mode)
         RCCEGraphics::resetBuffer(self)
     End Method
 

--- a/src/Modules/Graphics/RenderSanity.bb
+++ b/src/Modules/Graphics/RenderSanity.bb
@@ -1,0 +1,133 @@
+Strict
+
+; =============================================================================
+; RenderSanity.bb -- boot-time detection + bounded recovery for issue #40
+; =============================================================================
+;
+; Issue #40: randomly, on some launches, the application comes up with every
+; DirectDraw surface dead -- no textures, no text, no loading screens, no
+; mouse cursor -- under the Blitz-DDraw -> dgVoodoo -> D3D11 -> ReShade
+; wrapper stack. It is unreproducible on demand, so the engine previously
+; booted blind into the unusable state and the user's only remedy was to
+; notice visually and restart by hand.
+;
+; This module turns that into: PROBE (do 2D surface blits actually reach the
+; backbuffer?), bounded RE-INIT (EndGraphics + Graphics3D again, the same
+; remedy a manual restart performs, up to RS_MAX_REINITS times), and REPORT
+; (log-friendly return codes for the caller, plus an AppTitle notice on
+; final failure -- the title bar is OS-rendered, NOT a DirectDraw surface,
+; so it stays visible precisely when everything in the window is dead).
+;
+; Builtins only -- no module dependencies -- so every target (Client, GUE,
+; Loom, Project Manager via RCCEGraphics) can include it. Call
+; EnsureRenderSanity immediately after Graphics3D and BEFORE InitExt /
+; FastExt setup, so a re-init never has to tear down cached device state.
+;
+; Env hooks (for validation + field measurement, since the failure cannot
+; be triggered on demand and agent-side runtime launch is unavailable):
+;   RCCE_GFXPROBE=fail      every probe reports failure -- exercises the
+;                           retry loop + AppTitle notice on a healthy box
+;   RCCE_GFXPROBE=exit      write PASS / RECOVERED n / FAIL to
+;                           gfxprobe_result.txt and End after resolution --
+;                           lets scripts/gfxprobe_loop.ps1 measure the
+;                           real-world incidence rate (run it with vs.
+;                           without bin\dxgi.dll to test the ReShade theory)
+;   RCCE_GFXPROBE=failexit  both.
+
+Const RS_MAX_REINITS% = 2
+Const RS_PROBE_SIZE%  = 32
+
+; Result of the last EnsureRenderSanity call: 0 = clean first try,
+; N>0 = recovered after N re-inits, -1 = still dead after all retries.
+Global RenderSanityResult% = 0
+
+; True when 2D image blits and text actually reach the backbuffer. Draws
+; without ever Flipping, so the probe is never user-visible; cleans up after
+; itself (frees the probe image, restores black ClsColor, clears the buffer).
+Function RenderSanityProbe%()
+
+	If Instr(GetEnv("RCCE_GFXPROBE"), "fail") > 0 Then Return False
+
+	Local img.BBImage = CreateImage(RS_PROBE_SIZE, RS_PROBE_SIZE)
+	If img = Null Then Return False
+
+	; Fill the image magenta through its own buffer, then blit it onto a
+	; black backbuffer next to a white text glyph. If the wrapper came up
+	; with dead surfaces, none of these writes land and the scan below
+	; reads pure black.
+	SetBuffer ImageBuffer(img)
+	ClsColor 255, 0, 255
+	Cls
+	SetBuffer BackBuffer()
+	ClsColor 0, 0, 0
+	Cls
+	DrawBlock img, 0, 0
+	Color 255, 255, 255
+	Text RS_PROBE_SIZE + 8, 8, "RC"
+
+	Local hit% = False
+	Local x%, y%
+	For y = 2 To RS_PROBE_SIZE - 2 Step 6
+		For x = 0 To RS_PROBE_SIZE + 24 Step 2
+			If (ReadPixel(x, y) And $FFFFFF) <> 0
+				hit = True
+				Exit
+			EndIf
+		Next
+		If hit = True Then Exit
+	Next
+
+	FreeImage img
+	Cls
+
+	Return hit
+
+End Function
+
+; Probe; on failure tear the graphics mode down and re-init with the SAME
+; parameters (bounded), re-probing each time. Stores + returns the result
+; code (0 clean / N recovered / -1 dead) -- callers log it with their own
+; logger; this module deliberately has no logging dependency.
+Function EnsureRenderSanity%(w%, h%, d%, mode%)
+
+	Local attempt%
+	Local result% = -1
+	For attempt = 0 To RS_MAX_REINITS
+		If RenderSanityProbe() = True
+			result = attempt
+			Exit
+		EndIf
+		If attempt < RS_MAX_REINITS
+			EndGraphics
+			Graphics3D(w, h, d, mode)
+			SetBuffer BackBuffer()
+		EndIf
+	Next
+
+	If result < 0
+		; Title-bar text is rendered by the OS, not DirectDraw, so this is
+		; readable even though nothing inside the window is.
+		AppTitle "RCCE: GRAPHICS BROKE (no textures - issue #40). Restart; if it recurs, remove bin\dxgi.dll"
+	EndIf
+
+	RenderSanityResult = result
+
+	; Measurement mode: record + quit so a harness can tally incidence.
+	If Instr(GetEnv("RCCE_GFXPROBE"), "exit") > 0
+		Local rf.BBStream = WriteFile("gfxprobe_result.txt")
+		If rf <> Null
+			If result = 0
+				WriteLine rf, "PASS"
+			ElseIf result > 0
+				WriteLine rf, "RECOVERED " + result
+			Else
+				WriteLine rf, "FAIL"
+			EndIf
+			CloseFile rf
+		EndIf
+		End
+	EndIf
+
+	Return result
+
+End Function

--- a/src/Modules/MainMenu.bb
+++ b/src/Modules/MainMenu.bb
@@ -48,22 +48,29 @@ Function RunMenu()
        Select FullScreen 
           Case 0 
              Graphics3D(Width, Height, Depth,2) 
+				EnsureRenderSanity(Width, Height, Depth, 2)
 				InitExt
 
           Case 1 
              Graphics3D(Width, Height, Depth,1) ;1
+				EnsureRenderSanity(Width, Height, Depth, 1)
 				InitExt
        End Select 
     Else 
        Select FullScreen 
           Case 0 
              Graphics3D(800, 600, 0,2) 
+				EnsureRenderSanity(800, 600, 0, 2)
 				InitExt
           Case 1 
              Graphics3D(800, 600, 0,1) 
+				EnsureRenderSanity(800, 600, 0, 1)
 				InitExt
        End Select 
     EndIf
+	; Issue #40 instrumentation: 0 = clean, N = recovered after N re-inits,
+	; -1 = surfaces still dead (the probe module set an AppTitle notice).
+	If RenderSanityResult <> 0 Then WriteLog(MainLog, "RenderSanity (menu boot): result " + RenderSanityResult + " -- issue #40 signature")
 				;multithreading cysis145 ???
 				;Local pointer1 = FunctionPointer()
 				;Goto skip1


### PR DESCRIPTION
## Summary (non-technical)

[Issue #40](https://github.com/RydeTec/rcce2/issues/40) — the only open bug, milestoned for the 2.0.0 stable release — is the random launch where nothing textures: no text, no loading screens, no mouse cursor. It's been stuck for four months because it can't be reproduced on demand. This PR makes the engine **detect** that state the instant it happens, **retry** graphics init automatically (the same thing a manual restart does — up to twice), and **report** it: a log line, plus a title-bar notice that stays readable precisely because the title bar is the one piece of text Windows draws instead of the broken graphics stack. A bundled script can now also measure how often it actually happens — with vs. without ReShade — turning the four-month-old hypothesis into numbers.

## Technical summary

- **`Modules\Graphics\RenderSanity.bb`** (Strict, builtins only — includable by every target): `RenderSanityProbe%()` blits a magenta `CreateImage` block + white `Text` onto a Cls-black backbuffer and `ReadPixel`-scans for any non-black pixel — the exact surface operations the bug kills. No `Flip`, so it's invisible on healthy boots. `EnsureRenderSanity%(w,h,d,mode)` wraps it with a bounded `EndGraphics`+`Graphics3D` re-init loop (max 2), stores the result in `RenderSanityResult` (0 clean / N recovered / -1 dead) and sets the **AppTitle** failure notice.
- **Wiring** (immediately after every `Graphics3D` in the engine, 9 sites): Client menu boot ×4 and game boot ×2 — **before `InitExt`** so a re-init never orphans FastExt's cached D3D7 device; GUE — **before `FUI_Initialise`** for the same staleness reason, with its later `AppTitle` guarded so the notice survives; Loom (same guard); `RCCEGraphics::init` (Project Manager). `Server.bb` has no `Graphics3D` — the issue's "Server too" report is noted as future scope.
- **`RCCE_GFXPROBE` env hook**: `fail` forces probe failure (validates the retry + notice plumbing on demand — the failure itself can't be triggered); `exit` writes `PASS / RECOVERED n / FAIL` to `gfxprobe_result.txt` and quits.
- **`scripts/gfxprobe_loop.ps1`**: N-run incidence harness. Run once normally and once with `bin\dxgi.dll` renamed (ReShade disabled) to confirm or kill the ReShade theory with data.

## What this deliberately does NOT do

Ship a guessed root-cause fix. One recon theory (menu→game double-`Graphics3D` invalidating Media.bb's cached texture handles) was **rejected without measurement**: that mechanism would fire deterministically on every launch, but the bug is random. The post-flake-fix lesson (blitz-forge #85/#86) is to measure before fixing intermittent bugs — this PR is the measurement instrument, and its field data (RECOVERED vs FAIL ratios) directly informs the eventual real fix.

## Acceptance criteria

- [x] Probe module exists, builtins-only; called after all 9 engine `Graphics3D` sites
- [x] Retry placed before `InitExt`/`FUI_Initialise` so re-init never strands wrapper-cached state
- [x] Final failure → log marker + AppTitle notice (OS-rendered, visible when surfaces are dead); app continues
- [x] Zero behavior change on healthy boots (no Flip in probe; `Cls` cleanup; `ClsColor` restored)
- [x] `RCCE_GFXPROBE=fail/exit` plumbing for validation + measurement; harness script included
- [x] Full `compile.bat` (all five targets + tools) clean; `test.bat` 50/50 green

## Verification ceiling (honest)

Agent-launched `Graphics3D` is blocked in this environment, and the real failure can't be triggered on demand by anyone — so the probe's coverage of the true failure mode is verified by construction (it exercises the exact ops the symptoms kill) + forced-failure path review, not by a live repro. **User asks:** (1) one normal Client/GUE launch to confirm healthy boots look identical; (2) optionally run `scripts\gfxprobe_loop.ps1 -Exe bin\Client.exe -Runs 100` twice (with/without `dxgi.dll`) and post the tallies to issue #40 — that's the data the eventual root-cause fix needs.

## Deferred

- Root-cause fix in the dgVoodoo/ReShade hook chain (needs the harness data first)
- ReShade fork bump (separate risky iteration)
- The seven `src/Tools` editors (same wiring pattern applies if ever needed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)