### PR TITLE
fix(server): fail closed on stale AreaInstance guards

### DIFF
--- a/src/Server.bb
+++ b/src/Server.bb
@@ -359,12 +359,14 @@ Repeat
 					For AI.ActorInstance = Each ActorInstance
 						If AI\RNID > 0
 							AInstance.AreaInstance = Object.AreaInstance(AI\ServerArea)
-							If AInstance <> Null And AInstance\Area = GameArea
-								If AI\Name$ + " (" + AInstance\ID + ")" = Name$
-									DataAux$ = RCE_StrFromInt(AI\RNID)
-									RCE_FSend(0, RCE_PlayerKicked, DataAux$, True, Len(DataAux$))
-									RCE_FSend(AI\RNID, P_KickedPlayer, "", True, 0)
-									Exit
+							If AInstance <> Null
+								If AInstance\Area = GameArea
+									If AI\Name$ + " (" + AInstance\ID + ")" = Name$
+										DataAux$ = RCE_StrFromInt(AI\RNID)
+										RCE_FSend(0, RCE_PlayerKicked, DataAux$, True, Len(DataAux$))
+										RCE_FSend(AI\RNID, P_KickedPlayer, "", True, 0)
+										Exit
+									EndIf
 								EndIf
 							EndIf
 						EndIf
@@ -401,8 +403,10 @@ Repeat
 				For AI.ActorInstance = Each ActorInstance
 					If AI\RNID > 0
 						AInstance.AreaInstance = Object.AreaInstance(AI\ServerArea)
-						If AInstance <> Null And AInstance\Area = GameArea
-							AddListBoxItem(Game\PlayersList, AI\Name$ + " (" + AInstance\ID + ")")
+						If AInstance <> Null
+							If AInstance\Area = GameArea
+								AddListBoxItem(Game\PlayersList, AI\Name$ + " (" + AInstance\ID + ")")
+							EndIf
 						EndIf
 					EndIf
 				Next
@@ -579,81 +583,83 @@ Repeat
 				For AI.ActorInstance = Each ActorInstance
 					If AI\RuntimeID > -1 And AI\RNID > 0
 						AInstance.AreaInstance = Object.AreaInstance(AI\ServerArea)
