### PR TITLE
fix(gooey): safely restart recursive teardown walks

### DIFF
--- a/src/Modules/Gooey.bb
+++ b/src/Modules/Gooey.bb
@@ -219,9 +219,11 @@ End Type
 
 ; Removes all present gadgets
 Function GY_ClearGadgets()
-	For gadget.GY_Gadget = Each GY_Gadget
-		GY_FreeGadget(Handle(gadget))
-	Next
+	Local Gadget.GY_Gadget = First GY_Gadget
+	While Gadget <> Null
+		GY_FreeGadget(Handle(Gadget))
+		Gadget = First GY_Gadget
+	Wend
 End Function
 
 
@@ -3766,10 +3768,17 @@ Function GY_FreeGadget(GHandle)
 	G.GY_Gadget = Object.GY_Gadget(GHandle)
 	If G = Null Then Return False
 
-	; Free children
-	For Child.GY_Gadget = Each GY_Gadget
-		If Child\Parent = G Then GY_FreeGadget(Handle(Child))
-	Next
+	; Free children. Recursion can delete entries beyond the current cursor, so
+	; restart after a delete instead of advancing a stale For Each cursor.
+	Local Child.GY_Gadget = First GY_Gadget
+	While Child <> Null
+		If Child\Parent = G
+			GY_FreeGadget(Handle(Child))
+			Child = First GY_Gadget
+		Else
+			Child = After Child
+		EndIf
+	Wend
 
 	; If it's a window
 	If Object.GY_Window(G\TypeHandle) <> Null
@@ -4032,13 +4041,18 @@ End Function
 ; Unloads everything being used by Gooey
 Function GY_Unload()
 
-	; Free gadgets
-	For W.GY_Window = Each GY_Window
+	; Free gadgets. Each call deletes the current window/gadget Type, so restart
+	; from First rather than advancing a cursor through a deleted instance.
+	Local W.GY_Window = First GY_Window
+	While W <> Null
 		GY_FreeGadget(Handle(W\Gadget))
-	Next
-	For G.GY_Gadget = Each GY_Gadget
+		W = First GY_Window
+	Wend
+	Local G.GY_Gadget = First GY_Gadget
+	While G <> Null
 		GY_FreeGadget(Handle(G))
-	Next
+		G = First GY_Gadget
+	Wend
 
 	; Textures
 	FreeTexture(GY_Window)
