### PR TITLE
fix(client): safely tear down unload pools

### DIFF
--- a/src/Modules/ClientLoaders.bb
+++ b/src/Modules/ClientLoaders.bb
@@ -378,21 +378,32 @@ Function UnloadGame()
 	Unload_Radar()
 	GY_Unload()
 	
-	For L.Light = Each Light
+	; Capture the next node before deleting the current one. BlitzForge's
+	; For-Each cursor otherwise advances through the freed Light on shutdown.
+	Local L.Light = First Light
+	Local LNext.Light = Null
+	While L <> Null
+		LNext = After L
 		FreeEntity(L\EN)
 		Delete L
-	Next
+		L = LNext
+	Wend
 	
 	For i = 0 To 65534
 		UnloadTexture(i)
 		UnloadMesh(i)
 	Next
 	
-	; Clear all actor 3D instances
-	For AI.ActorInstance = Each Actorinstance
+	; Clear all actor 3D instances. FreeActorInstance3D destroys the current
+	; instance, so preserve its successor before tearing it down.
+	Local AI.ActorInstance = First ActorInstance
+	Local AINext.ActorInstance = Null
+	While AI <> Null
+		AINext = After AI
 		FreeActorInstance3D(AI)
 		Delete(AI)
-	Next
+		AI = AINext
+	Wend
 	AreaName$ = ""
 	OldAreaName$ = ""
 	OldAreaID = 0

--- a/src/Tests/Modules/ClientLoadersUnloadIteratorTest.bb
+++ b/src/Tests/Modules/ClientLoadersUnloadIteratorTest.bb
@@ -1,0 +1,51 @@
+Strict
+EnableGC
+
+; Client teardown is graphics-heavy, so bind the bounded production cursor
+; contract without pulling its renderer dependency graph into this test.
+Function UnloadGameTeardownUsesAfterCursors%(Path$)
+	Local F.BBStream = ReadFile(Path$)
+	Local InUnload%, Stage%
+	Local Line$
+	If F = Null Then F = ReadFile("..\" + Path$)
+	If F = Null Then Return False
+
+	While Not Eof(F)
+		Line$ = ReadLine$(F)
+		If Instr(Line$, "Function UnloadGame") > 0 Then InUnload = True
+		If InUnload = True
+			If Instr(Line$, "For L.Light = Each Light") > 0 Or Instr(Line$, "For AI.ActorInstance = Each Actorinstance") > 0
+				CloseFile F
+				Return False
+			EndIf
+			If Stage = 0 And Instr(Line$, "Local L.Light = First Light") > 0 Then Stage = 1
+			If Stage = 1 And Instr(Line$, "Local LNext.Light = Null") > 0 Then Stage = 2
+			If Stage = 2 And Instr(Line$, "While L <> Null") > 0 Then Stage = 3
+			If Stage = 3 And Instr(Line$, "LNext = After L") > 0 Then Stage = 4
+			If Stage = 4 And Instr(Line$, "FreeEntity(L\EN)") > 0 Then Stage = 5
+			If Stage = 5 And Instr(Line$, "Delete L") > 0 Then Stage = 6
+			If Stage = 6 And Instr(Line$, "L = LNext") > 0 Then Stage = 7
+			If Stage = 7 And Instr(Line$, "Wend") > 0 Then Stage = 8
+			If Stage = 8 And Instr(Line$, "Local AI.ActorInstance = First ActorInstance") > 0 Then Stage = 9
+			If Stage = 9 And Instr(Line$, "Local AINext.ActorInstance = Null") > 0 Then Stage = 10
+			If Stage = 10 And Instr(Line$, "While AI <> Null") > 0 Then Stage = 11
+			If Stage = 11 And Instr(Line$, "AINext = After AI") > 0 Then Stage = 12
+			If Stage = 12 And Instr(Line$, "FreeActorInstance3D(AI)") > 0 Then Stage = 13
+			If Stage = 13 And Instr(Line$, "Delete(AI)") > 0 Then Stage = 14
+			If Stage = 14 And Instr(Line$, "AI = AINext") > 0 Then Stage = 15
+			If Stage = 15 And Instr(Line$, "Wend") > 0 Then Stage = 16
+			If Instr(Line$, "End Function") > 0
+				CloseFile F
+				Return Stage = 16
+			EndIf
+		EndIf
+	Wend
+
+	CloseFile F
+	Return False
+
+End Function
+
+Test testUnloadGameTeardownUsesAfterCursors()
+	Assert(UnloadGameTeardownUsesAfterCursors%("Modules\ClientLoaders.bb") = True)
+End Test


### PR DESCRIPTION
## Outcome

Client shutdown now walks every Light and ActorInstance safely instead of advancing an iterator through a node it just deleted. This prevents skipped teardown work or cursor corruption in populated unloads.

## Changes

- Replace both UnloadGame For Each delete loops with capture-next-before-destruction walks.
- Add a focused source-contract regression test for the two teardown paths.

Fixes #672

## Acceptance evidence

- Both Light and ActorInstance pools use typed First / After / While traversal.
- Each successor is captured before FreeEntity/Delete or FreeActorInstance3D/Delete.
- The regression contract rejects both legacy loops and requires the ordered safe walks.

## Baseline, RED, GREEN, and final verification

- Baseline: source inspection found both legacy For Each teardown loops in ClientLoaders.bb at lines 381-384 and 392-395.
- RED: focused source-contract probe exited 1 with legacy_light=1 legacy_actor=1 light_first=0 actor_first=0.
- GREEN: the same probe exited 0 with legacy_light=0 legacy_actor=0 stage=16.
- Final: git diff --check origin/develop exited 0; final source-contract probe exited 0 with the same stage-16 result.
- Local compiler limitation: test.sh ClientLoadersUnloadIteratorTest reports compiler/BlitzForge/bin/blitzcc missing after pinned-submodule initialization. CI is the executable Blitz proof.

## Review

Fresh independent review: ACCEPT. It confirmed FreeActorInstance3D releases only 3D resources and leaves the ActorInstance for the retained Delete(AI); it also confirmed the bounded source contract covers both paths.

## Compatibility, risk, and rollback

No API, wire, persistence, or gameplay contract changes. The calls and teardown order are retained; only iterator control changes. Roll back with a normal revert of this PR.

## Deferred

ClientNet projectile cleanup remains tracked separately by #653 and is outside this reservation.