### PR TITLE
fix(b3dfile): cap chunk-stack depth + reject negative chunk size on malformed .b3d

### DIFF
--- a/src/Modules/b3dfile.bb
+++ b/src/Modules/b3dfile.bb
@@ -44,10 +44,21 @@ Function b3dReadString$()
 End Function
 
 Function b3dReadChunk$()
+	; Soft-fail guard for malformed / hostile .b3d input. b3d_stack is
+	; Dim'd (100) -> valid indices 0..100, so b3d_tos must never exceed
+	; 100. A file nested deeper than the stack capacity would otherwise
+	; OOB-write b3d_stack on the push below. Return an empty tag (which
+	; no chunk reader matches) without pushing, rather than corrupt memory.
+	If b3d_tos+1 > 100 Then Return ""
 	For k=1 To 4
 		tag$=tag$+Chr$(b3dReadByte())
 	Next
 	sz=ReadInt( b3d_file )
+	; Reject a negative chunk size read from the file: b3d_stack(tos) is
+	; FilePos+sz and is later consumed by b3dChunkSize()/b3dExitChunk() as
+	; a seek target. A negative sz seeks backwards (infinite re-read); soft-
+	; fail the same way (empty tag, no push) instead of mis-seeking.
+	If sz<0 Then Return ""
 	b3d_tos=b3d_tos+1
 	b3d_stack(b3d_tos)=FilePos( b3d_file )+sz
 	Return tag$


### PR DESCRIPTION
## What

Two additive soft-fail guards in `b3dReadChunk$` (`src/Modules/b3dfile.bb`) hardening the `.b3d` mesh chunk reader against malformed/hostile input:

1. **Chunk-stack depth cap** — `If b3d_tos+1 > 100 Then Return ""` before the `b3d_tos` push. `b3d_stack` is `Dim b3d_stack(100)` (valid `0..100`); a file nested deeper than the stack capacity would otherwise OOB-write `b3d_stack`.
2. **Negative chunk-size reject** — `If sz < 0 Then Return ""` before `sz` is stored as a seek target (`FilePos + sz`), preventing a backward/infinite mis-seek.

Both fail by returning an empty tag (matches no chunk reader) **without** advancing `b3d_tos`, so neither path can OOB-write or corrupt parser state. Valid `.b3d` files are unaffected.

## Why

Untrusted-input parse-path hardening per the project's soft-fail / bounds-check doctrine (CLAUDE.md). `b3dfile.bb` is Tools-shared (RC Terrain / RC Tree editors).

## Verification

- Independent verifier (not the implementer): **PASS** — diff minimal/additive, boundary math exact (allows slot 100, rejects 101; `sz = 0` allowed, `sz < 0` rejected), no new OOB/underflow.
- FULL `compile.bat` clean (exit 0); both `RC Terrain Editor` and `RC Tree Editor` build.
- A pre-existing `b3dExitChunk` underflow is out of scope (tracked separately); the read-side helpers have no in-repo callers today, so this is risk-free defensive hardening.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
