### PR TITLE
feat(client): render own cast effects/projectiles (SPL-8)

### DIFF
--- a/client-rs/crates/rcce-client/src/world.rs
+++ b/client-rs/crates/rcce-client/src/world.rs
@@ -1731,11 +1731,29 @@ impl World {
     }
 
     /// Resolve a runtime id to a world position (self or a tracked actor).
+    ///
+    /// For the LOCAL player this is the **displayed** body position
+    /// (`me_render_x/z`), not the raw server echo (`me_x/z`) — Blitz positions a
+    /// projectile at `EntityX(Source\CollisionEN)` (Projectiles3D.bb:59), i.e.
+    /// the entity the player sees. Under the client-authoritative movement model
+    /// the echo lags the visible body by up to a network round-trip, so an
+    /// own-cast projectile sourced from `me_x` would visibly detach from the
+    /// caster while moving (SPL-8). Falls back to the echo before the first
+    /// `tick_movement` primes the render position.
     fn actor_pos(&self, rid: u16) -> Option<[f32; 3]> {
         if rid == self.my_runtime_id {
-            Some([self.me_x, self.me_y, self.me_z])
+            Some(self.me_display_pos())
         } else {
             self.actors.get(&rid).map(|a| [a.x, a.y, a.z])
+        }
+    }
+
+    /// The local player's displayed body position (see `actor_pos`).
+    fn me_display_pos(&self) -> [f32; 3] {
+        if self.me_render_init {
+            [self.me_render_x, self.me_y, self.me_render_z]
+        } else {
+            [self.me_x, self.me_y, self.me_z]
         }
     }
 
