### PR TITLE
fix(combat): armour durability wear targeted the attacker instead of the defender

### DIFF
--- a/src/Modules/GameServer.bb
+++ b/src/Modules/GameServer.bb
@@ -548,16 +548,20 @@ Function ActorAttack(A1.ActorInstance, A2.ActorInstance)
 		EndIf
 	EndIf
 
-	; Damage armour
+	; Damage armour. The DEFENDER's (A2's) equipped armour absorbed the
+	; blow (the damage formulas read GetArmourLevel(A2\Inventory)), so it
+	; is A2's armour that wears -- this block was historically a
+	; copy-paste of the weapon-wear block above, which left the wear
+	; target as A1 (the attacker).
 	If ArmourDamage = True
 		For i = SlotI_Shield To SlotI_Feet
-			If A1\Inventory\Items[i] <> Null
-				If A1\Inventory\Items[i]\ItemHealth > 0
+			If A2\Inventory\Items[i] <> Null
+				If A2\Inventory\Items[i]\ItemHealth > 0
 					If Rand(1, 5) = 1
-						A1\Inventory\Items[i]\ItemHealth = A1\Inventory\Items[i]\ItemHealth - 1
-						If A1\RNID > 0
-							Pa$ = RCE_StrFromInt$(i, 1) + RCE_StrFromInt$(A1\Inventory\Items[i]\ItemHealth, 2)
-							RCE_Send(Host, A1\RNID, P_ItemHealth, Pa$, True)
+						A2\Inventory\Items[i]\ItemHealth = A2\Inventory\Items[i]\ItemHealth - 1
+						If A2\RNID > 0
+							Pa$ = RCE_StrFromInt$(i, 1) + RCE_StrFromInt$(A2\Inventory\Items[i]\ItemHealth, 2)
+							RCE_Send(Host, A2\RNID, P_ItemHealth, Pa$, True)
 						EndIf
 					EndIf
 				EndIf

--- a/src/Tests/Modules/CombatDamageFormulaTest.bb
+++ b/src/Tests/Modules/CombatDamageFormulaTest.bb
@@ -829,13 +829,17 @@ End Test
 ; ActorAttack -- equipment wear
 ; ============================================================================
 
-; FLAG-FOR-HUMAN: the "Damage armour" block in ActorAttack wears down the
-; ATTACKER's (A1's) equipped armour, not the defender's (A2's), even
-; though A2's armour is what absorbed the blow. Pinned as shipped: after
-; 300 swings with ArmourDamage on, the defender's chest piece is still at
-; exactly 100 health while the attacker's has lost some (1-in-5 chance
-; per swing; P(zero losses in 300) ~ 1e-29).
-Test testArmourWearHitsAttackerNotDefender()
+; The "Damage armour" block in ActorAttack wears down the DEFENDER's
+; (A2's) equipped armour -- the armour that absorbed the blow. This test
+; originally pinned (FLAG-FOR-HUMAN) the opposite, shipped-buggy behavior:
+; the block was a copy-paste of the weapon-wear block above it and wore
+; the ATTACKER's (A1's) armour instead. That bug is now fixed in
+; GameServer.bb (A1 -> A2 in the armour-wear block only), and this test
+; was deliberately flipped to assert the corrected behavior: after 300
+; swings with ArmourDamage on, the defender's chest piece has lost some
+; health (1-in-5 chance per swing; P(zero losses in 300) ~ 1e-29) while
+; the attacker's is still at exactly 100.
+Test testArmourWearHitsDefender()
 	ResetWorld()
 	SeedRnd(4001)
 	CombatFormula = 2
@@ -849,9 +853,9 @@ Test testArmourWearHitsAttackerNotDefender()
 	For i = 1 To 300
 		ActorAttack(A1, A2)
 	Next
-	Assert(DefenderChest\ItemHealth = 100)              ; FLAG-FOR-HUMAN
-	Assert(AttackerChest\ItemHealth < 100)              ; FLAG-FOR-HUMAN
-	Assert(AttackerChest\ItemHealth > 0)
+	Assert(DefenderChest\ItemHealth < 100)
+	Assert(DefenderChest\ItemHealth > 0)
+	Assert(AttackerChest\ItemHealth = 100)
 	ResetWorld()
 End Test
 


### PR DESCRIPTION
## The bug (gameplay, runtime-confirmed, found by PR #572's pins)

In `ActorAttack`'s melee path, the \"Damage armour\" block (`GameServer.bb:551-566`) iterated **`A1`** (the attacker's) inventory over the armour slots and echoed `P_ItemHealth` to `A1\RNID` — but the armour that absorbed the blow is the **defender's** (all three damage formulas read `GetArmourLevel(A2\Inventory)`). Net effect: attacking wore down your *own* armour; the defender's never degraded. Almost certainly a copy-paste of the weapon-wear block above it (`:537-549`), where `A1` is correct. Pinned empirically in #572: defender chest stayed exactly 100 over 300 swings.

## The fix

`A1` → `A2` inside that one block only — the inventory iterated/decremented and the echo recipient. Structure, guards, `Rand(1,5)` wear rate, slot range, and packet shape unchanged. NPC defenders wear silently under the existing `If RNID > 0` convention (same as the weapon block); their armour state stays authoritative server-side.

**Wire-routing correctness (verifier-checked):** the `P_ItemHealth` handler (`ClientNet.bb:249-252`) carries no actor ID — it updates the *recipient's own* inventory slot. So sending to `A2\RNID` makes the defending player's client update the same slot the server just decremented in A2's authoritative inventory. Server and client share the `SlotI_*` constants; the mapping is exact.

**Coherence bonus:** `GetArmourLevel` only counts pieces with `ItemHealth > 0`, so the fix closes the intended loop — the defender's armour degrades and eventually stops protecting the defender (previously, attacking nonsensically degraded the attacker's own defense).

Plus the deliberate flip of the #572 pin: `testArmourWearHitsAttackerNotDefender` → `testArmourWearHitsDefender` (defender wears, attacker stays 100; 300 swings × 1-in-5 wear ≈ 60 expected decrements, so the assertions discriminate with enormous margin). The weapon-wear pin is untouched.

**Deliberately untouched:** the formula-3 vulnerability paradox at `:521` (separate, maintainer-gated) and the block's position/conditions (wear still rolls on the melee path exactly where it did).

**Out-of-scope observation for a follow-up:** the projectile hit path (`GameServer.bb:268-304`) reads `GetArmourLevel(A2\Inventory)` but has no armour-wear block at all — ranged hits never wear the defender's armour, before or after this fix.

## Verification (independent verifier ≠ implementer)

- Diff = the one block in `GameServer.bb` (+ comment) and the one test flip; weapon-wear block and `:521` byte-identical; no generator-gated files.
- No other consumer of the attacker-wear side effect exists (repair UI, serialisation, BVM accessors all wear-source-agnostic).
- Full suite **`Ran 58 files: 58 passed, 0 failed.`**; FULL `compile.bat` (engine + all 7 tools) exit 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)