### PR TITLE
test(rcce-script): make shipped-script parse coverage a hard 0-failure gate

### DIFF
--- a/server-rs/crates/rcce-script/tests/real_scripts.rs
+++ b/server-rs/crates/rcce-script/tests/real_scripts.rs
@@ -1,6 +1,7 @@
-//! Coverage probe: how many of the shipped `.rsl` scripts the current parser
-//! accepts. Not a pass/fail gate (the parser is still growing) — it reports the
-//! ratio so the next parser work targets the real gaps.
+//! Parse-coverage gate: every shipped `.rsl` script must parse. Parity depends
+//! on 0 parse failures across `data/Server Data/Scripts` (docs/rust-server/
+//! PARITY.md, Cycle 96), so a parser regression fails this test rather than
+//! passing CI silently. The per-file breakdown is still printed for diagnostics.
 
 use std::path::PathBuf;
 
@@ -31,4 +32,9 @@ fn parse_all_shipped_scripts() {
     for (f, e) in fails.iter().take(12) {
         eprintln!("  FAIL {f}: {e}");
     }
+    assert!(ok > 0, "no .rsl scripts found in {dir:?} — coverage gate ran against nothing");
+    assert_eq!(
+        fail, 0,
+        "{fail} shipped script(s) failed to parse (see FAIL lines above) — parity requires 0 parse failures"
+    );
 }


### PR DESCRIPTION
## Summary
- `server-rs/crates/rcce-script/tests/real_scripts.rs` printed `RSL parse coverage: 55 ok / 55 total` but explicitly did not assert on failures ("Not a pass/fail gate"). Since parity now depends on 0 parse failures across `data/Server Data/Scripts` (docs/rust-server/PARITY.md, Cycle 96), a parser regression would have passed CI silently.
- The test now `assert_eq!(fail, 0)` with a pointer to the printed `FAIL` lines, and `assert!(ok > 0)` so an empty/misresolved scripts dir can't pass trivially. The per-file diagnostic breakdown is unchanged.

## Verification
- `cargo test -p rcce-script` — all 27 tests pass, coverage line still prints `55 ok / 55 total`.
- Negative check: injected a deliberately malformed `.rsl` into the scripts dir → the test fails with `1 shipped script(s) failed to parse … parity requires 0 parse failures` and the `FAIL <file>: <error>` diagnostic line. Temp file removed afterward.

🤖 Generated with [Claude Code](https://claude.com/claude-code)