@@ -2091,7 +2109,10 @@ impl World {
     /// (within 2 units). Homing projectiles re-acquire the live target position.
     pub fn tick_projectiles(&mut self, dt: f32) {
         let my = self.my_runtime_id;
-        let me = [self.me_x, self.me_y, self.me_z];
+        // Homing at ME re-acquires the displayed body (same convention as the
+        // spawn in `actor_pos`; Blitz tracks the CollisionEN entity,
+        // Projectiles3D.bb:79-81).
+        let me = self.me_display_pos();
         for p in &mut self.projectiles {
             if p.homing {
                 let tp = if p.target_rid == my {
@@ -2865,6 +2886,89 @@ mod tests {
         w.apply(&msg(pk::PROJECTILE, { let mut q = MsgWriter::new(); q.u16(2).u16(3).u16(65535).u16(0).u16(0).u8(0).u8(65).str8("").raw(b""); q.into_bytes() }));
         assert_ne!(w.projectiles[0].id, w.projectiles[1].id);
         assert_eq!(w.projectiles[1].emitter, "", "no emitter name → plain glow");
+    }
+
+    // SPL-8: the local player's own cast. Blitz has NO local spawn-on-cast — all
+    // three client cast sites (Interface3D.bb:1128/:1258/:1543) only send
+    // P_SpellUpdate "F"; the spell script's FireProjectile then broadcasts
+    // P_Projectile to every player in the zone INCLUDING the caster
+    // (GameServer.bb:257-266), and the client handler spawns for any source, Me
+    // included (ClientNet.bb:217-238). This test walks that echo round-trip: the
+    // caster's own P_Projectile (src == my rid) must spawn from the DISPLAYED
+    // body position (Blitz sources it at EntityX(Source\CollisionEN),
+    // Projectiles3D.bb:59 — not the lagged server echo), carry the spell's
+    // emitter/texture template, home on the target, and reuse the PRJ-1
+    // flight/impact machinery unchanged.
+    #[test]
+    fn own_cast_projectile_spawns_at_visible_body() {
+        let mut w = World { my_runtime_id: 1, ..Default::default() };
+        // Server echo (me_x) lags the displayed body (me_render_x) while moving.
+        w.me_x = 5.0;
+        w.me_y = 2.0;
+        w.me_z = 0.0;
+        w.me_render_x = 6.5;
+        w.me_render_z = 0.5;
+        w.me_render_init = true;
+        w.actors.insert(2, Actor { runtime_id: 2, x: 30.0, alive: true, ..Default::default() });
+        // The outbound cast itself ("F" + [2]spellID + [2]targetRID,
+        // Interface3D.bb:1128) is pinned by net::tests::cast_packet_*; here the
+        // server has run the spell script and echoes the projectile back to us.
+        // Echo field order per GameServer.bb:257-261: [2]src [2]tgt [2]mesh
+        // [2]tex1 [2]tex2 [1]homing [1]speed [1]len+Emitter1 Emitter2.
+        let mut p = MsgWriter::new();
+        p.u16(1).u16(2).u16(65535).u16(3).u16(7).u8(1).u8(50).str8("Default").raw(b"Fireball");
+        w.apply(&msg(pk::PROJECTILE, p.into_bytes()));
+        assert_eq!(w.projectiles.len(), 1, "own-cast echo spawns a projectile");
+        let pr = &w.projectiles[0];
+        assert!((pr.x - 6.5).abs() < 1e-4 && (pr.z - 0.5).abs() < 1e-4, "spawns at the displayed body, not the echo (got {},{})", pr.x, pr.z);
+        assert!((pr.y - 5.0).abs() < 1e-4, "spawn y = me_y + 3 (Blitz spawn-height offset)");
+        assert!(pr.homing && pr.target_rid == 2, "homing on the cast target");
+        assert_eq!((pr.emitter1.as_str(), pr.emitter1_tex), ("Default", 3));
+        assert_eq!((pr.emitter.as_str(), pr.emitter_tex), ("Fireball", 7));
+        // Same PRJ-1 machinery flies + impacts it (no own-cast special case).
+        for _ in 0..20 {
+            w.tick_projectiles(0.1);
+        }
+        assert!(w.projectiles.is_empty(), "own-cast projectile impacted + removed");
+    }
+
+    // SPL-8 soft-fail tier: a malformed own-cast echo must spawn nothing and
+    // must not panic. Mirrors Blitz's `If TargetAI <> Null And AI <> Null`
+    // (ClientNet.bb:225) and the workspace no-panic-on-wire-data invariant.
+    #[test]
+    fn own_cast_projectile_soft_fails() {
+        let mut w = World { my_runtime_id: 1, ..Default::default() };
+        w.actors.insert(2, Actor { runtime_id: 2, x: 30.0, alive: true, ..Default::default() });
+        // Truncated: header cut mid-field (missing speed byte onward).
+        let mut short = MsgWriter::new();
+        short.u16(1).u16(2).u16(0).u16(0).u16(0).u8(1);
+        w.apply(&msg(pk::PROJECTILE, short.into_bytes()));
+        assert!(w.projectiles.is_empty(), "truncated echo spawns nothing");
+        // Unknown target rid: the caster resolves (me) but the target doesn't.
+        let mut ghost = MsgWriter::new();
+        ghost.u16(1).u16(999).u16(0).u16(0).u16(0).u8(0).u8(50).u8(0);
+        w.apply(&msg(pk::PROJECTILE, ghost.into_bytes()));
+        assert!(w.projectiles.is_empty(), "unknown target rid spawns nothing");
+    }
+
+    // A homing projectile targeting ME re-acquires the displayed body each tick
+    // (same displayed-body convention as the own-cast spawn; Blitz tracks the
+    // live CollisionEN entity, Projectiles3D.bb:79-81).
+    #[test]
+    fn homing_projectile_tracks_my_displayed_body() {
+        let mut w = World { my_runtime_id: 1, ..Default::default() };
+        w.actors.insert(2, Actor { runtime_id: 2, x: 100.0, alive: true, ..Default::default() });
+        w.me_render_init = true;
+        let mut p = MsgWriter::new();
+        p.u16(2).u16(1).u16(0).u16(0).u16(0).u8(1).u8(50).u8(0);
+        w.apply(&msg(pk::PROJECTILE, p.into_bytes()));
+        assert_eq!(w.projectiles.len(), 1);
+        // The body glides to a new displayed position; the homing tick follows it.
+        w.me_render_x = 40.0;
+        w.me_render_z = 8.0;
+        w.tick_projectiles(0.01);
+        let pr = &w.projectiles[0];
+        assert!((pr.tx - 40.0).abs() < 1e-4 && (pr.tz - 8.0).abs() < 1e-4, "re-acquired the displayed body (got {},{})", pr.tx, pr.tz);
     }
 
     // A plain say "<Name> text" (no colour-code prefix) becomes a speech bubble over

--- a/docs/rust-client/ACCEPTANCE.md
+++ b/docs/rust-client/ACCEPTANCE.md
@@ -166,7 +166,7 @@ Auto-attack on a flagged target: `AttackTarget=True` + `PlayerTarget` drives `Up
 | SPL-5 | Action bar: assign item (`"I"`), assign spell (`"S"`), clear (`"N"`); 12 slots fire on F1-F12 / click; 3-page swap | PARTIAL | ref `Interface3D.bb:1077-1280,1169-1212`; Rust fires 1-9, paging/assign unclear | live |
 | SPL-6 | Action bar loaded from the `P_StartGame` payload (3 slot-groups) | PARTIAL | ref `ClientNet.bb:62-106` | live |
 | SPL-7 | Incoming `P_KnownSpellUpdate` A/D/L (add/remove/level) updates known spells + resort | DONE ✅ | new `KNOWN_SPELL_UPDATE` const (26) + `World::on_known_spell_update` maintains a `known_spells: Vec<KnownSpell{id,name,level}>` — "A" adds (parses level/id/thumb/recharge/name·str16) keeping it name-sorted, "D" removes by name, "L" sets a spell's level by name. ref `ClientNet.bb:823-933` | unit test `known_spell_add_remove_level` (A adds 2 sorted, L levels Fireball→3, D removes Heal) green (66 lib tests). (The live list is state-only; the spellbook render of it is SPL-1.) |
-| SPL-8 | Render own cast effects / projectiles (currently send-only) | MISSING | audit §5c: `SPELL_UPDATE` send-only | live |
+| SPL-8 | Render own cast effects / projectiles (currently send-only) | DONE ✅ | Ground truth: Blitz has **no local spawn-on-cast** — all three client cast sites (`Interface3D.bb:1128/:1258/:1543`) only send `P_SpellUpdate "F"` + start the cooldown; the spell script's `FireProjectile` broadcasts `P_Projectile` to everyone in the zone **including the caster** (`GameServer.bb:257-266`), and the client handler spawns for any source, Me included (`ClientNet.bb:217-238`). The Rust client already matched this shape via the PRJ-1 echo path (the audit-§5c "send-only" note predates PRJ-1); the one real gap fixed here: `World::actor_pos`/`tick_projectiles` sourced ME from the lagged server echo (`me_x/z`) instead of the **displayed** body (`me_render_x/z`) that Blitz uses (`EntityX(Source\CollisionEN)`, `Projectiles3D.bb:59/:79-81`), so an own-cast projectile visibly detached from the caster while moving. Cast anim ("Pray" via `P_AnimateActor`), cast sound (`P_Sound`), and target/caster emitters (`P_CreateEmitter`, attach-follow via `actor_world_pos`) were already me-aware. Cooldowns stay keyed by spell ID 0-999 — untouched. | unit tests `own_cast_projectile_spawns_at_visible_body` (send → echo round-trip: spawns at displayed body with the spell's emitter/tex template, homes on target, reuses the PRJ-1 flight/impact machinery) + `own_cast_projectile_soft_fails` (truncated / unknown-target echo: nothing spawns, no panic) + `homing_projectile_tracks_my_displayed_body`; outbound wire bytes pinned by `net::tests` `cast_packet_*`. `cargo test` 343 green + `clippy -D warnings` clean. Send-path interaction ⇒ unit-test tier per the SPL-7 lesson |
 
 ---
 
@@ -279,13 +279,20 @@ Auto-attack on a flagged target: `AttackTarget=True` + `PlayerTarget` drives `Up
 
 ## Parity scorecard (2026-06-01 baseline)
 
-Counting concrete criteria (excluding DEFERRED): **DONE ≈ 62, PARTIAL ≈ 24** (Phases 1-5 + breadth incl. ANIM-8, PRJ-1, CHAT-2/3/4, ENV-5/6, HUD-8, SPL-7, QST-1/2, PTY-1/2, TGT-7, HUD-3, CAM-5, MOVE-7+ANIM-7 jump, CAM-4, MOVE-6, ANIM-6, SPL-4, 2026-06-01). **All four headline play-test gaps are now closed.** Every non-content-gated MISSING criterion is now DONE. The 8 remaining MISSING rows are all **live-only-with-content**: MOVE-8 / ANIM-4 / ANIM-5 / CAM-6 / ENV-4 (water·swim·ride — need a water zone / mount), TRD-3 (2 live players), TGT-8 (a scripted text-input NPC), SPL-8 (own-cast projectile FX). The remaining PARTIAL rows are substantially functional with only content-gated or polish sub-features outstanding (noted per-row).
+Counting concrete criteria (excluding DEFERRED): **DONE ≈ 62, PARTIAL ≈ 24** (Phases 1-5 + breadth incl. ANIM-8, PRJ-1, CHAT-2/3/4, ENV-5/6, HUD-8, SPL-7, QST-1/2, PTY-1/2, TGT-7, HUD-3, CAM-5, MOVE-7+ANIM-7 jump, CAM-4, MOVE-6, ANIM-6, SPL-4, 2026-06-01). **All four headline play-test gaps are now closed.** Every non-content-gated MISSING criterion is now DONE. The 7 remaining MISSING rows are all **live-only-with-content**: MOVE-8 / ANIM-4 / ANIM-5 / CAM-6 / ENV-4 (water·swim·ride — need a water zone / mount), TRD-3 (2 live players), TGT-8 (a scripted text-input NPC). (SPL-8, own-cast projectile FX, closed 2026-07-10 — see its row.) The remaining PARTIAL rows are substantially functional with only content-gated or polish sub-features outstanding (noted per-row).
 
 1. ~~**MENU-SCENE** — dedicated 3D menu scene with posed character~~ **DONE ✅** (Phase 3; backdrop-art polish = MENU-SCENE-b).
 2. ~~**ANIM-1** — local-player walk/run animation~~ **DONE ✅** (Phase 1).
 3. ~~**MOVE-5** — click-to-move~~ **DONE ✅** (Phase 2).
 4. ~~Targeting + combat: TGT-1..6 (select / highlight / panel / context menu / NPC dialog) + CBT-1/2 (attack-the-mob auto-loop)~~ **DONE ✅** (Phases 4-5).
 
-**Remaining work is non-headline parity breadth** (PARTIAL/MISSING): combat anims (ANIM-8), spell effects/projectiles (SPL-8/PRJ-1), quests/party (QST/PTY), water (ENV-4), chat colors/scrollback (CHAT-2..4), trade completeness (TRD-3), camera modes (CAM-4..6), swim/ride anims (ANIM-4/5), and the MENU-SCENE-b backdrop polish.
+**Remaining work is non-headline parity breadth** (PARTIAL/MISSING): combat anims (ANIM-8), quests/party (QST/PTY), water (ENV-4), chat colors/scrollback (CHAT-2..4), trade completeness (TRD-3), camera modes (CAM-4..6), swim/ride anims (ANIM-4/5), and the MENU-SCENE-b backdrop polish. (Spell effects/projectiles — PRJ-1 + SPL-8 — are now DONE.)
 
 These drive the Phase ordering in `PLAN.md`.
+
+### Post-scorecard punch-list (the informal "C-series")
+
+Small parity items picked up after the 2026-06-01 scorecard, previously tracked only in commit messages — recorded here so they're durable:
+
+- **C1 — character-create appearance picker**: face/hair/body/beard selection on the create screen. Shipped in commit `6ce8b51c` (PR #587).
+- **C2 — `P_SelectScenery` activation**: click-to-activate ownable animated scenery. Shipped in commit `9799911e` (PR #588); maps to row TGT-10, where the local mesh-toggle animation remains **deferred** (Rust scenery renders as static instances).


### PR DESCRIPTION
## SPL-8 — render the local player's own cast effects/projectiles

### Ground truth (from the Blitz source)

The question SPL-8 hinged on: *does the server echo `P_Projectile` back to the caster, or does the client spawn locally on cast?* Answer: **the server echoes**.

- All three Blitz client cast sites — action-bar click (`Interface3D.bb:1128`), action-bar hotkey (`:1258`), spellbook click (`:1543`) — only send `P_SpellUpdate "F"` and start the local cooldown. **No local projectile/effect/animation is spawned at cast time.**
- The spell script's `FireProjectile` (`ScriptingCommands.bb:1406` → `GameServer.bb:243`) broadcasts `P_Projectile` to **every player in the zone, including the caster** (`GameServer.bb:257-266`).
- The Blitz client handler (`ClientNet.bb:217-238`) spawns for any source with no Me-filter; the projectile is positioned at `EntityX(Source\CollisionEN)` — the **displayed** entity (`Projectiles3D.bb:59`), and homing re-acquires it live (`:79-81`).

The Rust client already matched this shape end-to-end via the PRJ-1 echo path (the ACCEPTANCE audit-§5c "send-only" note predates PRJ-1); cast anim (`P_AnimateActor`), cast sound (`P_Sound`), and caster/target emitters (`P_CreateEmitter` attach-follow) were already me-aware.

### The actual fix

`World::actor_pos` (projectile spawn) and `tick_projectiles` (homing re-acquire) resolved the **local player** from the lagged server echo (`me_x/z`) instead of the displayed body (`me_render_x/z`). Under the client-authoritative movement model the echo trails the visible body by up to a round-trip, so an own-cast projectile departed from a point visibly behind the moving caster. Both sites now share a `me_display_pos()` helper (echo fallback before the first `tick_movement` primes the render position), matching Blitz's displayed-entity sourcing and the App-side `actor_world_pos` convention. PRJ-1's spawn/homing/impact machinery is reused unchanged — no duplication, no own-cast special case. Cooldowns stay keyed by spell ID 0-999.

### Evidence (SPL-7 lesson tier — unit tests for send-path interactions)

- `own_cast_projectile_spawns_at_visible_body` — cast → echo round-trip: `P_Projectile` with src == my rid spawns at the displayed body (not the echo), carries the spell's emitter/tex template, homes on the target, flies + impacts through the PRJ-1 path.
- `own_cast_projectile_soft_fails` — truncated / unknown-target echo spawns nothing, no panic (wire soft-fail invariant).
- `homing_projectile_tracks_my_displayed_body` — homing-at-me re-acquires the displayed body each tick.
- Outbound wire bytes (`"F"` + \[2]spellID + \[2]targetRID, LE per the rcce-net codec) already pinned by `net::tests::cast_packet_*`.

Gates (from `client-rs/`): `cargo build --release` zero warnings · `cargo test --workspace` **343 passed / 0 failed** (baseline 340/0) · `cargo clippy --all-targets -- -D warnings` clean. No headless PNG — per ACCEPTANCE, the unit-test tier is the accepted evidence for send-path interactions.

### Docs (same PR)

- `docs/rust-client/ACCEPTANCE.md`: SPL-8 → **DONE** with the ground truth + tests cited; scorecard tallies updated (7 remaining MISSING rows).
- New **Post-scorecard punch-list** subsection making the informal commit-only C-series durable: C1 = character-create appearance picker (`6ce8b51c`, PR #587, shipped); C2 = `P_SelectScenery` activation (`9799911e`, PR #588, maps to TGT-10; local mesh anim still deferred).

No `.bb` or `data/` files touched; GPU-skinning default untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)