### PR TITLE
fix(loom): Settings save path — port dual-write, Hosts.dat line 3, Wind weather slot

### DIFF
--- a/src/Modules/Loom/Composer.bb
+++ b/src/Modules/Loom/Composer.bb
@@ -1471,10 +1471,11 @@ Type Composer
             If fieldId = "outdoors"       Then Ar\Outdoors = (value = "1") : Return
             If fieldId = "pvp"            Then Ar\PvP      = (value = "1") : Return
 
-            // Weather chances -- 4 slots
+            // Weather chances -- 5 slots (WeatherChance[4] is inclusive:
+            // Rain/Snow/Fog/Storm/Wind = W_* - 1, see Environment.bb)
             If Left$(fieldId, 8) = "weather_"
                 Local wIdx% = Int(Mid$(fieldId, 9))
-                If wIdx >= 0 And wIdx <= 3 Then Ar\WeatherChance[wIdx] = Composer::parseIntClamped(self, value, Ar\WeatherChance[wIdx], 0, 1000)
+                If wIdx >= 0 And wIdx <= 4 Then Ar\WeatherChance[wIdx] = Composer::parseIntClamped(self, value, Ar\WeatherChance[wIdx], 0, 1000)
                 Return
             EndIf
 
@@ -3600,11 +3601,13 @@ Type Composer
         y = Composer::row(self, panelX, panelW, y, "Triggers",  Str(triggers))
         y = Composer::row(self, panelX, panelW, y, "Waypoints", Str(waypoints))
 
-        // Weather -- 4 chance slots (clear / rain / snow / etc, project-specific)
+        // Weather -- 5 chance slots (Rain/Snow/Fog/Storm/Wind, indexed by
+        // the W_* constants from Environment.bb minus 1). GUE edits all
+        // five spinners; WeatherChance[4] is a 5-slot inclusive array.
         y = Composer::sectionHeader(self, panelX, panelW, y, "Weather chances")
         Local wi%
-        For wi = 0 To 3
-            y = Composer::editableIntRow(self, panelX, panelW, y, "Slot " + Str(wi), "zone", h, "weather_" + Str(wi), Ar\WeatherChance[wi], mx, my, clicked)
+        For wi = 0 To 4
+            y = Composer::editableIntRow(self, panelX, panelW, y, Composer::weatherSlotLabel(self, wi), "zone", h, "weather_" + Str(wi), Ar\WeatherChance[wi], mx, my, clicked)
         Next
 
         // Scripts -- always editable
@@ -4105,6 +4108,21 @@ Type Composer
         If idx = 120 Then Return "Stand up"
         If idx = 119 Then Return "Strafe right"
         Return ""
+    End Method
+
+
+    // -------------------------------------------------------------------------
+    // weatherSlotLabel -- friendly name for a WeatherChance[] slot. Slots map
+    // to the W_* weather-type constants in Environment.bb minus 1 (the array
+    // is 0-based, the constants are 1-based).
+    // -------------------------------------------------------------------------
+    Method weatherSlotLabel$(idx%)
+        If idx = W_Rain - 1  Then Return "Rain"
+        If idx = W_Snow - 1  Then Return "Snow"
+        If idx = W_Fog - 1   Then Return "Fog"
+        If idx = W_Storm - 1 Then Return "Storm"
+        If idx = W_Wind - 1  Then Return "Wind"
+        Return "Slot " + Str(idx)
     End Method
 
 

--- a/src/Modules/Loom/Settings.bb
+++ b/src/Modules/Loom/Settings.bb
@@ -33,6 +33,12 @@ Global LoomCfg_UpdateMusic$    = ""
 ; ---- Hosts.dat --------------------------------------------------------------
 Global LoomCfg_ServerHost$     = ""
 Global LoomCfg_UpdateHost$     = ""
+; Line 3: allow-account-creation flag (0/1). The client's login dialog reads
+; it (MainMenu.bb, LogIn); GUE writes it as Hosts.dat line 3 and mirrors it
+; into Server Data\Misc.dat byte 15 (AllowAccountCreation). Loom has no
+; editor surface for it yet -- it is loaded and written back verbatim so a
+; Settings save doesn't truncate it away. Template default is 1 (enabled).
+Global LoomCfg_AccountsEnabled = 1
 
 ; ---- Other.dat --------------------------------------------------------------
 Global LoomCfg_HideNametags     = 0
@@ -110,6 +116,23 @@ Function Loom_LoadSettings()
     If F <> 0
         LoomCfg_ServerHost$ = ReadLine$(F)
         LoomCfg_UpdateHost$ = ReadLine$(F)
+        If Not Eof(F)
+            LoomCfg_AccountsEnabled = Int(ReadLine$(F))
+        Else
+            ; Line 3 missing -- earlier Loom builds wrote only two lines,
+            ; truncating the allow-account-creation flag on every save.
+            ; Recover it from its server-side twin: GUE keeps Hosts.dat
+            ; line 3 and Server Data\Misc.dat byte 15 in lockstep, so the
+            ; byte is authoritative when the line is gone.
+            F2 = ReadFile("Data\Server Data\Misc.dat")
+            If F2 <> 0
+                If FileSize("Data\Server Data\Misc.dat") >= 16
+                    SeekFile(F2, 15)
+                    LoomCfg_AccountsEnabled = ReadByte(F2)
+                EndIf
+                CloseFile(F2)
+            EndIf
+        EndIf
         CloseFile(F)
     EndIf
 
@@ -206,12 +229,17 @@ Function Loom_SaveSettings()
     If Result = False Then Return False
 
     ; --- Hosts.dat ----------------------------------------------------------
