### PR TITLE
fix(gue): preserve water records through area save and deletion

### DIFF
--- a/src/GUE.bb
+++ b/src/GUE.bb
@@ -2942,7 +2942,7 @@ Cls
 							Else
 								W.Water = New Water
 								SW.ServerWater = New ServerWater
-								SW\Area = CurrentArea
+								ServerWaterAttach(SW, CurrentArea)
 								W\ServerWater = Handle(SW)
 								W\TexHandle = GetTexture(NewID, True)
 								W\TexID = NewID
@@ -8780,6 +8780,7 @@ Function ZoneDeleteEntity(EN, NoUndo = False)
 			PokeInt(B, 30, SW\Damage)
 			PokeInt(B, 34, SW\DamageType)
 		EndIf
+		ServerWaterDetach(SW)
 		Delete(SW)
 		FreeTexture(W\TexHandle)
 		UnloadTexture(W\TexID)
@@ -9555,6 +9556,7 @@ Function PerformUndo()
 					; Recover information from extra info bank
 					W.Water = New Water
 					SW.ServerWater = New ServerWater
+					ServerWaterAttach(SW, CurrentArea)
 					W\TexScale# = PeekFloat#(U\ExtraInfo, 0)
 					X# = PeekFloat#(U\ExtraInfo, 4)
 					Y# = PeekFloat#(U\ExtraInfo, 8)

--- a/src/Modules/ServerAreas.bb
+++ b/src/Modules/ServerAreas.bb
@@ -41,13 +41,51 @@ Type ServerWater
 	Field X#, Y#, Z#
 	Field Width#, Depth#
 	Field Damage, DamageType
-	; Next link in Area\FirstWater chain. Maintained at allocation
-	; (ServerLoadArea below). Becomes dangling when the owning Area
+	; Next link in Area\FirstWater chain. Maintained by ServerWaterAttach.
+	; Becomes dangling when the owning Area
 	; is deleted (ServerUnloadArea Deletes both the chain heads and
 	; every linked ServerWater in a single call, so no caller can
 	; observe a stale NextWater pointer).
 	Field NextWater.ServerWater
 End Type
