### PR TITLE
docs: clarify macOS source-build installation

### DIFF
--- a/ReadMe.md
+++ b/ReadMe.md
@@ -67,14 +67,16 @@ RealmCrafter was one of the earliest tools that let solo developers and small te
 
 ## Quick start
 
-### Install a release (recommended)
+### Install a release (Windows)
 
-1. Grab the latest build for your OS from [**Releases**](https://github.com/RydeTec/rcce2/releases/latest).
+1. Windows users can grab the latest release from [**Releases**](https://github.com/RydeTec/rcce2/releases/latest).
 2. Unzip it.
-3. Launch **Project Manager** (`Project Manager.exe` on Windows, `Project Manager` on macOS).
+3. Launch **Project Manager** (`Project Manager.exe`).
 4. Open the bundled sample project, hit **Run Server**, then **Run Client**.
 
-> **macOS users — alpha.** RCCE produces native Apple Silicon binaries via [BlitzForge's macOS port](compiler/BlitzForge#macos-apple-silicon--alpha), which is currently **alpha**: the runtime path is incomplete, many language and standard-library features are not yet wired up, and breakage is expected. Use the macOS build for development and feedback, not for shipping a game. See [macOS Apple Silicon notes](docs/macos-apple-silicon.md) for the current source-build flow and compatibility caveats.
+### macOS (Apple Silicon, alpha)
+
+macOS currently has no downloadable release package. Build from source using the [macOS Apple Silicon notes](docs/macos-apple-silicon.md). RCCE produces native Apple Silicon binaries via [BlitzForge's macOS port](compiler/BlitzForge#macos-apple-silicon--alpha), which is currently **alpha**: the runtime path is incomplete, many language and standard-library features are not yet wired up, and breakage is expected. Use the macOS build for development and feedback, not for shipping a game.
 
 ### Build from source
 

--- a/src/Tests/Modules/ReadMeMacOSInstallTest.bb
+++ b/src/Tests/Modules/ReadMeMacOSInstallTest.bb
@@ -8,8 +8,8 @@ EnableGC
 Function FileContains%(Path$, Needle$)
 	Local F.BBStream = ReadFile(Path$)
 	Local Line$
-	If F = Null Then F = ReadFile("..\\" + Path$)
-	If F = Null Then F = ReadFile("..\\..\\" + Path$)
+	If F = Null Then F = ReadFile("..\" + Path$)
+	If F = Null Then F = ReadFile("..\..\" + Path$)
 	If F = Null Then Return False
 	While Not Eof(F)
 		Line$ = ReadLine$(F)

--- a/src/Tests/Modules/ReadMeMacOSInstallTest.bb
+++ b/src/Tests/Modules/ReadMeMacOSInstallTest.bb
@@ -1,0 +1,35 @@
+Strict
+EnableGC
+
+; Source-contract regression for the public macOS install path. The README is
+; the onboarding contract here, so read its bounded wording rather than pulling
+; any runtime module into this focused test.
+
+Function FileContains%(Path$, Needle$)
+	Local F.BBStream = ReadFile(Path$)
+	Local Line$
+	If F = Null Then F = ReadFile("..\\" + Path$)
+	If F = Null Then F = ReadFile("..\\..\\" + Path$)
+	If F = Null Then Return False
+	While Not Eof(F)
+		Line$ = ReadLine$(F)
+		If Instr(Line$, Needle$) > 0
+			CloseFile F
+			Return True
+		EndIf
+	Wend
+	CloseFile F
+	Return False
+End Function
+
+Test testWindowsReleaseInstructionsDoNotPromiseAnOSAgnosticBuild()
+	Assert(FileContains%("ReadMe.md", "### Install a release (Windows)") = True)
+	Assert(FileContains%("ReadMe.md", "Grab the latest build for your OS") = False)
+	Assert(FileContains%("ReadMe.md", "Project Manager` on macOS") = False)
+End Test
+
+Test testMacOSInstructionsPointToTheSupportedSourceBuildPath()
+	Assert(FileContains%("ReadMe.md", "### macOS (Apple Silicon, alpha)") = True)
+	Assert(FileContains%("ReadMe.md", "macOS currently has no downloadable release package") = True)
+	Assert(FileContains%("ReadMe.md", "[macOS Apple Silicon notes](docs/macos-apple-silicon.md)") = True)
+End Test


### PR DESCRIPTION
## Outcome

macOS visitors now see the supported source-build path immediately instead of being led to expect a downloadable per-OS release; Windows release installation remains explicit.

Fixes #647

## Technical changes

- Split the README quick start into Windows release installation and macOS Apple-Silicon alpha guidance.
- Link the macOS section to the maintained source-build notes.
- Add a focused README source-contract regression test.

## Acceptance evidence

| Criterion | Evidence |
| --- | --- |
| No generic per-OS release promise | Focused contract GREEN: old `Grab the latest build for your OS` text is absent |
| Windows release path remains clear | Contract requires `Install a release (Windows)` |
| macOS points to source build | Contract requires the alpha heading, no-downloadable-release wording, and the Apple-Silicon guide link |
| No runtime/release behavior changed | Diff is limited to `ReadMe.md` and the bounded source-contract test |

## TDD and verification

- Baseline/RED: focused README contract exited `1`, reporting the missing Windows/macOS headings and legacy generic-release/macOS-launch claims.
- GREEN: the same source contract exited `0` with all six checks true.
- Final local checks: `git diff --check` exited `0`; the modified `docs/macos-apple-silicon.md` target exists.
- Focused compiled test: `./test.sh ReadMeMacOSInstallTest` exited `1` because this Linux checkout has no `compiler/BlitzForge/bin/blitzcc`. The required submodule initialized successfully at `bdbfd9f`; CI is the Windows compiler/test gate.

## Compatibility, risk, rollback

No executable, data, protocol, release workflow, or runtime behavior changes. Roll back with a normal revert of this commit.

## Deferred

Do not ship a macOS release or alter publishing/CI in this PR. Optional Rust-client/server discoverability remains a separate documentation decision.

## Independent review

Fresh independent review of exact head `eb2c262c466569d7b681f0a49654c0197aa65784`: **ACCEPT**. The earlier doubled-backslash test-path finding was corrected before this review.