### PR TITLE
fix(client): guard optional Chat during startup

### DIFF
--- a/src/Modules/ClientLoaders.bb
+++ b/src/Modules/ClientLoaders.bb
@@ -202,17 +202,19 @@ Function LoadGame()
 
 	; User interface
 	If Not LoadInterfaceSettings("Data\Game Data\Interface.dat") Then RuntimeError("Could not load interface!")
-	If Chat <> Null And Chat\Texture <> 65535
-		ChatBar = New InterfaceComponent
-		ChatBar\Texture = Chat\Texture
-		ChatBar\X# = Chat\X#
-		ChatBar\Y# = Chat\Y#
-		ChatBar\Width# = Chat\Width#
-		ChatBar\Height# = Chat\Height#
-		ChatBar\Alpha# = Chat\Alpha#
-		ChatBar\R = Chat\R
-		ChatBar\G = Chat\G
-		ChatBar\B = Chat\B
+	If Chat <> Null
+		If Chat\Texture <> 65535
+			ChatBar = New InterfaceComponent
+			ChatBar\Texture = Chat\Texture
+			ChatBar\X# = Chat\X#
+			ChatBar\Y# = Chat\Y#
+			ChatBar\Width# = Chat\Width#
+			ChatBar\Height# = Chat\Height#
+			ChatBar\Alpha# = Chat\Alpha#
+			ChatBar\R = Chat\R
+			ChatBar\G = Chat\G
+			ChatBar\B = Chat\B
+		EndIf
 	End If
 	
 	CreateInterface()

--- a/src/Tests/Modules/ClientLoadersChatGuardTest.bb
+++ b/src/Tests/Modules/ClientLoadersChatGuardTest.bb
@@ -17,6 +17,7 @@ Function ChatTextureReadIsNested%(Path$)
 	Local F.BBStream = ReadFile(Path$)
 	Local Line$
 	Local Stage%, NullIndent%, TextureIndent%
