### PR TITLE
fix(mysql): bounds-check ItemList index + clamp KnownSpells in dormant MySQL actor load (static-only)

### DIFF
--- a/src/Modules/MySQL.bb
+++ b/src/Modules/MySQL.bb
@@ -746,7 +746,20 @@ Function My_LoadActorInstance.ActorInstance(ActID, Q.Questlog, C.ActionBarData, 
 			If ID <> 65535 Then
 				
 				; This code for debugging
-				If ItemList(ID) = Null
+				; ItemList is Dim'd (65534) -> valid 0..65534. ID comes
+				; straight from the DB (ReadSQLField, a raw 32-bit value),
+				; so a corrupt/tampered rc_items.iid outside that range
+				; would OOB-index ItemList on the shared server process.
+				; BlitzForge's Or is non-short-circuit, so the range test
+				; is kept in its OWN branch ahead of the ItemList(ID) deref
+				; (an inline `... Or ItemList(ID) = Null` would still wild-
+				; read the array). Soft-fail to the same "item removed"
+				; recovery the flat-file path (ReadItemInstance) and the
+				; existing Null branch use: drop the item, keep loading.
+				If ID < 0 Or ID > 65534
+					WriteLog(MainLog, "Item Removal: Item with out-of-range ID " + ID + " dropped during actor load!")
+					A\Inventory\Items[i] = Null
+				ElseIf ItemList(ID) = Null
 					WriteLog(MainLog, "Item Removal: Item with ID " + ID + " has been removed from actor as it is no longer existant!")
 					A\Inventory\Items[i] = Null
 				Else
@@ -849,6 +862,17 @@ Function My_LoadActorInstance.ActorInstance(ActID, Q.Questlog, C.ActionBarData, 
 		If i = 0 Then A\Spell_ID	= ReadSQLField(SpellRow, "id")
 		A\KnownSpells[i]			= ReadSQLField(SpellRow, "known")
 		A\SpellLevels[i]			= ReadSQLField(SpellRow, "level")
+		; KnownSpells[i] is a spell ID used directly as a SpellsList(...)
+		; index (Dim'd (65534), valid 0..65534). ReadSQLField is an
+		; unbounded DB value, so a corrupt rc_spells.known would OOB the
+		; SpellsList read on the SHARED server process (character-list
+		; send, etc.). Zero both the id and its paired level so the slot
+		; is inert everywhere the `SpellLevels[i] > 0` gate is checked,
+		; mirroring the flat-file ReadActorInstance clamp in Actors.bb.
+		If A\KnownSpells[i] < 0 Or A\KnownSpells[i] > 65534
+			A\KnownSpells[i] = 0
+			A\SpellLevels[i] = 0
+		EndIf
 		
 		; Clean up
 		FreeSQLRow(SpellRow)


### PR DESCRIPTION
## What

Brings the **MySQL** actor loader (`My_LoadActorInstance`, `src/Modules/MySQL.bb`) to parity with the hardened flat-file loader (`ReadActorInstance`, `Actors.bb`):

1. **Item-ID range guard** — restructured to `If ID < 0 Or ID > 65534 ... ElseIf ItemList(ID) = Null ... Else ...` so the range test sits in its own branch *ahead* of any `ItemList(ID)` deref. Required because BlitzForge `Or` is **non-short-circuit** — an inline `... Or ItemList(ID)=Null` would still wild-index `ItemList` at an arbitrary DB-supplied offset. (`ItemList` is `Dim(65534)`.)
2. **`KnownSpells` / `SpellLevels` clamp** — out-of-range spell ids from a DB row are zeroed, identical to the flat-file analog at `Actors.bb:535-538` (`SpellsList` is `Dim(65534)`).

Both soft-fail (WriteLog + skip/clamp), purely additive; valid data is unchanged.

## ⚠️ Verification status: STATIC-ONLY (dormant, non-compiling module)

Be explicit: **`MySQL.bb` is not built by anything.** `src/Server.bb` has `//Include "Modules\MySQL.bb"` commented out and no other target includes it, so neither local `compile.bat` nor CI parses this file. A temporary-include experiment further showed the module **cannot compile in this tree at all** — it fails at `mysql.bb:60` (`Type BBThread` collides with the `SQLDLL.dll` userlib in `src/userlibs/BBThread.decls`), which is the real reason it's disabled.

Consequences:
- This change has **zero impact on any shipping binary** — it hardens dormant code for a hypothetical future MySQL revival (which would also need the `BBThread` collision fixed first).
- It is verified by **independent static review only** (byte-for-byte parity with the compiled `Actors.bb` analog, bounds matched to the actual `Dim`s, syntax matched to 7 existing in-file `ElseIf` blocks). No compiler has parsed the edited function.

Merging is safe precisely because the code is inert; it is intentionally **not** claimed as compiler-verified.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
