### PR TITLE
docs: scope source builds to macOS Apple Silicon

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -40,7 +40,7 @@ compile.bat -t           # engine only — fastest iteration loop (~10× faster 
 compile.bat -b           # also rebuild BlitzForge from source (slow, MSBuild)
 compile.bat -e           # skip engine, build tools only
 
-# macOS / Linux (alpha)
+# macOS (Apple Silicon, alpha)
 ./compile.sh
 ```
 
@@ -55,7 +55,7 @@ compile.bat -e           # skip engine, build tools only
 ```powershell
 test.bat                 # run every test file under src/Tests/
 test.bat ItemsTest       # run only files whose basename contains "ItemsTest"
-./test.sh ItemsTest      # macOS / Linux equivalent
+./test.sh ItemsTest      # macOS equivalent
 ```
 
 The runner prints `[RUN ]` / `[PASS]` / `[FAIL]` per file plus an end-of-run summary. CI calls `test.bat` with no args and only checks the exit code.

--- a/docs/start.md
+++ b/docs/start.md
@@ -51,7 +51,7 @@ publish.bat
 test.bat
 ```
 
-### macOS / Linux
+### macOS (Apple Silicon, alpha)
 
 Use the shell scripts from the repository root:
 
@@ -63,9 +63,8 @@ Use the shell scripts from the repository root:
 ./test.sh
 ```
 
-`bootstrap_macos.sh` is required on macOS before the first source build. The
-script name is historical; it prepares the Unix-side toolchain used by the
-current shell workflow.
+`bootstrap_macos.sh` is required on macOS before the first source build. It
+prepares the macOS toolchain used by the current shell workflow.
 
 macOS support is currently alpha because the underlying BlitzForge runtime is
 still incomplete there. Treat the macOS path as a development and feedback

--- a/src/Tests/Modules/ReadMeMacOSInstallTest.bb
+++ b/src/Tests/Modules/ReadMeMacOSInstallTest.bb
@@ -33,3 +33,12 @@ Test testMacOSInstructionsPointToTheSupportedSourceBuildPath()
 	Assert(FileContains%("ReadMe.md", "macOS currently has no downloadable release package") = True)
 	Assert(FileContains%("ReadMe.md", "[macOS Apple Silicon notes](docs/macos-apple-silicon.md)") = True)
 End Test
+
+Test testSourceBuildOnboardingDoesNotAdvertiseTheMacOSBootstrapForLinux()
+	Assert(FileContains%("docs/start.md", "### macOS (Apple Silicon, alpha)") = True)
+	Assert(FileContains%("docs/start.md", "### macOS / Linux") = False)
+	Assert(FileContains%("docs/start.md", "bootstrap_macos.sh` is required on macOS") = True)
+	Assert(FileContains%("CONTRIBUTING.md", "# macOS (Apple Silicon, alpha)") = True)
+	Assert(FileContains%("CONTRIBUTING.md", "# macOS / Linux (alpha)") = False)
+	Assert(FileContains%("CONTRIBUTING.md", "macOS equivalent") = True)
+End Test


### PR DESCRIPTION
## Outcome

Contributors are no longer told that a macOS-only bootstrap works on Linux; the source-build path now names its supported macOS Apple Silicon alpha platform.

## Changes

- Align docs/start.md and CONTRIBUTING.md with the bootstrap script's Darwin-only guard.
- Add a focused source-contract regression for both onboarding surfaces.

Fixes #705

## Acceptance evidence

- macOS-only headings replace the combined macOS/Linux headings.
- The regression requires the supported macOS wording and rejects the obsolete combined-platform wording.
- Existing macOS bootstrap command and alpha caveat are retained.

## TDD and verification

- Baseline: bash -n test.sh compile.sh scripts/bootstrap_macos.sh exited 0; ./test.sh ReadMeMacOSInstallTest exited 1 because this Linux checkout has no compiler/BlitzForge/bin/blitzcc after submodule initialization.
- RED: focused source-contract probe exited 1 while the combined headings remained.
- GREEN: the same probe exited 0 after the documentation changes.
- Final: bash -n test.sh compile.sh scripts/bootstrap_macos.sh and git diff --check exited 0.

## Compatibility, risk, rollback

Documentation/test-only, low risk. This preserves all supported commands and removes no runtime behavior. Revert fafb770f to restore the prior wording if needed. Linux bootstrap implementation remains intentionally deferred.

## Independent review

ACCEPT — fresh review of exact head fafb770f found only the three issue-scoped files changed, confirmed the docs match the Darwin guard and project intent, and found no correctness, security, performance, concurrency, or hidden-interface concerns. CI remains an independent merge gate.