### PR TITLE
ci(rust): pin declared toolchain and lock release builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,7 +78,8 @@ jobs:
         run: test.bat
 
       # The Rust client (client-rs/) ships its own deterministic unit + parser
-      # robustness tests. windows-latest has the Rust toolchain preinstalled.
+      # robustness tests. Select the repository MSRV instead of relying on the
+      # mutable toolchain preinstalled on windows-latest.
       # Gate ALL four logic crates on every PR:
       #   - rcce-data / rcce-net: parsers + wire codec — the "soft-fail, never
       #     panic on hostile input" invariant must not regress.
@@ -90,6 +91,17 @@ jobs:
       #     crates the project changes most) on a fresh checkout. The one-time
       #     wgpu/winit compile is amortised by the cache step below (which already
       #     lists client-rs/target). The i686-only rcenet-ffi-probe is excluded.
+      - name: Set up Rust 1.85.0 (client)
+        uses: dtolnay/rust-toolchain@1.85.0
+        with:
+          components: clippy
+
+      - name: Report Rust toolchain (client)
+        shell: bash
+        run: |
+          rustc --version
+          cargo --version
+
       - name: Cache Rust build (client-rs)
         uses: actions/cache@v4
         with:
@@ -98,7 +110,7 @@ jobs:
             ~/.cargo/registry/cache
             ~/.cargo/git/db
             client-rs/target
-          key: cargo-${{ runner.os }}-${{ hashFiles('client-rs/Cargo.lock') }}
+          key: cargo-${{ runner.os }}-${{ hashFiles('client-rs/Cargo.lock', 'rust-toolchain.toml') }}
           restore-keys: |
             cargo-${{ runner.os }}-
 
@@ -157,6 +169,16 @@ jobs:
       - name: Check out repository
         uses: actions/checkout@v4
 
+      - name: Set up Rust 1.85.0 (server)
+        uses: dtolnay/rust-toolchain@1.85.0
+        with:
+          components: clippy
+
+      - name: Report Rust toolchain (server)
+        run: |
+          rustc --version
+          cargo --version
+
       - name: Cache Rust build (server-rs)
         uses: actions/cache@v4
         with:
@@ -165,7 +187,7 @@ jobs:
             ~/.cargo/registry/cache
             ~/.cargo/git/db
             server-rs/target
-          key: cargo-server-${{ runner.os }}-${{ hashFiles('server-rs/Cargo.lock') }}
+          key: cargo-server-${{ runner.os }}-${{ hashFiles('server-rs/Cargo.lock', 'rust-toolchain.toml') }}
           restore-keys: |
             cargo-server-${{ runner.os }}-
 