@@ -5057,4 +5071,4 @@ End Function
 Function GYFovCam(Cam, xWidth, yHeight)
    Local FOV# = (2 * ATan(Tan((74) / 2) * xWidth / yHeight))
    CameraZoom(Cam, 1.0 / Tan(FOV# / 2))
-End Function 
+End Function

--- a/src/Tests/Modules/GooeyTeardownIteratorTest.bb
+++ b/src/Tests/Modules/GooeyTeardownIteratorTest.bb
@@ -1,0 +1,117 @@
+Strict
+EnableGC
+
+; GY_FreeGadget recursively deletes both gadget and window Type instances.
+; BlitzForge For Each cursors cannot advance after their current instance was
+; deleted, so these bounded source contracts require restart-on-delete walks.
+
+Function ClearGadgetsRestartsAfterDelete%(Path$)
+	Local F.BBStream = ReadFile(Path$)
+	Local InFunction%, Stage%
+	Local Line$
+	If F = Null Then F = ReadFile("..\" + Path$)
+	If F = Null Then Return False
+
+	While Not Eof(F)
+		Line$ = ReadLine$(F)
+		If Instr(Line$, "Function GY_ClearGadgets()") > 0 Then InFunction = True
+		If InFunction = True
+			If Instr(Line$, "For gadget.GY_Gadget = Each GY_Gadget") > 0
+				CloseFile F
+				Return False
+			EndIf
+			If Stage = 0 And Instr(Line$, "Local Gadget.GY_Gadget = First GY_Gadget") > 0 Then Stage = 1
+			If Stage = 1 And Instr(Line$, "While Gadget <> Null") > 0 Then Stage = 2
+			If Stage = 2 And Instr(Line$, "GY_FreeGadget(Handle(Gadget))") > 0 Then Stage = 3
+			If Stage = 3 And Instr(Line$, "Gadget = First GY_Gadget") > 0 Then Stage = 4
+			If Stage = 4 And Instr(Line$, "Wend") > 0 Then Stage = 5
+			If Instr(Line$, "End Function") > 0
+				CloseFile F
+				Return Stage = 5
+			EndIf
+		EndIf
+	Wend
+
+	CloseFile F
+	Return False
+
+End Function
+
+Function FreeGadgetChildrenRestartAfterDelete%(Path$)
+	Local F.BBStream = ReadFile(Path$)
+	Local InChildren%, Stage%
+	Local Line$
+	If F = Null Then F = ReadFile("..\" + Path$)
+	If F = Null Then Return False
+
+	While Not Eof(F)
+		Line$ = ReadLine$(F)
+		If Instr(Line$, "; Free children") > 0 Then InChildren = True
+		If InChildren = True
+			If Instr(Line$, "For Child.GY_Gadget = Each GY_Gadget") > 0
+				CloseFile F
+				Return False
+			EndIf
+			If Stage = 0 And Instr(Line$, "Local Child.GY_Gadget = First GY_Gadget") > 0 Then Stage = 1
+			If Stage = 1 And Instr(Line$, "While Child <> Null") > 0 Then Stage = 2
+			If Stage = 2 And Instr(Line$, "If Child\Parent = G") > 0 Then Stage = 3
+			If Stage = 3 And Instr(Line$, "GY_FreeGadget(Handle(Child))") > 0 Then Stage = 4
+			If Stage = 4 And Instr(Line$, "Child = First GY_Gadget") > 0 Then Stage = 5
+			If Stage = 5 And Instr(Line$, "Else") > 0 Then Stage = 6
+			If Stage = 6 And Instr(Line$, "Child = After Child") > 0 Then Stage = 7
+			If Stage = 7 And Instr(Line$, "EndIf") > 0 Then Stage = 8
+			If Stage = 8 And Instr(Line$, "Wend") > 0 Then Stage = 9
+			If Instr(Line$, "; If it's a window") > 0
+				CloseFile F
+				Return Stage = 9
+			EndIf
+		EndIf
+	Wend
+
+	CloseFile F
+	Return False
+
+End Function
+
+Function UnloadRestartsAfterDelete%(Path$)
+	Local F.BBStream = ReadFile(Path$)
+	Local InFunction%, Stage%
+	Local Line$
+	If F = Null Then F = ReadFile("..\" + Path$)
+	If F = Null Then Return False
+
+	While Not Eof(F)
+		Line$ = ReadLine$(F)
+		If Instr(Line$, "Function GY_Unload()") > 0 Then InFunction = True
+		If InFunction = True
+			If Instr(Line$, "For W.GY_Window = Each GY_Window") > 0 Or Instr(Line$, "For G.GY_Gadget = Each GY_Gadget") > 0
+				CloseFile F
+				Return False
+			EndIf
+			If Stage = 0 And Instr(Line$, "Local W.GY_Window = First GY_Window") > 0 Then Stage = 1
+			If Stage = 1 And Instr(Line$, "While W <> Null") > 0 Then Stage = 2
+			If Stage = 2 And Instr(Line$, "GY_FreeGadget(Handle(W\Gadget))") > 0 Then Stage = 3
+			If Stage = 3 And Instr(Line$, "W = First GY_Window") > 0 Then Stage = 4
+			If Stage = 4 And Instr(Line$, "Wend") > 0 Then Stage = 5
+			If Stage = 5 And Instr(Line$, "Local G.GY_Gadget = First GY_Gadget") > 0 Then Stage = 6
+			If Stage = 6 And Instr(Line$, "While G <> Null") > 0 Then Stage = 7
+			If Stage = 7 And Instr(Line$, "GY_FreeGadget(Handle(G))") > 0 Then Stage = 8
+			If Stage = 8 And Instr(Line$, "G = First GY_Gadget") > 0 Then Stage = 9
+			If Stage = 9 And Instr(Line$, "Wend") > 0 Then Stage = 10
+			If Instr(Line$, "; Textures") > 0
+				CloseFile F
+				Return Stage = 10
+			EndIf
+		EndIf
+	Wend
+
+	CloseFile F
+	Return False
+
+End Function
+
+Test testGooeyTeardownRestartsAfterRecursiveDeletes()
+	Assert(ClearGadgetsRestartsAfterDelete%("Modules\Gooey.bb") = True)
+	Assert(FreeGadgetChildrenRestartAfterDelete%("Modules\Gooey.bb") = True)
+	Assert(UnloadRestartsAfterDelete%("Modules\Gooey.bb") = True)
+End Test


### PR DESCRIPTION
## Outcome

Gooey now tears down all recursively owned UI gadgets without advancing a Blitz3D iterator through the instance it just deleted. This prevents skipped cleanup and stale cursor access when clearing multiple gadgets or unloading UI resources.

## Technical changes

- Replaced the three unsafe teardown loops in `GY_ClearGadgets`, recursive `GY_FreeGadget` child cleanup, and `GY_Unload` with the documented restart-on-delete traversal.
- Added `GooeyTeardownIteratorTest.bb`, a bounded source-contract regression that rejects each legacy `For Each` delete loop and requires the safe traversal shape.
- Normalized the existing final `End Function` whitespace in the edited Gooey file so diff validation remains meaningful.

Fixes #668

## Acceptance criteria and evidence

1. No affected active-cursor `For Each` delete loop remains — final structural source contract exited 0.
2. Each teardown path restarts from `First` after deletion, while the child scan advances with `After` only when no deletion occurred — final structural source contract exited 0.
3. Focused regression coverage was added — RED structural probe exited 1 on the old source (`clear_restart=False`, `children_restart=False`, `unload_restart=False`); GREEN exited 0 after the implementation.
4. Public Gooey interfaces and resource cleanup calls remain unchanged — inspected in the two-file diff.

## Verification

- `python3` bounded source contract: RED exit 1; GREEN/final exit 0.
- `bash scripts/gen_packet_index.sh --check`: exit 0.
- `bash scripts/gen_bvm_reference.sh --check`: exit 0 (existing warnings for `BVM_SETOWNER` and `BVM_SCENERYOWNER`).
- `git diff --check`: exit 0.
- `./test.sh GooeyTeardownIteratorTest`: exit 1 locally only because `compiler/BlitzForge/bin/blitzcc` is absent; Windows CI is the executable Blitz proof.

## Compatibility, risk, and rollback

No external API, serialization, or UI behavior changes. The only behavioral change is safe traversal during recursive teardown. Roll back by reverting this single commit. Deferred: unrelated Gooey/F-UI cleanup and the active ServerNet/Loom work items.

## Independent reviewer verdict

Fresh reviewer verdict: **ACCEPT** for exact head `31cf8ad847975ee8caec21e3cae5b30ed0933403` against base `b7f8ffdcead9bce2fc74775105fd58fe77758504`. It confirmed the restart-on-delete shape, single-backslash source-test paths, scope, and static verification. The verdict remains valid only while that head/base remain unchanged.