### PR TITLE
fix(editor): atomically save emitter configurations

### DIFF
--- a/docs/modules/rottparticles.md
+++ b/docs/modules/rottparticles.md
@@ -119,12 +119,12 @@ Three shape-specific setters (`RP_ConfigShapeSphere`, `RP_ConfigShapeCylinder`, 
 - [`Media.bb`](media.md) — provides the underlying `Texture` handles consumed by `RP_ConfigTexture`. `RP_FreeEmitterConfig` calls Blitz `FreeTexture` directly, not `UnloadTexture` — so freeing an emitter's texture does **not** clear `Media.bb`'s `LoadedTextures(ID)` cache slot. This is a known asymmetry; consumers who want full media-cache invalidation must call `UnloadTexture` themselves afterward.
 - [`Client.bb`](../../src/Client.bb) — calls `RP_Update(Delta)` once per main-loop frame.
 - [`Server.bb`](../../src/Server.bb) — also calls `RP_Update` for any server-side emitters (rare; mostly client-only feature).
-- [`Logging.bb`](logging.md) — provides `SafeWriteOpen` / `SafeWriteCommit` (not yet adopted here — see migration candidate above).
+- [`Logging.bb`](logging.md) — provides the `SafeWriteOpen` / `SafeWriteCommit` recovery-safe save path used by `RP_SaveEmitterConfig`.
 
 ## See also
 
 - CLAUDE.md → "Iterator-during-iteration hazards" — `RP_Update` and `RP_Clear` are canonical after-cursor examples.
-- CLAUDE.md → "Atomic writes" — `RP_SaveEmitterConfig` is a candidate migration site.
+- CLAUDE.md → "Atomic writes" — `RP_SaveEmitterConfig` follows the established SafeWrite persistence contract.
 - CLAUDE.md → "Float sanitisation at the BVM / wire boundary" — `RP_SetParticleFrame`'s `/0` guard is the same family of defenses.
 - [`projectiles3d.md`](projectiles3d.md) — the canonical consumer.
 

--- a/docs/modules/rottparticles.md
+++ b/docs/modules/rottparticles.md
@@ -77,7 +77,7 @@ Byte   RStart, GStart, BStart                   ; initial colour
 Float  RChange, GChange, BChange                ; per-frame colour delta
 ```
 
-**Format note — not SafeWrite.** `RP_SaveEmitterConfig` uses plain `WriteFile` ([`RottParticles.bb:1126`](../../src/Modules/RottParticles.bb#L1126)) — no atomic-rename, no `.bak` retention. A crash mid-save leaves a truncated `.rpc`; subsequent loads `ReadInt` past EOF and get zero-filled fields (Blitz3D doesn't error on past-EOF reads). This is a known candidate for a `SafeWriteOpen` / `SafeWriteCommit` migration following the [`reference_safewrite_migration_template.md`](../../../../.claude/projects/C--Users-dyanr-Desktop-rcce2/memory/reference_safewrite_migration_template.md) pattern. Not yet done.
+**Format note — recovery-safe save.** `RP_SaveEmitterConfig` writes the unchanged positional payload to the temporary path returned by `SafeWriteOpen$`, then finishes through `SafeWriteCommit%`. A crash mid-save therefore cannot replace the prior `.rpc` with a truncated file; the helper retains a `.bak` recovery copy until the completed temporary payload is promoted. `RP_LoadEmitterConfig` still reads the same 40 fields in the same order.
 
 **`Name$`** is derived from the file path at load time (`RP_LoadEmitterConfig` strips the directory and extension at [`RottParticles.bb:1188-1195`](../../src/Modules/RottParticles.bb#L1188)) — it's not persisted in the file. Save preserves the path-derived name on load round-trips.
 
@@ -110,7 +110,7 @@ Three shape-specific setters (`RP_ConfigShapeSphere`, `RP_ConfigShapeCylinder`, 
 - **`RP_Particle` instances are recycled during normal per-frame operation, not freed.** The `InUse = False` flag is the "dead" state, and `RP_SpawnParticle` flips it back to `True` for a respawn. The exception is emitter teardown — `RP_FreeEmitter` ([`RottParticles.bb:1390-1392`](../../src/Modules/RottParticles.bb#L1390)) walks `For P = Each RP_Particle / If P\E = E Then Delete P`, deleting every particle owned by the dying emitter. New per-particle fields that need a reset on respawn should be reset in `RP_SpawnParticle` ([`RottParticles.bb:241`](../../src/Modules/RottParticles.bb#L241)), not in `RP_CreateParticle` (which runs once at slot pre-allocation in `RP_CreateEmitter`).
 - **Both `RP_Update`'s emitter walk and `RP_Clear` use the after-cursor pattern.** Any new function that walks `For Each RP_Emitter` AND can free emitters mid-walk must do the same `First / After / While <> Null` shape.
 - **The texture-share defensive walk** in `RP_FreeEmitterConfig` and `RP_FreeEmitter(..., FreeTex=True)` is the canonical pattern for "free a resource that might be shared across siblings." Replicate it if you add another shared-resource field.
-- **`RP_SaveEmitterConfig` is a SafeWrite migration candidate.** Direct `WriteFile` to production path is the legacy shape; adopting `SafeWriteOpen` / `SafeWriteCommit` would close the truncated-on-crash failure mode. Follow the memory template.
+- **`RP_SaveEmitterConfig` uses the SafeWrite helper.** It preserves the existing 40-field payload while a failed or interrupted save retains a recovery path instead of exposing a partial replacement.
 
 ## Related modules
 
@@ -136,7 +136,7 @@ The module exports 55 functions across the families: 1 update loop (`RP_Update`)
 
 ### <a id="rp_saveemitterconfig"></a>`RP_SaveEmitterConfig(ID, File$)`
 
-Write the config to `File$` (typically `.rpc` extension under `Data\Emitter Configs\`). Returns `True` on success, `False` on bad ID or `WriteFile` failure. **Not atomic** — see migration candidate note above.
+Write the config to `File$` (typically `.rpc` extension under `Data\Emitter Configs\`). Returns the result of `SafeWriteCommit` after writing the unchanged 40-field payload to a temporary file; returns `False` on bad ID, temporary `WriteFile` failure, or a failed commit.
 
 ### <a id="rp_loademitterconfig"></a>`RP_LoadEmitterConfig(File$, Texture, FaceEntity)`
 

--- a/src/Modules/RottParticles.bb
+++ b/src/Modules/RottParticles.bb
@@ -1123,7 +1123,8 @@ Function RP_SaveEmitterConfig(ID, File$)
 
 	C.RP_EmitterConfig = Object.RP_EmitterConfig(ID)
 	If C <> Null
-		F = WriteFile(File$)
+		Local Temp$ = SafeWriteOpen$(File$)
+		F = WriteFile(Temp$)
 		If F = 0 Then Return False
 
 			WriteInt F, C\MaxParticles
@@ -1167,8 +1168,7 @@ Function RP_SaveEmitterConfig(ID, File$)
 			WriteFloat F, C\GChange#
 			WriteFloat F, C\BChange#
 
-		CloseFile(F)
-		Return True
+		Return SafeWriteCommit%(Temp$, File$, F)
 	Else
 		Return False
 	EndIf

--- a/src/Tests/Modules/RottParticlesAtomicSaveTest.bb
+++ b/src/Tests/Modules/RottParticlesAtomicSaveTest.bb
@@ -1,0 +1,80 @@
+Strict
+EnableGC
+
+; RottParticles is renderer-heavy, so this bounded source contract protects
+; the .rpc persistence handoff without loading the graphics dependency graph.
+
+Function RottParticlesSaveUsesSafeWrite%(Path$)
+	Local F.BBStream = ReadFile(Path$)
+	Local InFunction%, Stage%
+	Local Line$
+	If F = Null Then F = ReadFile("..\" + Path$)
+	If F = Null Then Return False
+
+	While Not Eof(F)
+		Line$ = ReadLine$(F)
+		If Instr(Line$, "Function RP_SaveEmitterConfig(ID, File$)") > 0 Then InFunction = True
+		If InFunction = True
+			If Instr(Line$, "WriteFile(File$)") > 0
+				CloseFile F
+				Return False
+			EndIf
+			If Stage = 0 And Instr(Line$, "Local Temp$ = SafeWriteOpen$(File$)") > 0 Then Stage = 1
+			If Stage = 1 And Instr(Line$, "F = WriteFile(Temp$)") > 0 Then Stage = 2
+			If Stage = 2 And Instr(Line$, "If F = 0 Then Return False") > 0 Then Stage = 3
+			If Stage = 3 And Instr(Line$, "WriteInt F, C\MaxParticles") > 0 Then Stage = 4
+			If Stage = 4 And Instr(Line$, "WriteInt F, C\ParticlesPerFrame") > 0 Then Stage = 5
+			If Stage = 5 And Instr(Line$, "WriteInt F, C\TexAcross") > 0 Then Stage = 6
+			If Stage = 6 And Instr(Line$, "WriteInt F, C\TexDown") > 0 Then Stage = 7
+			If Stage = 7 And Instr(Line$, "WriteInt F, C\RndStartFrame") > 0 Then Stage = 8
+			If Stage = 8 And Instr(Line$, "WriteInt F, C\TexAnimSpeed") > 0 Then Stage = 9
+			If Stage = 9 And Instr(Line$, "WriteInt F, C\VShapeBased") > 0 Then Stage = 10
+			If Stage = 10 And Instr(Line$, "WriteFloat F, C\VelocityX#") > 0 Then Stage = 11
+			If Stage = 11 And Instr(Line$, "WriteFloat F, C\VelocityY#") > 0 Then Stage = 12
+			If Stage = 12 And Instr(Line$, "WriteFloat F, C\VelocityZ#") > 0 Then Stage = 13
+			If Stage = 13 And Instr(Line$, "WriteFloat F, C\VelocityRndX#") > 0 Then Stage = 14
+			If Stage = 14 And Instr(Line$, "WriteFloat F, C\VelocityRndY#") > 0 Then Stage = 15
+			If Stage = 15 And Instr(Line$, "WriteFloat F, C\VelocityRndZ#") > 0 Then Stage = 16
+			If Stage = 16 And Instr(Line$, "WriteFloat F, C\ForceX#") > 0 Then Stage = 17
+			If Stage = 17 And Instr(Line$, "WriteFloat F, C\ForceY#") > 0 Then Stage = 18
+			If Stage = 18 And Instr(Line$, "WriteFloat F, C\ForceZ#") > 0 Then Stage = 19
+			If Stage = 19 And Instr(Line$, "WriteFloat F, C\ScaleStart#") > 0 Then Stage = 20
+			If Stage = 20 And Instr(Line$, "WriteFloat F, C\ScaleChange#") > 0 Then Stage = 21
+			If Stage = 21 And Instr(Line$, "WriteInt F, C\Lifespan") > 0 Then Stage = 22
+			If Stage = 22 And Instr(Line$, "WriteFloat F, C\AlphaStart#") > 0 Then Stage = 23
+			If Stage = 23 And Instr(Line$, "WriteFloat F, C\AlphaChange#") > 0 Then Stage = 24
+			If Stage = 24 And Instr(Line$, "WriteInt F, C\BlendMode") > 0 Then Stage = 25
+			If Stage = 25 And Instr(Line$, "WriteInt F, C\Shape") > 0 Then Stage = 26
+			If Stage = 26 And Instr(Line$, "WriteFloat F, C\MinRadius#") > 0 Then Stage = 27
+			If Stage = 27 And Instr(Line$, "WriteFloat F, C\MaxRadius#") > 0 Then Stage = 28
+			If Stage = 28 And Instr(Line$, "WriteFloat F, C\Width#") > 0 Then Stage = 29
+			If Stage = 29 And Instr(Line$, "WriteFloat F, C\Height#") > 0 Then Stage = 30
+			If Stage = 30 And Instr(Line$, "WriteFloat F, C\Depth#") > 0 Then Stage = 31
+			If Stage = 31 And Instr(Line$, "WriteInt F, C\ShapeAxis") > 0 Then Stage = 32
+			If Stage = 32 And Instr(Line$, "WriteShort F, C\DefaultTextureID") > 0 Then Stage = 33
+			If Stage = 33 And Instr(Line$, "WriteFloat F, C\ForceModX#") > 0 Then Stage = 34
+			If Stage = 34 And Instr(Line$, "WriteFloat F, C\ForceModY#") > 0 Then Stage = 35
+			If Stage = 35 And Instr(Line$, "WriteFloat F, C\ForceModZ#") > 0 Then Stage = 36
+			If Stage = 36 And Instr(Line$, "WriteInt F, C\ForceShaping") > 0 Then Stage = 37
+			If Stage = 37 And Instr(Line$, "WriteByte F, C\RStart") > 0 Then Stage = 38
+			If Stage = 38 And Instr(Line$, "WriteByte F, C\GStart") > 0 Then Stage = 39
+			If Stage = 39 And Instr(Line$, "WriteByte F, C\BStart") > 0 Then Stage = 40
+			If Stage = 40 And Instr(Line$, "WriteFloat F, C\RChange#") > 0 Then Stage = 41
+			If Stage = 41 And Instr(Line$, "WriteFloat F, C\GChange#") > 0 Then Stage = 42
+			If Stage = 42 And Instr(Line$, "WriteFloat F, C\BChange#") > 0 Then Stage = 43
+			If Stage = 43 And Instr(Line$, "Return SafeWriteCommit%(Temp$, File$, F)") > 0
+					CloseFile F
+					Return True
+				EndIf
+			If Instr(Line$, "End Function") > 0 Then Exit
+		EndIf
+	Wend
+
+	CloseFile F
+	Return False
+
+End Function
+
+Test testEmitterConfigSaveKeepsAllFieldsAndUsesSafeWrite()
+	Assert(RottParticlesSaveUsesSafeWrite%("Modules\RottParticles.bb") = True)
+End Test


### PR DESCRIPTION
## Outcome

Interrupted particle-emitter edits now preserve the previous .rpc configuration instead of replacing it with a truncated, zero-filled payload.

Fixes #658

## Technical changes

- Route RP_SaveEmitterConfig through SafeWriteOpen, a temporary WriteFile, and SafeWriteCommit.
- Keep all 40 serialized fields in their existing order and preserve the existing bad-ID and temporary-write failure behavior.
- Add a bounded source-contract test for the SafeWrite sequence, direct-final-write rejection, and every serialized field order.
- Update the RottParticles module documentation to describe the completed recovery-safe path.

## Acceptance evidence

| Criterion | Evidence |
| --- | --- |
| No direct final .rpc write | RED source probe observed direct_final_write=True; GREEN observed direct_final_write=False |
| Temp write then commit | GREEN source probe observed safe_sequence=True |
| 40 fields retain order | GREEN source probe observed payload_writes=40 and field_order=True |
| Docs match behavior | docs/modules/rottparticles.md now describes the SafeWrite path and unchanged payload |

## TDD and verification

- Baseline: source inspection found one direct final WriteFile, zero SafeWrite calls, and 40 payload writes. git diff --check, packet-index check, and BVM-reference check exited 0.
- RED: after adding the focused contract, the mirrored source probe exited 1 because direct_final_write=True and ordered_atomic_payload=False.
- GREEN: the mirrored source probe exited 0 with direct_final_write=False, safe_sequence=True, payload_writes=40, and field_order=True.
- Final local checks: git diff --check, bash scripts/gen_packet_index.sh --check, and bash scripts/gen_bvm_reference.sh --check exited 0.
- Local compiled test limitation: ./test.sh RottParticlesAtomicSaveTest exited 1 because compiler/BlitzForge/bin/blitzcc is absent in this Linux worktree. Exact-head Build and test CI is required to compile and run the new Blitz test.

## Compatibility, risk, and rollback

The .rpc schema, 40-field order, callers, loader, and rendering behavior are unchanged. SafeWriteCommit retains a recovery copy when publication fails. Roll back with a normal revert of this one commit.

## Deferred

No loader validation or .rpc schema changes are included.

## Independent review

Fresh independent review verdict: ACCEPT for exact head b096075be7394cc15caad51075ad508822b7f887 after the documentation correction.