### PR TITLE
fix(server): guard stale AreaInstance on NPC tick + fix ActorEffect iterator-delete

### DIFF
--- a/src/Modules/Actors.bb
+++ b/src/Modules/Actors.bb
@@ -1565,7 +1565,17 @@ Function DestroyActorEffect( AE.ActorEffect )
 End Function
 
 Function RemoveActorEffectFromActor( AI.ActorInstance, EffectName$ )
-	For AE.ActorEffect = Each ActorEffect
+	; After-cursor walk (CLAUDE.md "Iterator-during-iteration hazards",
+	; pattern #1). The body Deletes the current AE. Blitz3D's For-Each
+	; advances the cursor via the deleted element's "next" pointer, so the
+	; original `For AE = Each ActorEffect / ... / Delete AE` shape leaves a
+	; dangling cursor. Capture `After AE` BEFORE the Delete and advance via
+	; the saved pointer. Mirrors the effect-expiry sweep in
+	; GameServer.bb::UpdateActorInstances.
+	Local AE.ActorEffect = First ActorEffect
+	Local AENext.ActorEffect = Null
+	While AE <> Null
+		AENext = After AE
 		If AE\Owner = AI
 			If Upper$(AE\Name$) = Upper$(EffectName$)
 				If AE\Owner\RNID > 0
@@ -1586,6 +1596,7 @@ Function RemoveActorEffectFromActor( AI.ActorInstance, EffectName$ )
 				Return True
 			EndIf
 		EndIf
-	Next
+		AE = AENext
+	Wend
 	Return False
 End Function

--- a/src/Modules/GameServer.bb
+++ b/src/Modules/GameServer.bb
@@ -837,6 +837,18 @@ Function UpdateActorInstances(Broadcast)
 			; Update AI
 			If AI\RNID = -1
 				AInstance.AreaInstance = Object.AreaInstance(AI\ServerArea)
+				; Stale-handle Null discipline (CLAUDE.md): AI\ServerArea is
+				; re-resolved here, but it can change mid-tick (a combat or
+				; water-damage warp earlier in this same iteration) or the
+				; zone can be freed by another actor processed earlier this
+				; tick. Either makes Object.AreaInstance return Null, and the
+				; AI block below derefs AInstance\Area\SpawnWaypoint[],
+				; WaypointX/Y/Z[], WaypointPause[], etc. for waypoint/patrol
+				; movement -- each an unguarded one-tick server crash. Skip
+				; the AI update this tick when the lookup is Null; the actor's
+				; intrinsic state (position, HP, mode) is preserved and the
+				; next tick re-resolves once SetArea settles.
+				If AInstance <> Null
 				; Wait mode
 				If AI\AIMode = AI_Wait
 					; Look for targets now and then
@@ -1040,6 +1052,7 @@ Function UpdateActorInstances(Broadcast)
 						EndIf
 					EndIf
 				EndIf
+				EndIf  ; closes the re-resolved AInstance <> Null guard (AI\RNID = -1)
 			EndIf
 			EndIf  ; closes the AInstance <> Null guard added above
 		EndIf


### PR DESCRIPTION
## Summary

Two server-stability hardening fixes following the documented CLAUDE.md patterns. Both are recoverable-failure paths in the authoritative server tick — a single crash disconnects every connected player.

## Fix A — Stale `AreaInstance` deref on NPC tick (`src/Modules/GameServer.bb`)

`UpdateActorInstances` gates the per-actor body on `AInstance <> Null` once (around `GameServer.bb:687`), but the `If AI\RNID = -1` AI branch **re-resolves** the lookup:

```
GameServer.bb:839   AInstance.AreaInstance = Object.AreaInstance(AI\ServerArea)
...
GameServer.bb:857   If AInstance\Area\SpawnWaypoint[i] = AI\CurrentWaypoint
```

and then derefs `AInstance\Area\SpawnWaypoint[]`, `WaypointX#/Y#/Z#[]`, `NextWaypointA/B[]`, `PrevWaypoint[]`, `WaypointPause[]` with **no re-check**.

**Crash scenario:** `AI\ServerArea` can change between the first resolve and this branch — a combat or water-damage warp earlier in the *same* iteration retargets the actor, or another actor processed earlier in the *same* tick triggers a zone unload that frees the area. `Object.AreaInstance(...)` then returns `Null` (stale handle → Null, never errors) and the first `AInstance\Area\...` deref is a one-tick `Memory access violation` that takes down the whole server.

**Pattern applied:** Handle-lookup Null discipline. Wrap the AI block in `If AInstance <> Null` immediately after the re-resolve; skip the per-tick AI update when Null. The actor's intrinsic state (position, HP, AI mode) is untouched, and the next tick re-resolves once `SetArea` settles. Mirrors the existing outer guard at `:687` and the `Object.AreaInstance` Null-skip pattern already used in the broadcast loop at `:1073`.

## Fix B — Iterator-delete in `RemoveActorEffectFromActor` (`src/Modules/Actors.bb`)

```
Actors.bb:1568   For AE.ActorEffect = Each ActorEffect
...
Actors.bb:1585       Delete AE
```

`Delete AE` inside a `For AE = Each ActorEffect` loop leaves the For-Each cursor dangling (Blitz3D advances the cursor through the deleted element's "next" pointer).

**Pattern applied:** After-cursor walk (CLAUDE.md pattern #1) — convert to a `While` loop, capture `AENext = After AE` **before** the Delete, advance via the saved pointer. This mirrors the effect-expiry sweep already shipped in `GameServer.bb::UpdateActorInstances` (`:635-667`).

**Honest scope note:** in the *current* code the matching branch `Return True`s immediately after the single `Delete AE`, so the dangling cursor is never actually dereferenced on the live path — the early return masks the hazard today. This change is therefore **convention-alignment + future-proofing** rather than a live-crash fix: it makes the function robust if the early `Return` is ever removed or multi-effect removal is added, and keeps the codebase consistent with the documented after-cursor pattern (the existing `IteratorAfterCursorTest.bb` pins this exact shape). Flagging this rather than overselling it.

## Tests

No new test added — deliberately. The existing `src/Tests/Modules/IteratorAfterCursorTest.bb` already pins the after-cursor walk pattern (single-delete, multi-delete, empty/single-item boundaries) against a mock Type pool, which is exactly the shape Fix B adopts. A `RemoveActorEffectFromActor`-specific test would require stubbing `ActorEffect`/`ActorInstance`/`RCE_Send`/`Host`/`P_ActorEffect` and duplicate the existing pattern test with no added coverage. Fix A is a per-tick path that needs live world/RakNet/AreaInstance deps the Strict test harness cannot `Include`, so it is not isolable into a meaningful unit test. Per the "do not add a weak/trivial test" guidance, coverage rests on the existing pattern test + clean compile.

## Verification

- `.\compile.bat -t` — clean, all five engine targets (Server, Project Manager, GUE, Loom, Client).
- `.\test.bat` — `Ran 50 files: 50 passed, 0 failed.`
- `git diff --stat` — only `src/Modules/Actors.bb` and `src/Modules/GameServer.bb`. **No generator-source file** (ServerNet/ClientNet/Packets/RC_Standard_Invoker/ScriptingCommands) touched, so no doc regeneration required.
