### PR TITLE
fix(bvm): gate BVM_SETSUPERGLOBAL + BVM_SETACTORGLOBAL behind privilege check

### DIFF
--- a/docs/bvm-reference.md
+++ b/docs/bvm-reference.md
@@ -91,7 +91,7 @@ none = void/Bool. Parameter sigils inside the argument list use the same.
 | `SETACTORDESTINATION` | `SETACTORDESTINATION(PARAM1%, PARAM2#, PARAM3#)` | SelfOrPrivileged |
 | `SETACTORFACE` | `SETACTORFACE(PARAM1%, PARAM2%)` | Privileged |
 | `SETACTORGENDER` | `SETACTORGENDER(PARAM1%, PARAM2%)` | Privileged |
-| `SETACTORGLOBAL` | `SETACTORGLOBAL(PARAM1%, PARAM2%, PARAM3$)` | None |
+| `SETACTORGLOBAL` | `SETACTORGLOBAL(PARAM1%, PARAM2%, PARAM3$)` | SelfOrPrivileged |
 | `SETACTORGROUP` | `SETACTORGROUP(PARAM1%, PARAM2%)` | Privileged |
 | `SETACTORGUILD` | `SETACTORGUILD(PARAM1%, PARAM2%)` | Privileged |
 | `SETACTORHAIR` | `SETACTORHAIR(PARAM1%, PARAM2%)` | Privileged |
@@ -321,7 +321,7 @@ none = void/Bool. Parameter sigils inside the argument list use the same.
 | `SETOWNER` | `SETOWNER(PARAM1%, PARAM2$, PARAM3%, PARAM4% = 0)` | Dead |
 | `SETREPUTATION` | `SETREPUTATION(PARAM1%, PARAM2%)` | Privileged |
 | `SETRESISTANCE` | `SETRESISTANCE(PARAM1%, PARAM2$, PARAM3%)` | Privileged |
-| `SETSUPERGLOBAL` | `SETSUPERGLOBAL(PARAM1%, PARAM2$)` | None |
+| `SETSUPERGLOBAL` | `SETSUPERGLOBAL(PARAM1%, PARAM2$)` | Privileged |
 | `SETTAG` | `SETTAG(PARAM1%, PARAM2$)` | Privileged |
 | `SETWAITINFO` | `SETWAITINFO(PARAM1%, PARAM2%)` | None |
 | `SETWAITING` | `SETWAITING(X%)` | None |

--- a/src/Modules/ScriptingCommands.bb
+++ b/src/Modules/ScriptingCommands.bb
@@ -2809,6 +2809,20 @@ Function BVM_OPENTRADING(Param1%, Param2%)
 End Function
 
 Function BVM_SETACTORGLOBAL(Param1%, Param2%, Param3$)
+	; Self-or-priv gate. ScriptGlobals$[] is per-actor script state
+	; (skill XP, quest/login flags, marriage state). Shipped non-priv
+	; scripts legitimately write their OWN actor's globals -- Login.rsl
+	; (Player = Actor() -> SI\AI), the BlackSmithing skill template, and
+	; the ProcessGlobals.rcm PushGlobal helper they call. The privileged
+	; marriage / Click_marriage scripts (on Privileged Scripts.dat) write
+	; a *second* actor (the spouse, `Found`) and pass via the priv branch.
+	; The gate blocks a non-priv clicker-driven NPC script (Examine /
+	; Trade / RightClick / ItemScript, where SI\AI = Handle(clicker))
+	; from injecting into a THIRD actor's globals. Full-priv would break
+	; the shipped self-targeting scripts, so RequireSelfOrPrivileged is
+	; the correct choice here (peer: BVM_SETSUPERGLOBAL is full-priv as
+	; it has no actor handle and is server-wide state).
+	If Not BVM_RequireSelfOrPrivileged(Param1%) Then Return
 	; ScriptGlobals$ is Field [9] (10 slots); without this bound a
 	; script could write past the actor record into adjacent fields.
 	If Param2% < 0 Or Param2% > 9 Then Return
