### PR TITLE
fix(inventory): equip exclusivity gate used slot-name constant where slot index belongs

### DIFF
--- a/src/Modules/Inventories.bb
+++ b/src/Modules/Inventories.bb
@@ -226,7 +226,7 @@ End Function
 Function ActorHasSlot(A.Actor, SlotI, I.Item)
 
 	; If it's an equipped slot
-	If SlotI < Slot_Backpack
+	If SlotI < SlotI_Backpack
 		If I\ExclusiveRace$ <> ""
 			; Allow even disabled equipment slots to be used if the item is exclusive to this race
 			If Upper$(I\ExclusiveRace$) = Upper$(A\Race$)

--- a/src/Tests/Modules/InventoryEquipRulesTest.bb
+++ b/src/Tests/Modules/InventoryEquipRulesTest.bb
@@ -12,10 +12,12 @@ EnableGC
 ; computes today, including the surprising forks. Anything that looks like
 ; a latent bug is pinned as-is and marked with a `; FLAG-FOR-HUMAN:`
 ; comment at the assertion. Current flags:
-;   1. ActorHasSlot's exclusivity fork gates on `SlotI < Slot_Backpack`
-;      (the 1-based slot NAME constant, 11) instead of SlotI_Backpack (the
-;      slot INDEX, 14), so indices 11-13 (Ring4, Amulet1, Amulet2) skip
-;      the ExclusiveRace$/ExclusiveClass$ checks entirely.
+;   1. FIXED: ActorHasSlot's exclusivity fork used to gate on
+;      `SlotI < Slot_Backpack` (the 1-based slot NAME constant, 11) instead
+;      of SlotI_Backpack (the slot INDEX, 14), letting indices 11-13 (Ring4,
+;      Amulet1, Amulet2) skip the ExclusiveRace$/ExclusiveClass$ checks.
+;      The gate now uses SlotI_Backpack; the assertions below pin the
+;      corrected denials.
 ;   2. A matching ExclusiveRace$ returns True immediately, skipping both
 ;      the ExclusiveClass$ check and the disabled-slot flag check.
 ;
@@ -225,7 +227,7 @@ Test testActorHasSlotRaceMatchOverridesDisabledSlot()
 	Assert(ActorHasSlot(A\Actor, SlotI_Ring3, elfBlade) = True)
 
 	; The override only applies to the exclusivity-checked index range
-	; (SlotI < Slot_Backpack = 11). A backpack index still falls through to
+	; (SlotI < SlotI_Backpack = 14). A backpack index still falls through to
 	; the (disabled) backpack flag.
 	Assert(ActorHasSlot(A\Actor, SlotI_Backpack, elfBlade) = False)
 
@@ -245,15 +247,13 @@ Test testActorHasSlotWrongRaceDenied()
 	Assert(ActorHasSlot(A\Actor, SlotI_Ring1, orcAxe) = False)
 	Assert(ActorHasSlot(A\Actor, SlotI_Ring3, orcAxe) = False)
 
-	; FLAG-FOR-HUMAN: the exclusivity fork gates on `SlotI < Slot_Backpack`
-	; -- Slot_Backpack is the 1-based slot NAME constant (11), not the slot
-	; INDEX SlotI_Backpack (14). Slot indices 11..13 (Ring4, Amulet1,
-	; Amulet2) therefore SKIP the race/class exclusivity check entirely: a
-	; wrong-race ring is denied in Ring1-3 but ALLOWED in Ring4, and a
-	; wrong-race amulet is allowed in both amulet slots (flag permitting).
-	Assert(ActorHasSlot(A\Actor, SlotI_Ring4, orcAxe) = True)
-	Assert(ActorHasSlot(A\Actor, SlotI_Amulet1, orcAxe) = True)
-	Assert(ActorHasSlot(A\Actor, SlotI_Amulet2, orcAxe) = True)
+	; Fixed: the exclusivity fork now gates on `SlotI < SlotI_Backpack` (the
+	; slot INDEX, 14) instead of Slot_Backpack (the 1-based NAME constant,
+	; 11), so indices 11..13 (Ring4, Amulet1, Amulet2) run the race check
+	; like every other equip index: wrong race is denied everywhere.
+	Assert(ActorHasSlot(A\Actor, SlotI_Ring4, orcAxe) = False)
+	Assert(ActorHasSlot(A\Actor, SlotI_Amulet1, orcAxe) = False)
+	Assert(ActorHasSlot(A\Actor, SlotI_Amulet2, orcAxe) = False)
 
 	; Backpack indices never run the exclusivity check either -- a
 	; wrong-race item can always sit in the backpack (flag permitting).