+    ; Three lines, matching GUE's writer (TServerHost / TUpdatesHost /
+    ; BNewAccounts cases): host, updates host, allow-account-creation flag.
+    ; The client's login dialog reads line 3 -- writing only two lines
+    ; silently disabled account creation on every Settings save.
     FinalPath$ = "Data\Game Data\Hosts.dat"
     TempPath$  = SafeWriteOpen$(FinalPath$)
     F = WriteFile(TempPath$)
     If F = 0 Then Return False
     WriteLine(F, LoomCfg_ServerHost$)
     WriteLine(F, LoomCfg_UpdateHost$)
+    WriteLine(F, Str(LoomCfg_AccountsEnabled))
     Result = SafeWriteCommit%(TempPath$, FinalPath$, F)
     If Result = False Then Return False
 
@@ -231,6 +259,38 @@ Function Loom_SaveSettings()
     WriteByte(F, LoomCfg_BubblesB)
     Result = SafeWriteCommit%(TempPath$, FinalPath$, F)
     If Result = False Then Return False
+
+    ; --- Server Data\Misc.dat (ServerPort dual-write) ------------------------
+    ; Server.exe reads its listen port from Server Data\Misc.dat (Server.bb,
+    ; "Misc settings" block), NOT from Game Data\Other.dat -- GUE dual-writes
+    ; both files (GUE.bb, Case TServerPort: SeekFile 17 + WriteInt). Without
+    ; this mirror a port edit in Loom never reaches the server. Copy the
+    ; existing file through a bank and poke the port at byte offset 17 so
+    ; the fields Loom doesn't edit (StartGold .. MaxAccountChars,
+    ; RequireMemorise) survive, then commit atomically.
+    FinalPath$ = "Data\Server Data\Misc.dat"
+    F = ReadFile(FinalPath$)
+    If F <> 0
+        MiscSize = FileSize(FinalPath$)
+        If MiscSize >= 21   ; port occupies bytes 17..20
+            MiscBank = CreateBank(MiscSize)
+            ReadBytes(MiscBank, F, 0, MiscSize)
+            CloseFile(F)
+            PokeInt(MiscBank, 17, LoomCfg_ServerPort)
+            TempPath$ = SafeWriteOpen$(FinalPath$)
+            F = WriteFile(TempPath$)
+            If F = 0 Then FreeBank(MiscBank) : Return False
+            WriteBytes(MiscBank, F, 0, MiscSize)
+            Result = SafeWriteCommit%(TempPath$, FinalPath$, F)
+            FreeBank(MiscBank)
+            If Result = False Then Return False
+        Else
+            CloseFile(F)
+            WriteLog(LoomLog, "Settings: Server Data\Misc.dat only " + MiscSize + " bytes; skipping port dual-write")
+        EndIf
+    Else
+        WriteLog(LoomLog, "Settings: Server Data\Misc.dat missing; skipping port dual-write")
+    EndIf
 
     ; --- Money.dat ----------------------------------------------------------
     FinalPath$ = "Data\Game Data\Money.dat"


### PR DESCRIPTION
## Summary

Fixes three confirmed bugs in Loom's Settings save path and zone composer.

### 1. Server-port edit was ineffective
`Loom_SaveSettings` wrote the port only to `Game Data\Other.dat`, but `Server.exe` reads its listen port from `Server Data\Misc.dat` (Server.bb "Misc settings" block, offset 17). GUE dual-writes both files (`Case TServerPort`: `SeekFile 17 + WriteInt`). Loom now mirrors the port into `Server Data\Misc.dat` by copying the existing file through a bank — preserving StartGold…MaxAccountChars and RequireMemorise, which Loom doesn't edit — poking the port at byte 17, and committing atomically via `SafeWriteOpen$` / `SafeWriteCommit%`. Missing or short files soft-fail with a log line instead of aborting the save.

### 2. Hosts.dat truncated to 2 lines on every save
GUE writes 3 lines (host, updates host, allow-account-creation flag) and the client's login dialog reads line 3 (`MainMenu.bb` `LogIn`). Loom wrote only 2 lines, silently disabling account creation on every Settings save. The flag is now loaded into a new `LoomCfg_AccountsEnabled` global and written back as line 3. Self-healing: if line 3 is already missing (a file truncated by earlier Loom builds), the flag is recovered from its server-side twin at `Server Data\Misc.dat` byte 15 (`AllowAccountCreation`), which GUE keeps in lockstep — so an admin who had disabled account creation doesn't get it silently re-enabled by the default.

### 3. Weather slot off-by-one (Wind hidden)
`WeatherChance[4]` is a 5-slot inclusive array (Rain/Snow/Fog/Storm/Wind = `W_* - 1`, Environment.bb). GUE edits all five spinners, but Loom's zone composer rendered and clamped only slots 0..3. The render walk and the `writeField` clamp now cover 0..4, and rows are labelled by weather name (new `weatherSlotLabel` method) instead of "Slot N".

## Verification

- `compile.bat -t` — clean compile on all five engine targets (Server, Client, GUE, Loom, Project Manager)
- `Server Data\Misc.dat` binary layout verified against the template project: 22 bytes, port int at 17-20 (0x61A8 = 25000), AllowAccountCreation byte at 15 — matching GUE's seek offsets and Server.bb's read order
- Template `Hosts.dat` verified: 3 lines with line 3 = `1`
- No shared (non-Loom) modules touched; generator-gated files untouched

🤖 Generated with [Claude Code](https://claude.com/claude-code)