### PR TITLE
fix(server): fail closed BVM_SETLEADER stale areas

### DIFF
--- a/src/Modules/ScriptingCommands.bb
+++ b/src/Modules/ScriptingCommands.bb
@@ -1039,19 +1039,21 @@ Function BVM_SETLEADER(Param1%, Param2%)
 				; no zone to patrol in.
 				AInstance.AreaInstance = Object.AreaInstance(Actor\ServerArea)
 				Found = False
-				If AInstance <> Null And AInstance\Area <> Null
-					For i = 0 To 249
-						If AInstance\Area\PrevWaypoint[i] <> 255
-							Actor\OldX# = Actor\X#
-							Actor\OldZ# = Actor\Z#
-							Actor\AIMode = AI_Patrol
-							Actor\DestX# = AInstance\Area\WaypointX#[i] + Rnd#(-5.0, 5.0)
-							Actor\DestZ# = AInstance\Area\WaypointZ#[i] + Rnd#(-5.0, 5.0)
-							Actor\CurrentWaypoint = i
-							Found = True
-							Exit
-						EndIf
-					Next
+				If AInstance <> Null
+					If AInstance\Area <> Null
+						For i = 0 To 249
+							If AInstance\Area\PrevWaypoint[i] <> 255
+								Actor\OldX# = Actor\X#
+								Actor\OldZ# = Actor\Z#
+								Actor\AIMode = AI_Patrol
+								Actor\DestX# = AInstance\Area\WaypointX#[i] + Rnd#(-5.0, 5.0)
+								Actor\DestZ# = AInstance\Area\WaypointZ#[i] + Rnd#(-5.0, 5.0)
+								Actor\CurrentWaypoint = i
+								Found = True
+								Exit
+							EndIf
+						Next
+					EndIf
 				EndIf
 				; Die if no waypoint available (or area is gone)
 				If Found = False Then KillActor(Actor, Null)

--- a/src/Tests/Modules/ScriptingCommandsGuardTest.bb
+++ b/src/Tests/Modules/ScriptingCommandsGuardTest.bb
@@ -1,0 +1,61 @@
+Strict
+EnableGC
+
+; Regression contract for BVM_SETLEADER's no-leader patrol fallback.
+; ScriptingCommands.bb cannot be included by a standalone Strict test because
+; it pulls in the server, world, and BVM graphs. Pin the bounded source shape
+; instead: BlitzForge evaluates And without short-circuiting, so a combined
+; AInstance/Area condition still dereferences a stale AreaInstance.
+
+Function SectionContains%(Path$, StartMarker$, EndMarker$, Needle$)
+	Local F.BBStream = ReadFile(Path$)
+	Local InSection%
+	Local Line$
+	If F = Null Then F = ReadFile("..\\" + Path$)
+	If F = Null Then Return False
+	While Not Eof(F)
+		Line$ = ReadLine$(F)
+		If Instr(Line$, StartMarker$) > 0 Then InSection = True
+		If InSection = True And Instr(Line$, EndMarker$) > 0 Then Exit
+		If InSection = True And Instr(Line$, Needle$) > 0
+			CloseFile F
+			Return True
+		EndIf
+	Wend
+	CloseFile F
+	Return False
+End Function
+
+Function SectionHasOrderedPatrolGuard%(Path$)
+	Local F.BBStream = ReadFile(Path$)
+	Local Stage%
+	Local Line$
+	If F = Null Then F = ReadFile("..\\" + Path$)
+	If F = Null Then Return False
+	While Not Eof(F)
+		Line$ = ReadLine$(F)
+		; Anchor after the no-leader branch initializes Found. An earlier
+		; AreaInstance guard in the set-pet branch must not satisfy this test.
+		If Instr(Line$, "Found = False") > 0 Then Stage = 1
+		If Stage = 1 And Instr(Line$, "If AInstance <> Null") > 0 Then Stage = 2
+		If Stage = 2 And Instr(Line$, "If AInstance\\Area <> Null") > 0 Then Stage = 3
+		If Stage = 3 And Instr(Line$, "For i = 0 To 249") > 0 Then Stage = 4
+		If Stage = 4 And Instr(Line$, "AInstance\\Area\\PrevWaypoint") > 0 Then Stage = 5
+		If Stage = 5 And Instr(Line$, "AInstance\\Area\\WaypointX#") > 0 Then Stage = 6
+		If Stage = 6 And Instr(Line$, "AInstance\\Area\\WaypointZ#") > 0
+			CloseFile F
+			Return True
+		EndIf
+		If Stage > 0 And Instr(Line$, "; Die if no waypoint available") > 0 Then Exit
+	Wend
+	CloseFile F
+	Return False
+End Function
+
+Test testSetLeaderRejectsUnsafeCombinedNestedAreaGuard()
+	Assert(SectionContains%("Modules\\ScriptingCommands.bb", "Function BVM_SETLEADER", "Function BVM_ACTORLEADER", "AInstance <> Null And AInstance\\Area") = False)
+End Test
+
+Test testSetLeaderPatrolReadsAreaOnlyAfterNestedGuards()
+	Assert(SectionHasOrderedPatrolGuard%("Modules\\ScriptingCommands.bb") = True)
+End Test

