### PR TITLE
fix(client): fail closed for stale combat targets

### DIFF
--- a/src/Modules/ClientCombat.bb
+++ b/src/Modules/ClientCombat.bb
@@ -25,7 +25,15 @@ Function UpdateCombat()
 		; pathway, or simply a missed cleanup site). Treat a Null
 		; lookup the same as a dead target so the next deref doesn't
 		; crash UpdateCombat -- this runs every frame.
-		If A = Null Or A\Attributes\Value[HealthStat] < 1
+		If A = Null
+			PlayerTarget = 0
+			HideEntity(ActorSelectEN)			; Replace through clean function
+			DestroyCharInteractionWindow()
+			If useClickMovement then ShowEntity(ClickMarkerEN)			; Replace through clean function
+			Return
+		EndIf
+
+		If A\Attributes\Value[HealthStat] < 1
 			PlayerTarget = 0
 			HideEntity(ActorSelectEN)			; Replace through clean function
 			DestroyCharInteractionWindow()

--- a/src/Tests/Modules/ClientCombatTargetGuardTest.bb
+++ b/src/Tests/Modules/ClientCombatTargetGuardTest.bb
@@ -1,0 +1,43 @@
+Strict
+EnableGC
+
+; UpdateCombat depends on the full client and renderer graph, so this bounded
+; source contract protects the stale PlayerTarget guard without importing it.
+; BlitzForge evaluates Or eagerly: a missing ActorInstance must return before
+; the target health field is read.
+
+Function StalePlayerTargetReturnsBeforeHealthRead%(Path$)
+	Local F.BBStream = ReadFile(Path$)
+	Local Stage%
+	Local Line$
+	If F = Null Then F = ReadFile("..\" + Path$)
+	If F = Null Then Return False
+
+	While Not Eof(F)
+		Line$ = ReadLine$(F)
+		If Instr(Line$, "Function UpdateCombat()") > 0 Then Stage = 1
+		If Stage = 1 And Instr(Line$, "If A = Null Or A\Attributes\Value[HealthStat] < 1") > 0
+			CloseFile F
+			Return False
+		EndIf
+		If Stage = 1 And Instr(Line$, "If A = Null") > 0 Then Stage = 2
+		If Stage = 2 And Instr(Line$, "PlayerTarget = 0") > 0 Then Stage = 3
+		If Stage = 3 And Instr(Line$, "HideEntity(ActorSelectEN)") > 0 Then Stage = 4
+		If Stage = 4 And Instr(Line$, "DestroyCharInteractionWindow()") > 0 Then Stage = 5
+		If Stage = 5 And Instr(Line$, "Return") > 0 Then Stage = 6
+		If Stage = 6 And Instr(Line$, "EndIf") > 0 Then Stage = 7
+		If Stage = 7 And Instr(Line$, "If A\Attributes\Value[HealthStat] < 1") > 0
+			CloseFile F
+			Return True
+		EndIf
+		If Stage > 0 And Instr(Line$, "End Function") > 0 Then Exit
+	Wend
+
+	CloseFile F
+	Return False
+
+End Function
+
+Test testStalePlayerTargetReturnsBeforeHealthRead()
+	Assert(StalePlayerTargetReturnsBeforeHealthRead%("Modules\ClientCombat.bb") = True)
+End Test

--- a/src/Tests/Modules/ClientCombatTargetGuardTest.bb
+++ b/src/Tests/Modules/ClientCombatTargetGuardTest.bb
@@ -16,7 +16,7 @@ Function StalePlayerTargetReturnsBeforeHealthRead%(Path$)
 	While Not Eof(F)
 		Line$ = ReadLine$(F)
 		If Instr(Line$, "Function UpdateCombat()") > 0 Then Stage = 1
-		If Stage = 1 And Instr(Line$, "If A = Null Or A\Attributes\Value[HealthStat] < 1") > 0
+		If Stage > 0 And Stage < 7 And Instr(Line$, "A\Attributes\Value[HealthStat]") > 0
 			CloseFile F
 			Return False
 		EndIf

--- a/src/Tests/Modules/ClientCombatTargetGuardTest.bb
+++ b/src/Tests/Modules/ClientCombatTargetGuardTest.bb
@@ -6,9 +6,19 @@ EnableGC
 ; BlitzForge evaluates Or eagerly: a missing ActorInstance must return before
 ; the target health field is read.
 
+Function LeadingTabs%(Line$)
+	Local Count%, Pos% = 1
+	While Pos <= Len(Line$)
+		If Mid$(Line$, Pos, 1) <> Chr$(9) Then Exit
+		Count = Count + 1
+		Pos = Pos + 1
+	Wend
+	Return Count
+End Function
+
 Function StalePlayerTargetReturnsBeforeHealthRead%(Path$)
 	Local F.BBStream = ReadFile(Path$)
-	Local Stage%
+	Local Stage%, GuardIndent%
 	Local Line$
 	If F = Null Then F = ReadFile("..\" + Path$)
 	If F = Null Then Return False
@@ -20,12 +30,22 @@ Function StalePlayerTargetReturnsBeforeHealthRead%(Path$)
 			CloseFile F
 			Return False
 		EndIf
-		If Stage = 1 And Instr(Line$, "If A = Null") > 0 Then Stage = 2
+		If Stage = 1 And Instr(Line$, "If A = Null") > 0
+			GuardIndent = LeadingTabs(Line$)
+			Stage = 2
+		EndIf
 		If Stage = 2 And Instr(Line$, "PlayerTarget = 0") > 0 Then Stage = 3
 		If Stage = 3 And Instr(Line$, "HideEntity(ActorSelectEN)") > 0 Then Stage = 4
 		If Stage = 4 And Instr(Line$, "DestroyCharInteractionWindow()") > 0 Then Stage = 5
-		If Stage = 5 And Instr(Line$, "Return") > 0 Then Stage = 6
-		If Stage = 6 And Instr(Line$, "EndIf") > 0 Then Stage = 7
+		If Stage = 5 And Instr(Line$, "Return") > 0
+			If LeadingTabs(Line$) <> GuardIndent + 1 Then Return False
+			If Mid$(Line$, LeadingTabs(Line$) + 1, 6) <> "Return" Then Return False
+			Stage = 6
+		EndIf
+		If Stage = 6 And Instr(Line$, "EndIf") > 0
+			If LeadingTabs(Line$) < GuardIndent Then Return False
+			If LeadingTabs(Line$) = GuardIndent Then Stage = 7
+		EndIf
 		If Stage = 7 And Instr(Line$, "If A\Attributes\Value[HealthStat] < 1") > 0
 			CloseFile F
 			Return True


### PR DESCRIPTION
## Outcome

A stale combat target no longer reaches a target-health dereference in the every-frame client combat update. The existing selection cleanup now runs and returns first.

Fixes #645

## Technical changes

- Split the eager `A = Null Or A\Attributes\Value[HealthStat] < 1` condition in `UpdateCombat`.
- Preserve the existing cleanup actions for stale and dead targets.
- Add a bounded regression contract that rejects the eager form and requires the missing-target return before the first health read.

## Acceptance evidence

| Criterion | Evidence |
| --- | --- |
| Missing target returns before a target field read | RED source contract exit 1 on the old eager predicate; GREEN source contract exit 0 on the split guard |
| Stale target cleanup is preserved | The guard contract requires `PlayerTarget = 0`, selection hide, interaction-window cleanup, and return before health access |
| Dead live target retains cleanup | Existing health branch remains after the new missing-target branch |
| No generated-doc or shell-script drift | `bash scripts/gen_packet_index.sh --check`, `bash scripts/gen_bvm_reference.sh --check`, and `bash -n compile.sh test.sh scripts/*.sh` all exited 0 |

## Baseline and verification

- Baseline: source inspection found one eager stale-target predicate; focused native command `./test.sh ClientCombatTargetGuardTest` exited 1 because `compiler/BlitzForge/bin/blitzcc` is unavailable in this Linux worktree.
- RED: focused source-contract probe exited 1 against the existing eager predicate.
- GREEN: the same probe exited 0 after the split guard.
- Final local checks: `git diff --check`, packet-index and BVM-reference `--check`, and Bash syntax all exited 0.
- The focused compiled test cannot run locally because this pinned BlitzForge checkout lacks a runnable Linux compiler. Exact-head CI is required for compile/test proof.

## Compatibility, risk, and rollback

No packet, save, editor, or server behavior changes. Valid and dead targets retain their existing cleanup semantics. Rollback is a normal revert of this small PR.

## Independent review

Pending fresh review of the exact PR head.

## Deferred

The distinct stale `ServerWater` predicate, Rust toolchain policy, and documentation-link repairs are intentionally out of scope.
