### PR TITLE
docs(protocol): detail pages for the account/auth packet cluster

### DIFF
--- a/docs/protocol/index.md
+++ b/docs/protocol/index.md
@@ -37,12 +37,12 @@ pages is a per-iteration documentation task — see CONTRIBUTING.md.
 
 | ID | Packet | Direction | Server handler | Client handler | Detail |
 |---|---|---|---|---|---|
-| 1 | `P_CreateAccount` | C→S | [ServerNet.bb:2344](../../src/Modules/ServerNet.bb#L2344) | — | — |
-| 2 | `P_VerifyAccount` | C→S | [ServerNet.bb:2398](../../src/Modules/ServerNet.bb#L2398) | — | — |
+| 1 | `P_CreateAccount` | C→S | [ServerNet.bb:2344](../../src/Modules/ServerNet.bb#L2344) | — | [P_CreateAccount](packets/P_CreateAccount.md) |
+| 2 | `P_VerifyAccount` | C→S | [ServerNet.bb:2398](../../src/Modules/ServerNet.bb#L2398) | — | [P_VerifyAccount](packets/P_VerifyAccount.md) |
 | 3 | `P_FetchCharacter` | C→S | [ServerNet.bb:2590](../../src/Modules/ServerNet.bb#L2590) | — | — |
 | 4 | `P_CreateCharacter` | C→S | [ServerNet.bb:2714](../../src/Modules/ServerNet.bb#L2714) | — | — |
 | 5 | `P_DeleteCharacter` | C→S | [ServerNet.bb:2951](../../src/Modules/ServerNet.bb#L2951) | — | — |
-| 6 | `P_ChangePassword` | C→S | [ServerNet.bb:2533](../../src/Modules/ServerNet.bb#L2533) | — | — |
+| 6 | `P_ChangePassword` | C→S | [ServerNet.bb:2533](../../src/Modules/ServerNet.bb#L2533) | — | [P_ChangePassword](packets/P_ChangePassword.md) |
 | 7 | `P_FetchActors` | C→S | [ServerNet.bb:2236](../../src/Modules/ServerNet.bb#L2236) | — | — |
 | 8 | `P_FetchItems` | Unused | — | — | — |
 | 9 | `P_ChangeArea` | Both | [ServerNet.bb:734](../../src/Modules/ServerNet.bb#L734) | [ClientNet.bb:1637](../../src/Modules/ClientNet.bb#L1637) | — |

--- a/docs/protocol/packets/P_ChangePassword.md
+++ b/docs/protocol/packets/P_ChangePassword.md
@@ -1,0 +1,85 @@
+# P_ChangePassword
+
+**Direction:** C -> S (request), S -> C (single-byte result reply)
+**Numeric ID:** 6 ([Packets.bb:7](../../../src/Modules/Packets.bb#L7))
+**Client send site:** **none in the current engine** — see "No live sender" below. The only sender in the tree is the legacy snapshot at [Tools/Modules_old/ServerNet.bb:1728](../../../src/Tools/Modules_old/ServerNet.bb#L1728) (not built).
+**Server handler:** [ServerNet.bb:2533](../../../src/Modules/ServerNet.bb#L2533) (`Case P_ChangePassword`)
+
+## Purpose
+
+Rotate the password on an existing account. The requester sends a username, the MD5 of the current password, and the MD5 of the new password; the server verifies the current password **and** that the requester currently holds the account's live session, then stores the new password in the salted-SHA-256 v1 format.
+
+The session check ([`RequesterOwnsAccountSession`](../../../src/Modules/AccountsServer.bb#L124)) is what distinguishes this from a pure pre-auth packet: although any peer can *send* it, the change only commits if the sender is the account's currently-logged-in connection. Without that gate a captured/replayed packet carrying the (replayable) MD5 could permanently steal the account.
+
+### No live sender
+
+Grep of `src/Modules` finds `P_ChangePassword` only in [Packets.bb](../../../src/Modules/Packets.bb#L7) (the constant) and [ServerNet.bb](../../../src/Modules/ServerNet.bb#L2533) (the handler). The current [MainMenu.bb](../../../src/Modules/MainMenu.bb) has **no** "change password" UI or `RCE_Send(..., P_ChangePassword, ...)` call — the only client-side sender is the un-built legacy copy under `Tools/Modules_old/`. The handler is therefore live and hardened but currently unreachable from the shipping client. The field layout below is reconstructed from the handler's reads and the legacy sender's writes (the two agree on framing); a future client that re-adds the feature must match it.
+
+## Field layout
+
+Reconstructed from the server reads ([ServerNet.bb:2534-2557](../../../src/Modules/ServerNet.bb#L2534)) and the legacy sender ([Tools/Modules_old/ServerNet.bb:1715-1727](../../../src/Tools/Modules_old/ServerNet.bb#L1715)). Both password fields are MD5 hex (`MD5$(plaintext)`), per the account cluster's convention.
+
+| # | Field | Width | Sender write (legacy) | Receiver read (ServerNet.bb) |
+|---|---|---|---|---|
+| 1 | Username length | 1 byte | `RCE_StrFromInt$(Len(Name$), 1)` | `RCE_IntFromStr(Left$(M\MessageData$, 1))` -> `UsernameLen` [:2534](../../../src/Modules/ServerNet.bb#L2534) |
+| 2 | Username | `UsernameLen` bytes | `Name$` (concat) | `Mid$(M\MessageData$, 2, UsernameLen)` [:2535](../../../src/Modules/ServerNet.bb#L2535) |
+| 3 | Current password (MD5 hex) length | 1 byte | `RCE_StrFromInt$(Len(OldMD5$), 1)` | `RCE_IntFromStr(Mid$(M\MessageData$, Offset, 1))` where `Offset = 2 + UsernameLen` [:2540-2541](../../../src/Modules/ServerNet.bb#L2540) |
+| 4 | Current password (MD5 hex) | `PwdLen` bytes | `OldMD5$` (concat) | `Mid$(M\MessageData$, Offset + 1, PwdLen)` [:2552](../../../src/Modules/ServerNet.bb#L2552) |
+| 5 | New password (MD5 hex) length | 1 byte | `RCE_StrFromInt$(Len(NewMD5$), 1)` | `RCE_IntFromStr(Mid$(M\MessageData$, Offset, 1))` where `Offset = 2 + PwdLen` [:2553-2554](../../../src/Modules/ServerNet.bb#L2553) |
+| 6 | New password (MD5 hex) | `PwdLen` (re-read) bytes | `NewMD5$` (concat) | `Mid$(M\MessageData$, Offset + 1, PwdLen)` [:2557](../../../src/Modules/ServerNet.bb#L2557) |
+
+All length prefixes are 1 byte; the sender writes match fields 1-6.
+
+**LATENT OFFSET BUG (field 5).** After verifying the current password, the handler recomputes the offset of the new-password block as `Offset = 2 + PwdLen` ([:2553](../../../src/Modules/ServerNet.bb#L2553)), where `PwdLen` is the *current*-password length. The new-password length prefix actually sits at byte `2 + UsernameLen + 1 + PwdLen` (username block, then current-password block). The code drops the `UsernameLen + 1` term entirely, so for any real packet (`UsernameLen >= 1`) it reads the new-password length and bytes from the **wrong offset** — landing inside the username or current-password field. The stored new password would be garbage, locking the user out. This is masked today only because there is **no live sender** (see above); the identical bug is in the legacy snapshot ([Tools/Modules_old/ServerNet.bb:1725](../../../src/Tools/Modules_old/ServerNet.bb#L1725)). A future client re-adding this feature would hit it immediately. The correct expression is `Offset = 2 + UsernameLen + 1 + PwdLen` (mirroring `P_VerifyAccount`/`P_CreateAccount`, which thread `Offset` forward additively rather than recomputing from scratch). Documented here as a latent bug rather than fixed in this docs-only change: any client that re-adds the change-password feature must correct this offset (and the identical one in the legacy snapshot) at the same time, ideally with a handler test in the spirit of [`ChangePasswordEnumerationTest.bb`](../../../src/Tests/Modules/ChangePasswordEnumerationTest.bb).
+
+### Reply
+
+| Reply byte | Meaning | Server emit | Client mapping |
+|---|---|---|---|
+| `"Y"` | Password changed | [ServerNet.bb:2558](../../../src/Modules/ServerNet.bb#L2558) | (no live client; legacy showed success) |
+| `"P"` | Any failure — wrong password, not session owner, empty stored hash, truncated packet, **or username not found** | [:2562](../../../src/Modules/ServerNet.bb#L2562) / [:2586](../../../src/Modules/ServerNet.bb#L2586) | (no live client) |
+
+The legacy server additionally sent `"N"` for "account not found" ([Tools/Modules_old/ServerNet.bb:1740](../../../src/Tools/Modules_old/ServerNet.bb#L1740)); the current handler collapses that into `"P"` to close the enumeration oracle (PR [#265](https://github.com/RydeTec/rcce2/pull/265)).
+
+## Validation requirements (server-side)
+
+1. **Account lookup** ([:2538-2539](../../../src/Modules/ServerNet.bb#L2538)) — case-insensitive (`Upper$`) scan.
+2. **Combined verify gate** ([:2552](../../../src/Modules/ServerNet.bb#L2552)) — a single `And` chain that must all hold to commit:
+   - `PwdLen >= 1` — rejects truncated / empty-password packets (an empty supplied password would otherwise match an account historically stored with an empty `Pass$`).
+   - `A\Pass$ <> ""` — rejects accounts with an empty stored hash.
+   - `VerifyPassword%(A\Pass$, currentMD5)` — current password verifies (constant-time, both legacy MD5 and v1 accepted).
+   - `RequesterOwnsAccountSession(A, M\FromID)` — the requester is the account's currently-logged-in connection ([AccountsServer.bb:124-133](../../../src/Modules/AccountsServer.bb#L124)). This is the replay/theft mitigation.
+3. **On success** ([:2557](../../../src/Modules/ServerNet.bb#L2557)) — `A\Pass$ = HashPassword$(newMD5)` stores the new password in v1 salted format immediately (not the raw client MD5); reply `"Y"`.
+4. **On any failure of the gate** ([:2562](../../../src/Modules/ServerNet.bb#L2562)) — reply `"P"`.
+5. **Account-not-found path** ([:2582-2586](../../../src/Modules/ServerNet.bb#L2582)) — `If Exists = False`, the handler still reads the current-password field and calls `VerifyPassword%("", ...)` to pay the SHA-256 cost (timing-uniform with the found-account-wrong-password path), then replies `"P"` — the same code as a credential failure, so the reply does not betray whether the username is registered.
+
+## Anti-cheat / abuse surface
+
+- **Account theft via replay — defended.** `RequesterOwnsAccountSession` means a captured packet (carrying the replayable MD5) cannot change the password unless the attacker also currently holds the victim's live session. PR [#76](https://github.com/RydeTec/rcce2/pull/76) (`756ad1ab`) added this gate.
+- **Username enumeration — defended (post PR #265).** Found-but-failed and not-found both reply `"P"`; the no-account path pays the dummy SHA-256 cost so timing is uniform. Pinned by [`ChangePasswordEnumerationTest.bb`](../../../src/Tests/Modules/ChangePasswordEnumerationTest.bb).
+- **No `LoginAttemptOk` throttle — NOT defended.** Unlike `P_VerifyAccount`, `P_StartGame`, `P_FetchCharacter`, `P_CreateCharacter`, and `P_DeleteCharacter`, this handler has **no** per-source rate limit (verified: no `LoginAttemptOk` call between [:2533](../../../src/Modules/ServerNet.bb#L2533) and the next handler at [:2590](../../../src/Modules/ServerNet.bb#L2590)). Because every code path — including not-found — calls `VerifyPassword%`, which runs a full SHA-256, an attacker can pump the server's hashing CPU at line rate with bogus `P_ChangePassword` packets. This is exactly the line-rate dummy-hash DoS that PR [#268](https://github.com/RydeTec/rcce2/pull/268) closed for the other auth handlers, and it was not extended here. The session gate prevents *theft*, not the *cost-amplification* DoS.
+- **Wire replay of the new password — NOT defended.** As with the whole cluster, the MD5 travels on the wire; a sniffer learns the new password's MD5. Out of scope without TLS.
+
+## Historical bugs / PR references
+
+| PR / commit | Relevance |
+|---|---|
+| PR [#76](https://github.com/RydeTec/rcce2/pull/76) (`756ad1ab`) | Added the `RequesterOwnsAccountSession` gate — a replayed/captured packet can no longer steal an account by knowing the (broken-MD5) hash. |
+| PR [#118](https://github.com/RydeTec/rcce2/pull/118) (`88aaf393`) | New password stored as salted SHA-256 v1 (`HashPassword$`) rather than raw client MD5. |
+| PR [#265](https://github.com/RydeTec/rcce2/pull/265) (`03ccdc99`) | Collapsed the `"N"` (not-found) vs `"P"` (auth-fail) enumeration oracle into a single `"P"`, plus dummy-hash on the not-found path. Sibling fix to PR [#264](https://github.com/RydeTec/rcce2/pull/264) for `P_VerifyAccount`. Pinned by [`ChangePasswordEnumerationTest.bb`](../../../src/Tests/Modules/ChangePasswordEnumerationTest.bb). |
+| PR [#268](https://github.com/RydeTec/rcce2/pull/268) (`82410986`) | Extended the throttle to four sibling handlers — **excluding** `P_ChangePassword`. The throttle gap above is current behavior. |
+
+The post-collapse state machine is mirrored in [`ChangePasswordEnumerationTest.bb`](../../../src/Tests/Modules/ChangePasswordEnumerationTest.bb) (`ChangePasswordResponse$`); production changes must update both copies.
+
+## Related packets
+
+- [`P_VerifyAccount`](P_VerifyAccount.md) — the login handler this one mirrors for the enumeration-oracle fix.
+- [`P_CreateAccount`](P_CreateAccount.md) — registration; same username/MD5 framing, also missing the throttle.
+- `P_DeleteCharacter` ([ServerNet.bb:2951](../../../src/Modules/ServerNet.bb#L2951)) — the other handler gated by `RequesterOwnsAccountSession` (PR #76).
+
+## See also
+
+- [`../encoding.md`](../encoding.md) — `RCE_StrFromInt$` / `RCE_IntFromStr`, 1-byte length prefixes.
+- [`../handler-conventions.md`](../handler-conventions.md) — auth-before-disclosure, bounds-then-deref, soft-fail.
+- [`AccountsServer.bb`'s `RequesterOwnsAccountSession`](../../../src/Modules/AccountsServer.bb#L124) — the session-ownership gate.
+- [`PasswordHash.bb`](../../../src/Modules/PasswordHash.bb) — `VerifyPassword%`, `HashPassword$`, timing-uniformity contract.

--- a/docs/protocol/packets/P_CreateAccount.md
+++ b/docs/protocol/packets/P_CreateAccount.md
@@ -1,0 +1,88 @@
+# P_CreateAccount
+
+**Direction:** C -> S (request), S -> C (single-byte result reply)
+**Numeric ID:** 1 ([Packets.bb:2](../../../src/Modules/Packets.bb#L2))
+**Client send site:** [MainMenu.bb:1204](../../../src/Modules/MainMenu.bb#L1204) (the "New account" button handler; reply read at [MainMenu.bb:1216-1218](../../../src/Modules/MainMenu.bb#L1216))
+**Server handler:** [ServerNet.bb:2344](../../../src/Modules/ServerNet.bb#L2344) (`Case P_CreateAccount`)
+
+## Purpose
+
+Pre-authentication account registration. A peer that has connected but not logged in submits a desired username, an MD5 of the desired password, and an (obfuscated) email address. The server validates the character set, rejects duplicates, and on success appends a new `Account` record to `Accounts.dat` via [`AddAccount`](../../../src/Modules/AccountsServer.bb#L193).
+
+This is one of three C->S pre-auth packets in the account cluster ([`P_VerifyAccount`](P_VerifyAccount.md), [`P_ChangePassword`](P_ChangePassword.md)). Any connected peer can send any bytes; the handler runs **before** any identity is established.
+
+The whole handler is gated by `If AllowAccountCreation = True` ([ServerNet.bb:2345](../../../src/Modules/ServerNet.bb#L2345)) — a server-config byte read from the server settings file at [Server.bb:262](../../../src/Modules/ServerNet.bb#L262) (declared [Server.bb:152](../../../src/Modules/ServerNet.bb#L152)). When account creation is disabled the handler **silently no-ops**: no reply is sent at all (see Anti-cheat surface).
+
+## Field layout
+
+The password is sent as the 32-char lowercase-hex MD5 of the typed password (`MD5Pass$ = MD5$(Pass$)`), not the plaintext. The email is obfuscated client-side with `Encrypt$(Email$, -1)` (a reversible Caesar-shift-plus-reverse, see [Client.bb:1034](../../../src/Client.bb#L1034)) and de-obfuscated server-side with `Encrypt$(..., 1)`.
+
+Request body, built at [MainMenu.bb:1200-1202](../../../src/Modules/MainMenu.bb#L1200):
+
+| # | Field | Width | Sender write (MainMenu.bb) | Receiver read (ServerNet.bb) |
+|---|---|---|---|---|
+| 1 | Username length | 1 byte | `RCE_StrFromInt$(Len(Name$), 1)` | `RCE_IntFromStr(Left$(M\MessageData$, 1))` -> `UsernameLen` [:2346](../../../src/Modules/ServerNet.bb#L2346) |
+| 2 | Username | `UsernameLen` bytes | `Name$` (concat) | `Mid$(M\MessageData$, 2, UsernameLen)` [:2347](../../../src/Modules/ServerNet.bb#L2347) |
+| 3 | Password (MD5 hex) length | 1 byte | `RCE_StrFromInt$(Len(MD5Pass$), 1)` | `RCE_IntFromStr(Mid$(M\MessageData$, Offset, 1))` where `Offset = 2 + UsernameLen` [:2359-2360](../../../src/Modules/ServerNet.bb#L2359) |
+| 4 | Password (MD5 hex) | `PwdLen` bytes | `MD5Pass$` (concat) | `Mid$(M\MessageData$, Offset + 1, PwdLen)` [:2361](../../../src/Modules/ServerNet.bb#L2361) |
+| 5 | Email length | 1 byte | `RCE_StrFromInt$(Len(Email$), 1)` | `RCE_IntFromStr(Mid$(M\MessageData$, Offset, 1))` where `Offset = Offset + 1 + PwdLen` [:2362-2363](../../../src/Modules/ServerNet.bb#L2362) |
+| 6 | Email (Caesar-obfuscated) | `EmailLen` bytes | `Encrypt$(Email$, -1)` (concat) | `Encrypt$(Mid$(M\MessageData$, Offset + 1, EmailLen), 1)` [:2364](../../../src/Modules/ServerNet.bb#L2364) |
+
+All length prefixes are **1 byte** here (not the 4-byte file-string convention) — sender and receiver widths match for every field. Note field 5's length prefix is written by the client as `RCE_StrFromInt$(Len(Email$), 1)` over the **plaintext** length, and `Encrypt$` is a 1:1 byte transform (it does not change length), so the prefix correctly counts the obfuscated bytes.
+
+### Reply
+
+| Reply byte | Meaning | Server emit | Client action |
+|---|---|---|---|
+| `"Y"` | Account created | [ServerNet.bb:2388](../../../src/Modules/ServerNet.bb#L2388) | `Result = True` -> `LS_NewAccountCreated` message ([MainMenu.bb:1240](../../../src/Modules/MainMenu.bb#L1240)) |
+| `"N"` | Duplicate username **or** failed validation | [ServerNet.bb:2390](../../../src/Modules/ServerNet.bb#L2390) / [:2393](../../../src/Modules/ServerNet.bb#L2393) | any non-`"Y"` -> `Result = False` -> `LS_UsernameAlreadyExists` message ([MainMenu.bb:1238](../../../src/Modules/MainMenu.bb#L1238)) |
+| *(no reply)* | `AllowAccountCreation = False` | handler body skipped | client waits in its receive loop until disconnect / Escape |
+
+## Validation requirements (server-side)
+
+All server-side, since the packet is attacker-controlled. In sequence:
+
+1. **`AllowAccountCreation = True`** ([:2345](../../../src/Modules/ServerNet.bb#L2345)) — config gate. False -> no-op, no reply.
+2. **Duplicate-username check** ([:2349-2356](../../../src/Modules/ServerNet.bb#L2349)) — `For A.Account = Each Account : If Upper$(A\User$) = Upper$(Username$) Then Exists = True`. Case-insensitive via `Upper$`. On duplicate, reply `"N"` and stop ([:2393](../../../src/Modules/ServerNet.bb#L2393)).
+3. **Username character set** ([:2367-2370](../../../src/Modules/ServerNet.bb#L2367)) — each byte must be `0-9` (48-57), `A-Z` (65-90), `a-z` (97-122), `_` (95), **or `>= 192`** (high/extended bytes pass). Any other byte sets `Valid = False`.
+4. **Password (MD5 hex) character set** ([:2372-2375](../../../src/Modules/ServerNet.bb#L2372)) — same alnum set plus `.` (46), `_` (95), or `>= 192`. (The client always sends 32 lowercase hex chars, which trivially pass; the check guards a hand-rolled packet.)
+5. **Email character set** ([:2377-2380](../../../src/Modules/ServerNet.bb#L2377)) — validated **after** `Encrypt$(..., 1)` de-obfuscation, so the check runs on the plaintext email. Allowed: alnum, `@` (64), `*` (42), `+` (43), `-` (45), `.` (46), `=` (61), `_` (95), or `>= 192`.
+6. **Length caps** ([:2381](../../../src/Modules/ServerNet.bb#L2381)) — `Len(Username$) > 50 Or Len(Password$) > 50 Or Len(Email$) > 200` -> `Valid = False`.
+7. On `Valid = True`, [`AddAccount(Username$, Password$, Email$)`](../../../src/Modules/AccountsServer.bb#L193) creates the record (storing the password as a salted SHA-256 v1 hash via [`HashPassword$`](../../../src/Modules/PasswordHash.bb#L209)) and appends to `Accounts.dat`; reply `"Y"`. Otherwise reply `"N"`.
+
+### Gaps in the validation (verified against source)
+
+These are **not** defended and are documented here honestly rather than implied:
+
+- **No minimum-length / non-empty check.** A zero-length username passes step 3 (the `For i = 1 To Len(Username$)` loop never runs, so `Valid` stays `True`). The client enforces `Len(Name$) >= 2` ([MainMenu.bb:1195](../../../src/Modules/MainMenu.bb#L1195)) and `Len(Pass$) >= 2` ([:1196](../../../src/Modules/MainMenu.bb#L1196)), but a hand-rolled packet bypasses that — the server will create an empty-username / empty-password account.
+- **No `LoginAttemptOk` throttle.** Unlike [`P_VerifyAccount`](P_VerifyAccount.md), `P_StartGame`, `P_FetchCharacter`, `P_CreateCharacter`, and `P_DeleteCharacter` (all throttled by PR [#266](https://github.com/RydeTec/rcce2/pull/266) / [#268](https://github.com/RydeTec/rcce2/pull/268)), `P_CreateAccount` has no per-source rate limit. See Anti-cheat surface.
+
+## Anti-cheat / abuse surface
+
+`P_CreateAccount` runs before authentication; any connected peer can send it repeatedly.
+
+- **Account-creation flooding (undefended).** There is no throttle and no minimum-length check, so a peer can create accounts at line rate (subject only to the `AllowAccountCreation` config gate). Each accepted account is appended to `Accounts.dat` ([AccountsServer.bb:207-213](../../../src/Modules/AccountsServer.bb#L207)) and added to an in-memory list, so a flood grows the file and the `Account` list unboundedly. The practical mitigation today is operational: run with `AllowAccountCreation = False` and provision accounts out-of-band, or front the server with a network-level rate limiter. This is the most notable gap relative to the sibling auth handlers, which were all given the `LoginAttemptOk` throttle.
+- **Username squatting / enumeration via duplicate check.** The `"N"` reply collapses *both* "duplicate username" and "failed validation" into one code, so the reply does **not** by itself leak whether a username already exists vs. was malformed. (Contrast the historical `P_VerifyAccount` enumeration oracle, which *was* exploitable — see [`P_VerifyAccount`](P_VerifyAccount.md).) However, a probe with a known-valid character set still discriminates "taken" (`"N"`) from "created" (`"Y"`), which is an inherent property of any open-registration endpoint.
+- **Password is MD5-over-the-wire.** The wire carries `MD5$(plaintext)`; the at-rest copy is salted SHA-256 of that MD5 ([PasswordHash.bb storage notes](../../../src/Modules/PasswordHash.bb#L19)). A wire sniffer who captures the registration packet learns the MD5, which is replayable against this server forever — true of the entire account cluster. Closing that requires TLS or challenge/response; see the module header at [PasswordHash.bb:14-17](../../../src/Modules/PasswordHash.bb#L14).
+- **Misleading client message.** The client renders **any** non-`"Y"` reply as `LS_UsernameAlreadyExists` ([MainMenu.bb:1238](../../../src/Modules/MainMenu.bb#L1238)), so a registration rejected for an invalid character or an over-length field is shown to a legitimate user as "username already exists." This is a UX defect, not a security one.
+
+## Historical bugs / PR references
+
+| PR / commit | Relevance |
+|---|---|
+| PR [#118](https://github.com/RydeTec/rcce2/pull/118) (`88aaf393`) | Server-side password-hash migration. `AddAccount` now stores `HashPassword$(Pass$)` (salted SHA-256 v1) instead of the raw client MD5, so theft of `Accounts.dat` no longer yields working wire credentials. The wire format (client sends MD5) is unchanged. |
+| PR [#266](https://github.com/RydeTec/rcce2/pull/266) / [#268](https://github.com/RydeTec/rcce2/pull/268) | Introduced and extended the `LoginAttemptOk` throttle across the auth handlers — **but not** `P_CreateAccount`. The absence here is current behavior, not an oversight that was later patched. |
+
+No dedicated regression test exists for `P_CreateAccount` (contrast [`AccountEnumerationTest.bb`](../../../src/Tests/Modules/AccountEnumerationTest.bb) for `P_VerifyAccount`). The validation logic is exercised only end-to-end.
+
+## Related packets
+
+- [`P_VerifyAccount`](P_VerifyAccount.md) — the login counterpart; reuses the same `1B-len + name + 1B-len + MD5` username/password framing.
+- [`P_ChangePassword`](P_ChangePassword.md) — password rotation for an existing account; same framing plus a second password block.
+
+## See also
+
+- [`../encoding.md`](../encoding.md) — `RCE_StrFromInt$` / `RCE_IntFromStr`, 1-byte length-prefix convention.
+- [`../handler-conventions.md`](../handler-conventions.md) — bounds-then-deref, soft-fail, and pre-auth handler discipline.
+- [`AccountsServer.bb`'s `AddAccount`](../../../src/Modules/AccountsServer.bb#L193) — the record-creation + atomic-append path.
+- [`PasswordHash.bb`](../../../src/Modules/PasswordHash.bb) — salted SHA-256 v1 storage format and `HashPassword$`.

--- a/docs/protocol/packets/P_VerifyAccount.md
+++ b/docs/protocol/packets/P_VerifyAccount.md
@@ -1,0 +1,90 @@
+# P_VerifyAccount
+
+**Direction:** C -> S (login request), S -> C (result + character-list reply)
+**Numeric ID:** 2 ([Packets.bb:3](../../../src/Modules/Packets.bb#L3))
+**Client send site:** [MainMenu.bb:813](../../../src/Modules/MainMenu.bb#L813) (the "Log in" button handler; reply read at [MainMenu.bb:829-844](../../../src/Modules/MainMenu.bb#L829))
+**Server handler:** [ServerNet.bb:2398](../../../src/Modules/ServerNet.bb#L2398) (`Case P_VerifyAccount`) — the canonical bounds-check / auth-before-disclosure example.
+
+## Purpose
+
+The login packet. A peer submits a username and the MD5 of a typed password; the server verifies the password against the salted-SHA-256-at-rest record and, on success, replies with the account's character list. This is the gate that turns a connected-but-anonymous peer into an authenticated session.
+
+It is the most security-sensitive packet in the account cluster: it is pre-auth, attacker-controllable, and its reply historically leaked whether a username existed, whether it was banned, and whether it was already online. PR [#264](https://github.com/RydeTec/rcce2/pull/264) collapsed those oracles (see Historical bugs).
+
+A large MySQL variant of this handler is present but **commented out** ([ServerNet.bb:2403-2436](../../../src/Modules/ServerNet.bb#L2403)); only the in-memory `Account`-list path is live.
+
+## Field layout
+
+Request body, built at [MainMenu.bb:811-812](../../../src/Modules/MainMenu.bb#L811) (`MD5Pass$ = MD5$(Pass$)`):
+
+| # | Field | Width | Sender write (MainMenu.bb) | Receiver read (ServerNet.bb) |
+|---|---|---|---|---|
+| 1 | Username length | 1 byte | `RCE_StrFromInt$(Len(Name$), 1)` | `RCE_IntFromStr(Left$(M\MessageData$, 1))` -> `UsernameLen` [:2399](../../../src/Modules/ServerNet.bb#L2399) |
+| 2 | Username | `UsernameLen` bytes | `Name$` (concat) | `Mid$(M\MessageData$, 2, UsernameLen)` [:2400](../../../src/Modules/ServerNet.bb#L2400) |
+| 3 | Password (MD5 hex) length | 1 byte | `RCE_StrFromInt$(Len(MD5Pass$), 1)` | `RCE_IntFromStr(Mid$(M\MessageData$, Offset, 1))` where `Offset = 2 + UsernameLen` [:2461-2462](../../../src/Modules/ServerNet.bb#L2461) |
+| 4 | Password (MD5 hex) | `PwdLen` bytes | `MD5Pass$` (concat) | `Mid$(M\MessageData$, Offset + 1, PwdLen)` [:2476](../../../src/Modules/ServerNet.bb#L2476) / [:2488](../../../src/Modules/ServerNet.bb#L2488) |
+
+All length prefixes are 1 byte; sender and receiver widths match.
+
+### Reply
+
+| Reply byte(s) | Meaning | Server emit | Client mapping ([MainMenu.bb:835-843](../../../src/Modules/MainMenu.bb#L835)) |
+|---|---|---|---|
+| `"Y"` + char blocks | Success — password verified, not banned, not online | [ServerNet.bb:2526](../../../src/Modules/ServerNet.bb#L2526) | `Result = 1`, `CharList$ = Right$(...)` -> proceed to `P_FetchActors` |
+| `"P"` | Auth failure (any cause — see below) | [:2450](../../../src/Modules/ServerNet.bb#L2450) / [:2478](../../../src/Modules/ServerNet.bb#L2478) / [:2496](../../../src/Modules/ServerNet.bb#L2496) | `Result = -1` -> `LS_InvalidPassword` |
+| `"B"` | Banned (**only after** password verifies) | [:2505](../../../src/Modules/ServerNet.bb#L2505) | `Result = 0` -> `LS_YouAreBanned` |
+| `"L"` | Already logged in (**only after** password verifies) | [:2511](../../../src/Modules/ServerNet.bb#L2511) | `Result = -3` -> `LS_AccountAlreadyConnected` |
+| `"N"` | *legacy only* — not emitted by the post-collapse server | (none in current source) | folded into the same `Result = -1` branch as `"P"` for legacy-server compat ([MainMenu.bb:830-836](../../../src/Modules/MainMenu.bb#L830)) |
+
+The `"Y"` reply is followed by up to 10 character blocks ([:2518-2525](../../../src/Modules/ServerNet.bb#L2518)), each: `1B name-len + name + 2B ActorID + 1B Gender + 1B FaceTex + 1B Hair + 1B Beard + 1B BodyTex`.
+
+## Validation requirements (server-side)
+
+The handler implements an **auth-before-disclosure** state machine. Branch order:
+
+1. **Rate-limit gate** — `If Not LoginAttemptOk(M\FromID)` ([:2449](../../../src/Modules/ServerNet.bb#L2449)) -> reply `"P"` (same code as a normal failure, so the throttle is not itself an oracle). The throttle is per-source `FromID`: 5 failures in a 60s window ([AccountsServer.bb:64-89](../../../src/Modules/AccountsServer.bb#L64)). A success resets the counter via `LoginAttemptRecord(..., True)`.
+2. **Find account without disclosing the result** ([:2453-2459](../../../src/Modules/ServerNet.bb#L2453)) — case-insensitive (`Upper$`) scan into a local `FoundA`; no reply is emitted yet.
+3. **Truncated / empty-password guard** ([:2469](../../../src/Modules/ServerNet.bb#L2469)) — `If FoundA = Null Or PwdLen < 1`. Rejects the 1-byte packet whose empty password would otherwise match any account historically stored with an empty `Pass$`. **Crucially this path still calls `VerifyPassword%("", ...)`** ([:2476](../../../src/Modules/ServerNet.bb#L2476)) to pay the SHA-256 cost, so the no-account / truncated path is timing-indistinguishable from a wrong-password path. Records a failed attempt and replies `"P"`.
+4. **Empty stored hash -> fail** ([:2485-2486](../../../src/Modules/ServerNet.bb#L2485)) — an account whose `Pass$` is `""` can never authenticate.
+5. **Password verify** ([:2488](../../../src/Modules/ServerNet.bb#L2488)) — `VerifyPassword%(FoundA\Pass$, suppliedMD5)`. Accepts both legacy raw-MD5 and v1 `$1$<salt>$<sha256>` records; uses `ConstantTimeStrEq` (no first-differing-byte short-circuit). Wrong password -> record failure, reply `"P"` ([:2491-2496](../../../src/Modules/ServerNet.bb#L2491)).
+6. **Banned check** ([:2497](../../../src/Modules/ServerNet.bb#L2497)) — only reached after the password verifies, so `"B"` is disclosed only to the legitimate owner. Counted as a failed attempt for throttle bookkeeping ([:2504](../../../src/Modules/ServerNet.bb#L2504)).
+7. **Already-online check** ([:2506](../../../src/Modules/ServerNet.bb#L2506)) — `FoundA\LoggedOn <> -1` -> `"L"`, again only post-verify.
+8. **Success** ([:2512-2526](../../../src/Modules/ServerNet.bb#L2512)) — record success, **lazy-migrate** the on-disk hash to v1 via `UpgradePasswordIfLegacy$` ([:2516](../../../src/Modules/ServerNet.bb#L2516)), build and send the character list.
+
+The local-hoist of the verify result (`Local PwdOk%`, [:2484](../../../src/Modules/ServerNet.bb#L2484)) exists to dodge a BlitzForge parser rejection of `Or Not <call>` inside an `ElseIf` condition (PR `4f212035`).
+
+## Anti-cheat / abuse surface
+
+This packet is the front line for credential attacks.
+
+- **Credential stuffing / brute force — defended by the per-source throttle.** `LoginAttemptOk` caps a single `FromID` at 5 failures / 60s ([AccountsServer.bb:64-65](../../../src/Modules/AccountsServer.bb#L64)). Note the throttle keys on `M\FromID` (the ENet peer), so an attacker controlling many source connections is throttled per-connection, not globally — distributed stuffing is only partially mitigated.
+- **Username / ban / presence enumeration — defended (post PR #264).** Every failure mode collapses to `"P"`; `"B"` and `"L"` are emitted **only after** the password verifies. A pre-auth attacker therefore cannot use the reply code to learn whether a username is registered, banned, or online.
+- **Timing oracle — defended (post PR #267).** `VerifyPassword%` always runs a dummy SHA-256 on the no-account / malformed path ([PasswordHash.bb:277](../../../src/Modules/PasswordHash.bb#L277), with an explicit "do not remove" warning at [:275](../../../src/Modules/PasswordHash.bb#L274)), so wall-clock delta no longer discriminates "account doesn't exist" from "wrong password." Both compare paths use `ConstantTimeStrEq`.
+- **Wire replay — NOT defended.** The wire carries `MD5$(password)`; a sniffer who captures one login packet can replay it indefinitely. The salted-SHA-256-at-rest format protects `Accounts.dat` theft, not the wire. TLS / challenge-response is out of scope (see [PasswordHash.bb:14-17](../../../src/Modules/PasswordHash.bb#L14)).
+- **Truncated-packet matching — defended.** The `PwdLen < 1` guard ([:2469](../../../src/Modules/ServerNet.bb#L2469)) blocks the empty-password-matches-empty-stored-hash trick, and pays the hash cost anyway to stay timing-uniform.
+
+## Historical bugs / PR references
+
+| PR / commit | Fixed |
+|---|---|
+| PR [#75](https://github.com/RydeTec/rcce2/pull/75) (`4b27d204`) | Added the initial `LoginAttemptOk` rate-limit to throttle credential stuffing. |
+| PR [#118](https://github.com/RydeTec/rcce2/pull/118) (`88aaf393`) | Salted-SHA-256-at-rest migration + lazy upgrade on first successful login. |
+| PR [#264](https://github.com/RydeTec/rcce2/pull/264) (`31a88955`, `2cc350f1`) | Collapsed the username / ban / presence enumeration oracle: single `"P"` failure code; `"B"`/`"L"` gated behind password verification. Pinned by [`AccountEnumerationTest.bb`](../../../src/Tests/Modules/AccountEnumerationTest.bb). |
+| PR [#267](https://github.com/RydeTec/rcce2/pull/267) (`4572e854`, `d6dd78b0`) | Closed the timing oracle: constant-time compare + dummy SHA-256 on the no-account path. The `DummyOut$` assignment carries a reinforced "do not remove" warning. |
+| PR [#268](https://github.com/RydeTec/rcce2/pull/268) (`82410986`) | Extended the throttle to the four sibling auth handlers (`P_StartGame`, `P_FetchCharacter`, `P_CreateCharacter`, `P_DeleteCharacter`) so they can't be used to pump the dummy-hash CPU cost at line rate. (`P_ChangePassword` was **not** included — see [`P_ChangePassword`](P_ChangePassword.md).) |
+
+The post-collapse state machine is mirrored verbatim in [`AccountEnumerationTest.bb`](../../../src/Tests/Modules/AccountEnumerationTest.bb) (`VerifyAccountResponse$`): any production change must update both copies.
+
+## Related packets
+
+- [`P_CreateAccount`](P_CreateAccount.md) — registration; same username/password framing.
+- [`P_ChangePassword`](P_ChangePassword.md) — sibling auth handler with the same enumeration threat model (closed by PR [#265](https://github.com/RydeTec/rcce2/pull/265)).
+- `P_StartGame` ([ServerNet.bb:2100](../../../src/Modules/ServerNet.bb#L2100)) — re-verifies the same username/MD5 before entering a character into the world; shares the throttle.
+- [`P_FetchActors`](../index.md) — the client's next request after a `"Y"` reply, to download actor/item/attribute tables.
+
+## See also
+
+- [`../encoding.md`](../encoding.md) — `RCE_StrFromInt$` / `RCE_IntFromStr`, 1-byte length prefixes.
+- [`../handler-conventions.md`](../handler-conventions.md) — bounds-then-deref, auth-before-disclosure, soft-fail discipline.
+- [`PasswordHash.bb`](../../../src/Modules/PasswordHash.bb) — `VerifyPassword%`, `ConstantTimeStrEq`, `UpgradePasswordIfLegacy$`, dummy-hash timing-uniformity contract.
+- [`AccountsServer.bb`](../../../src/Modules/AccountsServer.bb#L64) — `LoginAttemptOk` / `LoginAttemptRecord` throttle.


### PR DESCRIPTION
## Summary

Adds hand-written per-packet detail pages for the **account / auth packet cluster** and wires them into the generated protocol index:

- `P_CreateAccount` (ID 1) — pre-auth registration
- `P_VerifyAccount` (ID 2) — login / auth-before-disclosure state machine
- `P_ChangePassword` (ID 6) — password rotation (handler live, no shipping client sender)

Each page follows the `packets/README.md` template: field layout (1-byte length prefixes, MD5-over-the-wire, Caesar-obfuscated email), server-side validation sequence, reply codes, and an honest anti-cheat surface. Notable documented gaps (verified against source, not implied):

- `P_CreateAccount` and `P_ChangePassword` lack the `LoginAttemptOk` throttle the four sibling auth handlers received in #268 — so both are line-rate dummy-hash CPU-amplification vectors.
- `P_ChangePassword` has a **latent new-password offset bug** (`Offset = 2 + PwdLen` drops the `UsernameLen + 1` term), masked today only because there is no live client sender. Documented as a fix-on-revival item rather than patched in this docs-only change.

`docs/protocol/index.md` was regenerated by `scripts/gen_packet_index.sh` so the Detail column links the three new pages (the only diff). Both CI generator-staleness checks (`gen_packet_index.sh --check`, `gen_bvm_reference.sh --check`) pass locally.

## Test plan

- [x] `scripts/gen_packet_index.sh --check` exits 0 (index not stale)
- [x] `scripts/gen_bvm_reference.sh --check` exits 0 (unaffected)
- [x] All source/PR/test references in the three pages resolve (`AccountEnumerationTest.bb`, `ChangePasswordEnumerationTest.bb` exist; handler line refs verified)
- [x] No source `.bb` files touched — docs-only, so engine compile is unaffected

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
