### PR TITLE
ci: pin GitHub Actions to reviewed immutable SHAs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,8 @@ jobs:
 
     steps:
       - name: Check out repository
-        uses: actions/checkout@v4
+        # actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
         with:
           # BlitzForge submodule; nested reshade deps are not needed for
           # compile/test so we skip recursive to keep the checkout fast.
@@ -38,7 +39,8 @@ jobs:
 
       - name: Restore BlitzForge bin from cache
         id: bf-cache
-        uses: actions/cache@v4
+        # actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830
         with:
           path: |
             compiler/BlitzForge/bin/blitzcc.exe
@@ -49,7 +51,8 @@ jobs:
 
       - name: Add MSBuild to PATH
         if: steps.bf-cache.outputs.cache-hit != 'true'
-        uses: microsoft/setup-msbuild@v2
+        # microsoft/setup-msbuild@v2
+        uses: microsoft/setup-msbuild@6fb02220983dee41ce7ae257b6f4d8f9bf5ed4ce
 
       - name: Build BlitzForge compiler
         if: steps.bf-cache.outputs.cache-hit != 'true'
@@ -92,7 +95,8 @@ jobs:
       #     wgpu/winit compile is amortised by the cache step below (which already
       #     lists client-rs/target). The i686-only rcenet-ffi-probe is excluded.
       - name: Set up Rust 1.85.0 (client)
-        uses: dtolnay/rust-toolchain@1.85.0
+        # dtolnay/rust-toolchain@1.85.0
+        uses: dtolnay/rust-toolchain@98effd2fc0b766278e30ab86762dd5e9a8531399
         with:
           components: clippy
 
@@ -103,7 +107,8 @@ jobs:
           cargo --version
 
       - name: Cache Rust build (client-rs)
-        uses: actions/cache@v4
+        # actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830
         with:
           path: |
             ~/.cargo/registry/index
@@ -167,10 +172,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository
-        uses: actions/checkout@v4
+        # actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
 
       - name: Set up Rust 1.85.0 (server)
-        uses: dtolnay/rust-toolchain@1.85.0
+        # dtolnay/rust-toolchain@1.85.0
+        uses: dtolnay/rust-toolchain@98effd2fc0b766278e30ab86762dd5e9a8531399
         with:
           components: clippy
 
@@ -180,7 +187,8 @@ jobs:
           cargo --version
 
       - name: Cache Rust build (server-rs)
-        uses: actions/cache@v4
+        # actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830
         with:
           path: |
             ~/.cargo/registry/index

