### PR TITLE
fix(client): guard stale swimming water handles

### DIFF
--- a/src/Modules/Interface3D.bb
+++ b/src/Modules/Interface3D.bb
@@ -566,8 +566,10 @@ Function UpdateInterface()
 				; Do not allow above water surface if swimming
 				If Me\Underwater <> 0
 					W.Water = Object.Water(Me\Underwater)
-					If EntityY#(Me\CollisionEN) > EntityY#(W\EN) - 0.5
-						PositionEntity(Me\CollisionEN, EntityX#(Me\CollisionEN), EntityY#(W\EN) - 0.505, EntityZ#(Me\CollisionEN))
+					If W <> Null
+						If EntityY#(Me\CollisionEN) > EntityY#(W\EN) - 0.5
+							PositionEntity(Me\CollisionEN, EntityX#(Me\CollisionEN), EntityY#(W\EN) - 0.505, EntityZ#(Me\CollisionEN))
+						EndIf
 					EndIf
 				EndIf
 				QuitActive = False

--- a/src/Tests/Modules/Interface3DWaterHandleTest.bb
+++ b/src/Tests/Modules/Interface3DWaterHandleTest.bb
@@ -1,0 +1,55 @@
+Strict
+EnableGC
+
+; UpdateInterface depends on the legacy graphics runtime, so this focused
+; source-contract test protects the stale water-handle boundary without loading
+; the client module in the headless test harness.
+
+Function HasSafeSwimmingClamp%(Path$)
+	Local F.BBStream = ReadFile(Path$)
+	Local Line$
+	Local Step = 0
+	If F = Null Then F = ReadFile("..\" + Path$)
+	If F = Null Then F = ReadFile("..\..\" + Path$)
+	If F = Null Then Return False
+	While Not Eof(F)
+		Line$ = ReadLine$(F)
+		Select Step
+			Case 0
+				If Instr(Line$, "W.Water = Object.Water(Me\Underwater)") > 0 Then Step = 1
+			Case 1
+				If Instr(Line$, "If W <> Null") > 0 Then Step = 2
+			Case 2
+				If Instr(Line$, "If EntityY#(Me\CollisionEN) > EntityY#(W\EN) - 0.5") > 0 Then Step = 3
+			Case 3
+				If Instr(Line$, "PositionEntity(Me\CollisionEN, EntityX#(Me\CollisionEN), EntityY#(W\EN) - 0.505, EntityZ#(Me\CollisionEN))") > 0
+					CloseFile F
+					Return True
+				EndIf
+		End Select
+	Wend
+	CloseFile F
+	Return False
+End Function
+
+Function FileContains%(Path$, Needle$)
+	Local F.BBStream = ReadFile(Path$)
+	Local Line$
+	If F = Null Then F = ReadFile("..\" + Path$)
+	If F = Null Then F = ReadFile("..\..\" + Path$)
+	If F = Null Then Return False
+	While Not Eof(F)
+		Line$ = ReadLine$(F)
+		If Instr(Line$, Needle$) > 0
+			CloseFile F
+			Return True
+		EndIf
+	Wend
+	CloseFile F
+	Return False
+End Function
+
+Test testSwimmingAscentGuardsAStaleWaterHandle()
+	Assert(HasSafeSwimmingClamp%("src\Modules\Interface3D.bb") = True)
+	Assert(FileContains%("src\Modules\Interface3D.bb", "If W <> Null And EntityY#(Me\CollisionEN)") = False)
+End Test

--- a/src/Tests/Modules/Interface3DWaterHandleTest.bb
+++ b/src/Tests/Modules/Interface3DWaterHandleTest.bb
@@ -18,14 +18,32 @@ Function HasSafeSwimmingClamp%(Path$)
 			Case 0
 				If Instr(Line$, "W.Water = Object.Water(Me\Underwater)") > 0 Then MatchStep = 1
 			Case 1
-				If Instr(Line$, "If W <> Null") > 0 Then MatchStep = 2
-			Case 2
-				If Instr(Line$, "If EntityY#(Me\CollisionEN) > EntityY#(W\EN) - 0.5") > 0 Then MatchStep = 3
-			Case 3
-				If Instr(Line$, "PositionEntity(Me\CollisionEN, EntityX#(Me\CollisionEN), EntityY#(W\EN) - 0.505, EntityZ#(Me\CollisionEN))") > 0
+				If Instr(Line$, "If W <> Null") = 0
 					CloseFile F
-					Return True
+					Return False
 				EndIf
+				MatchStep = 2
+			Case 2
+				If Instr(Line$, "If EntityY#(Me\CollisionEN) > EntityY#(W\EN) - 0.5") = 0
+					CloseFile F
+					Return False
+				EndIf
+				MatchStep = 3
+			Case 3
+				If Instr(Line$, "PositionEntity(Me\CollisionEN, EntityX#(Me\CollisionEN), EntityY#(W\EN) - 0.505, EntityZ#(Me\CollisionEN))") = 0
+					CloseFile F
+					Return False
+				EndIf
+				MatchStep = 4
+			Case 4
+				If Instr(Line$, "EndIf") = 0
+					CloseFile F
+					Return False
+				EndIf
+				MatchStep = 5
+			Case 5
+				CloseFile F
+				Return Instr(Line$, "EndIf") > 0
 		End Select
 	Wend
 	CloseFile F

--- a/src/Tests/Modules/Interface3DWaterHandleTest.bb
+++ b/src/Tests/Modules/Interface3DWaterHandleTest.bb
@@ -18,7 +18,7 @@ Function HasSafeSwimmingClamp%(Path$)
 			Case 0
 				If Instr(Line$, "W.Water = Object.Water(Me\Underwater)") > 0 Then MatchStep = 1
 			Case 1
-				If Instr(Line$, "If W <> Null") = 0
+				If Trim$(Line$) <> "If W <> Null"
 					CloseFile F
 					Return False
 				EndIf

--- a/src/Tests/Modules/Interface3DWaterHandleTest.bb
+++ b/src/Tests/Modules/Interface3DWaterHandleTest.bb
@@ -8,19 +8,19 @@ EnableGC
 Function HasSafeSwimmingClamp%(Path$)
 	Local F.BBStream = ReadFile(Path$)
 	Local Line$
-	Local Step = 0
+	Local MatchStep = 0
 	If F = Null Then F = ReadFile("..\" + Path$)
 	If F = Null Then F = ReadFile("..\..\" + Path$)
 	If F = Null Then Return False
 	While Not Eof(F)
 		Line$ = ReadLine$(F)
-		Select Step
+		Select MatchStep
 			Case 0
-				If Instr(Line$, "W.Water = Object.Water(Me\Underwater)") > 0 Then Step = 1
+				If Instr(Line$, "W.Water = Object.Water(Me\Underwater)") > 0 Then MatchStep = 1
 			Case 1
-				If Instr(Line$, "If W <> Null") > 0 Then Step = 2
+				If Instr(Line$, "If W <> Null") > 0 Then MatchStep = 2
 			Case 2
-				If Instr(Line$, "If EntityY#(Me\CollisionEN) > EntityY#(W\EN) - 0.5") > 0 Then Step = 3
+				If Instr(Line$, "If EntityY#(Me\CollisionEN) > EntityY#(W\EN) - 0.5") > 0 Then MatchStep = 3
 			Case 3
 				If Instr(Line$, "PositionEntity(Me\CollisionEN, EntityX#(Me\CollisionEN), EntityY#(W\EN) - 0.505, EntityZ#(Me\CollisionEN))") > 0
 					CloseFile F


### PR DESCRIPTION
## Outcome

Swimming input no longer dereferences a deleted water object during the frame immediately following a zone unload. Players retain the normal surface clamp whenever the water handle is live.

## Changes

- Guard the existing swimming ascent surface-clamp reads behind an explicit `W <> Null` branch.
- Add a focused source-contract regression test for the lookup, nested guard, preserved clamp, and rejection of an eager `And` guard.

Fixes #662

## Acceptance evidence

| Criterion | Evidence |
| --- | --- |
| Stale handle has no `W\EN` dereference | Guard is before the first water-entity read; source probe observed `lookup=568`, `guard=569`, `first_deref=570`. |
| Live clamp is unchanged | The original `EntityY` comparison and `PositionEntity` correction remain inside the live-handle branch. |
| Regression coverage | `Interface3DWaterHandleTest.bb` reads the bounded source path, requires the ordered guard/clamp sequence, and rejects `If W <> Null And ...`. |
| Generated references remain current | `bash scripts/gen_packet_index.sh --check` and `bash scripts/gen_bvm_reference.sh --check` exited 0. |

## TDD and verification

- Baseline: explicit-guard source probe exited 1 (`explicit_null_guard=False`); generated packet/BVM checks and `git diff --check` exited 0.
- RED: after adding the focused regression test, the same source-contract probe exited 1 because the `W <> Null` branch was missing.
- GREEN: after the minimal guard, the ordered source contract exited 0 (`safe_clamp_sequence=True`; no eager guard). `git diff --check`, packet-index, and BVM-reference checks exited 0.
- Native Blitz command: `./test.sh Interface3DWaterHandleTest` cannot run in this Linux worktree because `compiler/BlitzForge/bin/blitzcc` is absent. A 60-second `git submodule update --init compiler/BlitzForge` timed out during clone; a depth-1 retry exited 128 because the pinned revision is unavailable. Exact-head `Build and test` is the required executable proof.

## Compatibility, rollback, and deferred work

No packet, persistence, schema, or protocol changes. A live water handle follows the exact prior clamp. For a stale handle, only that frame's clamp is skipped rather than crashing. Roll back with a normal revert of commit `405bb37c`.

Deferred: clearing `Me\Underwater` on unload, broader swimming behavior changes, and #653's separate ClientNet projectile cleanup.

## Independent review

Pending fresh review after exact PR head is available.

## Independent review verdict

Fresh final review of exact head 5820bcf2f76c3a9e2bdf67acb2bd931634477b18: **ACCEPT**. The reviewer verified the standalone W <> Null guard, both W\EN reads inside its lexical scope, the unchanged live clamp, and the regression test full nested sequence plus eager-And rejection.