### PR TITLE
fix(client): clean simultaneous BloodSpurt expirations safely

### DIFF
--- a/src/Modules/ClientCombat.bb
+++ b/src/Modules/ClientCombat.bb
@@ -68,13 +68,19 @@ Function UpdateCombat()
 		EndIf
 	EndIf
 
-	; Update blood spurts
-	For B.BloodSpurt = Each BloodSpurt
+	; BloodSpurts can expire together after a burst hit. Capture the next
+	; live-Type node before deleting the current one; a For-Each cursor would
+	; otherwise advance through the deleted instance and skip its sibling.
+	Local B.BloodSpurt = First BloodSpurt
+	Local BNext.BloodSpurt = Null
+	While B <> Null
+		BNext = After B
 		If MilliSecs() - B\Timer > 600
 			RP_KillEmitter(B\EmitterEN, False, False)
 			Delete(B)
 		EndIf
-	Next
+		B = BNext
+	Wend
 
 End Function
 

--- a/src/Tests/Modules/ClientCombatIteratorTest.bb
+++ b/src/Tests/Modules/ClientCombatIteratorTest.bb
@@ -1,0 +1,42 @@
+Strict
+EnableGC
+
+; Regression contract for UpdateCombat's BloodSpurt expiry sweep. ClientCombat
+; cannot be included by a standalone Strict test without the full client and
+; renderer graph, so this pins the bounded source shape instead. The loop
+; deletes live BloodSpurt instances; it must capture After B before cleanup so
+; simultaneous expirations cannot advance through a deleted iterator node.
+
+Function BloodSpurtCleanupUsesAfterCursor%(Path$)
+	Local F.BBStream = ReadFile(Path$)
+	Local Stage%
+	Local Line$
+	If F = Null Then F = ReadFile("..\" + Path$)
+	If F = Null Then Return False
+	While Not Eof(F)
+		Line$ = ReadLine$(F)
+		If Instr(Line$, "; BloodSpurts can expire together") > 0 Then Stage = 1
+		If Stage = 1 And Instr(Line$, "For B.BloodSpurt = Each BloodSpurt") > 0
+			CloseFile F
+			Return False
+		EndIf
+		If Stage = 1 And Instr(Line$, "Local B.BloodSpurt = First BloodSpurt") > 0 Then Stage = 2
+		If Stage = 2 And Instr(Line$, "Local BNext.BloodSpurt = Null") > 0 Then Stage = 3
+		If Stage = 3 And Instr(Line$, "While B <> Null") > 0 Then Stage = 4
+		If Stage = 4 And Instr(Line$, "BNext = After B") > 0 Then Stage = 5
+		If Stage = 5 And Instr(Line$, "RP_KillEmitter(B\EmitterEN, False, False)") > 0 Then Stage = 6
+		If Stage = 6 And Instr(Line$, "Delete(B)") > 0 Then Stage = 7
+		If Stage = 7 And Instr(Line$, "B = BNext") > 0
+			CloseFile F
+			Return True
+		EndIf
+		If Stage > 0 And Instr(Line$, "End Function") > 0 Then Exit
+	Wend
+	CloseFile F
+	Return False
+
+End Function
+
+Test testBloodSpurtCleanupCapturesNextBeforeDelete()
+	Assert(BloodSpurtCleanupUsesAfterCursor%("Modules\ClientCombat.bb") = True)
+End Test


### PR DESCRIPTION
## Outcome

Burst combat no longer risks skipping cleanup or advancing through a deleted particle node when multiple blood-spurt emitters expire in the same client frame.

Fixes #641

## Technical changes

- Replace the `For ... Each BloodSpurt` expiry loop with the repository-standard `First` / `After` / `While` cursor walk.
- Capture the next live node before emitter shutdown and deletion.
- Add a bounded source-contract regression test for the production cleanup sequence.

## Acceptance evidence

| Criterion | Evidence |
|---|---|
| Capture next node before deletion | Focused source-contract probe found `First`, `BNext = After B`, and `B = BNext` in order |
| Preserve one emitter shutdown before deletion | Probe found `RP_KillEmitter(B\EmitterEN, False, False)` before `Delete(B)` |
| Remove unsafe cursor | Probe confirmed the bounded section contains no `For B.BloodSpurt = Each BloodSpurt` |
| CI-compilable regression contract | `ClientCombatIteratorTest.bb` follows the established standalone source-contract test shape; exact-head Windows CI is pending |

## TDD and verification

- Baseline: production section used `For B.BloodSpurt = Each BloodSpurt` and `Delete(B)`; the focused test runner could not start because `compiler/BlitzForge/bin/blitzcc` is absent.
- RED: focused source-contract probe exited 1 with `legacy_loop=0 first_cursor=1 next_capture=1 advance=1`, proving the existing section violated the intended after-cursor contract.
- GREEN: the same probe exited 0 after the minimal cursor rewrite.
- Final local checks: `git diff --check` exit 0; source-contract probe exit 0.
- Native local test limitation: `git submodule update --init compiler/BlitzForge` first timed out at 60s, then safe shallow retry succeeded; the pinned checkout has no runnable `bin/blitzcc`, and its `compile.sh` explicitly rejects Linux runnable host builds. Exact-head CI is required for compiled-test proof.

## Compatibility, risk, rollback

No packet, asset, data-format, timing, or server behavior changes. The existing 600ms expiry and emitter-kill API call remain intact; only the iterator mechanics change. Rollback is a normal revert of this one commit.

## Deferred follow-ups

Broader delete-during-iteration audits, BloodSpurt creation behavior, Loom front-door copy, and Rust-toolchain reproducibility remain intentionally out of scope.

## Independent review

Fresh review verdict: **ACCEPT** for exact head `35ba5fc19f3444ccdc135c07182b7b6b16dbd7d2`. The reviewer independently confirmed ordered `After B` capture, one emitter kill before deletion, absence of the legacy cursor, test fit, and disjointness from #635/#636. Compiled local proof remains unavailable; CI is the remaining gate.