### PR TITLE
security(server): rate-limit password-change hashing

### DIFF
--- a/docs/protocol/index.md
+++ b/docs/protocol/index.md
@@ -39,9 +39,9 @@ pages is a per-iteration documentation task — see CONTRIBUTING.md.
 |---|---|---|---|---|---|
 | 1 | `P_CreateAccount` | C→S | [ServerNet.bb:2411](../../src/Modules/ServerNet.bb#L2411) | — | [P_CreateAccount](packets/P_CreateAccount.md) |
 | 2 | `P_VerifyAccount` | C→S | [ServerNet.bb:2465](../../src/Modules/ServerNet.bb#L2465) | — | [P_VerifyAccount](packets/P_VerifyAccount.md) |
-| 3 | `P_FetchCharacter` | C→S | [ServerNet.bb:2659](../../src/Modules/ServerNet.bb#L2659) | — | — |
-| 4 | `P_CreateCharacter` | C→S | [ServerNet.bb:2783](../../src/Modules/ServerNet.bb#L2783) | — | — |
-| 5 | `P_DeleteCharacter` | C→S | [ServerNet.bb:3020](../../src/Modules/ServerNet.bb#L3020) | — | — |
+| 3 | `P_FetchCharacter` | C→S | [ServerNet.bb:2670](../../src/Modules/ServerNet.bb#L2670) | — | — |
+| 4 | `P_CreateCharacter` | C→S | [ServerNet.bb:2794](../../src/Modules/ServerNet.bb#L2794) | — | — |
+| 5 | `P_DeleteCharacter` | C→S | [ServerNet.bb:3031](../../src/Modules/ServerNet.bb#L3031) | — | — |
 | 6 | `P_ChangePassword` | C→S | [ServerNet.bb:2600](../../src/Modules/ServerNet.bb#L2600) | — | [P_ChangePassword](packets/P_ChangePassword.md) |
 | 7 | `P_FetchActors` | C→S | [ServerNet.bb:2303](../../src/Modules/ServerNet.bb#L2303) | — | — |
 | 8 | `P_FetchItems` | Unused | — | — | — |

--- a/docs/protocol/packets/P_ChangePassword.md
+++ b/docs/protocol/packets/P_ChangePassword.md
@@ -3,7 +3,7 @@
 **Direction:** C -> S (request), S -> C (single-byte result reply)
 **Numeric ID:** 6 ([Packets.bb:7](../../../src/Modules/Packets.bb#L7))
 **Client send site:** **none in the current engine** — see "No live sender" below. The only sender in the tree is the legacy snapshot at [Tools/Modules_old/ServerNet.bb:1728](../../../src/Tools/Modules_old/ServerNet.bb#L1728) (not built).
-**Server handler:** [ServerNet.bb:2533](../../../src/Modules/ServerNet.bb#L2533) (`Case P_ChangePassword`)
+**Server handler:** [ServerNet.bb:2600](../../../src/Modules/ServerNet.bb#L2600) (`Case P_ChangePassword`)
 
 ## Purpose
 
@@ -13,20 +13,20 @@ The session check ([`RequesterOwnsAccountSession`](../../../src/Modules/Accounts
 
 ### No live sender
 
-Grep of `src/Modules` finds `P_ChangePassword` only in [Packets.bb](../../../src/Modules/Packets.bb#L7) (the constant) and [ServerNet.bb](../../../src/Modules/ServerNet.bb#L2533) (the handler). The current [MainMenu.bb](../../../src/Modules/MainMenu.bb) has **no** "change password" UI or `RCE_Send(..., P_ChangePassword, ...)` call — the only client-side sender is the un-built legacy copy under `Tools/Modules_old/`. The handler is therefore live and hardened but currently unreachable from the shipping client. The field layout below is reconstructed from the handler's reads and the legacy sender's writes (the two agree on framing); a future client that re-adds the feature must match it.
+Grep of `src/Modules` finds `P_ChangePassword` only in [Packets.bb](../../../src/Modules/Packets.bb#L7) (the constant) and [ServerNet.bb](../../../src/Modules/ServerNet.bb#L2600) (the handler). The current [MainMenu.bb](../../../src/Modules/MainMenu.bb) has **no** "change password" UI or `RCE_Send(..., P_ChangePassword, ...)` call — the only client-side sender is the un-built legacy copy under `Tools/Modules_old/`. The handler is therefore live and hardened but currently unreachable from the shipping client. The field layout below is reconstructed from the handler's reads and the legacy sender's writes (the two agree on framing); a future client that re-adds the feature must match it.
 
 ## Field layout
 
-Reconstructed from the server reads ([ServerNet.bb:2534-2557](../../../src/Modules/ServerNet.bb#L2534)) and the legacy sender ([Tools/Modules_old/ServerNet.bb:1715-1727](../../../src/Tools/Modules_old/ServerNet.bb#L1715)). Both password fields are MD5 hex (`MD5$(plaintext)`), per the account cluster's convention.
+Reconstructed from the server reads ([ServerNet.bb:2608-2634](../../../src/Modules/ServerNet.bb#L2608)) and the legacy sender ([Tools/Modules_old/ServerNet.bb:1715-1727](../../../src/Tools/Modules_old/ServerNet.bb#L1715)). Both password fields are MD5 hex (`MD5$(plaintext)`), per the account cluster's convention.
 
 | # | Field | Width | Sender write (legacy) | Receiver read (ServerNet.bb) |
 |---|---|---|---|---|
-| 1 | Username length | 1 byte | `RCE_StrFromInt$(Len(Name$), 1)` | `RCE_IntFromStr(Left$(M\MessageData$, 1))` -> `UsernameLen` [:2534](../../../src/Modules/ServerNet.bb#L2534) |
-| 2 | Username | `UsernameLen` bytes | `Name$` (concat) | `Mid$(M\MessageData$, 2, UsernameLen)` [:2535](../../../src/Modules/ServerNet.bb#L2535) |
-| 3 | Current password (MD5 hex) length | 1 byte | `RCE_StrFromInt$(Len(OldMD5$), 1)` | `RCE_IntFromStr(Mid$(M\MessageData$, Offset, 1))` where `Offset = 2 + UsernameLen` [:2540-2541](../../../src/Modules/ServerNet.bb#L2540) |
-| 4 | Current password (MD5 hex) | `PwdLen` bytes | `OldMD5$` (concat) | `Mid$(M\MessageData$, Offset + 1, PwdLen)` [:2552](../../../src/Modules/ServerNet.bb#L2552) |
+| 1 | Username length | 1 byte | `RCE_StrFromInt$(Len(Name$), 1)` | `RCE_IntFromStr(Left$(M\MessageData$, 1))` -> `UsernameLen` [:2608](../../../src/Modules/ServerNet.bb#L2608) |
+| 2 | Username | `UsernameLen` bytes | `Name$` (concat) | `Mid$(M\MessageData$, 2, UsernameLen)` [:2609](../../../src/Modules/ServerNet.bb#L2609) |
+| 3 | Current password (MD5 hex) length | 1 byte | `RCE_StrFromInt$(Len(OldMD5$), 1)` | `RCE_IntFromStr(Mid$(M\MessageData$, Offset, 1))` where `Offset = 2 + UsernameLen` [:2614-2615](../../../src/Modules/ServerNet.bb#L2614) |
+| 4 | Current password (MD5 hex) | `PwdLen` bytes | `OldMD5$` (concat) | `Mid$(M\MessageData$, Offset + 1, PwdLen)` [:2626](../../../src/Modules/ServerNet.bb#L2626) |
 | 5 | New password (MD5 hex) length | 1 byte | `RCE_StrFromInt$(Len(NewMD5$), 1)` | `RCE_IntFromStr(Mid$(M\MessageData$, Offset, 1))` after advancing `Offset = Offset + 1 + PwdLen` past the current-password block |
-| 6 | New password (MD5 hex) | `PwdLen` (re-read) bytes | `NewMD5$` (concat) | `Mid$(M\MessageData$, Offset + 1, PwdLen)` [:2557](../../../src/Modules/ServerNet.bb#L2557) |
+| 6 | New password (MD5 hex) | `PwdLen` (re-read) bytes | `NewMD5$` (concat) | `Mid$(M\MessageData$, Offset + 1, PwdLen)` [:2633](../../../src/Modules/ServerNet.bb#L2633) |
 
 All length prefixes are 1 byte; the sender writes match fields 1-6.
 
@@ -36,28 +36,29 @@ All length prefixes are 1 byte; the sender writes match fields 1-6.
 
 | Reply byte | Meaning | Server emit | Client mapping |
 |---|---|---|---|
-| `"Y"` | Password changed | [ServerNet.bb:2558](../../../src/Modules/ServerNet.bb#L2558) | (no live client; legacy showed success) |
-| `"P"` | Any failure — wrong password, not session owner, empty stored hash, truncated packet, **or username not found** | [:2562](../../../src/Modules/ServerNet.bb#L2562) / [:2586](../../../src/Modules/ServerNet.bb#L2586) | (no live client) |
+| `"Y"` | Password changed | [ServerNet.bb:2635](../../../src/Modules/ServerNet.bb#L2635) | (no live client; legacy showed success) |
+| `"P"` | Any failure — including throttle, wrong password, not session owner, empty stored hash, truncated packet, or username not found | [:2606](../../../src/Modules/ServerNet.bb#L2606) / [:2640](../../../src/Modules/ServerNet.bb#L2640) / [:2665](../../../src/Modules/ServerNet.bb#L2665) | (no live client) |
 
 The legacy server additionally sent `"N"` for "account not found" ([Tools/Modules_old/ServerNet.bb:1740](../../../src/Tools/Modules_old/ServerNet.bb#L1740)); the current handler collapses that into `"P"` to close the enumeration oracle (PR [#265](https://github.com/RydeTec/rcce2/pull/265)).
 
 ## Validation requirements (server-side)
 
-1. **Account lookup** ([:2538-2539](../../../src/Modules/ServerNet.bb#L2538)) — case-insensitive (`Upper$`) scan.
-2. **Combined verify gate** ([:2552](../../../src/Modules/ServerNet.bb#L2552)) — a single `And` chain that must all hold to commit:
+1. **Per-source throttle** ([:2605-2607](../../../src/Modules/ServerNet.bb#L2605)) — `LoginAttemptOk(M\FromID)` rejects exhausted sources with the same `"P"` reply before packet parsing, account lookup, or SHA-256 work. Failed real/dummy-hash paths call `LoginAttemptRecord(M\FromID, False)` and successful changes call it with `True`, so this handler feeds and clears the shared limiter.
+2. **Account lookup** ([:2612-2613](../../../src/Modules/ServerNet.bb#L2612)) — case-insensitive (`Upper$`) scan.
+3. **Combined verify gate** ([:2626](../../../src/Modules/ServerNet.bb#L2626)) — a single `And` chain that must all hold to commit:
    - `PwdLen >= 1` — rejects truncated / empty-password packets (an empty supplied password would otherwise match an account historically stored with an empty `Pass$`).
    - `A\Pass$ <> ""` — rejects accounts with an empty stored hash.
    - `VerifyPassword%(A\Pass$, currentMD5)` — current password verifies (constant-time, both legacy MD5 and v1 accepted).
    - `RequesterOwnsAccountSession(A, M\FromID)` — the requester is the account's currently-logged-in connection ([AccountsServer.bb:124-133](../../../src/Modules/AccountsServer.bb#L124)). This is the replay/theft mitigation.
-3. **On success** ([:2557](../../../src/Modules/ServerNet.bb#L2557)) — `A\Pass$ = HashPassword$(newMD5)` stores the new password in v1 salted format immediately (not the raw client MD5); reply `"Y"`.
-4. **On any failure of the gate** ([:2562](../../../src/Modules/ServerNet.bb#L2562)) — reply `"P"`.
-5. **Account-not-found path** ([:2582-2586](../../../src/Modules/ServerNet.bb#L2582)) — `If Exists = False`, the handler still reads the current-password field and calls `VerifyPassword%("", ...)` to pay the SHA-256 cost (timing-uniform with the found-account-wrong-password path), then replies `"P"` — the same code as a credential failure, so the reply does not betray whether the username is registered.
+4. **On success** ([:2633-2635](../../../src/Modules/ServerNet.bb#L2633)) — `A\Pass$ = HashPassword$(newMD5)` stores the new password in v1 salted format immediately (not the raw client MD5), records a successful attempt, and replies `"Y"`.
+5. **On any failure of the gate** ([:2640](../../../src/Modules/ServerNet.bb#L2640)) — record the failed attempt, then reply `"P"`.
+6. **Account-not-found path** ([:2659-2665](../../../src/Modules/ServerNet.bb#L2659)) — `If Exists = False`, the handler still reads the current-password field and calls `VerifyPassword%("", ...)` to pay the SHA-256 cost (timing-uniform with the found-account-wrong-password path), records the failed attempt, then replies `"P"` — the same code as a credential failure, so the reply does not betray whether the username is registered.
 
 ## Anti-cheat / abuse surface
 
 - **Account theft via replay — defended.** `RequesterOwnsAccountSession` means a captured packet (carrying the replayable MD5) cannot change the password unless the attacker also currently holds the victim's live session. PR [#76](https://github.com/RydeTec/rcce2/pull/76) (`756ad1ab`) added this gate.
 - **Username enumeration — defended (post PR #265).** Found-but-failed and not-found both reply `"P"`; the no-account path pays the dummy SHA-256 cost so timing is uniform. Pinned by [`ChangePasswordEnumerationTest.bb`](../../../src/Tests/Modules/ChangePasswordEnumerationTest.bb).
-- **No `LoginAttemptOk` throttle — NOT defended.** Unlike `P_VerifyAccount`, `P_StartGame`, `P_FetchCharacter`, `P_CreateCharacter`, and `P_DeleteCharacter`, this handler has **no** per-source rate limit (verified: no `LoginAttemptOk` call between [:2533](../../../src/Modules/ServerNet.bb#L2533) and the next handler at [:2590](../../../src/Modules/ServerNet.bb#L2590)). Because every code path — including not-found — calls `VerifyPassword%`, which runs a full SHA-256, an attacker can pump the server's hashing CPU at line rate with bogus `P_ChangePassword` packets. This is exactly the line-rate dummy-hash DoS that PR [#268](https://github.com/RydeTec/rcce2/pull/268) closed for the other auth handlers, and it was not extended here. The session gate prevents *theft*, not the *cost-amplification* DoS.
+- **Password-hash DoS — defended.** `LoginAttemptOk(M\FromID)` now runs before the first password-related packet read and returns the handler's existing generic `"P"` reply when a source is exhausted. The below-threshold found and not-found paths still perform their matching real/dummy SHA-256 work, then record failure; a successful change clears the shared counter. That preserves the no-enumeration timing contract while preventing a single peer from pumping hash work at line rate. This closes the sibling-auth gap left by PR [#268](https://github.com/RydeTec/rcce2/pull/268).
 - **Wire replay of the new password — NOT defended.** As with the whole cluster, the MD5 travels on the wire; a sniffer learns the new password's MD5. Out of scope without TLS.
 
 ## Historical bugs / PR references
@@ -67,7 +68,7 @@ The legacy server additionally sent `"N"` for "account not found" ([Tools/Module
 | PR [#76](https://github.com/RydeTec/rcce2/pull/76) (`756ad1ab`) | Added the `RequesterOwnsAccountSession` gate — a replayed/captured packet can no longer steal an account by knowing the (broken-MD5) hash. |
 | PR [#118](https://github.com/RydeTec/rcce2/pull/118) (`88aaf393`) | New password stored as salted SHA-256 v1 (`HashPassword$`) rather than raw client MD5. |
 | PR [#265](https://github.com/RydeTec/rcce2/pull/265) (`03ccdc99`) | Collapsed the `"N"` (not-found) vs `"P"` (auth-fail) enumeration oracle into a single `"P"`, plus dummy-hash on the not-found path. Sibling fix to PR [#264](https://github.com/RydeTec/rcce2/pull/264) for `P_VerifyAccount`. Pinned by [`ChangePasswordEnumerationTest.bb`](../../../src/Tests/Modules/ChangePasswordEnumerationTest.bb). |
-| PR [#268](https://github.com/RydeTec/rcce2/pull/268) (`82410986`) | Extended the throttle to four sibling handlers — **excluding** `P_ChangePassword`. The throttle gap above is current behavior. |
+| PR [#268](https://github.com/RydeTec/rcce2/pull/268) (`82410986`) | Extended the throttle to four sibling handlers; the same gate now also covers `P_ChangePassword`. |
 
 The post-collapse state machine is mirrored in [`ChangePasswordEnumerationTest.bb`](../../../src/Tests/Modules/ChangePasswordEnumerationTest.bb) (`ChangePasswordResponse$`); production changes must update both copies.
 

--- a/src/Modules/ServerNet.bb
+++ b/src/Modules/ServerNet.bb
@@ -2598,6 +2598,13 @@ Function UpdateNetwork()
 
 			; Change account password request
 			Case P_ChangePassword
+				; The no-account path intentionally pays VerifyPassword%'s dummy
+				; SHA-256 cost to keep account existence timing-uniform. Apply the
+				; shared per-source throttle before any packet/hash work so an
+				; unauthenticated peer cannot pump that cost at line rate.
+				If Not LoginAttemptOk(M\FromID)
+					RCE_Send(Host, M\FromID, P_ChangePassword, "P", True)
+				Else
 				UsernameLen = RCE_IntFromStr(Left$(M\MessageData$, 1))
 				Username$ = Mid$(M\MessageData$, 2, UsernameLen)
 				; Find account
@@ -2624,10 +2631,12 @@ Function UpdateNetwork()
 							; Store the new password in the v1 salted format
 							; immediately, not the raw client MD5.
 							A\Pass$ = HashPassword$(Mid$(M\MessageData$, Offset + 1, PwdLen))
+							LoginAttemptRecord(M\FromID, True)
 							RCE_Send(Host, M\FromID, P_ChangePassword, "Y", True)
 							//If MySQL = True Then My_SaveAccount(A, False)
 						; Otherwise return password failure
 						Else
+							LoginAttemptRecord(M\FromID, False)
 							RCE_Send(Host, M\FromID, P_ChangePassword, "P", True)
 						EndIf
 						Exists = True
@@ -2652,7 +2661,9 @@ Function UpdateNetwork()
 					Offset = 2 + UsernameLen
 					PwdLen = RCE_IntFromStr(Mid$(M\MessageData$, Offset, 1))
 					VerifyPassword%("", Mid$(M\MessageData$, Offset + 1, PwdLen))
+					LoginAttemptRecord(M\FromID, False)
 					RCE_Send(Host, M\FromID, P_ChangePassword, "P", True)
+				EndIf
 				EndIf
 
 			; Request to fetch character data

--- a/src/Tests/Modules/ChangePasswordThrottleTest.bb
+++ b/src/Tests/Modules/ChangePasswordThrottleTest.bb
@@ -1,0 +1,93 @@
+Strict
+EnableGC
+
+; P_ChangePassword accepts packets from unauthenticated peers. Its failure
+; paths deliberately pay VerifyPassword%'s SHA-256 cost to avoid an account
+; enumeration timing oracle, so the per-source LoginAttemptOk gate must run
+; before the handler reads packet fields or starts account/hash work.
+;
+; ServerNet's live packet dispatcher pulls in the network/world graph and
+; cannot be included in the standalone test harness. This bounded source
+; contract pins the required case shape instead: throttle -> generic P reply
+; -> Else -> the existing packet parsing and verification path.
+
+Function LeadingTabs%(Line$)
+	Local Count%, Pos% = 1
+	While Pos <= Len(Line$)
+		If Mid$(Line$, Pos, 1) <> Chr$(9) Then Exit
+		Count = Count + 1
+		Pos = Pos + 1
+	Wend
+	Return Count
+
+End Function
+
+Function ChangePasswordThrottlesBeforeHashing%(Path$)
+	Local F.BBStream = ReadFile(Path$)
+	Local GuardIndent%, InCase%, Stage%
+	Local Line$
+	If F = Null Then F = ReadFile("..\\" + Path$)
+	If F = Null Then Return False
+
+	While Not Eof(F)
+		Line$ = ReadLine$(F)
+		If Instr(Line$, "Case P_ChangePassword") > 0 Then InCase = True
+		If InCase = True And Instr(Line$, "Case P_FetchCharacter") > 0 Then Exit
+		If InCase = True
+			; No packet read or hash work may precede the limiter.
+			If Stage = 0 And (Instr(Line$, "UsernameLen =") > 0 Or Instr(Line$, "VerifyPassword%(") > 0)
+				CloseFile F
+				Return False
+			EndIf
+			If Stage = 0 And Instr(Line$, "If Not LoginAttemptOk(M\\FromID)") > 0
+				GuardIndent = LeadingTabs(Line$)
+				Stage = 1
+			EndIf
+			If Stage = 1 And Instr(Line$, "RCE_Send(Host, M\\FromID, P_ChangePassword, \"P\", True)") > 0 And LeadingTabs(Line$) = GuardIndent + 1 Then Stage = 2
+			If Stage = 2 And Instr(Line$, "Else") > 0 And LeadingTabs(Line$) = GuardIndent Then Stage = 3
+			If Stage = 3 And Instr(Line$, "UsernameLen = RCE_IntFromStr(Left$(M\\MessageData$, 1))") > 0 And LeadingTabs(Line$) = GuardIndent Then Stage = 4
+			If Stage = 4 And Instr(Line$, "VerifyPassword%(") > 0
+				CloseFile F
+				Return True
+			EndIf
+		EndIf
+	Wend
+
+	CloseFile F
+	Return False
+
+End Function
+
+Function ChangePasswordRecordsThrottleOutcomes%(Path$)
+	Local F.BBStream = ReadFile(Path$)
+	Local FailureRecords%, InCase%, SuccessRecorded%
+	Local Line$
+	If F = Null Then F = ReadFile("..\\" + Path$)
+	If F = Null Then Return False
+
+	While Not Eof(F)
+		Line$ = ReadLine$(F)
+		If Instr(Line$, "Case P_ChangePassword") > 0 Then InCase = True
+		If InCase = True And Instr(Line$, "Case P_FetchCharacter") > 0 Then Exit
+		If InCase = True
+			If Instr(Line$, "LoginAttemptRecord(M\\FromID, True)") > 0 Then SuccessRecorded = True
+			If Instr(Line$, "LoginAttemptRecord(M\\FromID, False)") > 0 Then FailureRecords = FailureRecords + 1
+			If Instr(Line$, "RCE_Send(Host, M\\FromID, P_ChangePassword, \"Y\", True)") > 0 And SuccessRecorded = False
+				CloseFile F
+				Return False
+			EndIf
+		EndIf
+	Wend
+
+	CloseFile F
+	Return SuccessRecorded = True And FailureRecords = 2
+
+End Function
+
+Test testChangePasswordThrottlePrecedesPacketReadsAndHashing()
+	Assert(ChangePasswordThrottlesBeforeHashing%("Modules\\ServerNet.bb") = True)
+End Test
+
+Test testChangePasswordRecordsOutcomesForTheThrottle()
+	Assert(ChangePasswordRecordsThrottleOutcomes%("Modules\\ServerNet.bb") = True)
+End Test

--- a/src/Tests/Modules/ChangePasswordThrottleTest.bb
+++ b/src/Tests/Modules/ChangePasswordThrottleTest.bb
@@ -26,7 +26,7 @@ Function ChangePasswordThrottlesBeforeHashing%(Path$)
 	Local F.BBStream = ReadFile(Path$)
 	Local GuardIndent%, InCase%, Stage%
 	Local Line$
-	If F = Null Then F = ReadFile("..\\" + Path$)
+	If F = Null Then F = ReadFile("..\" + Path$)
 	If F = Null Then Return False
 
 	While Not Eof(F)
@@ -39,13 +39,13 @@ Function ChangePasswordThrottlesBeforeHashing%(Path$)
 				CloseFile F
 				Return False
 			EndIf
-			If Stage = 0 And Instr(Line$, "If Not LoginAttemptOk(M\\FromID)") > 0
+			If Stage = 0 And Instr(Line$, "If Not LoginAttemptOk(M\FromID)") > 0
 				GuardIndent = LeadingTabs(Line$)
 				Stage = 1
 			EndIf
-			If Stage = 1 And Instr(Line$, "RCE_Send(Host, M\\FromID, P_ChangePassword, " + Chr$(34) + "P" + Chr$(34) + ", True)") > 0 And LeadingTabs(Line$) = GuardIndent + 1 Then Stage = 2
+			If Stage = 1 And Instr(Line$, "RCE_Send(Host, M\FromID, P_ChangePassword, " + Chr$(34) + "P" + Chr$(34) + ", True)") > 0 And LeadingTabs(Line$) = GuardIndent + 1 Then Stage = 2
 			If Stage = 2 And Instr(Line$, "Else") > 0 And LeadingTabs(Line$) = GuardIndent Then Stage = 3
-			If Stage = 3 And Instr(Line$, "UsernameLen = RCE_IntFromStr(Left$(M\\MessageData$, 1))") > 0 And LeadingTabs(Line$) = GuardIndent Then Stage = 4
+			If Stage = 3 And Instr(Line$, "UsernameLen = RCE_IntFromStr(Left$(M\MessageData$, 1))") > 0 And LeadingTabs(Line$) = GuardIndent Then Stage = 4
 			If Stage = 4 And Instr(Line$, "VerifyPassword%(") > 0
 				CloseFile F
 				Return True
@@ -62,7 +62,7 @@ Function ChangePasswordRecordsThrottleOutcomes%(Path$)
 	Local F.BBStream = ReadFile(Path$)
 	Local FailureRecords%, InCase%, SuccessRecorded%
 	Local Line$
-	If F = Null Then F = ReadFile("..\\" + Path$)
+	If F = Null Then F = ReadFile("..\" + Path$)
 	If F = Null Then Return False
 
 	While Not Eof(F)
@@ -70,9 +70,9 @@ Function ChangePasswordRecordsThrottleOutcomes%(Path$)
 		If Instr(Line$, "Case P_ChangePassword") > 0 Then InCase = True
 		If InCase = True And Instr(Line$, "Case P_FetchCharacter") > 0 Then Exit
 		If InCase = True
-			If Instr(Line$, "LoginAttemptRecord(M\\FromID, True)") > 0 Then SuccessRecorded = True
-			If Instr(Line$, "LoginAttemptRecord(M\\FromID, False)") > 0 Then FailureRecords = FailureRecords + 1
-			If Instr(Line$, "RCE_Send(Host, M\\FromID, P_ChangePassword, " + Chr$(34) + "Y" + Chr$(34) + ", True)") > 0 And SuccessRecorded = False
+			If Instr(Line$, "LoginAttemptRecord(M\FromID, True)") > 0 Then SuccessRecorded = True
+			If Instr(Line$, "LoginAttemptRecord(M\FromID, False)") > 0 Then FailureRecords = FailureRecords + 1
+			If Instr(Line$, "RCE_Send(Host, M\FromID, P_ChangePassword, " + Chr$(34) + "Y" + Chr$(34) + ", True)") > 0 And SuccessRecorded = False
 				CloseFile F
 				Return False
 			EndIf
@@ -85,9 +85,9 @@ Function ChangePasswordRecordsThrottleOutcomes%(Path$)
 End Function
 
 Test testChangePasswordThrottlePrecedesPacketReadsAndHashing()
-	Assert(ChangePasswordThrottlesBeforeHashing%("Modules\\ServerNet.bb") = True)
+	Assert(ChangePasswordThrottlesBeforeHashing%("Modules\ServerNet.bb") = True)
 End Test
 
 Test testChangePasswordRecordsOutcomesForTheThrottle()
-	Assert(ChangePasswordRecordsThrottleOutcomes%("Modules\\ServerNet.bb") = True)
+	Assert(ChangePasswordRecordsThrottleOutcomes%("Modules\ServerNet.bb") = True)
 End Test

--- a/src/Tests/Modules/ChangePasswordThrottleTest.bb
+++ b/src/Tests/Modules/ChangePasswordThrottleTest.bb
@@ -43,7 +43,7 @@ Function ChangePasswordThrottlesBeforeHashing%(Path$)
 				GuardIndent = LeadingTabs(Line$)
 				Stage = 1
 			EndIf
-			If Stage = 1 And Instr(Line$, "RCE_Send(Host, M\\FromID, P_ChangePassword, \"P\", True)") > 0 And LeadingTabs(Line$) = GuardIndent + 1 Then Stage = 2
+			If Stage = 1 And Instr(Line$, "RCE_Send(Host, M\\FromID, P_ChangePassword, " + Chr$(34) + "P" + Chr$(34) + ", True)") > 0 And LeadingTabs(Line$) = GuardIndent + 1 Then Stage = 2
 			If Stage = 2 And Instr(Line$, "Else") > 0 And LeadingTabs(Line$) = GuardIndent Then Stage = 3
 			If Stage = 3 And Instr(Line$, "UsernameLen = RCE_IntFromStr(Left$(M\\MessageData$, 1))") > 0 And LeadingTabs(Line$) = GuardIndent Then Stage = 4
 			If Stage = 4 And Instr(Line$, "VerifyPassword%(") > 0

--- a/src/Tests/Modules/ChangePasswordThrottleTest.bb
+++ b/src/Tests/Modules/ChangePasswordThrottleTest.bb
@@ -72,7 +72,7 @@ Function ChangePasswordRecordsThrottleOutcomes%(Path$)
 		If InCase = True
 			If Instr(Line$, "LoginAttemptRecord(M\\FromID, True)") > 0 Then SuccessRecorded = True
 			If Instr(Line$, "LoginAttemptRecord(M\\FromID, False)") > 0 Then FailureRecords = FailureRecords + 1
-			If Instr(Line$, "RCE_Send(Host, M\\FromID, P_ChangePassword, \"Y\", True)") > 0 And SuccessRecorded = False
+			If Instr(Line$, "RCE_Send(Host, M\\FromID, P_ChangePassword, " + Chr$(34) + "Y" + Chr$(34) + ", True)") > 0 And SuccessRecorded = False
 				CloseFile F
 				Return False
 			EndIf


### PR DESCRIPTION
## Outcome

Password-change requests now share the authentication throttle, so a single unauthenticated peer cannot repeatedly force SHA-256 verification work at line rate.

Fixes #687

## Technical changes

- Gate P_ChangePassword with LoginAttemptOk before parsing or hash work.
- Preserve the handler existing generic P failure reply on throttle.
- Record failed real/dummy-hash paths and clear the counter on success.
- Add a bounded source-contract regression and update the canonical packet documentation plus generated index.

## Acceptance evidence

- Throttle is before the first packet read and VerifyPassword call: focused RED then GREEN structural contract.
- Throttle returns generic P: source contract requires the throttle reply before the Else path.
- Shared limiter is effective: source contract requires one success record and two failure records in the bounded handler.
- Existing cursor/session/Y/P behavior stays in the retained handler path; documentation anchors were updated.

## TDD and verification

- Baseline: git diff check, packet-index check, and BVM-reference check passed.
- RED: no LoginAttemptOk before packet/hash work; the outcome-accounting contract initially found 0 success and 0 failure records.
- GREEN: final structural probe reported guarded before parse/hash with success=1 and failures=2; generator checks and git diff check passed.
- Focused native test is environment-blocked: after initializing the pinned BlitzForge submodule, compiler/BlitzForge/bin/blitzcc is not shipped in this Linux checkout, so test.sh ChangePasswordThrottleTest exits 1 before compiling.

## Compatibility, risk, rollback

No packet layout, client UI, cryptography format, or reply code changes. The throttled path uses the same P code as current failures. Revert this PR to restore prior behavior.

## Deferred

TLS and a shipping client password-change UI remain out of scope.

## Independent review

Fresh independent review of exact head 20748c949 returned ACCEPT.