--- a/client-rs/crates/rcce-client/src/bin/client_window.rs
+++ b/client-rs/crates/rcce-client/src/bin/client_window.rs
@@ -9188,12 +9188,10 @@ impl App {
                         // AI\Reputation, Interface3D.bb:26). Signed; tinted by sign as
                         // a readability nicety over Blitz's plain label.
                         let rep = t.reputation;
-                        let rc = if rep < 0 {
-                            [1.0, 0.55, 0.5, 1.0]
-                        } else if rep > 0 {
-                            [0.6, 1.0, 0.6, 1.0]
-                        } else {
-                            [0.82, 0.82, 0.82, 1.0]
+                        let rc = match rep.cmp(&0) {
+                            std::cmp::Ordering::Less => [1.0, 0.55, 0.5, 1.0],
+                            std::cmp::Ordering::Greater => [0.6, 1.0, 0.6, 1.0],
+                            std::cmp::Ordering::Equal => [0.82, 0.82, 0.82, 1.0],
                         };
                         overlay.text_shadow(px0 + 8.0, py0 + 45.0, 1.0, &format!("Reputation: {rep}"), rc);
                     }
@@ -10287,12 +10285,10 @@ impl App {
                 } else if matches!(trade.kind, TradeKind::Player) {
                     // My offered gold (TradeCost). `+`/`-` adjust it; positive = I give
                     // gold, negative = I demand it. Shown above the Confirm button.
-                    let (c_txt, c_col) = if trade_cost > 0 {
-                        (format!("Your gold: +{trade_cost}  [+/- adjust]"), gold)
-                    } else if trade_cost < 0 {
-                        (format!("Your gold: {trade_cost}  [+/- adjust]"), [1.0, 0.6, 0.5, 1.0])
-                    } else {
-                        ("Your gold: 0  [+/- adjust]".to_string(), dimc)
+                    let (c_txt, c_col) = match trade_cost.cmp(&0) {
+                        std::cmp::Ordering::Greater => (format!("Your gold: +{trade_cost}  [+/- adjust]"), gold),
+                        std::cmp::Ordering::Less => (format!("Your gold: {trade_cost}  [+/- adjust]"), [1.0, 0.6, 0.5, 1.0]),
+                        std::cmp::Ordering::Equal => ("Your gold: 0  [+/- adjust]".to_string(), dimc),
                     };
                     overlay.text(px + 12.0, py + ph - 42.0, 1.0, &c_txt, c_col);
                     // Player↔player Confirm button — commits my staged offer (+ accepts

--- a/compile.bat
+++ b/compile.bat
@@ -130,12 +130,12 @@ if errorlevel 1 (
 )
 rem Rust client (client-rs) -> bin\ClientRS.exe
 cd /d "%ROOTDIR%\client-rs"
-cargo build --release -p rcce-client --bin client-window || (cd /d "%ROOTDIR%" & endlocal & exit /b 1)
+cargo build --release --locked -p rcce-client --bin client-window || (cd /d "%ROOTDIR%" & endlocal & exit /b 1)
 copy /Y "%ROOTDIR%\client-rs\target\release\client-window.exe" "%ROOTDIR%\bin\ClientRS.exe" >nul || (cd /d "%ROOTDIR%" & endlocal & exit /b 1)
 echo   Built bin\ClientRS.exe
 rem Rust server (server-rs) -> bin\ServerRS.exe (headless; Linux is the deploy target)
 cd /d "%ROOTDIR%\server-rs"
-cargo build --release --bin rcce-server || (cd /d "%ROOTDIR%" & endlocal & exit /b 1)
+cargo build --release --locked --bin rcce-server || (cd /d "%ROOTDIR%" & endlocal & exit /b 1)
 copy /Y "%ROOTDIR%\server-rs\target\release\rcce-server.exe" "%ROOTDIR%\bin\ServerRS.exe" >nul || (cd /d "%ROOTDIR%" & endlocal & exit /b 1)
 echo   Built bin\ServerRS.exe
 cd /d "%ROOTDIR%"

--- a/compile.sh
+++ b/compile.sh
@@ -154,12 +154,12 @@ if [[ "${BUILD_RUST}" -eq 1 ]]; then
   else
     mkdir -p "${ROOTDIR}/bin"
     # Rust client (client-rs) -> bin/ClientRS
-    (cd "${ROOTDIR}/client-rs" && cargo build --release -p rcce-client --bin client-window)
+    (cd "${ROOTDIR}/client-rs" && cargo build --release --locked -p rcce-client --bin client-window)
     cp -f "${ROOTDIR}/client-rs/target/release/client-window${EXE_SUFFIX}" \
       "${ROOTDIR}/bin/ClientRS${EXE_SUFFIX}"
     echo "  Built bin/ClientRS${EXE_SUFFIX}"
     # Rust server (server-rs) -> bin/ServerRS (headless; Linux is the deploy target)
-    (cd "${ROOTDIR}/server-rs" && cargo build --release --bin rcce-server)
+    (cd "${ROOTDIR}/server-rs" && cargo build --release --locked --bin rcce-server)
     cp -f "${ROOTDIR}/server-rs/target/release/rcce-server${EXE_SUFFIX}" \
       "${ROOTDIR}/bin/ServerRS${EXE_SUFFIX}"
     echo "  Built bin/ServerRS${EXE_SUFFIX}"

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,4 @@
+[toolchain]
+channel = "1.85.0"
+components = ["clippy"]
+profile = "minimal"

--- a/server-rs/crates/rcce-server-core/src/combat.rs
+++ b/server-rs/crates/rcce-server-core/src/combat.rs
@@ -57,15 +57,11 @@ pub fn melee_swing(formula: u8, input: &SwingInput, rolls: &Rolls) -> SwingResul
     // Base damage depends on the formula.
     let mut damage = match formula {
         1 => match input.weapon_damage {
-            Some(wd) => {
-                if input.strength < wd {
-                    wd - rolls.roll_5_8
-                } else if input.strength > wd {
-                    wd + rolls.roll_5_8
-                } else {
-                    wd + rolls.roll_n5_5
-                }
-            }
+            Some(wd) => match input.strength.cmp(&wd) {
+                std::cmp::Ordering::Less => wd - rolls.roll_5_8,
+                std::cmp::Ordering::Greater => wd + rolls.roll_5_8,
+                std::cmp::Ordering::Equal => wd + rolls.roll_n5_5,
+            },
             None => input.strength / 8 + rolls.roll_n5_5,
         },
         2 => match input.weapon_damage {

--- a/src/Tests/Modules/RustToolchainPolicyTest.bb
+++ b/src/Tests/Modules/RustToolchainPolicyTest.bb
@@ -1,0 +1,55 @@
+Strict
+EnableGC
+
+; Source-contract regression for the repository-owned Rust build policy. These
+; files are consumed by CI and contributor shells, so test their committed
+; contract without loading runtime/editor modules.
+
+Function FileContains%(Path$, Needle$)
+	Local F.BBStream = ReadFile(Path$)
+	Local Line$
+	If F = Null Then F = ReadFile("..\" + Path$)
+	If F = Null Then F = ReadFile("..\..\" + Path$)
+	If F = Null Then Return False
+	While Not Eof(F)
+		Line$ = ReadLine$(F)
+		If Instr(Line$, Needle$) > 0
+			CloseFile F
+			Return True
+		EndIf
+	Wend
+	CloseFile F
+	Return False
+End Function
+
+Function FileOccurrenceCount%(Path$, Needle$)
+	Local F.BBStream = ReadFile(Path$)
+	Local Line$
+	Local Count = 0
+	If F = Null Then F = ReadFile("..\" + Path$)
+	If F = Null Then F = ReadFile("..\..\" + Path$)
+	If F = Null Then Return 0
+	While Not Eof(F)
+		Line$ = ReadLine$(F)
+		If Instr(Line$, Needle$) > 0 Then Count = Count + 1
+	Wend
+	CloseFile F
+	Return Count
+End Function
+
+Test testDeclaredMSRVIsPinnedWithClippy()
+	Assert(FileContains%("rust-toolchain.toml", "channel = " + Chr$(34) + "1.85.0" + Chr$(34)) = True)
+	Assert(FileContains%("rust-toolchain.toml", "components = [" + Chr$(34) + "clippy" + Chr$(34) + "]") = True)
+End Test
+
+Test testRustCIUsesPolicyAndInvalidatesCachesWhenItChanges()
+	Assert(FileOccurrenceCount%(".github\workflows\ci.yml", "uses: dtolnay/rust-toolchain@1.85.0") = 2)
+	Assert(FileContains%(".github\workflows\ci.yml", "rust-toolchain.toml") = True)
+End Test
+
+Test testOptInReleaseBuildsKeepBothLockfilesLocked()
+	Assert(FileContains%("compile.sh", "cargo build --release --locked -p rcce-client --bin client-window") = True)
+	Assert(FileContains%("compile.sh", "cargo build --release --locked --bin rcce-server") = True)
+	Assert(FileContains%("compile.bat", "cargo build --release --locked -p rcce-client --bin client-window") = True)
+	Assert(FileContains%("compile.bat", "cargo build --release --locked --bin rcce-server") = True)
+End Test

--- a/src/Tests/Modules/RustToolchainPolicyTest.bb
+++ b/src/Tests/Modules/RustToolchainPolicyTest.bb
@@ -44,7 +44,10 @@ End Test
 
 Test testRustCIUsesPolicyAndInvalidatesCachesWhenItChanges()
 	Assert(FileOccurrenceCount%(".github\workflows\ci.yml", "uses: dtolnay/rust-toolchain@1.85.0") = 2)
-	Assert(FileContains%(".github\workflows\ci.yml", "rust-toolchain.toml") = True)
+	Assert(FileContains%(".github\workflows\ci.yml", "- name: Report Rust toolchain (client)") = True)
+	Assert(FileContains%(".github\workflows\ci.yml", "- name: Report Rust toolchain (server)") = True)
+	Assert(FileContains%(".github\workflows\ci.yml", "key: cargo-${{ runner.os }}-${{ hashFiles('client-rs/Cargo.lock', 'rust-toolchain.toml') }}") = True)
+	Assert(FileContains%(".github\workflows\ci.yml", "key: cargo-server-${{ runner.os }}-${{ hashFiles('server-rs/Cargo.lock', 'rust-toolchain.toml') }}") = True)
 End Test
 
 Test testOptInReleaseBuildsKeepBothLockfilesLocked()


### PR DESCRIPTION
## Outcome

Rust builds now use the repository's declared 1.85 MSRV instead of a mutable runner/default compiler, and opt-in Rust release builds cannot update lockfiles silently.

## Changes

- Add root `rust-toolchain.toml` pinning Rust 1.85.0 with Clippy.
- Install/report that toolchain in both CI Rust jobs; cache keys include the policy file.
- Add `--locked` to both client and server `-r`/`--rust` release builds in the Unix and Windows scripts.
- Add a focused source-contract regression test.
- Preserve existing strict Clippy under Rust 1.85 with three behavior-preserving comparison-to-`match` refactors discovered by the exact-MS​​RV gate.

Fixes #649

## Acceptance evidence

- Root policy, both CI setup steps/cache keys, and four locked release commands: final focused source-contract probe passed (exit 0).
- RED: before implementation the probe exited 1 because `rust-toolchain.toml` was absent and the required command strings were missing.
- GREEN: probe passed after the policy/workflow/script changes; `git diff --check` and `bash -n compile.sh` passed.
- Exact pinned local verification: Rust 1.85.0 client `cargo test -p rcce-client --locked` passed 156 tests; strict client Clippy passed. Server `cargo test --workspace --locked` passed (26 + 1 + 154 + 5 + 3 + 30 + 41 tests); strict server Clippy passed.

## Compatibility, risk, rollback

No protocol, dependency, lockfile, release, or deployment changes. Existing `-r` builders now intentionally fail rather than alter an out-of-date lockfile. Rust 1.85 surfaced three existing Clippy comparisons; their match refactors preserve less/equal/greater behavior. Rollback is reverting this commit, restoring the prior runner-default CI behavior and unlocked builds.

## Local limitations

The Linux Blitz test runner cannot compile the new `.bb` source-contract test because this checkout has no `compiler/BlitzForge/bin/blitzcc`; CI's Windows Build and test job exercises it. The local Rust-client gate used only an untracked `/tmp` ALSA pkg-config/linker shim because this host lacks ALSA development metadata.

## Independent review

Pending fresh review of this exact head after CI is available.

## Independent review update

Fresh review of exact head `7307dbe157c3e842ada163bd44fd9ce88804c2ea`: **ACCEPT**. The first review requested stronger report/cache assertions; the test-only follow-up binds both report steps and both exact cache-key lines. Fresh review found no remaining findings.