### PR TITLE
fix(server): safely finish spell memorisation after logout

### DIFF
--- a/src/Server.bb
+++ b/src/Server.bb
@@ -723,22 +723,28 @@ Repeat
 	; memorise (e.g. logout race): MemorisingSpell records were not
 	; previously reaped on FreeActorInstance, so a stale MS\AI here
 	; would null-deref on SpellLevels.
-	For MS.MemorisingSpell = Each MemorisingSpell
+	Local MS.MemorisingSpell = First MemorisingSpell
+	Local MSNext.MemorisingSpell = Null
+	While MS <> Null
+		MSNext = After MS
 		If MilliSecs() - MS\CreatedTime > 6000
-			If MS\AI <> Null And MS\KnownNum >= 0 And MS\KnownNum <= 999
-				If MS\AI\SpellLevels[MS\KnownNum] > 0
-					For i = 0 To 9
-						If MS\AI\MemorisedSpells[i] = 5000
-							MS\AI\MemorisedSpells[i] = MS\KnownNum
-							MS\AI\SpellCharge[MS\KnownNum] = 0
-							Exit
-						EndIf
-					Next
+			If MS\AI <> Null
+				If MS\KnownNum >= 0 And MS\KnownNum <= 999
+					If MS\AI\SpellLevels[MS\KnownNum] > 0
+						For i = 0 To 9
+							If MS\AI\MemorisedSpells[i] = 5000
+								MS\AI\MemorisedSpells[i] = MS\KnownNum
+								MS\AI\SpellCharge[MS\KnownNum] = 0
+								Exit
+							EndIf
+						Next
+					EndIf
 				EndIf
 			EndIf
 			Delete MS
 		EndIf
-	Next
+		MS = MSNext
+	Wend
 
 	; Scripts
 		UpdateScripts()

--- a/src/Tests/Modules/ServerSpellMemorisationSafetyTest.bb
+++ b/src/Tests/Modules/ServerSpellMemorisationSafetyTest.bb
@@ -25,41 +25,52 @@ Function SpellMemorisationCompletionIsSafe%(Path$)
 
 	While Not Eof(F)
 		Line$ = ReadLine$(F)
-		If Instr(Line$, "; Update spell memorisation progress.") > 0 Then Stage = 1
+		If Stage = 0 And Instr(Line$, "; Update spell memorisation progress.") > 0 Then Stage = 1
 		If Stage = 1 And Instr(Line$, "For MS.MemorisingSpell = Each MemorisingSpell") > 0
 			CloseFile F
 			Return False
 		EndIf