@@ -3178,6 +3192,13 @@ Function BVM_GETWAITRESULT$()
 End Function
 
 Function BVM_SETSUPERGLOBAL(Param1%, Param2$)
+	; Full-priv gate. SuperGlobals$() is server-wide shared state with no
+	; actor handle -- there is no "self" to scope to, so any non-priv
+	; script writing it is poisoning global state every other script and
+	; player observes (peer: BVM_SETGOLD-style server-state mutators are
+	; full-priv). No shipped content script calls SetSuperGlobal (grep of
+	; data/ found zero callers), so the gate breaks nothing.
+	If Not BVM_RequirePrivileged() Then Return
 	; SuperGlobals$ is Dim'd (99) -> 100 slots, indices 0..99.
 	; Without this bound a script's bad index is a Blitz Dim OOB write
 	; (no runtime check) and corrupts adjacent globals or crashes.

--- a/src/Tests/Modules/BVMPrivilegeGateTest.bb
+++ b/src/Tests/Modules/BVMPrivilegeGateTest.bb
@@ -28,6 +28,8 @@ EnableGC
 ;   BVM_SETACTORFACE        (cosmetic griefing) RequirePrivileged
 ;   BVM_SETACTORCLOTHES     (cosmetic griefing) RequirePrivileged
 ;   BVM_REMOVEZONEINSTANCE  (admin-only)        RequirePrivileged
+;   BVM_SETACTORGLOBAL      (per-actor state)   RequireSelfOrPrivileged
+;   BVM_SETSUPERGLOBAL      (server-wide state) RequirePrivileged
 ;
 ; Four sibling functions (SETACTORAISTATE / SETACTORTARGET / SETNAME /
 ; SETTAG) intentionally stay UNGATED -- shipped content scripts in
@@ -107,6 +109,8 @@ Global MutationSetResistance = 0
 Global MutationSetActorAppearance = 0  ; shared counter for the 5 appearance setters
 Global MutationSetActorGroup = 0
 Global MutationRemoveZone = 0
+Global MutationSetActorGlobal = 0  ; self-or-priv gated
+Global MutationSetSuperGlobal = 0  ; full-priv gated
 
 Function MockBVM_CHANGEGOLD(Param1%, Param2%)
 	If Not BVM_RequirePrivileged() Then Return
@@ -201,6 +205,26 @@ Function MockBVM_SETACTORGROUP(Param1%, Param2%)
 	MutationSetActorGroup = MutationSetActorGroup + 1
 End Function
 
+; SetActorGlobal gate. ScriptGlobals$[] is per-actor script state.
+; Self-or-priv (NOT full-priv) because shipped non-priv scripts write
+; their OWN actor's globals: Login.rsl (Player = Actor() -> SI\AI),
+; the BlackSmithing skill template, and the ProcessGlobals PushGlobal
+; helper. The privileged marriage scripts target a *second* actor and
+; pass via the priv branch. The gate's job is to stop a non-priv
+; clicker script from injecting into a third actor's globals.
+Function MockBVM_SETACTORGLOBAL(Param1%, Param2%, Param3$)
+	If Not BVM_RequireSelfOrPrivileged(Param1%) Then Return
+	MutationSetActorGlobal = MutationSetActorGlobal + 1
+End Function
+
+; SetSuperGlobal gate. SuperGlobals$() is server-wide shared state with
+; no actor handle -> full-priv (no "self" to scope to). Zero shipped
+; content-script callers, so the gate breaks nothing.
+Function MockBVM_SETSUPERGLOBAL(Param1%, Param2$)
+	If Not BVM_RequirePrivileged() Then Return
+	MutationSetSuperGlobal = MutationSetSuperGlobal + 1
+End Function
+
 ; --- Test fixture helpers ----------------------------------------------
 Function ResetMutationCounters()
 	MutationGold = 0
@@ -219,6 +243,8 @@ Function ResetMutationCounters()
 	MutationSetActorAppearance = 0
 	MutationSetActorGroup = 0
 	MutationRemoveZone = 0
+	MutationSetActorGlobal = 0
+	MutationSetSuperGlobal = 0
 	LastScriptLog$ = ""
 End Function
 