-						If AInstance <> Null And AInstance\Area = UpdateArea
-							; Portals
-							For i = 0 To 99
-								If Len(UpdateArea\PortalName$[i]) > 0
-									If Len(UpdateArea\PortalLinkArea$[i]) > 0
-										; Calculate distance
-										Size# = UpdateArea\PortalSize#[i] * UpdateArea\PortalSize#[i]
-										DistX# = Abs(AI\X# - UpdateArea\PortalX#[i])
-										DistY# = Abs(AI\Y# - UpdateArea\PortalY#[i])
-										DistZ# = Abs(AI\Z# - UpdateArea\PortalZ#[i])
-										Dist# = (DistX# * DistX#) + (DistY# * DistY#) + (DistZ# * DistZ#)
-										; Inside portal area
-										; Lock keys on the (Area, index) pair: a stale
-										; LastPortal index left over from a different
-										; area must not block a same-index portal in the
-										; current one, and the time floor still bars
-										; immediate re-entry of the exact portal the
-										; actor was just placed on.
-										;
-										; Lazy resolve LastPortalAreaName$ -> Handle.
-										; The persisted form is the area NAME (Handles
-										; are process-local); first time we see this
-										; actor in a portal area after login, re-bind
-										; the area handle. If the area was renamed /
-										; deleted between sessions, leave the handle
-										; at 0 and the lock just stays clear -- safe
-										; direction.
-										If AI\LastPortalArea = 0 And AI\LastPortalAreaName$ <> ""
-											Local LpAr.Area = FindArea(AI\LastPortalAreaName$)
-											If LpAr <> Null Then AI\LastPortalArea = Handle(LpAr)
-										EndIf
-										If Dist# < Size# And (AI\LastPortal <> i Or AI\LastPortalArea <> Handle(UpdateArea) Or (MilliSecs() - AI\LastPortalTime > PortalLockTime))
-											InPortal = False
-											Name$ = Upper$(UpdateArea\PortalLinkArea$[i])
-											For Ar.Area = Each Area
-												If Upper$(Ar\Name$) = Name$
-													Name$ = Upper$(UpdateArea\PortalLinkName$[i])
-													Port = 0
-													If Len(Name$) > 0
-														For j = 0 To 99
-															If Upper$(Ar\PortalName$[j]) = Name$ Then Port = j : Exit
-														Next
+						If AInstance <> Null
+							If AInstance\Area = UpdateArea
+								; Portals
+								For i = 0 To 99
+									If Len(UpdateArea\PortalName$[i]) > 0
+										If Len(UpdateArea\PortalLinkArea$[i]) > 0
+											; Calculate distance
+											Size# = UpdateArea\PortalSize#[i] * UpdateArea\PortalSize#[i]
+											DistX# = Abs(AI\X# - UpdateArea\PortalX#[i])
+											DistY# = Abs(AI\Y# - UpdateArea\PortalY#[i])
+											DistZ# = Abs(AI\Z# - UpdateArea\PortalZ#[i])
+											Dist# = (DistX# * DistX#) + (DistY# * DistY#) + (DistZ# * DistZ#)
+											; Inside portal area
+											; Lock keys on the (Area, index) pair: a stale
+											; LastPortal index left over from a different
+											; area must not block a same-index portal in the
+											; current one, and the time floor still bars
+											; immediate re-entry of the exact portal the
+											; actor was just placed on.
+											;
+											; Lazy resolve LastPortalAreaName$ -> Handle.
+											; The persisted form is the area NAME (Handles
+											; are process-local); first time we see this
+											; actor in a portal area after login, re-bind
+											; the area handle. If the area was renamed /
+											; deleted between sessions, leave the handle
+											; at 0 and the lock just stays clear -- safe
+											; direction.
+											If AI\LastPortalArea = 0 And AI\LastPortalAreaName$ <> ""
+												Local LpAr.Area = FindArea(AI\LastPortalAreaName$)
+												If LpAr <> Null Then AI\LastPortalArea = Handle(LpAr)
+											EndIf
+											If Dist# < Size# And (AI\LastPortal <> i Or AI\LastPortalArea <> Handle(UpdateArea) Or (MilliSecs() - AI\LastPortalTime > PortalLockTime))
+												InPortal = False
+												Name$ = Upper$(UpdateArea\PortalLinkArea$[i])
+												For Ar.Area = Each Area
+													If Upper$(Ar\Name$) = Name$
+														Name$ = Upper$(UpdateArea\PortalLinkName$[i])
+														Port = 0
+														If Len(Name$) > 0
+															For j = 0 To 99
+																If Upper$(Ar\PortalName$[j]) = Name$ Then Port = j : Exit
+															Next
+														EndIf
+														SetArea(AI, Ar, 0, -1, Port)
+														InPortal = True
+														Exit
 													EndIf
-													SetArea(AI, Ar, 0, -1, Port)
-													InPortal = True
-													Exit
-												EndIf
-											Next
-											If InPortal = True Then Exit
+												Next
+												If InPortal = True Then Exit
+											EndIf
 										EndIf
 									EndIf
-								EndIf
-							Next
+								Next
 
-							; Triggers
-							InTrigger = -1
-							For i = 0 To 149
-								If Len(UpdateArea\TriggerScript$[i]) > 0
-									; Calculate distance
-									Size# = UpdateArea\TriggerSize#[i] * UpdateArea\TriggerSize#[i]
-									DistX# = Abs(AI\X# - UpdateArea\TriggerX#[i])
-									DistY# = Abs(AI\Y# - UpdateArea\TriggerY#[i])
-									DistZ# = Abs(AI\Z# - UpdateArea\TriggerZ#[i])
-									Dist# = (DistX# * DistX#) + (DistY# * DistY#) + (DistZ# * DistZ#)
-									; Inside trigger area
-									If Dist# < Size#
-										InTrigger = i
-										; Only execute script if this trigger was not already executed
-										If AI\LastTrigger <> i
-											ThreadScript(UpdateArea\TriggerScript$[i], UpdateArea\TriggerMethod$[i], Handle(AI), 0, Str$(i))
+								; Triggers
+								InTrigger = -1
+								For i = 0 To 149
+									If Len(UpdateArea\TriggerScript$[i]) > 0
+										; Calculate distance
+										Size# = UpdateArea\TriggerSize#[i] * UpdateArea\TriggerSize#[i]
+										DistX# = Abs(AI\X# - UpdateArea\TriggerX#[i])
+										DistY# = Abs(AI\Y# - UpdateArea\TriggerY#[i])
+										DistZ# = Abs(AI\Z# - UpdateArea\TriggerZ#[i])
+										Dist# = (DistX# * DistX#) + (DistY# * DistY#) + (DistZ# * DistZ#)
+										; Inside trigger area
+										If Dist# < Size#
+											InTrigger = i
+											; Only execute script if this trigger was not already executed
+											If AI\LastTrigger <> i
+												ThreadScript(UpdateArea\TriggerScript$[i], UpdateArea\TriggerMethod$[i], Handle(AI), 0, Str$(i))
+											EndIf
 										EndIf
 									EndIf
