### PR TITLE
fix(gue): atomically save legacy area files

### DIFF
--- a/src/Modules/ClientAreas_FE.bb
+++ b/src/Modules/ClientAreas_FE.bb
@@ -999,10 +999,13 @@ Function LoadArea(Name$, CameraEN, DisplayItems = False, UpdateRottNet = False)
 
 End Function
 
-; Saves the current area back to file
+; Saves the current area back to file. Atomic rewrite keeps the previous
+; area file recoverable if a save is interrupted while serializing it.
 Function SaveArea(Name$)
 
-	F = WriteFile("Data\Areas\" + Name$ + ".dat")
+	Local FinalPath$ = "Data\Areas\" + Name$ + ".dat"
+	Local TempPath$ = SafeWriteOpen(FinalPath$)
+	F = WriteFile(TempPath$)
 	If F = 0 Then Return False
 
 		; Loading screen
@@ -1152,8 +1155,7 @@ Function SaveArea(Name$)
 			WriteByte F, SZ\Volume
 		Next
 
-	CloseFile(F)
-	Return True
+	Return SafeWriteCommit(TempPath$, FinalPath$, F)
 
 End Function
 

--- a/src/Tests/Modules/ClientAreasFEAtomicSaveTest.bb
+++ b/src/Tests/Modules/ClientAreasFEAtomicSaveTest.bb
@@ -1,0 +1,35 @@
+Strict
+EnableGC
+
+; ClientAreas_FE.bb includes the legacy client-area graph (Gooey, media,
+; terrain, particles, and runtime globals), so it cannot be loaded into the
+; standalone test runner safely. Pin its persistence boundary as a source
+; contract instead: SaveArea must stage the complete binary write in a temp
+; file and promote it through the shared atomic-write helper.
+
+Function FunctionBodyContains%(Path$, FunctionMarker$, Needle$)
+	Local F.BBStream = ReadFile(Path$)
+	Local InFunction%
+	Local Line$
+	; test.sh runs from src\Tests while IDEs commonly run from src.
+	If F = Null Then F = ReadFile("..\" + Path$)
+	If F = Null Then Return False
+	InFunction = False
+	While Not Eof(F)
+		Line$ = ReadLine$(F)
+		If Instr(Line$, FunctionMarker$) > 0 Then InFunction = True
+		If InFunction = True And Instr(Line$, Needle$) > 0
+			CloseFile F
+			Return True
+		EndIf
+		If InFunction = True And Instr(Line$, "End Function") > 0 Then Exit
+	Wend
+	CloseFile F
+	Return False
+End Function
+
+Test testSaveAreaStagesAndAtomicallyPromotesAreaFile()
+	Assert(FunctionBodyContains%("Modules\ClientAreas_FE.bb", "Function SaveArea(Name$)", "SafeWriteOpen(FinalPath$)") = True)
+	Assert(FunctionBodyContains%("Modules\ClientAreas_FE.bb", "Function SaveArea(Name$)", "WriteFile(TempPath$)") = True)
+	Assert(FunctionBodyContains%("Modules\ClientAreas_FE.bb", "Function SaveArea(Name$)", "SafeWriteCommit(TempPath$, FinalPath$, F)") = True)
+End Test


### PR DESCRIPTION
## Outcome
GUE now stages legacy area-file saves before replacing the live zone file, so an interrupted save leaves the previous `.dat` recoverable instead of truncating it in place.

## Technical changes
- Route `ClientAreas_FE.bb` `SaveArea(Name$)` through the existing `SafeWriteOpen` / `SafeWriteCommit` contract.
- Preserve the serializer's field order, public interface, and binary format.
- Add a focused source-contract regression test because this legacy module pulls the graphics/UI runtime and cannot safely load in the standalone test harness.

Fixes #625

## Acceptance evidence
1. Temp staging and atomic promotion: inspected `SaveArea` now contains `SafeWriteOpen(FinalPath$)`, `WriteFile(TempPath$)`, and `SafeWriteCommit(TempPath$, FinalPath$, F)`.
2. Failed/empty temp behavior and `.bak` recovery are supplied by the existing tested helper (`src/Modules/Logging.bb`, `SafeWriteTest.bb`); this change preserves its call contract.
3. Serializer compatibility: no field writes were changed; only the initial path and final close/return changed.
4. Regression coverage: `ClientAreasFEAtomicSaveTest.bb` pins all three required calls within `SaveArea`.

## RED → GREEN
- RED: a focused source-contract probe confirmed the pre-change `SaveArea` lacked all three atomic-save calls.
- GREEN: the same probe now passes all three required calls and rejects the old direct `WriteFile("Data\\Areas\\" + Name$ + ".dat")` shape.

## Verification
- `git diff --check` — exit 0.
- Focused source-contract probe — exit 0; all three postconditions observed.
- `./test.sh ClientAreasFEAtomicSaveTest` — exit 1 before compilation because this Linux worker has no runnable `compiler/BlitzForge/bin/blitzcc`. The pinned BlitzForge source was initialized, but its `compile.sh` explicitly supports runnable host builds only on macOS; CI remains the required executable gate.

## Compatibility, risk, and rollback
No area format or API changes. Roll back with a revert of `efbe3c8b`; successful saves retain the prior `.dat.bak` as one-cycle recovery evidence. No follow-up serializer sweep is included.

## Independent review
ACCEPT — fresh independent review of exact head `efbe3c8b5058b33fc9486af658ac7c7162c5c4b3`.