### PR TITLE
test(rust-server): stabilize zero-resistance ally-help fixture

### DIFF
--- a/docs/rust-server/STATE.md
+++ b/docs/rust-server/STATE.md
@@ -79,6 +79,12 @@ Headless Rust server at full feature parity with `bin/Server.exe`, runnable in a
 
 ## Cycle log
 
+### Cycle 108 — 2026-07-13 — TEST RELIABILITY: retain zero-resistance semantics in ally-help coverage (#612)
+- **Why:** the full Rust-server baseline was red: `world::tests::attacked_npc_calls_nearby_allies_for_help` selected an aggressive template with a valid zero resistance, then gave its NPC fixture only 100 HP. Blitz `ActorAttack` treats resistance as an armour adjustment `(resistance - 100)`, so this was a legitimately vulnerable target that could be removed before the test observed retaliation or `AICallForHelp`.
+- **Did:** preserved the live combat formula unchanged; added a direct pure-combat regression proving zero resistance causes 100 more damage than neutral in the deterministic scenario, and raised only the ally-help fixture's staged health to 10,000 so one legal hit cannot erase the observation subject.
+- **Proof (executed):** baseline `cd server-rs && cargo test --workspace --locked` with Rust 1.94.1 → exit 101 (145 passed, 1 failed); focused Red `cargo test -p rcce-server attacked_npc_calls_nearby_allies_for_help --locked -- --nocapture` → exit 101 (panic at `world.rs:4144`). Focused Green: the new core test and ally-help test both pass. Final `cargo test --workspace --locked` → exit 0 (252 passed, 0 failed); `cargo clippy --workspace --all-targets --locked -- -D warnings` → exit 0.
+- **Next:** submit #612 for independent review and merge; this restores a trustworthy server baseline before resuming blocked equipment-placement validation #611.
+
 ### Cycle 107 — 2026-07-13 — PARITY FIX: honor defender resistance in live melee (#607)
 - **Why:** player→NPC, PvP, and NPC→player constructed `SwingInput` with neutral `resistance: 100` even though both character and NPC-template resistance data were already loaded. Any non-neutral defender resistance therefore had no effect on live combat, despite the shared formula and Blitz `ActorAttack` applying it.
 - **Did:** added one bounded defender-resistance lookup (invalid/missing damage-type index → neutral 100) and supplied it to all three live melee paths. NPC defenders read their actor-template array; player defenders read their persisted character array. Extended the existing live combat tests to force a high-resistance defender and assert every landed hit floors at one; added the invalid-index fallback test. Updated PARITY.md and ACCEPTANCE.md: R-1 is closed and ACC-PLAY-3 is DONE.

--- a/server-rs/crates/rcce-server-core/src/combat.rs
+++ b/server-rs/crates/rcce-server-core/src/combat.rs
@@ -146,6 +146,17 @@ mod tests {
     }
 
     #[test]
+    fn zero_resistance_increases_damage_relative_to_neutral() {
+        let neutral = SwingInput { strength: 80, weapon_damage: None, armour: 0, resistance: 100, toughness: None };
+        let vulnerable = SwingInput { resistance: 0, ..neutral };
+
+        // Zero is a valid stored resistance, not a missing-value sentinel: Blitz
+        // applies `(resistance - 100)` as armour, so zero adds 100 damage here.
+        assert_eq!(melee_swing(1, &neutral, &rolls(50)), SwingResult::Hit { damage: 10, crit: false });
+        assert_eq!(melee_swing(1, &vulnerable, &rolls(50)), SwingResult::Hit { damage: 110, crit: false });
+    }
+
+    #[test]
     fn formula3_multiplies_weapon_by_strength() {
         let input = SwingInput { strength: 5, weapon_damage: Some(10), armour: 0, resistance: 100, toughness: None };
         // 10 * 5 = 50, no crit, no armour.

--- a/server-rs/crates/rcce-server/src/world.rs
+++ b/server-rs/crates/rcce-server/src/world.rs
@@ -4124,8 +4124,11 @@ mod tests {
                 x: 1.0,
                 y: 0.0,
                 z: 1.0,
-                hp: 100,
-                hp_max: 100,
+                // A zero resistance intentionally gives this template 100 fewer
+                // armour-equivalent points than neutral. Keep this fixture alive
+                // through one legal hit so it can observe retaliation and help.
+                hp: 10_000,
+                hp_max: 10_000,
                 target_peer: None,
                 last_attack_ms: 0,
                 script: String::new(),


### PR DESCRIPTION
## Outcome
Restores a trustworthy Rust-server test baseline without weakening valid zero-resistance combat behavior. The ally-help scenario now observes retaliation and nearby ally support instead of losing its NPC fixture to a legal high-damage hit.

## Technical changes
- Preserve the Blitz `(resistance - 100)` combat rule and add a deterministic zero-vs-neutral formula regression.
- Give only the ally-help test fixture a nonlethal 10,000 HP setup.
- Record the evidence in the Rust-server durable state.

Fixes #612

## Acceptance criteria and evidence
- Ally-help fixture is deterministic: `cargo test -p rcce-server attacked_npc_calls_nearby_allies_for_help --locked -- --nocapture` → exit 0, 1 passed.
- Zero resistance remains a vulnerability: `cargo test -p rcce-server-core zero_resistance_increases_damage_relative_to_neutral --locked -- --nocapture` → exit 0, 1 passed (10 neutral vs 110 at zero resistance).
- Existing high-resistance behavior remains covered by the server suite.
- Full server workspace and strict Clippy are green (below).

## RED → GREEN
- Baseline/RED: `cd server-rs && cargo test --workspace --locked` → exit 101, 145 passed / 1 failed; focused ally-help rerun → exit 101, panic at `world.rs:4144` after the attacked NPC was removed.
- GREEN: both focused commands above pass after the test-only correction.

## Final verification
- `cd server-rs && cargo test --workspace --locked` → exit 0; 252 passed, 0 failed.
- `cd server-rs && cargo clippy --workspace --all-targets --locked -- -D warnings` → exit 0.
- `git diff --check` → exit 0.
- Exact-head GitHub CI: `Build and test` and `Rust server (Linux)` both succeeded. The initial Linux run had an unrelated wait-speak test-order failure; its exact-head rerun passed after ten local full server-suite repetitions also passed.

## Compatibility, risk, rollback, and deferred work
No protocol, persistence, or player-visible combat behavior changes. Zero resistance remains intentionally non-neutral, matching Blitz `ActorAttack`. Revert commit `82bd57a8` to restore the prior fragile fixture. Workspace `cargo fmt --check` is currently red due to broad pre-existing formatting drift under Rust 1.94 and is excluded from this scoped increment. Equipment-placement validation #611 remains deferred until this PR merges.

## Independent review
**ACCEPT** — fresh reviewer inspected the exact current head `82bd57a83da4efeb8b73cd943bdefd4d8b9f7985`, the issue contract, Blitz parity source, test coverage, durable state, and verification evidence. No correctness, security, performance, compatibility, scope, or documentation findings. The reviewer independently observed focused tests, full workspace tests (252 passed), strict Clippy, and `git diff --check` succeed.