--- a/src/Tests/Modules/ScriptingCommandsGuardTest.bb
+++ b/src/Tests/Modules/ScriptingCommandsGuardTest.bb
@@ -26,9 +26,20 @@ Function SectionContains%(Path$, StartMarker$, EndMarker$, Needle$)
 	Return False
 End Function
 
+Function LeadingTabs%(Line$)
+	Local Count%, Pos% = 1
+	While Pos <= Len(Line$)
+		If Mid$(Line$, Pos, 1) <> Chr$(9) Then Exit
+		Count = Count + 1
+		Pos = Pos + 1
+	Wend
+	Return Count
+End Function
+
 Function SectionHasOrderedPatrolGuard%(Path$)
 	Local F.BBStream = ReadFile(Path$)
-	Local Stage%
+	Local Stage%, InstanceIndent%, AreaIndent%
+	Local SawPrev%, SawX%, SawZ%
 	Local Line$
 	If F = Null Then F = ReadFile("..\" + Path$)
 	If F = Null Then Return False
@@ -37,15 +48,32 @@ Function SectionHasOrderedPatrolGuard%(Path$)
 		; Anchor after the no-leader branch initializes Found. An earlier
 		; AreaInstance guard in the set-pet branch must not satisfy this test.
 		If Instr(Line$, "Found = False") > 0 Then Stage = 1
-		If Stage = 1 And Instr(Line$, "If AInstance <> Null") > 0 Then Stage = 2
-		If Stage = 2 And Instr(Line$, "If AInstance\Area <> Null") > 0 Then Stage = 3
-		If Stage = 3 And Instr(Line$, "For i = 0 To 249") > 0 Then Stage = 4
-		If Stage = 4 And Instr(Line$, "AInstance\Area\PrevWaypoint") > 0 Then Stage = 5
-		If Stage = 5 And Instr(Line$, "AInstance\Area\WaypointX#") > 0 Then Stage = 6
-		If Stage = 6 And Instr(Line$, "AInstance\Area\WaypointZ#") > 0
+		If Stage = 1 And Instr(Line$, "If AInstance <> Null") > 0
+			InstanceIndent = LeadingTabs(Line$)
+			Stage = 2
+		EndIf
+		If Stage = 2 And Instr(Line$, "If AInstance\Area <> Null") > 0
+			AreaIndent = LeadingTabs(Line$)
+			If AreaIndent <= InstanceIndent Then Return False
+			Stage = 3
+		EndIf
+		If Stage = 3 And Instr(Line$, "AInstance\Area\PrevWaypoint") > 0
+			If LeadingTabs(Line$) <= AreaIndent Then Return False
+			SawPrev = True
+		EndIf
+		If Stage = 3 And Instr(Line$, "AInstance\Area\WaypointX#") > 0
+			If LeadingTabs(Line$) <= AreaIndent Then Return False
+			SawX = True
+		EndIf
+		If Stage = 3 And Instr(Line$, "AInstance\Area\WaypointZ#") > 0
+			If LeadingTabs(Line$) <= AreaIndent Then Return False
+			SawZ = True
+		EndIf
+		If SawPrev = True And SawX = True And SawZ = True
 			CloseFile F
 			Return True
 		EndIf
+		If Stage = 3 And Instr(Line$, "EndIf") > 0 And LeadingTabs(Line$) <= AreaIndent Then Return False
 		If Stage > 0 And Instr(Line$, "; Die if no waypoint available") > 0 Then Exit
 	Wend
 	CloseFile F

--- a/src/Tests/Modules/ScriptingCommandsGuardTest.bb
+++ b/src/Tests/Modules/ScriptingCommandsGuardTest.bb
@@ -11,7 +11,7 @@ Function SectionContains%(Path$, StartMarker$, EndMarker$, Needle$)
 	Local F.BBStream = ReadFile(Path$)
 	Local InSection%
 	Local Line$
-	If F = Null Then F = ReadFile("..\\" + Path$)
+	If F = Null Then F = ReadFile("..\" + Path$)
 	If F = Null Then Return False
 	While Not Eof(F)
 		Line$ = ReadLine$(F)
@@ -30,7 +30,7 @@ Function SectionHasOrderedPatrolGuard%(Path$)
 	Local F.BBStream = ReadFile(Path$)
 	Local Stage%
 	Local Line$
-	If F = Null Then F = ReadFile("..\\" + Path$)
+	If F = Null Then F = ReadFile("..\" + Path$)
 	If F = Null Then Return False
 	While Not Eof(F)
 		Line$ = ReadLine$(F)
@@ -38,11 +38,11 @@ Function SectionHasOrderedPatrolGuard%(Path$)
 		; AreaInstance guard in the set-pet branch must not satisfy this test.
 		If Instr(Line$, "Found = False") > 0 Then Stage = 1
 		If Stage = 1 And Instr(Line$, "If AInstance <> Null") > 0 Then Stage = 2
-		If Stage = 2 And Instr(Line$, "If AInstance\\Area <> Null") > 0 Then Stage = 3
+		If Stage = 2 And Instr(Line$, "If AInstance\Area <> Null") > 0 Then Stage = 3
 		If Stage = 3 And Instr(Line$, "For i = 0 To 249") > 0 Then Stage = 4
-		If Stage = 4 And Instr(Line$, "AInstance\\Area\\PrevWaypoint") > 0 Then Stage = 5
-		If Stage = 5 And Instr(Line$, "AInstance\\Area\\WaypointX#") > 0 Then Stage = 6
-		If Stage = 6 And Instr(Line$, "AInstance\\Area\\WaypointZ#") > 0
+		If Stage = 4 And Instr(Line$, "AInstance\Area\PrevWaypoint") > 0 Then Stage = 5
+		If Stage = 5 And Instr(Line$, "AInstance\Area\WaypointX#") > 0 Then Stage = 6
+		If Stage = 6 And Instr(Line$, "AInstance\Area\WaypointZ#") > 0
 			CloseFile F
 			Return True
 		EndIf
@@ -53,9 +53,9 @@ Function SectionHasOrderedPatrolGuard%(Path$)
 End Function
 
 Test testSetLeaderRejectsUnsafeCombinedNestedAreaGuard()
-	Assert(SectionContains%("Modules\\ScriptingCommands.bb", "Function BVM_SETLEADER", "Function BVM_ACTORLEADER", "AInstance <> Null And AInstance\\Area") = False)
+	Assert(SectionContains%("Modules\ScriptingCommands.bb", "Function BVM_SETLEADER", "Function BVM_ACTORLEADER", "AInstance <> Null And AInstance\Area") = False)
 End Test
 
 Test testSetLeaderPatrolReadsAreaOnlyAfterNestedGuards()
-	Assert(SectionHasOrderedPatrolGuard%("Modules\\ScriptingCommands.bb") = True)
+	Assert(SectionHasOrderedPatrolGuard%("Modules\ScriptingCommands.bb") = True)
 End Test


### PR DESCRIPTION
## Outcome

The server now treats a stale zone during `SETLEADER(actor, 0)` as the existing safe orphaned-actor fallback instead of dereferencing a missing nested area and crashing the shared process.

## Technical changes

- Replaced the non-short-circuit `AInstance <> Null And AInstance\Area <> Null` predicate in `BVM_SETLEADER` with ordered nested guards.
- Added `ScriptingCommandsGuardTest.bb`, a bounded source-contract regression test for the no-leader patrol section.

Fixes #637

## Acceptance evidence

| Criterion | Evidence |
| --- | --- |
| No unsafe combined nested-area predicate | RED source contract found it; final contract passes only after its removal. |
| Waypoint reads occur after both guards | The regression scanner anchors at `Found = False`, validates guard indentation, and rejects any waypoint read outside the nested area guard. |
| Missing area retains fallback | Production keeps `Found = False` and the existing `If Found = False Then KillActor(Actor, Null)` immediately after the guarded block. |
| Valid patrol selection is unchanged | The original waypoint loop and assignments are unchanged, only nested one level deeper. |
| Focused regression exists | New `src/Tests/Modules/ScriptingCommandsGuardTest.bb` asserts both properties. |
| Generated docs remain current | Both generator `--check` commands exited 0. |

## RED → GREEN

- **Baseline / RED:** focused source probe exited 1 because `BVM_SETLEADER` contained `AInstance <> Null And AInstance\Area <> Null`.
- **Initial CI finding:** the new test first used doubled Blitz backslashes, so its ordered markers could not match source text. Windows CI compiled it but reported its second assertion failed (60/61 tests passed).
- **GREEN:** corrected single-backslash markers and added indentation-aware guard-scope validation. The final source-contract probe exited 0, and Windows CI passed all 61 test files.
- **Native local limitation:** `./test.sh ScriptingCommandsGuardTest` cannot run in this isolated Linux worktree because `compiler/BlitzForge/bin/blitzcc` is absent. Narrow submodule initialization timed out; shallow retry exited 128 (`Unable to find current revision`).

## Verification

- Focused final source-contract probe — exit 0.
- `git diff --check origin/develop...94865899` — exit 0.
- `bash scripts/gen_packet_index.sh --check` — exit 0.
- `bash scripts/gen_bvm_reference.sh --check` — exit 0 (existing dead-command warnings only).
- Exact-head CI: Build and test — success (4m22s, 61/61 test files); Rust server (Linux) — success on retry (57s).
- The initial Rust attempt failed only the known unrelated `waitspeak_and_waititem_resume_on_events` test (153/154 passed). The exact test passed locally with Rust 1.94 (`1 passed; 153 filtered`) before the successful GitHub retry.

## Compatibility, rollback, and deferred work

No protocol, persistence, opcode, or valid-area behavior changes. Roll back with a normal revert of this PR's merge commit. The broader Rust toolchain reproducibility and Loom release-state documentation candidates are deliberately deferred.

## Independent review

Fresh reviewer verdict: **ACCEPT** for exact head `94865899377e32c8307185a474ba098ab87ce210`. The review confirmed the nested guards contain all waypoint reads, preserve the fallback, retain valid patrol behavior, and keep scope limited to the BVM safety fix and focused test.