### PR TITLE
fix(gfx): issue #40 probe review fixes — result-file anchoring + notice survival

### DIFF
--- a/scripts/gfxprobe_loop.ps1
+++ b/scripts/gfxprobe_loop.ps1
@@ -19,21 +19,32 @@ param(
 
 $exePath = Resolve-Path $Exe -ErrorAction Stop
 $workDir = Split-Path $exePath
-$resultFile = Join-Path $workDir "gfxprobe_result.txt"
+# The probe writes its result anchored to the EXECUTABLE's directory
+# (SystemProperty("AppDir")). Also check the parent in case an older binary
+# (pre-fix: CWD-relative write + ChangeDir to the project root) is being
+# measured -- a silent location mismatch would tally everything as
+# NO-RESULT and masquerade as a 100% crash rate.
+$resultCandidates = @(
+    (Join-Path $workDir "gfxprobe_result.txt"),
+    (Join-Path (Split-Path $workDir) "gfxprobe_result.txt")
+)
 
 $tally = @{ "PASS" = 0; "RECOVERED" = 0; "FAIL" = 0; "NO-RESULT" = 0 }
 
 for ($i = 1; $i -le $Runs; $i++) {
-    if (Test-Path $resultFile) { Remove-Item $resultFile -Force }
+    foreach ($rf in $resultCandidates) {
+        if (Test-Path $rf) { Remove-Item $rf -Force }
+    }
     $env:RCCE_GFXPROBE = "exit"
-    $p = Start-Process -FilePath $exePath -WorkingDirectory $workDir -PassThru
+    $p = Start-Process -FilePath $exePath -WorkingDirectory $workDir -WindowStyle Minimized -PassThru
     if (-not $p.WaitForExit($TimeoutSec * 1000)) {
         $p.Kill()
         Write-Output ("run {0}: TIMEOUT (killed)" -f $i)
         $tally["NO-RESULT"]++
         continue
     }
-    if (Test-Path $resultFile) {
+    $resultFile = $resultCandidates | Where-Object { Test-Path $_ } | Select-Object -First 1
+    if ($resultFile) {
         $line = (Get-Content $resultFile -TotalCount 1).Trim()
         $key = ($line -split ' ')[0]
         if (-not $tally.ContainsKey($key)) { $key = "NO-RESULT" }
@@ -44,7 +55,7 @@ for ($i = 1; $i -le $Runs; $i++) {
         Write-Output ("run {0}: exited without writing a result" -f $i)
     }
 }
-$env:RCCE_GFXPROBE = ""
+Remove-Item Env:RCCE_GFXPROBE -ErrorAction SilentlyContinue
 
 Write-Output ""
 Write-Output ("=== {0} runs of {1} ===" -f $Runs, (Split-Path $exePath -Leaf))

--- a/src/GUE.bb
+++ b/src/GUE.bb
@@ -125,6 +125,9 @@ Graphics3D(GUE_width, GUE_height, 0, 2)
 EnsureRenderSanity(GUE_width, GUE_height, 0, 2)
 If RenderSanityResult <> 0 Then WriteLog(GUELog, "RenderSanity (GUE boot): result " + RenderSanityResult + " -- issue #40 signature")
 FUI_Initialise(GUE_width, GUE_height, 0, 2, True, True, "Realm Crafter Community Edition -" + rcceVersion)
+; FUI_Initialise sets AppTitle unconditionally -- restore the dead-surfaces
+; notice if the probe failed (no-op otherwise).
+RenderSanityReassertNotice()
 SetBuffer(BackBuffer())
 
 ;FUI_RemoveBorder()

--- a/src/Modules/Graphics/RenderSanity.bb
+++ b/src/Modules/Graphics/RenderSanity.bb
@@ -104,17 +104,15 @@ Function EnsureRenderSanity%(w%, h%, d%, mode%)
 		EndIf
 	Next
 
-	If result < 0
-		; Title-bar text is rendered by the OS, not DirectDraw, so this is
-		; readable even though nothing inside the window is.
-		AppTitle "RCCE: GRAPHICS BROKE (no textures - issue #40). Restart; if it recurs, remove bin\dxgi.dll"
-	EndIf
-
 	RenderSanityResult = result
+	RenderSanityReassertNotice()
 
 	; Measurement mode: record + quit so a harness can tally incidence.
+	; Anchor the result file to the EXECUTABLE's directory, not the working
+	; directory -- every shipped target ChangeDirs to the project root
+	; before this runs, while the harness looks next to the exe.
 	If Instr(GetEnv("RCCE_GFXPROBE"), "exit") > 0
-		Local rf.BBStream = WriteFile("gfxprobe_result.txt")
+		Local rf.BBStream = WriteFile(SystemProperty("AppDir") + "gfxprobe_result.txt")
 		If rf <> Null
 			If result = 0
 				WriteLine rf, "PASS"
@@ -130,4 +128,15 @@ Function EnsureRenderSanity%(w%, h%, d%, mode%)
 
 	Return result
 
+End Function
+
+; Re-assert the dead-surfaces title-bar notice. Title text is rendered by
+; the OS, not DirectDraw, so it is readable precisely when nothing inside
+; the window is -- but FUI_Initialise (GUE / Project Manager / Server) sets
+; AppTitle unconditionally AFTER the probe runs, so those boot paths must
+; call this again right after their F-UI init. No-op on healthy boots.
+Function RenderSanityReassertNotice%()
+	If RenderSanityResult >= 0 Then Return False
+	AppTitle "RCCE: GRAPHICS BROKE (no textures - issue #40). Restart; if it recurs, remove bin\dxgi.dll"
+	Return True
 End Function

--- a/src/Project Manager.bb
+++ b/src/Project Manager.bb
@@ -52,6 +52,9 @@ Type ProjectManager.RCCEApp
 		ProjectManager::loadProject(self)
 
 		FUI_Initialise(self\width, self\height, 0, 2, False, True, self\title, RCCEApp::version(self))
+		; FUI_Initialise sets AppTitle unconditionally -- restore the issue #40
+		; dead-surfaces notice if the boot probe (RCCEGraphics::init) failed.
+		RenderSanityReassertNotice()
 		
 		RCCEGraphics::resetBuffer(self\gfx)
 

--- a/src/Server.bb
+++ b/src/Server.bb
@@ -76,6 +76,9 @@ Type Server.RCCEApp
 		RCCEGraphics::push(self\gfx)
 
 		FUI_Initialise(self\width, self\height, 0, 2, False, True, self\title, RCCEApp::version(self))
+		; FUI_Initialise sets AppTitle unconditionally -- restore the issue #40
+		; dead-surfaces notice if the boot probe (RCCEGraphics::init) failed.
+		RenderSanityReassertNotice()
 
 		Server::loadAssets(self)
 		Server::loadComponents(self)


### PR DESCRIPTION
Review-cycle-2 follow-up to [#557](https://github.com/RydeTec/rcce2/pull/557), addressing all three REQUIRED CHANGES from the quality-gate review:

1. **The measurement instrument could never report.** The probe's `RCCE_GFXPROBE=exit` mode wrote `gfxprobe_result.txt` CWD-relative — but every shipped target `ChangeDir`s to the project root before the probe runs, while the harness reads next to the exe in `bin\`. Every run would have tallied **NO-RESULT** ("crash/timeout"), actively misleading the issue-#40 investigation as a 100% crash rate. The probe now anchors the write to `SystemProperty("AppDir")`; the harness also checks the parent directory as a belt-and-braces fallback for older binaries.

2. **The failure notice now survives F-UI.** `FUI_Initialise` sets `AppTitle` unconditionally *after* the probe on GUE / Project Manager / Server, clobbering the dead-surfaces title-bar notice (the only OS-rendered, always-visible signal). New `RenderSanityReassertNotice()` — a no-op on healthy boots — is called immediately after each of those three `FUI_Initialise` sites. Client and Loom were already correct.

3. **Record corrected: Server IS covered.** `Server.bb:69` boots its window through `RCCEGraphics::init`, so the #557 claim that "Server.bb has no Graphics3D" was wrong — Server has been probe-covered all along via the RCCEGraphics wiring (a fortunate accident, now intentional and documented). Issue #40's comment will be corrected accordingly. Note: `RCCE_GFXPROBE=exit` intentionally exits the Server at boot too — that's the measurement mode working as designed.

Full `compile.bat` (all targets + tools) clean; `test.bat` 50/50 green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