+	Local SawChatBar%, SawTextureCopy%
 	If F = Null Then F = ReadFile("..\" + Path$)
 	If F = Null Then Return False
 
@@ -48,8 +49,37 @@ Function ChatTextureReadIsNested%(Path$)
 				CloseFile F
 				Return False
 			EndIf
+			SawChatBar = True
+		EndIf
+		If Stage = 3 And Instr(Line$, "ChatBar\") > 0
+			If LeadingTabs(Line$) <> TextureIndent + 1
+				CloseFile F
+				Return False
+			EndIf
+		EndIf
+		If Stage = 3 And Instr(Line$, "Chat\Texture") > 0 And Instr(Line$, "If Chat\Texture <> 65535") = 0
+			If LeadingTabs(Line$) <> TextureIndent + 1
+				CloseFile F
+				Return False
+			EndIf
+			SawTextureCopy = True
+		EndIf
+		If Stage = 3 And LeadingTabs(Line$) = TextureIndent
+			If Instr(Line$, "EndIf") > 0 Or Instr(Line$, "End If") > 0 Then Stage = 4
+		EndIf
+		If Stage = 4 And Instr(Line$, "Chat\Texture") > 0
 			CloseFile F
-			Return True
+			Return False
+		EndIf
+		If Stage = 4 And Instr(Line$, "ChatBar") > 0
+			CloseFile F
+			Return False
+		EndIf
+		If Stage = 4 And LeadingTabs(Line$) = NullIndent
+			If Instr(Line$, "EndIf") > 0 Or Instr(Line$, "End If") > 0
+				CloseFile F
+				Return SawChatBar And SawTextureCopy
+			EndIf
 		EndIf
 		If Stage > 0 And Instr(Line$, "CreateInterface()") > 0 Then Exit
 	Wend

--- a/src/Tests/Modules/ClientLoadersChatGuardTest.bb
+++ b/src/Tests/Modules/ClientLoadersChatGuardTest.bb
@@ -36,52 +36,46 @@ Function ChatTextureReadIsNested%(Path$)
 			NullIndent = LeadingTabs(Line$)
 			Stage = 2
 		EndIf
+		If Stage > 0 And Instr(Line$, "Chat\Texture") > 0
+			If Stage = 2
+				If Instr(Line$, "If Chat\Texture <> 65535") = 0 Or LeadingTabs(Line$) <> NullIndent + 1
+					CloseFile F
+					Return False
+				EndIf
+			ElseIf Stage = 3
+				If LeadingTabs(Line$) <> TextureIndent + 1
+					CloseFile F
+					Return False
+				EndIf
+				SawTextureCopy = True
+			Else
+				CloseFile F
+				Return False
+			EndIf
+		EndIf
+		If Stage > 0 And Instr(Line$, "ChatBar") > 0
+			If Stage <> 3 Or LeadingTabs(Line$) <> TextureIndent + 1
+				CloseFile F
+				Return False
+			EndIf
+			If Instr(Line$, "ChatBar = New InterfaceComponent") > 0 Then SawChatBar = True
+		EndIf
 		If Stage = 2 And Instr(Line$, "If Chat\Texture <> 65535") > 0
 			TextureIndent = LeadingTabs(Line$)
-			If TextureIndent <> NullIndent + 1
-				CloseFile F
-				Return False
-			EndIf
 			Stage = 3
-		EndIf
-		If Stage = 3 And Instr(Line$, "ChatBar = New InterfaceComponent") > 0
-			If LeadingTabs(Line$) <> TextureIndent + 1
-				CloseFile F
-				Return False
-			EndIf
-			SawChatBar = True
-		EndIf
-		If Stage = 3 And Instr(Line$, "ChatBar\") > 0
-			If LeadingTabs(Line$) <> TextureIndent + 1
-				CloseFile F
-				Return False
-			EndIf
-		EndIf
-		If Stage = 3 And Instr(Line$, "Chat\Texture") > 0 And Instr(Line$, "If Chat\Texture <> 65535") = 0
-			If LeadingTabs(Line$) <> TextureIndent + 1
-				CloseFile F
-				Return False
-			EndIf
-			SawTextureCopy = True
 		EndIf
 		If Stage = 3 And LeadingTabs(Line$) = TextureIndent
 			If Instr(Line$, "EndIf") > 0 Or Instr(Line$, "End If") > 0 Then Stage = 4
 		EndIf
-		If Stage = 4 And Instr(Line$, "Chat\Texture") > 0
-			CloseFile F
-			Return False
-		EndIf
-		If Stage = 4 And Instr(Line$, "ChatBar") > 0
-			CloseFile F
-			Return False
-		EndIf
 		If Stage = 4 And LeadingTabs(Line$) = NullIndent
 			If Instr(Line$, "EndIf") > 0 Or Instr(Line$, "End If") > 0
-				CloseFile F
-				Return SawChatBar And SawTextureCopy
+				Stage = 5
 			EndIf
 		EndIf
-		If Stage > 0 And Instr(Line$, "CreateInterface()") > 0 Then Exit
+		If Stage > 0 And Instr(Line$, "CreateInterface()") > 0
+			CloseFile F
+			Return Stage = 5 And SawChatBar And SawTextureCopy
+		EndIf
 	Wend
 
 	CloseFile F

--- a/src/Tests/Modules/ClientLoadersChatGuardTest.bb
+++ b/src/Tests/Modules/ClientLoadersChatGuardTest.bb
@@ -1,0 +1,63 @@
+Strict
+EnableGC
+
+; LoadGame can run with no persisted Chat component. BlitzForge evaluates And
+; eagerly, so the optional component must be checked before its texture field.
+
+Function LeadingTabs%(Line$)
+	Local Count% = 0
+	While Count < Len(Line$)
+		If Mid$(Line$, Count + 1, 1) <> Chr$(9) Then Exit
+		Count = Count + 1
+	Wend
+	Return Count
+End Function
+
+Function ChatTextureReadIsNested%(Path$)
+	Local F.BBStream = ReadFile(Path$)
+	Local Line$
+	Local Stage%, NullIndent%, TextureIndent%
+	If F = Null Then F = ReadFile("..\" + Path$)
+	If F = Null Then Return False
+
+	While Not Eof(F)
+		Line$ = ReadLine$(F)
+		If Instr(Line$, "; User interface") > 0 Then Stage = 1
+		If Stage = 1 And Instr(Line$, "If Chat <> Null And Chat\Texture") > 0
+			CloseFile F
+			Return False
+		EndIf
+		If Stage = 1 And Instr(Line$, "If Chat <> Null") > 0
+			If Instr(Line$, "And") > 0 Or Instr(Line$, "Or") > 0
+				CloseFile F
+				Return False
+			EndIf
+			NullIndent = LeadingTabs(Line$)
+			Stage = 2
+		EndIf
+		If Stage = 2 And Instr(Line$, "If Chat\Texture <> 65535") > 0
+			TextureIndent = LeadingTabs(Line$)
+			If TextureIndent <> NullIndent + 1
+				CloseFile F
+				Return False
+			EndIf
+			Stage = 3
+		EndIf
+		If Stage = 3 And Instr(Line$, "ChatBar = New InterfaceComponent") > 0
+			If LeadingTabs(Line$) <> TextureIndent + 1
+				CloseFile F
+				Return False
+			EndIf
+			CloseFile F
+			Return True
+		EndIf
+		If Stage > 0 And Instr(Line$, "CreateInterface()") > 0 Then Exit
+	Wend
+
+	CloseFile F
+	Return False
+End Function
+
+Test testChatTextureReadIsNestedUnderNullGuard()
+	Assert(ChatTextureReadIsNested%("Modules\ClientLoaders.bb") = True)
+End Test


### PR DESCRIPTION
## Outcome

A missing optional Chat interface component no longer reaches an eager `Chat\Texture` dereference during client startup. Valid chat layouts and the existing `65535` no-texture sentinel retain their behavior.

Fixes #666

## Technical changes

- Replace the non-short-circuit `Chat <> Null And Chat\Texture <> 65535` predicate with nested Null then texture guards in `LoadGame`.
- Add a bounded source-contract test that rejects the legacy eager guard and requires the nested guard plus ChatBar creation hierarchy.

## Acceptance evidence

| Criterion | Evidence |
| --- | --- |
| Texture read is protected by a Null guard | GREEN source-contract probe: `legacy_eager_guard=False`, `nested_guard=True` (exit 0) |
| Legacy eager guard cannot return | `ClientLoadersChatGuardTest.bb` explicitly rejects `If Chat <> Null And Chat\Texture` |
| Valid ChatBar setup remains intact | Diff changes only conditional nesting; all existing field copies remain in the inner branch |

## TDD and verification

- Baseline: `git diff --check`, generated packet/BVM reference checks, and Bash syntax checks exited 0; source inspection found the legacy eager predicate at `ClientLoaders.bb:205`.
- RED: bounded source-contract probe exited 1 with `legacy_eager_guard=True`, `nested_guard=False`.
- GREEN: the same probe exited 0 with `legacy_eager_guard=False`, `nested_guard=True`.
- Final local checks: `git diff --check`, `bash scripts/gen_packet_index.sh --check`, `bash scripts/gen_bvm_reference.sh --check`, and `bash -n compile.sh test.sh scripts/*.sh` exited 0.
- Local compiled test is unavailable: `./test.sh ClientLoadersChatGuardTest` exited 1 because `compiler/BlitzForge/bin/blitzcc` is absent. Windows CI is the required compiled-test gate.

## Compatibility, risk, rollback

No packet, save-data, interface-layout, or valid Chat behavior changes. The only changed path skips optional ChatBar creation when Chat is absent. Roll back with a normal revert of this PR.

## Deferred

Interface.dat recovery and ChatEntry behavior are intentionally out of scope.

## Independent review

- Cycle 1: `REQUEST_CHANGES` — strengthened nested scope and field-read coverage.
- Cycle 2: `REQUEST_CHANGES` — scanned through `CreateInterface()` to reject all bounded-section escapes.
- Cycle 3: fresh independent review of exact head `a39bdfbe` returned `ACCEPT`.

## Final CI

Exact-head `Build and test` and `Rust server (Linux)` both completed successfully.