--- a/src/Tests/Modules/GitHubActionsPinTest.bb
+++ b/src/Tests/Modules/GitHubActionsPinTest.bb
@@ -1,0 +1,49 @@
+Strict
+EnableGC
+
+; CI actions are an external dependency boundary. Keep their reviewed commit
+; identities explicit so a moved tag cannot silently change build behavior.
+
+Function FileContains%(Path$, Needle$)
+	Local F.BBStream = ReadFile(Path$)
+	Local Line$
+	If F = Null Then F = ReadFile("..\" + Path$)
+	If F = Null Then F = ReadFile("..\..\" + Path$)
+	If F = Null Then Return False
+	While Not Eof(F)
+		Line$ = ReadLine$(F)
+		If Instr(Line$, Needle$) > 0
+			CloseFile F
+			Return True
+		EndIf
+	Wend
+	CloseFile F
+	Return False
+End Function
+
+Function FileOccurrenceCount%(Path$, Needle$)
+	Local F.BBStream = ReadFile(Path$)
+	Local Line$
+	Local Count = 0
+	If F = Null Then F = ReadFile("..\" + Path$)
+	If F = Null Then F = ReadFile("..\..\" + Path$)
+	If F = Null Then Return 0
+	While Not Eof(F)
+		Line$ = ReadLine$(F)
+		If Instr(Line$, Needle$) > 0 Then Count = Count + 1
+	Wend
+	CloseFile F
+	Return Count
+End Function
+
+Test testCIActionReferencesUseReviewedImmutablePins()
+	Assert(FileOccurrenceCount%(".github\workflows\ci.yml", "uses:") = 8)
+	Assert(FileOccurrenceCount%(".github\workflows\ci.yml", "uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5") = 2)
+	Assert(FileOccurrenceCount%(".github\workflows\ci.yml", "uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830") = 3)
+	Assert(FileOccurrenceCount%(".github\workflows\ci.yml", "uses: microsoft/setup-msbuild@6fb02220983dee41ce7ae257b6f4d8f9bf5ed4ce") = 1)
+	Assert(FileOccurrenceCount%(".github\workflows\ci.yml", "uses: dtolnay/rust-toolchain@98effd2fc0b766278e30ab86762dd5e9a8531399") = 2)
+	Assert(FileContains%(".github\workflows\ci.yml", "uses: actions/checkout@v4") = False)
+	Assert(FileContains%(".github\workflows\ci.yml", "uses: actions/cache@v4") = False)
+	Assert(FileContains%(".github\workflows\ci.yml", "uses: microsoft/setup-msbuild@v2") = False)
+	Assert(FileContains%(".github\workflows\ci.yml", "uses: dtolnay/rust-toolchain@1.85.0") = False)
+End Test

--- a/src/Tests/Modules/RustToolchainPolicyTest.bb
+++ b/src/Tests/Modules/RustToolchainPolicyTest.bb
@@ -43,7 +43,9 @@ Test testDeclaredMSRVIsPinnedWithClippy()
 End Test
 
 Test testRustCIUsesPolicyAndInvalidatesCachesWhenItChanges()
-	Assert(FileOccurrenceCount%(".github\workflows\ci.yml", "uses: dtolnay/rust-toolchain@1.85.0") = 2)
+	; The explicit 1.85.0 setup steps stay pinned to their reviewed action
+	; revision; the step names below retain the human-readable Rust policy.
+	Assert(FileOccurrenceCount%(".github\workflows\ci.yml", "uses: dtolnay/rust-toolchain@98effd2fc0b766278e30ab86762dd5e9a8531399") = 2)
 	Assert(FileContains%(".github\workflows\ci.yml", "- name: Report Rust toolchain (client)") = True)
 	Assert(FileContains%(".github\workflows\ci.yml", "- name: Report Rust toolchain (server)") = True)
 	Assert(FileContains%(".github\workflows\ci.yml", "key: cargo-${{ runner.os }}-${{ hashFiles('client-rs/Cargo.lock', 'rust-toolchain.toml') }}") = True)


### PR DESCRIPTION
## Outcome

CI now resolves its eight third-party GitHub Actions by immutable, reviewed commit SHA instead of mutable tags/branches. This prevents an upstream ref move from silently changing the build pipeline.

Fixes #678

## Technical changes

- Pin checkout, cache, setup-msbuild, and Rust-toolchain action references in both CI jobs.
- Keep a nearby human-readable comment for each reviewed ref.
- Add GitHubActionsPinTest.bb to require all expected pin counts and reject the mutable refs.
- Align the existing RustToolchainPolicyTest with the immutable Rust action pin while retaining its 1.85.0 policy checks.

## Acceptance evidence

| Criterion | Evidence |
| --- | --- |
| Every uses reference is immutable | Exact-head contract/CI: 8 uses, 2 checkout + 3 cache + 1 MSBuild + 2 Rust SHA pins |
| Pins retain reviewed source refs | Each pin has an adjacent v4/v2/1.85.0 comment; direct remote ref re-resolution matched all four SHAs |
| CI behavior otherwise unchanged | Diff changes only uses values/comments and static contracts; no job, command, permission, cache-key, runner, or trigger edit |

## TDD and verification

- Baseline/RED: action-pin probe exited 1 and found 8 mutable refs; after the first contract test was added, all required SHA counts were 0.
- GREEN: focused source contracts exited 0; Python YAML parse and git diff --check exited 0.
- Regression found by exact-head CI: the first head left RustToolchainPolicyTest expecting the mutable Rust ref (74/75 files passed). The scoped test-contract correction is in this final head.
- Final exact head 18ae7954: Build and test passed in 2m43s; Rust server (Linux) passed in 1m18s; commit check-runs were both completed/success and legacy status contexts were zero.
- Local compiled tests remain unavailable because compiler/BlitzForge/bin/blitzcc is absent in this Linux checkout; CI supplied the compiled proof.

## Compatibility, risk, rollback

The pins resolve to the inspected current refs, so build behavior remains unchanged. A normal revert restores tag/branch references. Future action updates must intentionally update both SHA/comment and contracts.

## Deferred

Action upgrades, runner changes, workflow redesign, and GitHub permission changes are out of scope.

## Independent review

Fresh exact-head review verdict: ACCEPT. It confirmed scope, pin resolutions, static verification, unchanged workflow semantics, and the corrected Rust policy contract.