-								EndIf
-							Next
-							AI\LastTrigger = InTrigger
+									Next
+									AI\LastTrigger = InTrigger
+							EndIf
 						EndIf
 					EndIf
 				Next

--- a/src/Tests/Modules/ServerAreaInstanceGuardTest.bb
+++ b/src/Tests/Modules/ServerAreaInstanceGuardTest.bb
@@ -1,0 +1,68 @@
+Strict
+EnableGC
+
+; Regression test for the three Server.bb paths that resolve an actor's
+; AreaInstance during a stale-handle window. Server.bb cannot be included in
+; a standalone Strict test because it boots the complete server/UI graph, so
+; this bounded source contract pins the required nested Null guards directly.
+;
+; BlitzForge evaluates `And` non-short-circuit. Therefore
+; `AInstance <> Null And AInstance\Area = ...` still dereferences the Null
+; instance. Each production section must first guard AInstance, then inspect
+; its Area only inside that branch.
+
+Function SectionContains%(Path$, StartMarker$, EndMarker$, Needle$)
+	Local F.BBStream = ReadFile(Path$)
+	Local InSection%
+	Local Line$
+	If F = Null Then F = ReadFile("..\" + Path$)
+	If F = Null Then Return False
+	While Not Eof(F)
+		Line$ = ReadLine$(F)
+		If Instr(Line$, StartMarker$) > 0 Then InSection = True
+		If InSection = True And Instr(Line$, EndMarker$) > 0 Then Exit
+		If InSection = True And Instr(Line$, Needle$) > 0
+			CloseFile F
+			Return True
+		EndIf
+	Wend
+	CloseFile F
+	Return False
+End Function
+
+Function SectionUsesNestedAreaGuard%(Path$, StartMarker$, EndMarker$, AreaNeedle$)
+	Local F.BBStream = ReadFile(Path$)
+	Local InSection%, SawInstanceGuard%
+	Local Line$
+	If F = Null Then F = ReadFile("..\" + Path$)
+	If F = Null Then Return False
+	While Not Eof(F)
+		Line$ = ReadLine$(F)
+		If Instr(Line$, StartMarker$) > 0 Then InSection = True
+		If InSection = True And Instr(Line$, EndMarker$) > 0 Then Exit
+		If InSection = True
+			If Instr(Line$, "If AInstance <> Null") > 0 Then SawInstanceGuard = True
+			If SawInstanceGuard = True And Instr(Line$, AreaNeedle$) > 0
+				CloseFile F
+				Return True
+			EndIf
+		EndIf
+	Wend
+	CloseFile F
+	Return False
+End Function
+
+Test testBootPlayerUsesNestedAreaInstanceGuard()
+	Assert(SectionUsesNestedAreaGuard%("Server.bb", "Case Game\BootButton", "Case Game\MessageButton", "If AInstance\Area = GameArea") = True)
+	Assert(SectionContains%("Server.bb", "Case Game\BootButton", "Case Game\MessageButton", "AInstance <> Null And AInstance\Area") = False)
+End Test
+
+Test testPlayerListRefreshUsesNestedAreaInstanceGuard()
+	Assert(SectionUsesNestedAreaGuard%("Server.bb", "Case Game\AreaCombo", "Case Game\ChatLogMode", "If AInstance\Area = GameArea") = True)
+	Assert(SectionContains%("Server.bb", "Case Game\AreaCombo", "Case Game\ChatLogMode", "AInstance <> Null And AInstance\Area") = False)
+End Test
+
+Test testPortalAndTriggerTickUsesNestedAreaInstanceGuard()
+	Assert(SectionUsesNestedAreaGuard%("Server.bb", "If AI\RuntimeID > -1 And AI\RNID > 0", "For i = 0 To 99", "If AInstance\Area = UpdateArea") = True)
+	Assert(SectionContains%("Server.bb", "If AI\RuntimeID > -1 And AI\RNID > 0", "For i = 0 To 99", "AInstance <> Null And AInstance\Area") = False)
+End Test

--- a/src/Tests/Modules/ServerAreaInstanceGuardTest.bb
+++ b/src/Tests/Modules/ServerAreaInstanceGuardTest.bb
@@ -42,9 +42,14 @@ Function SectionUsesNestedAreaGuard%(Path$, StartMarker$, EndMarker$, AreaNeedle
 		If InSection = True And Instr(Line$, EndMarker$) > 0 Then Exit
 		If InSection = True
 			If Instr(Line$, "If AInstance <> Null") > 0 Then SawInstanceGuard = True
-			If SawInstanceGuard = True And Instr(Line$, AreaNeedle$) > 0
-				CloseFile F
-				Return True
+			If SawInstanceGuard = True
+				If Instr(Line$, AreaNeedle$) > 0
+					CloseFile F
+					Return True
+				EndIf
+				; The outer branch ended before the Area read, so a following
+				; comparison would be an unsafe standalone dereference.
+				If Instr(Line$, "EndIf") > 0 Then Exit
 			EndIf
 		EndIf
 	Wend


### PR DESCRIPTION
## Outcome

Server administration and per-area portal/trigger ticks now fail closed when an actor's stale `ServerArea` no longer resolves to an `AreaInstance`, preventing a shared-server crash during warp or teardown.

## Changes

- Replace the three unsafe combined `AInstance <> Null And AInstance\Area = ...` predicates with explicit nested guards in `Server.bb`.
- Add a bounded source-contract regression test for the Boot player, player-list refresh, and portal/trigger sections.

Fixes #631

## Acceptance criteria and evidence

- Missing `AreaInstance` skips the three branches before any `AInstance\Area` read: focused source-contract probe passes all three bounded sections.
- Live area behavior remains within the existing inner comparisons: the diff only nests existing player matching/list and portal/trigger bodies.
- Unsafe non-short-circuit `And` form is forbidden by the focused regression test and by the passing source probe.

## RED -> GREEN

- **RED:** before production edits, the focused source-contract probe exited `1` with `AssertionError: unsafe combined guard remains in Case Game\BootButton`.
- **GREEN:** after adding the nested guards, the same probe exited `0` and reported `3 bounded Server.bb sections use nested AreaInstance guards`.

## Verification

- `bash scripts/gen_packet_index.sh --check` -> exit 0.
- `bash scripts/gen_bvm_reference.sh --check` -> exit 0 (two existing dead-API warnings only).
- `git diff --check` -> exit 0.
- `./test.sh ServerAreaInstanceGuardTest` -> exit 1 before test execution because `compiler/BlitzForge/bin/blitzcc` is absent. Two safe submodule initialization attempts could not resolve the pinned revision in this isolated worktree; full Blitz compile/test is therefore delegated to CI.

## Compatibility, risk, and rollback

No packet, save, command, authorization, portal, or trigger behavior changes for live areas. The change only suppresses work during an invalid transient lookup. Roll back by reverting `1a94fd00c2ddba8ad2ae944d19456dc90dfd81f4`.

## Deferred follow-up

None. Independent review and exact-head CI are pending.

## Independent review

`ACCEPT` — fresh reviewer inspected exact head `36e01d6ebfcd8456ecdb4524ffe7f68ee9cc7949`; all three `AInstance\Area` reads remain inside their Null branches, and the regression test rejects an empty Null guard followed by a standalone dereference.