+
+; Links a live water record into the authoritative chain used by area save,
+; unload, and water-damage traversal. Both the server loader and GUE's editor
+; creation paths use this helper so they cannot diverge on chain maintenance.
+Function ServerWaterAttach(W.ServerWater, A.Area)
+
+	If W = Null Then Return
+	If A = Null Then Return
+	W\Area = A
+	W\NextWater = A\FirstWater
+	A\FirstWater = W
+
+End Function
+
+; Removes a water record from its area's authoritative chain before a caller
+; deletes the record. The caller still owns the actual Delete operation.
+Function ServerWaterDetach(W.ServerWater)
+
+	If W = Null Then Return
+	Local A.Area = W\Area
+	If A = Null Then Return
+
+	If A\FirstWater = W
+		A\FirstWater = W\NextWater
+	Else
+		Local Previous.ServerWater = A\FirstWater
+		While Previous <> Null
+			If Previous\NextWater = W
+				Previous\NextWater = W\NextWater
+				Exit
+			EndIf
+			Previous = Previous\NextWater
+		Wend
+	EndIf
+
+	W\NextWater = Null
+
+End Function
 
 ; Each area instance may have up to 500 player owned items of scenery (e.g. chests, doors, etc.) {##}
 ;Type OwnedScenery
@@ -351,7 +389,6 @@ Function ServerLoadArea.Area(Name$)
 		Waters = ReadShort(F)
 		For i = 1 To Waters
 			W.ServerWater = New ServerWater
-			W\Area = A
 			W\X# = ReadFloat#(F)
 			W\Y# = ReadFloat#(F)
 			W\Z# = ReadFloat#(F)
@@ -364,18 +401,10 @@ Function ServerLoadArea.Area(Name$)
 			; SafeZone-damage loop (GameServer.bb ~773) indexes
 			; A\Resistances[SW\DamageType].
 			If W\DamageType < 0 Or W\DamageType > 19 Then W\DamageType = 0
-			; Link into A\FirstWater chain. With SaveArea +
-			; ServerUnloadArea also using the chain, the global
-			; `For Each ServerWater` collection still owns every
-			; record (creation and Delete are the only sites that
-			; touch the Each iterator), but no per-frame or
-			; per-save code paths have to filter it by Area.
-			; Head-insert is fine -- the underwater check Exits
-			; on first match and SaveArea writes are
-			; order-insensitive (ServerLoadArea just reads N
-			; records).
-			W\NextWater = A\FirstWater
-			A\FirstWater = W
+			; Save and damage handling use the per-Area chain rather than
+			; filtering the global collection. GUE uses the same helper for
+			; editor-created water records.
+			ServerWaterAttach(W, A)
 		Next
 
 	CloseFile(F)

--- a/src/Tests/Modules/GUEWaterChainTest.bb
+++ b/src/Tests/Modules/GUEWaterChainTest.bb
@@ -1,0 +1,116 @@
+Strict
+EnableGC
+
+; GUE owns the editor-side Water object, while ServerAreas owns the
+; authoritative per-Area ServerWater chain used by saving and unloading. This
+; focused source contract keeps all three GUE lifecycle paths bound to that
+; shared contract without loading the graphical editor into the test runner.
+
+Function FileContains%(Path$, Needle$)
+	Local F.BBStream = ReadFile(Path$)
+	Local Line$
+	If F = Null Then F = ReadFile("..\" + Path$)
+	If F = Null Then F = ReadFile("..\..\" + Path$)
+	If F = Null Then Return False
+
+	While Not Eof(F)
+		Line$ = ReadLine$(F)
+		If Instr(Line$, Needle$) > 0
+			CloseFile F
+			Return True
+		EndIf
+	Wend
+
+	CloseFile F
+	Return False
+
+End Function
+
+Function CountFileMatches%(Path$, Needle$)
+
+	Local F.BBStream = ReadFile(Path$)
+	Local Line$, Matches%
+	If F = Null Then F = ReadFile("..\" + Path$)
+	If F = Null Then F = ReadFile("..\..\" + Path$)
+	If F = Null Then Return 0
+
+	While Not Eof(F)
+		Line$ = ReadLine$(F)
+		If Instr(Line$, Needle$) > 0 Then Matches = Matches + 1
+	Wend
+
+	CloseFile F
+	Return Matches
+
+End Function
+
+Function WaterDeleteDetachesBeforeDelete%(Path$)
+
+	Local F.BBStream = ReadFile(Path$)
+	Local Line$, Stage%
+	If F = Null Then F = ReadFile("..\" + Path$)
+	If F = Null Then F = ReadFile("..\..\" + Path$)
+	If F = Null Then Return False
+
+	While Not Eof(F)
+		Line$ = Trim$(ReadLine$(F))
+		If Line$ = "Function ZoneDeleteEntity(EN, NoUndo = False)" Then Stage = 1
+		If Stage = 1 And Line$ = "ElseIf W <> Null" Then Stage = 2
+		If Stage = 2 And Line$ = "ServerWaterDetach(SW)" Then Stage = 3
+		If Stage = 3 And Line$ = "Delete(SW)"
+			CloseFile F
+			Return True
+		EndIf
+		If Stage > 1 And Line$ = "ElseIf CB <> Null" Then Exit
+	Wend
+
+	CloseFile F
+	Return False
+
+End Function
+
+Function ServerSaveAreaWalksWaterChain%(Path$)
+
+	Local F.BBStream = ReadFile(Path$)
+	Local InSave%, Line$, Stage%
+	If F = Null Then F = ReadFile("..\" + Path$)
+	If F = Null Then F = ReadFile("..\..\" + Path$)
+	If F = Null Then Return False
+
+	While Not Eof(F)
+		Line$ = Trim$(ReadLine$(F))
+		If Line$ = "Function ServerSaveArea(A.Area)" Then InSave = True
+		If InSave = True
+			If Stage = 0 And Line$ = "W = A\FirstWater" Then Stage = 1
+			If Stage = 1 And Line$ = "While W <> Null" Then Stage = 2
+			If Stage = 2 And Line$ = "W = W\NextWater" Then Stage = 3
+			If Line$ = "End Function"
+				CloseFile F
+				Return Stage = 3
+			EndIf
+		EndIf
+	Wend
+
+	CloseFile F
+	Return False
+
+End Function
+
+Test testServerWaterLifecycleHelpersMaintainTheAreaChain()
+	Assert(FileContains%("Modules\ServerAreas.bb", "Function ServerWaterAttach(W.ServerWater, A.Area)") = True)
+	Assert(FileContains%("Modules\ServerAreas.bb", "Function ServerWaterDetach(W.ServerWater)") = True)
+	Assert(FileContains%("Modules\ServerAreas.bb", "W\NextWater = A\FirstWater") = True)
+	Assert(FileContains%("Modules\ServerAreas.bb", "A\FirstWater = W") = True)
+End Test
+
+Test testGUECreationAndUndoAttachWaterToTheCurrentArea()
+	Assert(CountFileMatches%("GUE.bb", "ServerWaterAttach(SW, CurrentArea)") = 2)
+End Test
+
+Test testGUEWaterDeletionDetachesBeforeDeletingTheServerRecord()
+	Assert(WaterDeleteDetachesBeforeDelete%("GUE.bb") = True)
+End Test
+
+Test testServerSaveAreaUsesTheAuthoritativeWaterChain()
+	Assert(ServerSaveAreaWalksWaterChain%("Modules\ServerAreas.bb") = True)
+End Test


### PR DESCRIPTION
## Outcome

GUE water edits now remain part of the same per-area water chain that the server saves, unloads, and uses for water damage. Newly placed or restored water persists, and deleted water no longer leaves a stale chain node.

## Technical changes

- Added `ServerWaterAttach` / `ServerWaterDetach` as the single lifecycle contract for `Area\\FirstWater` and `ServerWater\\NextWater`.
- Routed server loading and GUE's normal creation, undo restoration, and deletion paths through that contract.
- Added a focused source-contract regression for both creation paths, deletion order, helper semantics, and `ServerSaveArea` traversal.

Fixes #695

## Acceptance evidence

| Criterion | Evidence |
| --- | --- |
| New and restored water joins its area chain | `ServerWaterAttach(SW, CurrentArea)` occurs in both GUE creation paths. |
| Deleted water is unlinked first | Focused source proof requires `ServerWaterDetach(SW)` before `Delete(SW)` within `ZoneDeleteEntity`. |
| Loader, save, unload, and damage share the contract | `ServerLoadArea` calls the helper; `ServerSaveArea` still walks `FirstWater -> NextWater`. |
| Regression coverage | `src/Tests/Modules/GUEWaterChainTest.bb` statically protects helper shape, both create paths, deletion order, and save traversal. |

## Verification

- **Baseline:** `git diff --check` exited 0; the prospective source probe exited 1 with `attach=0 detach=0 helper_attach=0 helper_detach=0` (`RED_EXPECTED`).
- **RED:** after adding `GUEWaterChainTest`, `./test.sh GUEWaterChainTest` exited 1 because this Linux checkout lacks `compiler/BlitzForge/bin/blitzcc`; the independent source probe exited 1 for the expected missing lifecycle behavior.
- **GREEN:** focused source contract exited 0 with `attach=2 detach=1 helper_attach=1 helper_detach=1 loader=1`; `git diff --check`, `bash scripts/gen_packet_index.sh --check`, and `bash scripts/gen_bvm_reference.sh --check` exited 0.
- **Native test caveat:** the focused Blitz test still cannot execute locally until the pinned compiler is built or supplied. CI is the remaining executable proof.

## Compatibility, risk, and rollback

No packet, save-file format, public API, or content change. The only behavior change is lifecycle integrity for editor-created water. The linked-list helper is covered at every changed call site; rollback is a normal revert of this PR.

## Deferred

Water rendering, water-format changes, broader GUE refactors, and the separate Linux onboarding documentation correction remain out of scope.

## Independent review

`ACCEPT` — fresh review of exact head `b5319289693b7467450416e0d3ed405ba6c659be` found the scope limited to the three intended files; both chain-head and interior unlink paths are correct; both GUE create paths attach; deletion detaches first; and the loader/saver chain contract remains intact. The reviewer independently observed `git diff --check`, both generated-reference checks, and exact-head CI green. Local native execution remains unavailable only because this host lacks `blitzcc`.