### PR TITLE
fix(bvm): return reliable CREATEDIR result

### DIFF
--- a/src/Modules/ScriptingCommands.bb
+++ b/src/Modules/ScriptingCommands.bb
@@ -2021,8 +2021,9 @@ End Function
 Function BVM_CREATEDIR%(Param1$)
 	If Not BVM_RequirePrivileged() Then Return 0
 	If Not BVM_ScriptPathIsSafe(Param1$) Then Return 0
-	CreateDir(RCScriptFiles$ + Param1$)
-Return Result%
+	Local Path$ = RCScriptFiles$ + Param1$
+	CreateDir(Path$)
+	Return FileType(Path$) = 2
 End Function
 
 Function BVM_FILESIZE%(Param1$)

--- a/src/Tests/Modules/CreateDirResultTest.bb
+++ b/src/Tests/Modules/CreateDirResultTest.bb
@@ -1,0 +1,77 @@
+Strict
+EnableGC
+
+; ScriptingCommands.bb pulls in the server/world/BVM graph, so this standalone
+; regression test pins the bounded CREATEDIR source contract instead. The BVM
+; has always advertised an Int result: scripts need a stable success value
+; after the existing privileged, path-safe directory operation.
+
+Function FunctionBodyContains%(Path$, FunctionMarker$, Needle$)
+	Local F.BBStream = ReadFile(Path$)
+	Local InFunction%
+	Local Line$
+	If F = Null Then F = ReadFile("..\" + Path$)
+	If F = Null Then Return False
+	While Not Eof(F)
+		Line$ = ReadLine$(F)
+		If Instr(Line$, FunctionMarker$) > 0 Then InFunction = True
+		If InFunction = True And Instr(Line$, Needle$) > 0
+			CloseFile F
+			Return True
+		EndIf
+		If InFunction = True And Instr(Line$, "End Function") > 0 Then Exit
+	Wend
+	CloseFile F
+	Return False
+End Function
+
+Function CreateDirResultHasSafeOrder%(Path$)
+	Local F.BBStream = ReadFile(Path$)
+	Local InFunction%, Stage%
+	Local Line$
+	If F = Null Then F = ReadFile("..\" + Path$)
+	If F = Null Then Return False
+	While Not Eof(F)
+		Line$ = ReadLine$(F)
+		If Instr(Line$, "Function BVM_CREATEDIR") > 0 Then InFunction = True
+		If InFunction = True And Instr(Line$, "Return Result%") > 0
+			CloseFile F
+			Return False
+		EndIf
+		If InFunction = True And Instr(Line$, "CreateDir(") > 0 And Stage < 3
+			CloseFile F
+			Return False
+		EndIf
+		If InFunction = True And Instr(Line$, "Return FileType(Path$) = 2") > 0 And Stage < 4
+			CloseFile F
+			Return False
+		EndIf
+		If InFunction = True And Instr(Line$, "If Not BVM_RequirePrivileged() Then Return 0") > 0 Then Stage = 1
+		If InFunction = True And Stage = 1 And Instr(Line$, "If Not BVM_ScriptPathIsSafe(Param1$) Then Return 0") > 0 Then Stage = 2
+		If InFunction = True And Stage = 2 And Instr(Line$, "Local Path$ = RCScriptFiles$ + Param1$") > 0 Then Stage = 3
+		If InFunction = True And Stage = 3 And Instr(Line$, "CreateDir(Path$)") > 0 Then Stage = 4
+		If InFunction = True And Stage = 4 And Instr(Line$, "Return FileType(Path$) = 2") > 0
+			CloseFile F
+			Return True
+		EndIf
+		If InFunction = True And Instr(Line$, "End Function") > 0 Then Exit
+	Wend
+	CloseFile F
+	Return False
+End Function
+
+Test testCreateDirReportsWhetherTheSafeTargetExists()
+	Assert(FunctionBodyContains%("Modules\ScriptingCommands.bb", "Function BVM_CREATEDIR", "If Not BVM_RequirePrivileged() Then Return 0") = True)
+	Assert(FunctionBodyContains%("Modules\ScriptingCommands.bb", "Function BVM_CREATEDIR", "If Not BVM_ScriptPathIsSafe(Param1$) Then Return 0") = True)
+	Assert(FunctionBodyContains%("Modules\ScriptingCommands.bb", "Function BVM_CREATEDIR", "Local Path$ = RCScriptFiles$ + Param1$") = True)
+	Assert(FunctionBodyContains%("Modules\ScriptingCommands.bb", "Function BVM_CREATEDIR", "CreateDir(Path$)") = True)
+	Assert(FunctionBodyContains%("Modules\ScriptingCommands.bb", "Function BVM_CREATEDIR", "Return FileType(Path$) = 2") = True)
+End Test
+
+Test testCreateDirDoesNotReturnTheUnassignedLegacyResult()
+	Assert(FunctionBodyContains%("Modules\ScriptingCommands.bb", "Function BVM_CREATEDIR", "Return Result%") = False)
+End Test
+
+Test testCreateDirGuardsTheSafePathBeforeReportingItsResult()
+	Assert(CreateDirResultHasSafeOrder%("Modules\ScriptingCommands.bb") = True)
+End Test


### PR DESCRIPTION
## Outcome
Privileged scripts can now reliably branch on whether `CREATEDIR()` leaves their safe target directory present, instead of receiving an unassigned return value.

## Technical changes
- Preserve the existing privilege and script-path validation gates.
- Build the safe script-root path once, perform the existing `CreateDir`, and return whether `FileType(path) = 2`.
- Add a bounded source-contract regression test covering guards, ordering, result semantics, and rejection of the legacy unassigned return.

Fixes #654

## Acceptance evidence
- Safe privileged path: the regression contract requires guarded `Path$`, `CreateDir(Path$)`, then `Return FileType(Path$) = 2` in that order.
- Unsafe/unprivileged behavior: the same contract requires both existing early `Return 0` guards before the operation.
- Compatibility: `CREATEDIR` declaration, dispatch case 351, and generated BVM reference are unchanged; both generated-document checks pass.

## TDD and verification
- Baseline: clean worktree and `git diff --check` exit 0; `bash scripts/gen_bvm_reference.sh --check` exit 0.
- RED: source-contract probe exited 1 on the prior unassigned `Return Result%` implementation.
- GREEN: the same probe exited 0 after the fix; `bash scripts/gen_bvm_reference.sh --check`, `bash scripts/gen_packet_index.sh --check`, and `git diff --check` all exited 0.
- Local compiled focused test: `./test.sh CreateDirResultTest` exits 1 because `compiler/BlitzForge/bin/blitzcc` is not present in this Linux checkout; Windows CI runs the test suite with the compiler available.

## Compatibility, risk, rollback, deferred work
Existing filesystem side effects, privilege handling, path validation, BVM name, signature, and opcode are unchanged. The return now reflects directory existence after the existing operation. Roll back by reverting this one commit. Broader filesystem-command semantics are explicitly deferred.

## Independent review
Fresh review of exact head `7744e82c81d67b5600f72029fc411a969e53cc8d`: **ACCEPT**. It confirmed the guards, sandboxed path, `FileType = 2` result semantics, unchanged BVM contract/opcode, meaningful source-contract coverage, and the local compiler limitation. No required changes.