### PR TITLE
fix(rust-server): do not acknowledge failed account saves

### DIFF
--- a/docs/rust-server/STATE.md
+++ b/docs/rust-server/STATE.md
@@ -79,6 +79,12 @@ Headless Rust server at full feature parity with `bin/Server.exe`, runnable in a
 
 ## Cycle log
 
+### Cycle 105 — 2026-07-13 — RELIABILITY: never acknowledge volatile account mutations (#603)
+- **Why:** account creation, password changes, character creation, and character deletion mutated the in-memory `AccountStore`, logged an atomic-save error, and still returned their success reply. A full disk, missing directory, or permissions failure could therefore tell a player a durable change succeeded even though it would disappear after restart.
+- **Did:** added `AccountStore::transaction`, which snapshots account records, applies one mutation, saves atomically, and restores the snapshot on any I/O error. The four wire handlers now return their established failure reply on a failed commit: create-account and character-create return `N`, password-change returns `P`, and character-delete returns `N`; successful replies and wire/file formats are unchanged. Added one deterministic missing-parent regression test per handler, each proving both the failure reply and in-memory rollback.
+- **Proof (executed):** baseline `cargo test --workspace --locked` (Rust 1.94 toolchain) → **244 passed, 0 failed**. RED `cargo test -p rcce-server --locked` → **139 passed, 4 failed** for the new save-failure tests (each observed the old success reply after `No such file or directory`). GREEN same command → **151 passed, 0 failed**. Final `cargo test --workspace --locked` → **248 passed, 0 failed**; `cargo clippy --workspace --all-targets --locked -- -D warnings` → exit 0.
+- **Compatibility / rollback:** no packet, account-file, or migration change; the only observable change is truthful failure replies when persistence fails. Revert the increment commit to restore the former behavior.
+
 ### Cycle 104 — 2026-07-13 — VERIFICATION/CLOSURE: authored ACCEPTANCE.md + reconciled the gap audit (PR #598)
 - **Why:** two dangling loose ends — (a) `ACCEPTANCE.md` (backlog #9, the contract `PLAN.md` references) was never written; (b) PARITY.md still carried the stale 44-gap synthesis with an unresolved note that the richer 2026-06-17 72-gap re-audit died before reconciling (task `wb2hhg24h`, raw list unrecoverable). Docs-/audit-only cycle: **no server behavior changed**.
 - **Did:**

--- a/server-rs/crates/rcce-server-accounts/src/store.rs
+++ b/server-rs/crates/rcce-server-accounts/src/store.rs
@@ -175,6 +175,22 @@ impl AccountStore {
         atomic_write(&self.path, &w.into_bytes())
     }
 
+    /// Apply an account mutation only if the resulting store can be persisted.
+    ///
+    /// The server must not acknowledge an account, password, or character
+    /// change that would disappear on the next restart. Account records are
+    /// cloneable, so retain a snapshot until the atomic write succeeds and
+    /// restore it on any I/O failure.
+    pub fn transaction<T>(&mut self, mutate: impl FnOnce(&mut Self) -> T) -> io::Result<T> {
+        let snapshot = self.accounts.clone();
+        let result = mutate(self);
+        if let Err(error) = self.save() {
+            self.accounts = snapshot;
+            return Err(error);
+        }
+        Ok(result)
+    }
+
     /// Case-insensitive lookup (`Upper$(User$)` scan in the handlers).
     pub fn find(&self, user: &str) -> Option<&Account> {
         self.accounts.iter().find(|a| a.user.eq_ignore_ascii_case(user))

--- a/server-rs/crates/rcce-server/src/characters.rs
+++ b/server-rs/crates/rcce-server/src/characters.rs
@@ -182,14 +182,15 @@ pub fn handle_create_character(
 
     // Free-slot / max-character check, then persist.
     let max = config.max_account_chars.min(10) as usize;
-    let acct = store.find_mut(&user_s).expect("account verified above");
-    if acct.characters.len() >= max {
+    if store.find(&user_s).expect("account verified above").characters.len() >= max {
         return deny;
     }
-    acct.characters.push(CharacterRecord::new(c));
     throttle.record(peer, true, now_ms);
-    if let Err(e) = store.save() {
+    if let Err(e) = store.transaction(|store| {
+        store.find_mut(&user_s).expect("account verified above").characters.push(CharacterRecord::new(c));
+    }) {
         eprintln!("[characters] CreateCharacter: save failed: {e}");
+        return deny;
     }
     (P_CREATE_CHARACTER, b"Y".to_vec())
 }
@@ -393,6 +394,14 @@ mod tests {
         AccountStore::load(&p).unwrap()
     }
 
+    /// A missing parent makes `AccountStore::save` fail deterministically.
+    fn failing_store(name: &str) -> AccountStore {
+        let mut parent = std::env::temp_dir();
+        parent.push(format!("rcce_createchar_save_failure_{name}_{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&parent);
+        AccountStore::load(parent.join("Accounts.dat")).unwrap()
+    }
+
     fn field(b: &[u8]) -> Vec<u8> {
         let mut v = vec![b.len() as u8];
         v.extend_from_slice(b);
@@ -466,6 +475,24 @@ mod tests {
         })
         .unwrap();
         assert_eq!(reloaded.find("hero").unwrap().characters[0].actor.name, "Aragorn");
+    }
+
+    #[test]
+    fn create_character_save_failure_returns_n_and_rolls_back() {
+        let dir = data_dir();
+        let catalog = ActorCatalog::load(dir.join("Server Data/Actors.dat"));
+        let Some(template) = catalog.templates.values().find(|t| t.playable && Area::load(&dir, &t.start_area).is_some()) else {
+            eprintln!("skipping: no playable race with loadable start area");
+            return;
+        };
+        let mut store = failing_store("create");
+        store.push(Account::new("hero", MD5, "h@x.com").unwrap());
+        let mut throttle = LoginThrottle::new();
+        let config = config_for(dir);
+        let packet = create_packet("hero", MD5, template.id, b"Aragorn");
+
+        assert_eq!(handle_create_character(&packet, &mut store, &mut throttle, &catalog, &config, 1, 0).1, b"N");
+        assert!(store.find("hero").unwrap().characters.is_empty());
     }
 
     #[test]

--- a/server-rs/crates/rcce-server/src/login.rs
+++ b/server-rs/crates/rcce-server/src/login.rs
@@ -122,9 +122,9 @@ pub fn handle_create_account(
     let email_s = String::from_utf8_lossy(&email).into_owned();
     match Account::new(&user_s, &pass_s, &email_s) {
         Ok(account) => {
-            store.push(account);
-            if let Err(e) = store.save() {
+            if let Err(e) = store.transaction(|store| store.push(account)) {
                 eprintln!("[login] AddAccount: save failed: {e}");
+                return deny();
             }
             Some((P_CREATE_ACCOUNT, b"Y".to_vec()))
         }
@@ -251,11 +251,12 @@ pub fn handle_change_password(
     let Ok(hashed) = password::hash_password(&new_s) else {
         return p;
     };
-    if let Some(m) = store.find_mut(&user_s) {
-        m.pass = hashed;
-        if let Err(e) = store.save() {
-            eprintln!("[login] change-password: save failed: {e}");
-        }
+    if let Err(e) = store.transaction(|store| {
+        let account = store.find_mut(&user_s).expect("account verified above");
+        account.pass = hashed;
+    }) {
+        eprintln!("[login] change-password: save failed: {e}");
+        return p;
     }
     (P_CHANGE_PASSWORD, b"Y".to_vec())
 }
@@ -317,18 +318,23 @@ pub fn handle_delete_character(
         return deny;
     }
 
-    let acct = store.find_mut(&user_s).expect("account found above");
-    // Characters are stored compacted in slot order, so removing index `slot`
-    // shifts the rest down exactly like the Blitz slot shift. Deleting an empty
-    // slot is a no-op (Blitz guards `Character[Number] <> Null`).
-    if (slot as usize) < acct.characters.len() {
-        acct.characters.remove(slot as usize);
-    }
-    let summary = char_summary(acct);
     throttle.record(peer, true, now_ms);
-    if let Err(e) = store.save() {
-        eprintln!("[login] DeleteCharacter: save failed: {e}");
-    }
+    let summary = match store.transaction(|store| {
+        let account = store.find_mut(&user_s).expect("account found above");
+        // Characters are stored compacted in slot order, so removing index
+        // `slot` shifts the rest down exactly like the Blitz slot shift.
+        // Deleting an empty slot is a no-op (Blitz guards it with Null).
+        if (slot as usize) < account.characters.len() {
+            account.characters.remove(slot as usize);
+        }
+        char_summary(account)
+    }) {
+        Ok(summary) => summary,
+        Err(e) => {
+            eprintln!("[login] DeleteCharacter: save failed: {e}");
+            return deny;
+        }
+    };
     (P_DELETE_CHARACTER, summary)
 }
 
@@ -343,6 +349,15 @@ mod tests {
         let _ = std::fs::remove_file(&p);
         // Load from the (absent) path so the store remembers it for save().
         AccountStore::load(&p).unwrap()
+    }
+
+    /// A path whose parent does not exist makes `AccountStore::save` fail
+    /// without relying on host permissions or a full disk.
+    fn failing_store(name: &str) -> AccountStore {
+        let mut parent = std::env::temp_dir();
+        parent.push(format!("rcce_login_save_failure_{name}_{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&parent);
+        AccountStore::load(parent.join("Accounts.dat")).unwrap()
     }
 
     /// Encode a 1-byte-length-prefixed field.
@@ -441,6 +456,18 @@ mod tests {
         );
     }
 
+    #[test]
+    fn create_account_save_failure_returns_n_and_rolls_back() {
+        let mut store = failing_store("create");
+        let enc: Vec<u8> = b"a@b.com".iter().rev().map(|b| b.wrapping_sub(26)).collect();
+        let mut create = field(b"alice");
+        create.extend_from_slice(&field(MD5_HELLO.as_bytes()));
+        create.extend_from_slice(&field(&enc));
+
+        assert_eq!(handle_create_account(&create, &mut store, true).unwrap().1, b"N");
+        assert!(!store.exists("alice"));
+    }
+
     fn account_with_chars(user: &str, chars: &[(u16, &str)]) -> rcce_server_accounts::store::Account {
         use rcce_server_core::character::Character;
         use rcce_server_core::record::CharacterRecord;
@@ -501,6 +528,19 @@ mod tests {
     }
 
     #[test]
+    fn delete_character_save_failure_returns_n_and_rolls_back() {
+        let mut store = failing_store("delete");
+        store.push(account_with_chars("hero", &[(5, "Aaa")]));
+        let mut throttle = LoginThrottle::new();
+        let mut del = field(b"hero");
+        del.extend_from_slice(&field(MD5_HELLO.as_bytes()));
+        del.push(0);
+
+        assert_eq!(handle_delete_character(&del, &mut store, &mut throttle, 1, 0).1, b"N");
+        assert_eq!(store.find("hero").unwrap().characters.len(), 1);
+    }
+
+    #[test]
     fn delete_wrong_password_is_n_and_keeps_chars() {
         let mut store = tmp_store("delete_bad");
         store.push(account_with_chars("hero", &[(5, "Aaa")]));
@@ -538,5 +578,18 @@ mod tests {
             handle_create_account(&create, &mut store, true).unwrap().1,
             b"N"
         );
+    }
+
+    #[test]
+    fn change_password_save_failure_returns_p_and_rolls_back() {
+        let mut store = failing_store("password");
+        store.push(Account::new("hero", MD5_HELLO, "h@x.com").unwrap());
+        let old_hash = store.find("hero").unwrap().pass.clone();
+        let mut change = field(b"hero");
+        change.extend_from_slice(&field(MD5_HELLO.as_bytes()));
+        change.extend_from_slice(&field(b"ffffffffffffffffffffffffffffffff"));
+
+        assert_eq!(handle_change_password(&change, &mut store, 7, Some(7)).1, b"P");
+        assert_eq!(store.find("hero").unwrap().pass, old_hash);
     }
 }


### PR DESCRIPTION
## Outcome

Players are no longer told that account, password, or character changes succeeded when `Accounts.dat` could not be saved. The server restores the pre-mutation account state and returns the established failure response instead.

## Technical changes

- Add `AccountStore::transaction`: snapshot → mutate → atomic save → restore snapshot on I/O failure.
- Route create-account, change-password, create-character, and delete-character through that boundary.
- Add deterministic missing-parent save-failure tests for all four handlers.
- Record the durable state update for this reliability increment.

Fixes #603

## Acceptance criteria and evidence

| Criterion | Evidence |
| --- | --- |
| Failed save leaves no in-memory account mutation | Four focused regression tests, each asserts rollback |
| Failed save returns existing failure response | create-account/create-character/delete → `N`; change-password → `P` |
| Success paths remain intact | Existing handler + ENet e2e tests pass |
| Full server gates pass | workspace tests and strict clippy below |

## TDD and verification

- Baseline: `RUSTC=.../rustc RUSTDOC=.../rustdoc cargo test --workspace --locked` → exit 0, **244 passed / 0 failed**.
- RED: `cargo test -p rcce-server --locked` after four new tests → exit 101, **139 passed / 4 failed**; each saw the legacy success reply after `No such file or directory`.
- GREEN: same targeted command → exit 0, **151 passed / 0 failed**.
- Final: `cargo test --workspace --locked` → exit 0, **248 passed / 0 failed**.
- Final: `cargo clippy --workspace --all-targets --locked -- -D warnings` → exit 0.

The environment's default Cargo 1.75 cannot parse this repository's v4 lockfile; all evidence above used the installed Rust 1.94 toolchain explicitly.

## Compatibility, risk, rollback

No wire protocol, account-file format, migration, or retry-policy change. The sole behavior change is a truthful failure reply when persistence fails. Revert commit `7ea58e3e` to restore the prior behavior.

## Deferred

No retry/backoff or periodic gameplay-autosave redesign is included.

## Independent review

Pending fresh adversarial review of this exact head SHA.

## Independent review verdict

**ACCEPT** — fresh reviewer inspected exact head `7ea58e3e`; no material findings across acceptance criteria, scope, correctness, test quality, repository fit, documentation, security, performance, or hidden costs. The reviewer did not independently rerun the suite because the default Cargo toolchain is too old for this lockfile; the PR retains the executed local 1.94-toolchain evidence above.