-		If Stage = 1 And Instr(Line$, "Local MS.MemorisingSpell = First MemorisingSpell") > 0 Then Stage = 2
-		If Stage = 2 And Instr(Line$, "Local MSNext.MemorisingSpell = Null") > 0 Then Stage = 3
-		If Stage = 3 And Instr(Line$, "While MS <> Null") > 0 Then Stage = 4
-		If Stage = 4 And Instr(Line$, "MSNext = After MS") > 0 Then Stage = 5
-	If Stage = 5 And Instr(Line$, "If MilliSecs() - MS\CreatedTime > 6000") > 0 Then Stage = 6
-	If Stage = 6
-		If Trim$(Line$) <> "If MS\AI <> Null"
-				CloseFile F
-				Return False
-			EndIf
-			GuardIndent = LeadingTabs(Line$)
-			Stage = 7
-		EndIf
-	If Stage = 7 And Instr(Line$, "If MS\KnownNum >= 0 And MS\KnownNum <= 999") > 0
-			If LeadingTabs(Line$) <> GuardIndent + 1 Then Return False
-			Stage = 8
-		EndIf
-	If Stage = 8 And Instr(Line$, "If MS\AI\SpellLevels[MS\KnownNum] > 0") > 0
-			If LeadingTabs(Line$) <= GuardIndent Then Return False
-			Stage = 9
-		EndIf
-		If Stage = 9 And Instr(Line$, "EndIf") > 0 And LeadingTabs(Line$) = GuardIndent Then Stage = 10
-		If Stage = 10 And Instr(Line$, "Delete MS") > 0
-			If LeadingTabs(Line$) <> GuardIndent Then Return False
-			Stage = 11
-		EndIf
-		If Stage = 11 And Instr(Line$, "MS = MSNext") > 0
-			CloseFile F
-			Return LeadingTabs(Line$) = GuardIndent - 1
-		EndIf
+		Select Stage
+			Case 1
+				If Instr(Line$, "Local MS.MemorisingSpell = First MemorisingSpell") > 0 Then Stage = 2
+			Case 2
+				If Instr(Line$, "Local MSNext.MemorisingSpell = Null") > 0 Then Stage = 3
+			Case 3
+				If Instr(Line$, "While MS <> Null") > 0 Then Stage = 4
+			Case 4
+				If Instr(Line$, "MSNext = After MS") > 0 Then Stage = 5
+			Case 5
+				If Instr(Line$, "If MilliSecs() - MS\CreatedTime > 6000") > 0 Then Stage = 6
+			Case 6
+				If Trim$(Line$) <> "If MS\AI <> Null"
+					CloseFile F
+					Return False
+				EndIf
+				GuardIndent = LeadingTabs(Line$)
+				Stage = 7
+			Case 7
+				If Instr(Line$, "If MS\KnownNum >= 0 And MS\KnownNum <= 999") > 0
+					If LeadingTabs(Line$) <> GuardIndent + 1 Then Return False
+					Stage = 8
+				EndIf
+			Case 8
+				If Instr(Line$, "If MS\AI\SpellLevels[MS\KnownNum] > 0") > 0
+					If LeadingTabs(Line$) <= GuardIndent Then Return False
+					Stage = 9
+				EndIf
+			Case 9
+				If Instr(Line$, "EndIf") > 0 And LeadingTabs(Line$) = GuardIndent Then Stage = 10
+			Case 10
+				If Instr(Line$, "Delete MS") > 0
+					If LeadingTabs(Line$) <> GuardIndent Then Return False
+					Stage = 11
+				EndIf
+			Case 11
+				If Instr(Line$, "MS = MSNext") > 0
+					CloseFile F
+					Return LeadingTabs(Line$) = GuardIndent - 1
+				EndIf
+		End Select
 		If Stage > 0 And Instr(Line$, "; Scripts") > 0 Then Exit
 	Wend
 

