### PR TITLE
fix(net): harden ServerNet wire handlers — P_RightClick area gate, bounded RuntimeID lookup, inventory length guard

### DIFF
--- a/docs/protocol/index.md
+++ b/docs/protocol/index.md
@@ -37,24 +37,24 @@ pages is a per-iteration documentation task — see CONTRIBUTING.md.
 
 | ID | Packet | Direction | Server handler | Client handler | Detail |
 |---|---|---|---|---|---|
-| 1 | `P_CreateAccount` | C→S | [ServerNet.bb:2344](../../src/Modules/ServerNet.bb#L2344) | — | [P_CreateAccount](packets/P_CreateAccount.md) |
-| 2 | `P_VerifyAccount` | C→S | [ServerNet.bb:2398](../../src/Modules/ServerNet.bb#L2398) | — | [P_VerifyAccount](packets/P_VerifyAccount.md) |
-| 3 | `P_FetchCharacter` | C→S | [ServerNet.bb:2590](../../src/Modules/ServerNet.bb#L2590) | — | — |
-| 4 | `P_CreateCharacter` | C→S | [ServerNet.bb:2714](../../src/Modules/ServerNet.bb#L2714) | — | — |
-| 5 | `P_DeleteCharacter` | C→S | [ServerNet.bb:2951](../../src/Modules/ServerNet.bb#L2951) | — | — |
-| 6 | `P_ChangePassword` | C→S | [ServerNet.bb:2533](../../src/Modules/ServerNet.bb#L2533) | — | [P_ChangePassword](packets/P_ChangePassword.md) |
-| 7 | `P_FetchActors` | C→S | [ServerNet.bb:2236](../../src/Modules/ServerNet.bb#L2236) | — | — |
+| 1 | `P_CreateAccount` | C→S | [ServerNet.bb:2365](../../src/Modules/ServerNet.bb#L2365) | — | [P_CreateAccount](packets/P_CreateAccount.md) |
+| 2 | `P_VerifyAccount` | C→S | [ServerNet.bb:2419](../../src/Modules/ServerNet.bb#L2419) | — | [P_VerifyAccount](packets/P_VerifyAccount.md) |
+| 3 | `P_FetchCharacter` | C→S | [ServerNet.bb:2611](../../src/Modules/ServerNet.bb#L2611) | — | — |
+| 4 | `P_CreateCharacter` | C→S | [ServerNet.bb:2735](../../src/Modules/ServerNet.bb#L2735) | — | — |
+| 5 | `P_DeleteCharacter` | C→S | [ServerNet.bb:2972](../../src/Modules/ServerNet.bb#L2972) | — | — |
+| 6 | `P_ChangePassword` | C→S | [ServerNet.bb:2554](../../src/Modules/ServerNet.bb#L2554) | — | [P_ChangePassword](packets/P_ChangePassword.md) |
+| 7 | `P_FetchActors` | C→S | [ServerNet.bb:2257](../../src/Modules/ServerNet.bb#L2257) | — | — |
 | 8 | `P_FetchItems` | Unused | — | — | — |
 | 9 | `P_ChangeArea` | Both | [ServerNet.bb:734](../../src/Modules/ServerNet.bb#L734) | [ClientNet.bb:1637](../../src/Modules/ClientNet.bb#L1637) | — |
-| 10 | `P_FetchUpdateFiles` | C→S | [ServerNet.bb:2221](../../src/Modules/ServerNet.bb#L2221) | — | — |
+| 10 | `P_FetchUpdateFiles` | C→S | [ServerNet.bb:2242](../../src/Modules/ServerNet.bb#L2242) | — | — |
 | 11 | `P_NewActor` | S→C | — | [ClientNet.bb:1596](../../src/Modules/ClientNet.bb#L1596) | — |
-| 12 | `P_StartGame` | C→S | [ServerNet.bb:2100](../../src/Modules/ServerNet.bb#L2100) | — | — |
+| 12 | `P_StartGame` | C→S | [ServerNet.bb:2121](../../src/Modules/ServerNet.bb#L2121) | — | — |
 | 13 | `P_ActorGone` | S→C | — | [ClientNet.bb:1560](../../src/Modules/ClientNet.bb#L1560) | — |
-| 14 | `P_StandardUpdate` | Both | [ServerNet.bb:1796](../../src/Modules/ServerNet.bb#L1796) | [ClientNet.bb:1500](../../src/Modules/ClientNet.bb#L1500) | [P_StandardUpdate](packets/P_StandardUpdate.md) |
-| 15 | `P_InventoryUpdate` | Both | [ServerNet.bb:1608](../../src/Modules/ServerNet.bb#L1608) | [ClientNet.bb:1281](../../src/Modules/ClientNet.bb#L1281) | [P_InventoryUpdate](packets/P_InventoryUpdate.md) |
+| 14 | `P_StandardUpdate` | Both | [ServerNet.bb:1817](../../src/Modules/ServerNet.bb#L1817) | [ClientNet.bb:1500](../../src/Modules/ClientNet.bb#L1500) | [P_StandardUpdate](packets/P_StandardUpdate.md) |
+| 15 | `P_InventoryUpdate` | Both | [ServerNet.bb:1620](../../src/Modules/ServerNet.bb#L1620) | [ClientNet.bb:1281](../../src/Modules/ClientNet.bb#L1281) | [P_InventoryUpdate](packets/P_InventoryUpdate.md) |
 | 16 | `P_ChatMessage` | Both | [ServerNet.bb:186](../../src/Modules/ServerNet.bb#L186) | [ClientNet.bb:1223](../../src/Modules/ClientNet.bb#L1223) | [P_ChatMessage](packets/P_ChatMessage.md) |
 | 17 | `P_WeatherChange` | S→C | — | [ClientNet.bb:1276](../../src/Modules/ClientNet.bb#L1276) | — |
-| 18 | `P_AttackActor` | Both | [ServerNet.bb:1582](../../src/Modules/ServerNet.bb#L1582) | [ClientNet.bb:1119](../../src/Modules/ClientNet.bb#L1119) | [P_AttackActor](packets/P_AttackActor.md) |
+| 18 | `P_AttackActor` | Both | [ServerNet.bb:1594](../../src/Modules/ServerNet.bb#L1594) | [ClientNet.bb:1119](../../src/Modules/ClientNet.bb#L1119) | [P_AttackActor](packets/P_AttackActor.md) |
 | 19 | `P_ActorDead` | S→C | — | [ClientNet.bb:1075](../../src/Modules/ClientNet.bb#L1075) | — |
 | 20 | `P_RightClick` | C→S | [ServerNet.bb:1454](../../src/Modules/ServerNet.bb#L1454) | — | — |
 | 21 | `P_Dialog` | Both | [ServerNet.bb:1300](../../src/Modules/ServerNet.bb#L1300) | [ClientNet.bb:1031](../../src/Modules/ClientNet.bb#L1031) | — |
@@ -83,7 +83,7 @@ pages is a per-iteration documentation task — see CONTRIBUTING.md.
 | 44 | `P_EatItem` | C→S | [ServerNet.bb:1326](../../src/Modules/ServerNet.bb#L1326) | — | — |
 | 45 | `P_ItemHealth` | S→C | — | [ClientNet.bb:249](../../src/Modules/ClientNet.bb#L249) | — |
 | 46 | `P_Jump` | Both | [ServerNet.bb:1080](../../src/Modules/ServerNet.bb#L1080) | [ClientNet.bb:241](../../src/Modules/ClientNet.bb#L241) | — |
-| 47 | `P_Dismount` | C→S | [ServerNet.bb:1781](../../src/Modules/ServerNet.bb#L1781) | — | — |
+| 47 | `P_Dismount` | C→S | [ServerNet.bb:1802](../../src/Modules/ServerNet.bb#L1802) | — | — |
 | 48 | `P_FloatingNumber` | S→C | — | [ClientNet.bb:205](../../src/Modules/ClientNet.bb#L205) | — |
 | 49 | `P_RepositionActor` | Both | [ServerNet.bb:727](../../src/Modules/ServerNet.bb#L727) | [ClientNet.bb:180](../../src/Modules/ClientNet.bb#L180) | — |
 | 50 | `P_Speech` | S→C | — | [ClientNet.bb:733](../../src/Modules/ClientNet.bb#L733) | — |
@@ -91,8 +91,8 @@ pages is a per-iteration documentation task — see CONTRIBUTING.md.
 | 52 | `P_BubbleMessage` | S→C | — | [ClientNet.bb:1213](../../src/Modules/ClientNet.bb#L1213) | — |
 | 53 | `P_ScriptInput` | Both | [ServerNet.bb:1321](../../src/Modules/ServerNet.bb#L1321) | [ClientNet.bb:1024](../../src/Modules/ClientNet.bb#L1024) | — |
 | 60 | `P_KickedPlayer` | S→C | — | [ClientNet.bb:1784](../../src/Modules/ClientNet.bb#L1784) | — |
-| 61 | `P_Examine` | C→S | [ServerNet.bb:1517](../../src/Modules/ServerNet.bb#L1517) | — | — |
-| 62 | `P_Trade` | C→S | [ServerNet.bb:1558](../../src/Modules/ServerNet.bb#L1558) | — | — |
+| 61 | `P_Examine` | C→S | [ServerNet.bb:1529](../../src/Modules/ServerNet.bb#L1529) | — | — |
+| 62 | `P_Trade` | C→S | [ServerNet.bb:1570](../../src/Modules/ServerNet.bb#L1570) | — | — |
 
 ---
 

--- a/src/Modules/Actors.bb
+++ b/src/Modules/Actors.bb
@@ -279,6 +279,22 @@ Function FindActorInstanceFromRNID.ActorInstance(RNID)
 
 End Function
 
+; Bounded RuntimeIDList lookup for wire-supplied RuntimeIDs.
+;
+; RuntimeIDList is Dim(65535). A 2-byte wire field decodes to 0..65535
+; (RCEnet.bb:85 -- RCE_IntFromStr zero-fills the bank and only writes the
+; bytes present), so every current caller is already in range. This wraps
+; the index in the documented bounds-before-index convention (CLAUDE.md)
+; at the wire boundary so a FUTURE read-width change (or a non-2-byte
+; caller) cannot index the Dim out of bounds and crash the shared server
+; process. Returns Null for an out-of-range ID; callers already Null-check
+; the result (the active protection today), matching the ActorList guard
+; in P_CreateCharacter (ServerNet.bb ~2814).
+Function RuntimeActorFromWire.ActorInstance(RuntimeID)
+	If RuntimeID < 0 Or RuntimeID > 65535 Then Return Null
+	Return RuntimeIDList(RuntimeID)
+End Function
+
 ; Finds an actor instance based on their name
 Function FindActorInstanceFromName.ActorInstance(Name$)
 

--- a/src/Modules/ServerNet.bb
+++ b/src/Modules/ServerNet.bb
@@ -1162,7 +1162,7 @@ Function UpdateNetwork()
 							; bytes to be present.
 							If Len(M\MessageData$) >= 5
 								RuntimeID = RCE_IntFromStr(Mid$(M\MessageData$, 4, 2))
-								Context = RuntimeIDList(RuntimeID)
+								Context = RuntimeActorFromWire(RuntimeID)
 								; Reject targets that are dead or in a different
 								; area. Without this, the spell script fires
 								; against an actor whose FreeActorInstance is
@@ -1396,7 +1396,7 @@ Function UpdateNetwork()
 					SlotIndex = RCE_IntFromStr(Left$(M\MessageData$, 1))
 					Local ItemScriptGateOk% = True
 					If Len(M\MessageData$) = 3
-						A2.ActorInstance = RuntimeIDList(RCE_IntFromStr(Mid$(M\MessageData$, 2)))
+						A2.ActorInstance = RuntimeActorFromWire(RCE_IntFromStr(Mid$(M\MessageData$, 2)))
 						; Same-area + InteractDist gate when the item
 						; targets another actor. Mirrors P_RightClick
 						; (range) and P_AttackActor (area). Items used
@@ -1454,12 +1454,24 @@ Function UpdateNetwork()
 			Case P_RightClick
 				AI.ActorInstance = FindActorInstanceFromRNID(M\FromID)
 				If AI <> Null And Len(M\MessageData$) = 2
-					A2.ActorInstance = RuntimeIDList(RCE_IntFromStr(M\MessageData$))
+					A2.ActorInstance = RuntimeActorFromWire(RCE_IntFromStr(M\MessageData$))
 					If A2 <> Null
+						; Same-area gate. Mirrors P_Examine / P_Trade /
+						; P_AttackActor. P_RightClick previously checked only
+						; InteractDist, so a wire-injecting client could trigger
+						; any actor's RightClick script -- and the mount branch
+						; below -- on actors anywhere on the shard, not just ones
+						; co-located with the sender. The same-area predicate
+						; (AInstance <> Null And AInstance = TInstance) is folded
+						; into the range test so the script/mount only fires when
+						; the target shares the sender's AreaInstance; otherwise
+						; the packet is dropped.
+						AInstance.AreaInstance = Object.AreaInstance(AI\ServerArea)
+						TInstance.AreaInstance = Object.AreaInstance(A2\ServerArea)
 						XDist# = Abs(AI\X# - A2\X#)
 						ZDist# = Abs(AI\Z# - A2\Z#)
 						Dist# = (XDist# * XDist#) + (ZDist# * ZDist#)
-						If Dist# < InteractDist
+						If Dist# < InteractDist And AInstance <> Null And AInstance = TInstance
 							; Start right click script
 							If A2\Script$ <> ""
 								Running = False
@@ -1517,7 +1529,7 @@ Function UpdateNetwork()
 			Case P_Examine
 				AI.ActorInstance = FindActorInstanceFromRNID(M\FromID)
 				If AI <> Null And Len(M\MessageData$) = 2
-					A2.ActorInstance = RuntimeIDList(RCE_IntFromStr(M\MessageData$))
+					A2.ActorInstance = RuntimeActorFromWire(RCE_IntFromStr(M\MessageData$))
 					If A2 <> Null
 						; Same-area + InteractDist gate. Mirrors
 						; P_AttackActor (area) and P_RightClick (range).
@@ -1558,7 +1570,7 @@ Function UpdateNetwork()
 				Case P_Trade
 				AI.ActorInstance = FindActorInstanceFromRNID(M\FromID)
 				If AI <> Null And Len(M\MessageData$) = 2
-					A2.ActorInstance = RuntimeIDList(RCE_IntFromStr(M\MessageData$))
+					A2.ActorInstance = RuntimeActorFromWire(RCE_IntFromStr(M\MessageData$))
 					If A2 <> Null
 						; Same-area + InteractDist gate. Without it, a
 						; wire-injecting client could pin any remote
@@ -1584,7 +1596,7 @@ Function UpdateNetwork()
 				If AI <> Null And Len(M\MessageData$) = 2
 					; Check combat delay and whether actor is riding a mount, to prevent cheating
 					If MilliSecs() - AI\LastAttack >= CombatDelay And AI\Mount = Null
-						A2.ActorInstance = RuntimeIDList(RCE_IntFromStr(M\MessageData$))
+						A2.ActorInstance = RuntimeActorFromWire(RCE_IntFromStr(M\MessageData$))
 						If A2 <> Null
 							; Require attacker and target to be in the same
 							; AreaInstance. Without this, a target mid-portal
@@ -1751,10 +1763,19 @@ Function UpdateNetwork()
 						; Bound BEFORE the Amount comparison at line 1346.
 						If SlotA < 0 Or SlotA > Slots_Inventory Then SlotA = -1
 						If SlotB < 0 Or SlotB > Slots_Inventory Then SlotB = -1
-						AI.ActorInstance = RuntimeIDList(RuntimeID)
+						AI.ActorInstance = RuntimeActorFromWire(RuntimeID)
 						AIFrom.ActorInstance = FindActorInstanceFromRNID(M\FromID)
-						; Check that actor instance is valid (e.g. it isn't trying to change someone else's inventory)
-						If AI <> Null And AIFrom <> Null And SlotA >= 0 And SlotB >= 0
+						; Reject truncated "S"/"A" packets. The payload is
+						; opcode(1) + RuntimeID(2) + SlotA(1) + SlotB(1) +
+						; Amount(2) = 7 bytes; the four Mid$ reads above have no
+						; length guard, so on a short packet RCE_IntFromStr of an
+						; empty slice decodes to 0 -- aliasing RuntimeID/slots to
+						; 0. The reads are pure and bounded (no OOB), so gating
+						; the full payload length HERE, before any inventory
+						; mutation, drops the malformed packet with no effect.
+						; Also check actor validity (e.g. not changing someone
+						; else's inventory).
+						If Len(M\MessageData$) >= 7 And AI <> Null And AIFrom <> Null And SlotA >= 0 And SlotB >= 0
 							; Walk AIFrom's FirstSlave chain to check if the
 							; target actor (AI) is one of the sender's pets.
 							; Replaces a global ActorInstance walk filtered

--- a/src/Tests/Modules/ServerNetWireBoundsTest.bb
+++ b/src/Tests/Modules/ServerNetWireBoundsTest.bb
@@ -1,0 +1,146 @@
+Strict
+EnableGC
+
+; Regression test pinning the ServerNet.bb wire-handler hardening in:
+;
+;   1. RuntimeActorFromWire        (Actors.bb -- bounded RuntimeIDList lookup
+;      used by P_SpellUpdate "F", P_ItemScript, P_RightClick, P_Examine,
+;      P_Trade, P_AttackActor, and P_InventoryUpdate "S"/"A").
+;   2. P_InventoryUpdate "S"/"A"   (ServerNet.bb ~1741 -- payload length guard
+;      before the 7-byte swap/add Mid$ reads).
+;
+; Threat model:
+;   - RuntimeIDList is Dim(65535) (Actors.bb:93). Wire RuntimeIDs are read
+;     with RCE_IntFromStr, which zero-fills a 4-byte bank and writes only the
+;     bytes present, so a 2-byte field always decodes 0..65535 (RCEnet.bb:85)
+;     -- i.e. already within range. The bounds guard in RuntimeActorFromWire
+;     is therefore the documented bounds-before-index convention (CLAUDE.md)
+;     applied at the wire boundary: it is defense in depth against a future
+;     read-width change (or a non-2-byte caller) that would otherwise index
+;     the Dim out of bounds and crash the shared server process. The active
+;     protection for an in-range-but-empty slot is the caller's Null-check.
+;     This test pins the full `< 0 Or > 65535 Or slot = Null` contract.
+;   - P_InventoryUpdate "S"/"A" had no length guard before its four Mid$
+;     reads. The payload is opcode(1)+RuntimeID(2)+SlotA(1)+SlotB(1)+
+;     Amount(2) = 7 bytes; a short packet silently decoded RuntimeID/slots
+;     to 0. The fix gates the action on the full payload length.
+;
+; ServerNet.bb / Actors.bb pull the entire network/world graph and can't be
+; Included into a Strict offline test build, so the guard predicates are
+; replicated here following the established RCEnet/ClampFloat/
+; WireParameterHardening convention. A production behaviour change MUST
+; update both copies; the duplication is the trigger to refresh the test.
+
+; --- Replicated RuntimeActorFromWire guard --------------------------------
+
+Const RuntimeIDMax% = 65535
+
+; Mirrors RuntimeActorFromWire's range guard: True iff the ID is a valid
+; index into RuntimeIDList's Dim(65535). An out-of-range ID makes the
+; production helper return Null BEFORE indexing the array.
+Function RuntimeIDInRange%(RuntimeID%)
+	If RuntimeID < 0 Or RuntimeID > RuntimeIDMax Then Return False
+	Return True
+End Function
+
+; Mirrors RuntimeActorFromWire + the caller's Null-check together: the
+; resolved actor is usable iff the ID is in range AND the slot is occupied.
+; This is the full `< 0 Or > 65535 Or slot = Null` contract the handlers
+; rely on.
+Function WireActorUsable%(RuntimeID%, SlotOccupied%)
+	If RuntimeIDInRange%(RuntimeID) = False Then Return False
+	If SlotOccupied = False Then Return False
+	Return True
+End Function
+
+; --- Replicated "S"/"A" payload length guard ------------------------------
+
+Const SwapAddPayloadBytes% = 7
+
+Function SwapAddPacketLenOk%(PayloadLen%)
+	If PayloadLen < SwapAddPayloadBytes Then Return False
+	Return True
+End Function
+
+; ====================================================================
+; RuntimeActorFromWire -- rejection: out of range
+; ====================================================================
+
+Test testRuntimeIDAboveMaxRejected()
+	; 70000 > 65535: a future 4-byte read could produce this. The guard
+	; rejects it (returns Null before indexing the Dim).
+	Assert(RuntimeIDInRange%(70000) = False)
+	Assert(WireActorUsable%(70000, True) = False)
+End Test
+
+Test testRuntimeIDNegativeRejected()
+	; A 4-byte signed decode could be negative; the guard rejects it.
+	Assert(RuntimeIDInRange%(-1) = False)
+	Assert(RuntimeIDInRange%(-32768) = False)
+	Assert(WireActorUsable%(-1, True) = False)
+End Test
+
+Test testRuntimeIDJustAboveMaxRejected()
+	; Boundary: 65536 is the first invalid index of a Dim(65535).
+	Assert(RuntimeIDInRange%(RuntimeIDMax + 1) = False)
+End Test
+
+; ====================================================================
+; RuntimeActorFromWire -- rejection: in range but empty slot
+; ====================================================================
+
+Test testRuntimeIDEmptySlotRejected()
+	; In range, slot empty -> Null. This is the case the callers'
+	; existing `<> Null` check protects against.
+	Assert(WireActorUsable%(500, False) = False)
+	Assert(WireActorUsable%(0, False) = False)
+	Assert(WireActorUsable%(RuntimeIDMax, False) = False)
+End Test
+
+; ====================================================================
+; RuntimeActorFromWire -- acceptance: in range AND occupied slot
+; ====================================================================
+
+Test testRuntimeIDOccupiedSlotAccepted()
+	Assert(WireActorUsable%(42, True) = True)
+End Test
+
+Test testRuntimeIDBoundarySlotsAccepted()
+	; The inclusive endpoints 0 and 65535 are both valid Dim indices.
+	Assert(RuntimeIDInRange%(0) = True)
+	Assert(RuntimeIDInRange%(RuntimeIDMax) = True)
+	Assert(WireActorUsable%(0, True) = True)
+	Assert(WireActorUsable%(RuntimeIDMax, True) = True)
+End Test
+
+; ====================================================================
+; P_InventoryUpdate "S"/"A" length guard
+; ====================================================================
+
+Test testSwapAddFullPayloadAccepted()
+	; Exactly 7 bytes -- the minimum complete payload.
+	Assert(SwapAddPacketLenOk%(7) = True)
+End Test
+
+Test testSwapAddOversizedPayloadAccepted()
+	; Longer than 7 is still fine; the handler reads fixed offsets.
+	Assert(SwapAddPacketLenOk%(8) = True)
+	Assert(SwapAddPacketLenOk%(64) = True)
+End Test
+
+Test testSwapAddTruncatedPayloadsRejected()
+	; Every length short of the full 7-byte payload must be dropped --
+	; pre-fix these decoded RuntimeID/slots to 0 via empty-slice Mid$.
+	Assert(SwapAddPacketLenOk%(0) = False)
+	Assert(SwapAddPacketLenOk%(1) = False)   ; opcode only
+	Assert(SwapAddPacketLenOk%(2) = False)
+	Assert(SwapAddPacketLenOk%(3) = False)   ; opcode + full RuntimeID, no slots
+	Assert(SwapAddPacketLenOk%(6) = False)   ; one byte short of Amount
+End Test
+
+Test testSwapAddBoundaryAtSeven()
+	; Pin the boundary: the production check is `>= 7`, so 6 rejects and
+	; 7 accepts. A future refactor that widens a field must update both.
+	Assert(SwapAddPacketLenOk%(6) = False)
+	Assert(SwapAddPacketLenOk%(7) = True)
+End Test


### PR DESCRIPTION
## Summary
Hardens three ServerNet wire handlers against malformed client input, per the project's soft-fail / bounds-check conventions: P_RightClick area gate, bounded RuntimeID lookup, inventory length guard. Adds ServerNetWireBoundsTest.bb and regenerates docs/protocol/index.md.

## Test plan
- [x] compile.bat -t clean (all 5 engine targets)
- [x] test.bat green (51/51) incl. ServerNetWireBoundsTest
- [x] scripts/gen_packet_index.sh --check exits 0