### PR TITLE
fix(gooey): free every combo and list item during teardown

### DIFF
--- a/src/Modules/Gooey.bb
+++ b/src/Modules/Gooey.bb
@@ -3838,9 +3838,12 @@ Function GY_FreeGadget(GHandle)
 		If Co\RightEN <> 0 Then FreeEntity(Co\RightEN)
 		If Co\ButtonGadget <> 0 Then GY_FreeGadget(Co\ButtonGadget)
 		; Free its items
-		For I.GY_ComboItem = Each GY_ComboItem
-			If I\Box = Co Then GY_Free3DText(I\LabelEN) : Delete I
-		Next
+		Local ComboItem.GY_ComboItem = First GY_ComboItem
+		While ComboItem <> Null
+			Local NextComboItem.GY_ComboItem = After ComboItem
+			If ComboItem\Box = Co Then GY_Free3DText(ComboItem\LabelEN) : Delete ComboItem
+			ComboItem = NextComboItem
+		Wend
 		Delete Co
 	; Listbox
 	ElseIf Object.GY_ListBox(G\TypeHandle) <> Null
@@ -3848,9 +3851,12 @@ Function GY_FreeGadget(GHandle)
 		If L\BorderEN <> 0 Then FreeEntity(L\BorderEN)
 		If L\ScrollGadget <> 0 Then GY_FreeGadget(L\ScrollGadget)
 		; Free its items
-		For Li.GY_ListItem = Each GY_ListItem
-			If Li\Box = L Then GY_Free3DText(Li\LabelEN) : Delete Li
-		Next
+		Local ListItem.GY_ListItem = First GY_ListItem
+		While ListItem <> Null
+			Local NextListItem.GY_ListItem = After ListItem
+			If ListItem\Box = L Then GY_Free3DText(ListItem\LabelEN) : Delete ListItem
+			ListItem = NextListItem
+		Wend
 		Delete L
 	; A scrollbar
 	ElseIf Object.GY_ScrollBar(G\TypeHandle) <> Null

--- a/src/Tests/Modules/GooeyTeardownIteratorTest.bb
+++ b/src/Tests/Modules/GooeyTeardownIteratorTest.bb
@@ -110,8 +110,44 @@ Function UnloadRestartsAfterDelete%(Path$)
 
 End Function
 
+Function FreeGadgetItemsAdvanceBeforeDelete%(Path$)
+	Local F.BBStream = ReadFile(Path$)
+	Local InFunction%, Stage%
+	Local Line$
+	If F = Null Then F = ReadFile("..\" + Path$)
+	If F = Null Then Return False
+
+	While Not Eof(F)
+		Line$ = ReadLine$(F)
+		If Instr(Line$, "Function GY_FreeGadget(GHandle)") > 0 Then InFunction = True
+		If InFunction = True
+			If Instr(Line$, "For I.GY_ComboItem = Each GY_ComboItem") > 0 Or Instr(Line$, "For Li.GY_ListItem = Each GY_ListItem") > 0
+				CloseFile F
+				Return False
+			EndIf
+			If Stage = 0 And Instr(Line$, "Local ComboItem.GY_ComboItem = First GY_ComboItem") > 0 Then Stage = 1
+			If Stage = 1 And Instr(Line$, "Local NextComboItem.GY_ComboItem = After ComboItem") > 0 Then Stage = 2
+			If Stage = 2 And Instr(Line$, "If ComboItem\Box = Co Then GY_Free3DText(ComboItem\LabelEN) : Delete ComboItem") > 0 Then Stage = 3
+			If Stage = 3 And Instr(Line$, "ComboItem = NextComboItem") > 0 Then Stage = 4
+			If Stage = 4 And Instr(Line$, "Local ListItem.GY_ListItem = First GY_ListItem") > 0 Then Stage = 5
+			If Stage = 5 And Instr(Line$, "Local NextListItem.GY_ListItem = After ListItem") > 0 Then Stage = 6
+			If Stage = 6 And Instr(Line$, "If ListItem\Box = L Then GY_Free3DText(ListItem\LabelEN) : Delete ListItem") > 0 Then Stage = 7
+			If Stage = 7 And Instr(Line$, "ListItem = NextListItem") > 0 Then Stage = 8
+			If Instr(Line$, "; A scrollbar") > 0
+				CloseFile F
+				Return Stage = 8
+			EndIf
+		EndIf
+	Wend
+
+	CloseFile F
+	Return False
+
+End Function
+
 Test testGooeyTeardownRestartsAfterRecursiveDeletes()
 	Assert(ClearGadgetsRestartsAfterDelete%("Modules\Gooey.bb") = True)
 	Assert(FreeGadgetChildrenRestartAfterDelete%("Modules\Gooey.bb") = True)
 	Assert(UnloadRestartsAfterDelete%("Modules\Gooey.bb") = True)
+	Assert(FreeGadgetItemsAdvanceBeforeDelete%("Modules\Gooey.bb") = True)
 End Test


### PR DESCRIPTION
## Outcome

Closing an editor combo box or list box now frees every owned item and label, avoiding orphaned UI resources when a widget contains multiple entries.

## Technical changes

- Replace the two delete-during-`For Each` loops in `GY_FreeGadget` with next-cursor walks for combo and list items.
- Extend `GooeyTeardownIteratorTest` to reject the legacy loops and require next capture before label free/delete in both paths.

Fixes #691

## Acceptance evidence

- Unsafe `GY_ComboItem` and `GY_ListItem` `For Each` deletion loops are absent.
- Bounded source checks found both `First -> After -> free/delete -> advance` sequences.
- The regression test binds both exact cleanup paths.

## Verification

- **Baseline**: `./test.sh GooeyTeardownIteratorTest` exited 1 because the initialized pinned BlitzForge submodule has no `compiler/BlitzForge/bin/blitzcc` for this Linux host; `git diff --check` exited 0; the unsafe-loop probe found both legacy loops.
- **RED**: after adding the regression contract and before production edits, the bounded probe exited 1 with `RED_EXPECTED: both unsafe delete-during-Each loops remain`.
- **GREEN**: bounded source contract reported `legacy=0 combo_sequence=0 list_sequence=0`; `git diff --check` exited 0. The focused native test remains unavailable locally for the same missing-binary reason; Windows CI will compile and execute it.

## Compatibility, risk, and rollback

No protocol, save format, or public API changes. The patch preserves existing label-free/delete behavior while changing only cursor management. Roll back by reverting commit `9e25bdb7`.

## Deferred

Correcting the separate macOS/Linux onboarding documentation drift is intentionally out of scope.

## Independent review

Fresh independent review: **ACCEPT** for exact head `9e25bdb7c59664b4be33cbaff06e7ddeba1645a9`. It confirmed the before-delete `After` captures, bounded contract coverage, issue-only scope, and absence of API/protocol/persistence impact. Windows Build and test CI remains the native execution proof.