@@ -702,4 +728,82 @@ Test testSetActorGroupGatePassesForPrivileged()
 	ResetMutationCounters()
 	MockBVM_SETACTORGROUP(999, 5)
 	Assert(MutationSetActorGroup = 1)
+End Test
+
+; ======================================================================
+; SetActorGlobal gate -- self-or-privileged. ScriptGlobals$[] is
+; per-actor script state; the gate must (a) refuse a non-priv script
+; writing an arbitrary third actor's globals, while (b) still allowing
+; a non-priv script to write its OWN actor/context globals (Login.rsl,
+; BlackSmithing skill template, ProcessGlobals helper all rely on this),
+; and (c) allowing any target for a privileged script (marriage writes
+; the spouse actor). RequireSelfOrPrivileged is the right gate; a full
+; priv gate would silently break the shipped self-targeting scripts.
+; ======================================================================
+
+Test testSetActorGlobalGateBlocksArbitraryTarget()
+	; Non-priv script, target is neither SI\AI nor SI\AIContext.
+	InstallScript(0, 100, 200)
+	ResetMutationCounters()
+	MockBVM_SETACTORGLOBAL(999, 8, "evil")
+	Assert(MutationSetActorGlobal = 0)
+	; Refusal must be audit-logged.
+	Assert(Len(LastScriptLog$) > 0)
+End Test
+
+Test testSetActorGlobalGateAllowsOwnAITarget()
+	; Login.rsl shape: Player = Actor() = SI\AI. Non-priv self-write
+	; must go through, or the shipped login/skill scripts break.
+	InstallScript(0, 777, 0)
+	ResetMutationCounters()
+	MockBVM_SETACTORGLOBAL(777, 8, "0,0,1,0,0,0,0,0,0,0")
+	Assert(MutationSetActorGlobal = 1)
+End Test
+
+Test testSetActorGlobalGateAllowsOwnContextTarget()
+	; A spawn shape where the writable actor is the context actor.
+	InstallScript(0, 100, 888)
+	ResetMutationCounters()
+	MockBVM_SETACTORGLOBAL(888, 1, "state")
+	Assert(MutationSetActorGlobal = 1)
+End Test
+
+Test testSetActorGlobalGatePassesForPrivileged()
+	; marriage.rsl is on Privileged Scripts.dat and writes the SPOUSE
+	; actor (Found), not its own. The priv branch must allow any target.
+	InstallScript(1, 0, 0)
+	ResetMutationCounters()
+	MockBVM_SETACTORGLOBAL(999, 1, "1|Spouse|spouseacct")
+	Assert(MutationSetActorGlobal = 1)
+End Test
+
+; ======================================================================
+; SetSuperGlobal gate -- full privileged. SuperGlobals$() is server-wide
+; shared state with no actor handle, so there is no "self" to scope to:
+; any non-priv write poisons global state for every script and player.
+; Zero shipped content-script callers, so full-priv breaks nothing.
+; ======================================================================
+
+Test testSetSuperGlobalGateBlocksNonPrivileged()
+	InstallScript(0, 0, 0)
+	ResetMutationCounters()
+	MockBVM_SETSUPERGLOBAL(5, "poison")
+	Assert(MutationSetSuperGlobal = 0)
+	Assert(Len(LastScriptLog$) > 0)
+End Test
+
+Test testSetSuperGlobalGateBlocksNonPrivilegedClickerShape()
+	; Even with SI\AI / SI\AIContext set (clicker-driven spawn), there's
+	; no actor handle on this BVM, so full-priv must still refuse.
+	InstallScript(0, 777, 200)
+	ResetMutationCounters()
+	MockBVM_SETSUPERGLOBAL(5, "poison")
+	Assert(MutationSetSuperGlobal = 0)
+End Test
+
+Test testSetSuperGlobalGatePassesForPrivileged()
+	InstallScript(1, 0, 0)
+	ResetMutationCounters()
+	MockBVM_SETSUPERGLOBAL(5, "value")
+	Assert(MutationSetSuperGlobal = 1)
 End Test


