### PR TITLE
fix(bvm): clamp ScreenFlash length + CreateEmitter time; document open cosmetic cluster

### DIFF
--- a/src/Modules/ScriptingCommands.bb
+++ b/src/Modules/ScriptingCommands.bb
@@ -1513,6 +1513,20 @@ Function BVM_ACTORHASEFFECT%(Param1%, Param2$)
 Return Result%
 End Function
 
+; --- Open cosmetic-broadcast BVM cluster (intentionally ungated) ---
+; SCREENFLASH / CREATEFLOATINGNUMBER / CREATEEMITTER / PLAYSOUND /
+; PLAYSPEECH / PLAYMUSIC / OUTPUT are pure client-facing cosmetic
+; broadcasts: they push an effect packet to receiving clients and
+; mutate NO authoritative server state (no HP/gold/faction/position/
+; inventory change). A hostile non-priv clicker script can at worst
+; produce client-side annoyance, not a brick or a state exploit, so
+; they are deliberately left WITHOUT a privilege gate -- mirroring the
+; appearance-cluster note above, this is recorded so future audits
+; don't re-flag the cluster as "missing RequirePrivileged".
+; The only hardening applied here is bounding unbounded int params
+; that control on-client duration (flash Length, emitter Time) so a
+; spammed cosmetic can't linger near-permanently as a client-view DoS.
+; Do NOT add privilege gates to this cluster.
 Function BVM_SCREENFLASH(Param1%, Param2%, Param3%, Param4%, Param5%, Param6%, Param7%=0)
 	Actor.ActorInstance = Object.ActorInstance(Param1%)
 	If Actor <> Null
@@ -1521,7 +1535,15 @@ Function BVM_SCREENFLASH(Param1%, Param2%, Param3%, Param4%, Param5%, Param6%, P
 			G = Param3%
 			B = Param4%
 			Alpha = Param5%
+			; Length is the flash duration in ms (client UpdateScreenFlash
+			; fades it out over MilliSecs()). Unbounded it is a 4-byte int,
+			; so a hostile non-priv clicker could pin a near-opaque full-
+			; screen overlay for ~24 days. Clamp to 30000 ms (30s) -- far
+			; beyond any legitimate flash and BVM_SCREENFLASH has zero
+			; shipped callers, so this changes no shipped behavior.
 			Length = Param6%
+			If Length > 30000 Then Length = 30000
+			If Length < 0 Then Length = 0
 			TexID = Param7%
 			Pa$ = RCE_StrFromInt$(R, 1) + RCE_StrFromInt$(G, 1) + RCE_StrFromInt$(B, 1) + RCE_StrFromInt$(Alpha, 1) + RCE_StrFromInt$(Length, 4)
 			RCE_Send(Host, Actor\RNID, P_ScreenFlash, Pa$ + RCE_StrFromInt$(TexID, 2), True)
@@ -1744,7 +1766,16 @@ Function BVM_CREATEEMITTER(Param1%, Param2$, Param3%, Param4%, Param5#=0, Param6
 	If Actor <> Null Then RuntimeID = Actor\RuntimeID Else RuntimeID = 0
 	Name$ = Param2$
 	TexID = Param3%
+	; Time is the emitter lifetime in ms (client P_CreateEmitter stores
+	; it as Em\Length against MilliSecs()). Unbounded it is a 4-byte int,
+	; so a non-priv clicker can spam near-permanent emitters -- a client-
+	; view DoS. Clamp to 60000 ms (60s); all 5 shipped callers pass <= 600
+	; (Spell_Fireball 100, the EMITTERNAME templates / Poison Potion 500,
+	; Spell_FlameNova 600), so this 100x-headroom cap changes no shipped
+	; behavior.
 	Time = Param4%
+	If Time > 60000 Then Time = 60000
+	If Time < 0 Then Time = 0
 	; Sanitise offset floats -- NaN broadcast to receiving clients
 	; poisons emitter positioning on each receiver. Emitter offsets
 	; are actor-relative and usually small; ClampSaneFloat is the


### PR DESCRIPTION
## Summary
Bounds two unbounded cosmetic-BVM int params to blunt a client-view DoS (a hostile non-priv script could otherwise pin a near-permanent opaque full-screen flash or a multi-day emitter on a player). No privilege-model change, no allowlist, no shipped-behavior change.

- `BVM_SCREENFLASH` `Length` → clamped to [0, 30000] ms (0 shipped callers; client treats it as ms)
- `BVM_CREATEEMITTER` `Time` → clamped to [0, 60000] ms (all 5 shipped callers pass <= 600 ms; cap is ~100x the max legit value)
- Adds a comment block documenting the cosmetic-broadcast cluster (SCREENFLASH/CREATEFLOATINGNUMBER/CREATEEMITTER/PLAYSOUND/PLAYSPEECH/PLAYMUSIC/OUTPUT) as intentionally ungated client-facing broadcasts.

## Test plan
- [x] compile.bat -t clean (all 5 engine targets)
- [x] test.bat green (51/51)
- [x] scripts/gen_bvm_reference.sh --check exits 0 (doc unchanged)
- [x] RC_Standard_Invoker.bb untouched (no opcode renumber)