@@ -274,9 +274,9 @@ Test testActorHasSlotClassExclusivity()
 	; Wrong class: denied on exclusivity-checked indices despite enabled flags.
 	Local W.ActorInstance = MakeActor(MaskAll, "", "Warrior")
 	Assert(ActorHasSlot(W\Actor, SlotI_Weapon, staff) = False)
-	; FLAG-FOR-HUMAN: same index-vs-name confusion as the race fork --
-	; Ring4/Amulet1/Amulet2 (indices 11..13) skip the class check too.
-	Assert(ActorHasSlot(W\Actor, SlotI_Ring4, staff) = True)
+	; Fixed: the gate now uses SlotI_Backpack (14), so Ring4 (index 11)
+	; runs the class check like every other equip index.
+	Assert(ActorHasSlot(W\Actor, SlotI_Ring4, staff) = False)
 
 	; Matching class (case-insensitive) falls through to the flag check --
 	; unlike the race match, it does NOT override a disabled slot.


### PR DESCRIPTION
## The bug (player-reachable, runtime-confirmed, found by PR #571's pins)

`src/Modules/Inventories.bb:229` gated the race/class exclusivity fork in `ActorHasSlot` on `SlotI < Slot_Backpack` — but `Slot_Backpack` (= 11) is the 1-based slot **name** constant while `SlotI` is a slot **index** (equip indices run 0..13; `SlotI_Backpack` = 14). Net effect: equip indices 11–13 (**Ring4, Amulet1, Amulet2**) skipped `ExclusiveRace$`/`ExclusiveClass$` entirely — a wrong-race ring or amulet equipped fine there. The adjacent comment ("If it's an equipped slot") shows the intent was all 14 equip indices.

## The fix

One line: `SlotI < Slot_Backpack` → `SlotI < SlotI_Backpack`. Indices 0–10 and 14+ behave identically before and after; only 11–13 now enter the exclusivity fork as intended.

Plus the **deliberate flips of exactly 4 pinned assertions** in `InventoryEquipRulesTest.bb` (the PR #571 pins that documented the bug): wrong-race denial at Ring4/Amulet1/Amulet2 and class-exclusivity denial at Ring4 — each now asserts the correct denial.

**Deliberately untouched:** the race-match-short-circuits-class behavior at ~:240 (an item matching `ExclusiveRace$` skips the `ExclusiveClass$` check). That is a separate OR-vs-AND semantics question awaiting a maintainer decision; its pin remains FLAG-FOR-HUMAN.

## Blast radius (independent verifier's sweep)

- All 8 `ActorHasSlot` call sites audited: 7 pass true slot indices (InventorySwap, server pickup/claim, client auto-equip, drag-drop); client and server both Include Inventories.bb so the tightening lands on both sides simultaneously — no desync.
- Shipped `data/` corroboration (Items.dat parsed, not grepped): **0 items use ExclusiveRace/ExclusiveClass, 0 with slot_type ≥ 11** — no shipped content relied on the bypass.
- Migration: save/load never calls `ActorHasSlot`, so an already-equipped now-illegal item stays put on load; it just can't be re-equipped once removed.
- Pre-existing, out-of-scope observation for a follow-up: `BVM_GIVEITEM` (`ScriptingCommands.bb:2908`) passes `It\SlotType` (a slot-NAME constant, 0–11) where `ActorHasSlot` expects a slot index — same name-vs-index family, harmless for all shipped data.

## Verification (independent verifier ≠ implementer)

- Diff = 1 engine line + the 4 test flips (`-U0` confirmed); no generator-gated files.
- `.\test.bat InventoryEquipRules` → `[PASS]` (denials visibly executing); full suite `Ran 55 files: 55 passed, 0 failed.`; FULL `compile.bat` (engine + all tools) exit 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)