### PR TITLE
fix(bvm): fail closed for stale quest Account guards

### DIFF
--- a/src/Modules/ScriptingCommands.bb
+++ b/src/Modules/ScriptingCommands.bb
@@ -2196,7 +2196,8 @@ Function BVM_NEWQUEST(Param1%, Param2$, Param3$, Param4%=255, Param5%=255, Param
 			; QuestLog is Field[9]; either condition would crash the
 			; server with a Blitz Field OOB or Null deref during a
 			; script-triggered quest mutation.
-			If A = Null Or A\LoggedOn < 0 Or A\LoggedOn > 9 Then Return
+			If A = Null Then Return
+			If A\LoggedOn < 0 Or A\LoggedOn > 9 Then Return
 			Name$ = Param2$
 			; Check it doesn't already exist
 			FreeSpace = -1
@@ -2229,7 +2230,8 @@ Function BVM_UPDATEQUEST(Param1%, Param2$, Param3$, Param4%=255, Param5%=255, Pa
 	If Actor <> Null
 		If Actor\RNID > 0
 			A.Account = Object.Account(Actor\Account)
-			If A = Null Or A\LoggedOn < 0 Or A\LoggedOn > 9 Then Return
+			If A = Null Then Return
+			If A\LoggedOn < 0 Or A\LoggedOn > 9 Then Return
 			Name$ = Upper$(Param2$)
 			Status$ = RCE_StrFromInt$(Param4%, 1)
 			Status$ = Status$ + RCE_StrFromInt$(Param5%, 1)
@@ -2254,7 +2256,8 @@ Function BVM_COMPLETEQUEST(Param1%, Param2$)
 	If Actor <> Null
 		If Actor\RNID > 0
 			A.Account = Object.Account(Actor\Account)
-			If A = Null Or A\LoggedOn < 0 Or A\LoggedOn > 9 Then Return
+			If A = Null Then Return
+			If A\LoggedOn < 0 Or A\LoggedOn > 9 Then Return
 			Name$ = Upper$(Param2$)
 			Status$ = Chr$(255) + Chr$(225) + Chr$(100) + Chr$(254)
 			For i = 0 To 499
@@ -2284,7 +2287,8 @@ Function BVM_DELETEQUEST(Param1%, Param2$)
 	If Actor <> Null
 		If Actor\RNID > 0
 			A.Account = Object.Account(Actor\Account)
-			If A = Null Or A\LoggedOn < 0 Or A\LoggedOn > 9 Then Return
+			If A = Null Then Return
+			If A\LoggedOn < 0 Or A\LoggedOn > 9 Then Return
 			Name$ = Upper$(Param2$)
 			For i = 0 To 499
 				If Upper$(A\QuestLog[A\LoggedOn]\EntryName$[i]) = Name$
@@ -2303,7 +2307,8 @@ Function BVM_QUESTSTATUS$(Param1%, Param2$)
 	If Actor <> Null
 		If Actor\RNID > 0
 			A.Account = Object.Account(Actor\Account)
-			If A = Null Or A\LoggedOn < 0 Or A\LoggedOn > 9 Then Return ""
+			If A = Null Then Return ""
+			If A\LoggedOn < 0 Or A\LoggedOn > 9 Then Return ""
 			Name$ = Upper$(Param2$)
 			For i = 0 To 499
 				If Upper$(A\QuestLog[A\LoggedOn]\EntryName$[i]) = Name$
@@ -2321,7 +2326,8 @@ Function BVM_QUESTCOMPLETE%(Param1%, Param2$)
 	If Actor <> Null
 		If Actor\RNID > 0
 			A.Account = Object.Account(Actor\Account)
-			If A = Null Or A\LoggedOn < 0 Or A\LoggedOn > 9 Then Return 0
+			If A = Null Then Return 0
+			If A\LoggedOn < 0 Or A\LoggedOn > 9 Then Return 0
 			Name$ = Upper$(Param2$)
 			For i = 0 To 499
 				If Upper$(A\QuestLog[A\LoggedOn]\EntryName$[i]) = Name$

--- a/src/Tests/Modules/ScriptingCommandsGuardTest.bb
+++ b/src/Tests/Modules/ScriptingCommandsGuardTest.bb
@@ -118,6 +118,6 @@ Test testQuestBVMsGuardStaleAccountBeforeQuestLogAccess()
 	Assert(QuestGuardSectionIsSafe%("Modules\ScriptingCommands.bb", "BVM_UPDATEQUEST", "") = True)
 	Assert(QuestGuardSectionIsSafe%("Modules\ScriptingCommands.bb", "BVM_COMPLETEQUEST", "") = True)
 	Assert(QuestGuardSectionIsSafe%("Modules\ScriptingCommands.bb", "BVM_DELETEQUEST", "") = True)
-	Assert(QuestGuardSectionIsSafe%("Modules\ScriptingCommands.bb", "BVM_QUESTSTATUS$", " \"\"") = True)
+	Assert(QuestGuardSectionIsSafe%("Modules\ScriptingCommands.bb", "BVM_QUESTSTATUS$", " " + Chr$(34) + Chr$(34)) = True)
 	Assert(QuestGuardSectionIsSafe%("Modules\ScriptingCommands.bb", "BVM_QUESTCOMPLETE%", " 0") = True)
 End Test

--- a/src/Tests/Modules/ScriptingCommandsGuardTest.bb
+++ b/src/Tests/Modules/ScriptingCommandsGuardTest.bb
@@ -87,3 +87,37 @@ End Test
 Test testSetLeaderPatrolReadsAreaOnlyAfterNestedGuards()
 	Assert(SectionHasOrderedPatrolGuard%("Modules\ScriptingCommands.bb") = True)
 End Test
+
+Function QuestGuardSectionIsSafe%(Path$, FunctionName$, ReturnValue$)
+	Local F.BBStream = ReadFile(Path$)
+	Local InSection%, SawNullGuard%, SawLoggedOnGuard%
+	Local Line$
+	If F = Null Then F = ReadFile("..\" + Path$)
+	If F = Null Then Return False
+	While Not Eof(F)
+		Line$ = ReadLine$(F)
+		If Instr(Line$, "Function " + FunctionName$) > 0 Then InSection = True
+		If InSection = True And Instr(Line$, "If A = Null Or A\LoggedOn") > 0
+			CloseFile F
+			Return False
+		EndIf
+		If InSection = True And Instr(Line$, "If A = Null Then Return" + ReturnValue$) > 0 Then SawNullGuard = True
+		If InSection = True And SawNullGuard = True And Instr(Line$, "If A\LoggedOn < 0 Or A\LoggedOn > 9 Then Return" + ReturnValue$) > 0 Then SawLoggedOnGuard = True
+		If InSection = True And Instr(Line$, "A\QuestLog") > 0 And SawLoggedOnGuard = False
+			CloseFile F
+			Return False
+		EndIf
+		If InSection = True And Instr(Line$, "End Function") > 0 Then Exit
+	Wend
+	CloseFile F
+	Return SawNullGuard = True And SawLoggedOnGuard = True
+End Function
+
+Test testQuestBVMsGuardStaleAccountBeforeQuestLogAccess()
+	Assert(QuestGuardSectionIsSafe%("Modules\ScriptingCommands.bb", "BVM_NEWQUEST", "") = True)
+	Assert(QuestGuardSectionIsSafe%("Modules\ScriptingCommands.bb", "BVM_UPDATEQUEST", "") = True)
+	Assert(QuestGuardSectionIsSafe%("Modules\ScriptingCommands.bb", "BVM_COMPLETEQUEST", "") = True)
+	Assert(QuestGuardSectionIsSafe%("Modules\ScriptingCommands.bb", "BVM_DELETEQUEST", "") = True)
+	Assert(QuestGuardSectionIsSafe%("Modules\ScriptingCommands.bb", "BVM_QUESTSTATUS$", " \"\"") = True)
+	Assert(QuestGuardSectionIsSafe%("Modules\ScriptingCommands.bb", "BVM_QUESTCOMPLETE%", " 0") = True)
+End Test


### PR DESCRIPTION
## Outcome

Quest scripts now fail closed during an account-handle transition instead of allowing an eager `Or` operand to dereference a stale account and crash the shared server.

Fixes #639

## Technical changes

- Split the combined Null/login-state predicates in all six quest BVMs into ordered Null then range guards.
- Preserve the existing void, string-empty, and integer-zero return contracts.
- Add focused source-contract coverage that rejects the unsafe combined predicate and requires both guards before every quest-log access.

## Acceptance evidence

| Criterion | Evidence |
|---|---|
| Six stale-account paths return safely | Ordered source contract observed all six functions safe after the change |
| Query defaults retained | Contract pins `Return ""` for `BVM_QUESTSTATUS$` and `Return 0` for `BVM_QUESTCOMPLETE%` |
| Unsafe eager form prohibited | Contract rejects `If A = Null Or A\LoggedOn` in each bounded function |
| Valid quest behavior / wire unchanged | Only guard structure changes; BVM declarations, dispatch, packets, and data formats are untouched |

## TDD and verification

- Baseline: `./test.sh ScriptingCommandsGuardTest` exited 1 because `compiler/BlitzForge/bin/blitzcc` was missing.
- RED: focused source-contract probe exited 1 and reported all six quest BVMs unsafe.
- GREEN: the same source-contract probe exited 0 and reported all six safe, with both guards ordered before the first `A\QuestLog` read.
- Final local checks: `bash scripts/gen_bvm_reference.sh --check` exit 0; `bash scripts/gen_packet_index.sh --check` exit 0; `git diff --check` exit 0.
- Native local compiler test remains unavailable: targeted submodule initialization succeeded, but BlitzForge reports runnable host builds are macOS-only and this Linux worktree has no `bin/blitzcc`. Exact-head CI is required for compiler/test proof.

## Compatibility, risk, rollback

No protocol, data schema, opcode, dispatch, or valid-account quest behavior changes. The failure-path behavior remains the intended fail-closed result. Rollback is a normal revert of `ea5c9e57`.

## Deferred follow-ups

A broader Account-handle audit, Loom marker Y-drag repair, contributor generated-doc guidance, and Rust toolchain policy are intentionally out of scope.

## Independent review

Fresh final independent review of exact head `ce3c9449f8729d242eca33722dbe4546663999c2`: **ACCEPT**. The reviewer confirmed ordered Null/range guards across all six BVMs, preserved query sentinels, valid `Chr$(34)` test construction, scoped change, and no compatibility/security concerns. Exact-head CI is terminal-successful: Build and test passed (61 files plus client tests/clippy/doc checks); Rust server passed after a safe rerun of the unrelated, locally-reproduced WaitSpeak flake.