### PR TITLE
fix(server): persist password changes before success reply

### DIFF
--- a/docs/protocol/index.md
+++ b/docs/protocol/index.md
@@ -39,9 +39,9 @@ pages is a per-iteration documentation task — see CONTRIBUTING.md.
 |---|---|---|---|---|---|
 | 1 | `P_CreateAccount` | C→S | [ServerNet.bb:2446](../../src/Modules/ServerNet.bb#L2446) | — | [P_CreateAccount](packets/P_CreateAccount.md) |
 | 2 | `P_VerifyAccount` | C→S | [ServerNet.bb:2502](../../src/Modules/ServerNet.bb#L2502) | — | [P_VerifyAccount](packets/P_VerifyAccount.md) |
-| 3 | `P_FetchCharacter` | C→S | [ServerNet.bb:2707](../../src/Modules/ServerNet.bb#L2707) | — | — |
-| 4 | `P_CreateCharacter` | C→S | [ServerNet.bb:2831](../../src/Modules/ServerNet.bb#L2831) | — | — |
-| 5 | `P_DeleteCharacter` | C→S | [ServerNet.bb:3047](../../src/Modules/ServerNet.bb#L3047) | — | — |
+| 3 | `P_FetchCharacter` | C→S | [ServerNet.bb:2713](../../src/Modules/ServerNet.bb#L2713) | — | — |
+| 4 | `P_CreateCharacter` | C→S | [ServerNet.bb:2837](../../src/Modules/ServerNet.bb#L2837) | — | — |
+| 5 | `P_DeleteCharacter` | C→S | [ServerNet.bb:3053](../../src/Modules/ServerNet.bb#L3053) | — | — |
 | 6 | `P_ChangePassword` | C→S | [ServerNet.bb:2637](../../src/Modules/ServerNet.bb#L2637) | — | [P_ChangePassword](packets/P_ChangePassword.md) |
 | 7 | `P_FetchActors` | C→S | [ServerNet.bb:2338](../../src/Modules/ServerNet.bb#L2338) | — | — |
 | 8 | `P_FetchItems` | Unused | — | — | — |

--- a/docs/protocol/packets/P_ChangePassword.md
+++ b/docs/protocol/packets/P_ChangePassword.md
@@ -50,8 +50,8 @@ The legacy server additionally sent `"N"` for "account not found" ([Tools/Module
    - `A\Pass$ <> ""` — rejects accounts with an empty stored hash.
    - `VerifyPassword%(A\Pass$, currentMD5)` — current password verifies (constant-time, both legacy MD5 and v1 accepted).
    - `RequesterOwnsAccountSession(A, M\FromID)` — the requester is the account's currently-logged-in connection ([AccountsServer.bb:124-133](../../../src/Modules/AccountsServer.bb#L124)). This is the replay/theft mitigation.
-4. **On success** ([:2633-2635](../../../src/Modules/ServerNet.bb#L2633)) — `A\Pass$ = HashPassword$(newMD5)` stores the new password in v1 salted format immediately (not the raw client MD5), records a successful attempt, and replies `"Y"`.
-5. **On any failure of the gate** ([:2640](../../../src/Modules/ServerNet.bb#L2640)) — record the failed attempt, then reply `"P"`.
+4. **On success** — the handler stages the old hash, stores `A\Pass$ = HashPassword$(newMD5)` in v1 salted format (not the raw client MD5), then requires `SaveAccounts()` to atomically commit it before recording a successful attempt and replying `"Y"`.
+5. **On any failure of the gate or commit** — the handler records a failed attempt, then replies `"P"`. A failed `SaveAccounts()` restores the staged in-memory hash first, so neither the reply nor a later save can claim the uncommitted password.
 6. **Account-not-found path** ([:2659-2665](../../../src/Modules/ServerNet.bb#L2659)) — `If Exists = False`, the handler still reads the current-password field and calls `VerifyPassword%("", ...)` to pay the SHA-256 cost (timing-uniform with the found-account-wrong-password path), records the failed attempt, then replies `"P"` — the same code as a credential failure, so the reply does not betray whether the username is registered.
 
 ## Anti-cheat / abuse surface

--- a/src/Modules/ServerNet.bb
+++ b/src/Modules/ServerNet.bb
@@ -2667,10 +2667,16 @@ Function UpdateNetwork()
 							PwdLen = RCE_IntFromStr(Mid$(M\MessageData$, Offset, 1))
 							; Store the new password in the v1 salted format
 							; immediately, not the raw client MD5.
+							Local OldPass$ = A\Pass$
 							A\Pass$ = HashPassword$(Mid$(M\MessageData$, Offset + 1, PwdLen))
-							LoginAttemptRecord(M\FromID, True)
-							RCE_Send(Host, M\FromID, P_ChangePassword, "Y", True)
-							//If MySQL = True Then My_SaveAccount(A, False)
+							If SaveAccounts()
+								LoginAttemptRecord(M\FromID, True)
+								RCE_Send(Host, M\FromID, P_ChangePassword, "Y", True)
+							Else
+								A\Pass$ = OldPass$
+								LoginAttemptRecord(M\FromID, False)
+								RCE_Send(Host, M\FromID, P_ChangePassword, "P", True)
+							EndIf
 						; Otherwise return password failure
 						Else
 							LoginAttemptRecord(M\FromID, False)

--- a/src/Tests/Modules/ChangePasswordDurabilityTest.bb
+++ b/src/Tests/Modules/ChangePasswordDurabilityTest.bb
@@ -1,0 +1,69 @@
+Strict
+EnableGC
+
+; ServerNet.bb depends on the live network and world graph, so this bounded
+; source contract verifies that P_ChangePassword cannot acknowledge a flat-file
+; password mutation until SaveAccounts commits it. A failed commit must restore
+; the prior in-memory hash and retain the generic failure reply.
+Function ChangePasswordSaveContract%(Path$)
+	Local F.BBStream = ReadFile(Path$)
+	Local InCase%, Stage%
+	Local SawOldPass%, SawAssignment%, SawCommitGate%, SawSuccessRecord%, SawSuccessReply%
+	Local SawRestore%, SawFailureRecord%, SawFailureReply%
+	Local Line$, Trimmed$
+	Local SuccessReply$, FailureReply$
+	SuccessReply$ = "RCE_Send(Host, M\FromID, P_ChangePassword, " + Chr$(34) + "Y" + Chr$(34) + ", True)"
+	FailureReply$ = "RCE_Send(Host, M\FromID, P_ChangePassword, " + Chr$(34) + "P" + Chr$(34) + ", True)"
+	If F = Null Then F = ReadFile("..\" + Path$)
+	If F = Null Then Return False
+
+	While Not Eof(F)
+		Line$ = ReadLine$(F)
+		Trimmed$ = Trim$(Line$)
+		If Trimmed$ = "Case P_ChangePassword" Then InCase = True
+		If InCase = True And Trimmed$ = "Case P_FetchCharacter" Then InCase = False
+		If InCase = True
+			If Trimmed$ = "Local OldPass$ = A\Pass$"
+				SawOldPass = True
+				Stage = 1
+			EndIf
+			If Stage = 1 And Trimmed$ = "A\Pass$ = HashPassword$(Mid$(M\MessageData$, Offset + 1, PwdLen))"
+				SawAssignment = True
+				Stage = 2
+			EndIf
+			If Stage = 2 And Trimmed$ = "If SaveAccounts()"
+				SawCommitGate = True
+				Stage = 3
+			EndIf
+			If Stage = 3 And Trimmed$ = "LoginAttemptRecord(M\FromID, True)"
+				SawSuccessRecord = True
+				Stage = 4
+			EndIf
+			If Stage = 4 And Trimmed$ = SuccessReply$
+				SawSuccessReply = True
+				Stage = 5
+			EndIf
+			If Stage = 5 And Trimmed$ = "Else" Then Stage = 6
+			If Stage = 6 And Trimmed$ = "A\Pass$ = OldPass$"
+				SawRestore = True
+				Stage = 7
+			EndIf
+			If Stage = 7 And Trimmed$ = "LoginAttemptRecord(M\FromID, False)"
+				SawFailureRecord = True
+				Stage = 8
+			EndIf
+			If Stage = 8 And Trimmed$ = FailureReply$
+				SawFailureReply = True
+				Stage = 9
+			EndIf
+		EndIf
+	Wend
+
+	CloseFile F
+	Return SawOldPass And SawAssignment And SawCommitGate And SawSuccessRecord And SawSuccessReply And SawRestore And SawFailureRecord And SawFailureReply
+
+End Function
+
+Test testChangePasswordSaveCommitsBeforeSuccessAndRollsBackOnFailure()
+	Assert(ChangePasswordSaveContract%("Modules\ServerNet.bb") = True)
+End Test

--- a/src/Tests/Modules/ChangePasswordThrottleTest.bb
+++ b/src/Tests/Modules/ChangePasswordThrottleTest.bb
@@ -80,7 +80,9 @@ Function ChangePasswordRecordsThrottleOutcomes%(Path$)
 	Wend
 
 	CloseFile F
-	Return SuccessRecorded = True And FailureRecords = 2
+	; Two authentication failures (bad/unknown account) plus a failed atomic
+	; password commit each retain the generic P reply and failure record.
+	Return SuccessRecorded = True And FailureRecords = 3
 
 End Function
 


### PR DESCRIPTION
## Outcome
Password changes now report success only after the account file commits, so a write failure cannot leave an account owner with a false success message and a password that disappears after restart.

## Technical changes
- Stage the existing password hash, save the new v1 hash through SaveAccounts(), and emit Y only after success.
- Restore the staged hash and use the existing generic P reply on a failed commit.
- Add bounded durability and throttle-outcome contracts; update the canonical packet page plus generated index anchors.

Fixes #701

## Acceptance evidence
- Old hash is retained before assignment; SaveAccounts gates LoginAttemptRecord(..., True) and Y.
- Failed commits restore the old hash, record failure, and reply P.
- MySQL behavior remains compatible because SaveAccounts returns True for that backend.
- The throttle contract now covers all three generic failure records: bad credentials/session, unknown account, and failed persistence.
- docs/protocol/packets/P_ChangePassword.md describes the durable success boundary; docs/protocol/index.md is generator-current.

## Baseline, RED, GREEN, and final verification
- Baseline: git diff --check origin/develop, bash scripts/gen_packet_index.sh --check, and bash scripts/gen_bvm_reference.sh --check all exited 0. The handler probe observed assigned=1 saved=0 success=1.
- RED: the bounded durability probe exited 1 with old=0 assign=0 gate=0 success_record=0 success_reply=0 restore=0 failure_record=0 failure_reply=0 against the original handler.
- GREEN: durability and throttle structural probes exited 0; generator checks and git diff --check exited 0.
- First CI head 0974357 exposed the adjacent throttle contract (82/83 files passed; ChangePasswordThrottleTest only). Follow-up a8de5fb8 updates its expected count to three.
- Final exact head a8de5fb8: Build and test SUCCESS (2m41s); Rust server (Linux) SUCCESS (1m29s); direct check-runs were terminal success and legacy commit statuses total 0.
- Local compiler caveat: bash test.sh ChangePasswordDurabilityTest exited 1 solely because compiler/BlitzForge/bin/blitzcc is absent in this initialized Linux worktree; exact-head CI supplied compiled test proof.

## Compatibility, risk, rollback, and follow-ups
- Existing packet layout, auth/session/throttle checks, and successful MySQL path are unchanged. Flat-file commit failures now use the established generic failure response.
- Roll back with a normal revert; no data migration or protocol change is involved.
- Deferred: password UI, transport security, throttle policy, and broader account refactoring.

## Independent review
Fresh independent review of exact head a8de5fb8 returned ACCEPT after the throttle-contract follow-up. It confirmed durability ordering/rollback, MySQL compatibility, three failure records, source-contract quality, documentation, scope, and security compatibility.