### PR DESCRIPTION
## Summary

Closes two privilege-gating holes in `src/Modules/ScriptingCommands.bb` where server-state mutators were callable by any non-privileged content script. A non-priv script runs with the clicker's actor handle for `Examine` / `Trade` / `RightClick` / `ItemScript` spawns (`ThreadScript(..., Handle(clicker), Handle(NPC))` → `SI\AI = Handle(clicker)`), so an unguarded mutator is reachable by any hostile NPC.

## Threat model

| BVM | What it writes | Pre-fix gate | Exploit |
|---|---|---|---|
| `BVM_SETSUPERGLOBAL` | `SuperGlobals$()` — server-wide shared array, no actor handle | **None** | Any NPC script poisons global state observed by every script/player |
| `BVM_SETACTORGLOBAL` | `ScriptGlobals$[]` on an arbitrary actor handle | **None** | A non-priv NPC script injects into another actor's per-actor script state (skill XP, quest/login flags, marriage state) |

## Gate decisions + reasoning

**`BVM_SETSUPERGLOBAL` → `BVM_RequirePrivileged()`**
`SuperGlobals$()` is server-wide shared state with **no actor handle** — there is no "self" to scope to, so any non-priv write is damage-to-everyone. Matches the full-priv shape of the other server-state mutators (`BVM_SETGOLD` family). **Zero shipped content-script callers**, so the gate breaks nothing.

**`BVM_SETACTORGLOBAL` → `BVM_RequireSelfOrPrivileged(Param1%)`**
`ScriptGlobals$[]` is per-actor script state. Shipped **non-privileged** scripts legitimately write their **own** actor's globals, so full-priv would silently break shipped content. Self-or-priv preserves those while blocking a non-priv clicker script from injecting into a **third** actor's globals; privileged scripts can still target any actor.

## Content-script grep findings (`data/`)

`grep -rni "SetActorGlobal|SetSuperGlobal" data/`:

- **`SetSuperGlobal`** — **0 callers**. Full-priv gate is clean.
- **`SetActorGlobal`** — callers:
  - `Login.rsl` (`Player = Actor()` → `SI\AI`) — **non-priv, self-target** → passes self-or-priv ✅
  - `BlackSmithing Skill Template.rsl` (`Player = Actor()`) — **non-priv, self-target** → passes ✅
  - `ProcessGlobals.rcm` `PushGlobal` helper (called with `Player` from the above) — **non-priv, self-target** → passes ✅
  - `marriage.rsl` / `Click_marriage.rsl` — on `Privileged Scripts.dat`, write the **spouse** actor (`Found`) — pass via the **priv** branch ✅

So no shipped script regresses, and the only blocked path is the previously-unguarded third-actor injection / server-wide poison.

## No opcode shift

Guards are added **inside the existing functions only** — no `BVM_*` added or removed. `RC_Standard_Invoker.bb` is untouched, so the alphabetical opcode numbering is unchanged (verified: file not in the diff).

## Tests

Extended `src/Tests/Modules/BVMPrivilegeGateTest.bb` with 7 cases following the file's replicated-gate pattern:

- `SETSUPERGLOBAL`: deny non-priv (+ audit log), deny non-priv even in clicker shape (`SI\AI`/`AIContext` set), allow priv.
- `SETACTORGLOBAL`: deny arbitrary target (+ audit log), allow own-AI target, allow own-context target, allow priv (any target).

## Verification

- `.\compile.bat -t` → **clean** (Server, Project Manager, GUE, Loom, Client all build).
- `.\test.bat BVMPrivilegeGateTest` → **`Ran 1 files: 1 passed, 0 failed.`** (60 assertions, 0 leaks).
- `scripts/gen_bvm_reference.sh` + `scripts/gen_packet_index.sh` regenerated; **`docs/bvm-reference.md` updated** (`SETACTORGLOBAL` None→SelfOrPrivileged, `SETSUPERGLOBAL` None→Privileged) and committed for the CI staleness gate. `docs/protocol/index.md` unchanged.

## Test plan

- [ ] CI green (compile + tests + generator-staleness gate).