--- a/src/Tests/Modules/ServerSpellMemorisationSafetyTest.bb
+++ b/src/Tests/Modules/ServerSpellMemorisationSafetyTest.bb
@@ -1,0 +1,72 @@
+Strict
+EnableGC
+
+; Server.bb owns the complete server/UI graph, so this focused source contract
+; protects the spell-memorisation completion sweep without loading that graph.
+; A MemorisingSpell can outlive its actor after logout: the actor guard must be
+; a standalone branch, and the sweep must capture its successor before Delete.
+
+Function LeadingTabs%(Line$)
+	Local Count%, Pos% = 1
+	While Pos <= Len(Line$)
+		If Mid$(Line$, Pos, 1) <> Chr$(9) Then Exit
+		Count = Count + 1
+		Pos = Pos + 1
+	Wend
+	Return Count
+End Function
+
+Function SpellMemorisationCompletionIsSafe%(Path$)
+	Local F.BBStream = ReadFile(Path$)
+	Local Stage%, GuardIndent%
+	Local Line$
+	If F = Null Then F = ReadFile("..\" + Path$)
+	If F = Null Then Return False
+
+	While Not Eof(F)
+		Line$ = ReadLine$(F)
+		If Instr(Line$, "; Update spell memorisation progress.") > 0 Then Stage = 1
+		If Stage = 1 And Instr(Line$, "For MS.MemorisingSpell = Each MemorisingSpell") > 0
+			CloseFile F
+			Return False
+		EndIf
+		If Stage = 1 And Instr(Line$, "Local MS.MemorisingSpell = First MemorisingSpell") > 0 Then Stage = 2
+		If Stage = 2 And Instr(Line$, "Local MSNext.MemorisingSpell = Null") > 0 Then Stage = 3
+		If Stage = 3 And Instr(Line$, "While MS <> Null") > 0 Then Stage = 4
+		If Stage = 4 And Instr(Line$, "MSNext = After MS") > 0 Then Stage = 5
+	If Stage = 5 And Instr(Line$, "If MilliSecs() - MS\CreatedTime > 6000") > 0 Then Stage = 6
+	If Stage = 6
+		If Trim$(Line$) <> "If MS\AI <> Null"
+				CloseFile F
+				Return False
+			EndIf
+			GuardIndent = LeadingTabs(Line$)
+			Stage = 7
+		EndIf
+	If Stage = 7 And Instr(Line$, "If MS\KnownNum >= 0 And MS\KnownNum <= 999") > 0
+			If LeadingTabs(Line$) <> GuardIndent + 1 Then Return False
+			Stage = 8
+		EndIf
+	If Stage = 8 And Instr(Line$, "If MS\AI\SpellLevels[MS\KnownNum] > 0") > 0
+			If LeadingTabs(Line$) <= GuardIndent Then Return False
+			Stage = 9
+		EndIf
+		If Stage = 9 And Instr(Line$, "EndIf") > 0 And LeadingTabs(Line$) = GuardIndent Then Stage = 10
+		If Stage = 10 And Instr(Line$, "Delete MS") > 0
+			If LeadingTabs(Line$) <> GuardIndent Then Return False
+			Stage = 11
+		EndIf
+		If Stage = 11 And Instr(Line$, "MS = MSNext") > 0
+			CloseFile F
+			Return LeadingTabs(Line$) = GuardIndent - 1
+		EndIf
+		If Stage > 0 And Instr(Line$, "; Scripts") > 0 Then Exit
+	Wend
+
+	CloseFile F
+	Return False
+End Function
+
+Test testSpellMemorisationCompletionHandlesStaleActorsAndCursorDeletes()
+	Assert(SpellMemorisationCompletionIsSafe%("Server.bb") = True)
+End Test


### PR DESCRIPTION
## Outcome

Stops the shared server from dereferencing a spell-memorisation owner after logout, and ensures simultaneous expired records are all visited during cleanup.

## Technical changes

- Replaced the deletion-inside-`For Each` sweep with `First` / `After` / `While` traversal.
- Put actor-field access behind a standalone live-actor branch.
- Added a bounded source-contract regression test for cursor capture, guard scope, cleanup, and advance ordering.

Fixes #664

## Acceptance evidence

- The successor is captured before each possible `Delete MS`.
- `MS\AI` is tested by a standalone branch before its fields are read.
- The existing six-second timing, spell-ID bounds, slot replacement, and cooldown reset stay intact for live actors.

## RED → GREEN and verification

- RED: the focused source probe exited 1 on the prior `For Each` and eager compound actor guard.
- GREEN: the matching source-contract probe exited 0 after the after-cursor and nested-guard change.
- `git diff --check origin/develop...HEAD`, `bash scripts/gen_packet_index.sh --check`, and `bash scripts/gen_bvm_reference.sh --check` each exited 0.
- `./test.sh ServerSpellMemorisationSafetyTest` exited 1 only because this Linux checkout lacks `compiler/BlitzForge/bin/blitzcc`; Windows CI is the executable Blitz proof.

## Compatibility, risk, rollback

No wire, persistence, schema, or spell-balance changes. Live memorisation behavior is retained; stale records are safely discarded. Roll back with a normal revert of these two commits.

## Review

Independent review: pending on this exact head.

## Independent review

Fresh independent reviewer verdict: ACCEPT for exact head `19347fddaad33f705c0153b33533380e25224d84`; it confirmed cursor safety, standalone actor guarding, test path/scope, compatibility, and active-lease disjointness.