### PR TITLE
fix(server): persist Accounts-window deletion before removal

### DIFF
--- a/src/Modules/AccountsServer.bb
+++ b/src/Modules/AccountsServer.bb
@@ -29,6 +29,10 @@ End Type
 Type Account
 	Field User$, Pass$, Email$, IsDM, IsBanned
 	Field ListID
+	; The Accounts-window delete path marks a record while SaveAccounts writes
+	; the prospective file. A failed atomic commit clears this marker so the
+	; still-live record and its UI entry remain authoritative.
+	Field PendingDelete
 	Field LoggedOn
 	Field Character.ActorInstance[9]
 	Field QuestLog.QuestLog[9]
@@ -247,29 +251,31 @@ Function SaveAccounts()
 		WriteByte F, ACCOUNTS_VERSION_CURRENT%
 
 		For A.Account = Each Account
-			WriteString F, A\User$
-			WriteString F, A\Pass$
-			WriteString F, A\Email$
-			WriteByte F, A\IsDM
-			WriteByte F, A\IsBanned
-			WriteString F, A\Ignore$
-			Chars = 0
-			For i = 0 To 9
-				If A\Character[i] <> Null Then Chars = Chars + 1
-			Next
-			WriteByte F, Chars
-			For i = 0 To 9
-				If A\Character[i] <> Null
-					WriteActorInstance(F, A\Character[i])
-					For j = 0 To 499
-						WriteString F, A\QuestLog[i]\EntryName$[j]
-						WriteString F, A\QuestLog[i]\EntryStatus$[j]
-					Next
-					For j = 0 To 35
-						WriteString F, A\ActionBar[i]\Slots$[j]
-					Next
-				EndIf
-			Next
+			If A\PendingDelete = False
+				WriteString F, A\User$
+				WriteString F, A\Pass$
+				WriteString F, A\Email$
+				WriteByte F, A\IsDM
+				WriteByte F, A\IsBanned
+				WriteString F, A\Ignore$
+				Chars = 0
+				For i = 0 To 9
+					If A\Character[i] <> Null Then Chars = Chars + 1
+				Next
+				WriteByte F, Chars
+				For i = 0 To 9
+					If A\Character[i] <> Null
+						WriteActorInstance(F, A\Character[i])
+						For j = 0 To 499
+							WriteString F, A\QuestLog[i]\EntryName$[j]
+							WriteString F, A\QuestLog[i]\EntryStatus$[j]
+						Next
+						For j = 0 To 35
+							WriteString F, A\ActionBar[i]\Slots$[j]
+						Next
+					EndIf
+				Next
+			EndIf
 		Next
 
 	Return SafeWriteCommit(TempPath$, FinalPath$, F)

--- a/src/Server.bb
+++ b/src/Server.bb
@@ -438,24 +438,30 @@ Repeat
 				If Confirm("Really remove account?") = True
 					A.Account = FindAccountByListID(SelectedGadgetItem(Accounts\List))
 					If A <> Null
-						; Remove from counters
-						Accounts\TotalAccounts = Accounts\TotalAccounts - 1
-						If A\IsDM = True Then Accounts\TotalDMs = Accounts\TotalDMs - 1
-						If A\IsBanned = True Then Accounts\TotalBanned = Accounts\TotalBanned - 1
-						SetGadgetText(Accounts\AccountsLabel, "Total accounts: " + Str(Accounts\TotalAccounts))
-						SetGadgetText(Accounts\DMLabel, "GM accounts: " + Str(Accounts\TotalDMs))
-						SetGadgetText(Accounts\BannedLabel, "Banned accounts: " + Str(Accounts\TotalBanned))
-						; Move all others up in the list
-						Ac2.Account = After A
-						While Ac2 <> Null
-							Ac2\ListID = Ac2\ListID - 1
-							Ac2 = After Ac2
-						Wend
-						; Delete it
-						WriteLog(MainLog, "Deleted account: " + A\User$)
-						Delete A
-						RemoveGadgetItem Accounts\List, SelectedGadgetItem(Accounts\List)
-						SaveAccounts()
+						; Keep the account/UI live until the prospective Accounts.dat write
+						; commits. A failed atomic save must leave memory matching disk.
+						A\PendingDelete = True
+						If SaveAccounts()
+							; Remove from counters only after the deletion is durable.
+							Accounts\TotalAccounts = Accounts\TotalAccounts - 1
+							If A\IsDM = True Then Accounts\TotalDMs = Accounts\TotalDMs - 1
+							If A\IsBanned = True Then Accounts\TotalBanned = Accounts\TotalBanned - 1
+							SetGadgetText(Accounts\AccountsLabel, "Total accounts: " + Str(Accounts\TotalAccounts))
+							SetGadgetText(Accounts\DMLabel, "GM accounts: " + Str(Accounts\TotalDMs))
+							SetGadgetText(Accounts\BannedLabel, "Banned accounts: " + Str(Accounts\TotalBanned))
+							; Move all others up in the list.
+							Ac2.Account = After A
+							While Ac2 <> Null
+								Ac2\ListID = Ac2\ListID - 1
+								Ac2 = After Ac2
+							Wend
+							WriteLog(MainLog, "Deleted account: " + A\User$)
+							Delete A
+							RemoveGadgetItem Accounts\List, SelectedGadgetItem(Accounts\List)
+						Else
+							A\PendingDelete = False
+							WriteLog(MainLog, "Could not delete account: " + A\User$ + " because Accounts.dat was not saved")
+						EndIf
 					EndIf
 				EndIf
 			; Lock/unlock updates server

--- a/src/Tests/Modules/AccountWindowDeleteDurabilityTest.bb
+++ b/src/Tests/Modules/AccountWindowDeleteDurabilityTest.bb
@@ -29,8 +29,8 @@ End Function
 Function AccountWindowDeleteCommitsBeforeLiveTeardown%(Path$)
 
 	Local F.BBStream = OpenContractFile(Path$)
-	Local InDeleteCase%, Stage%, SuccessStage%, FailureStage%
-	Local SawMark%, SawCommit%, SawCounters%, SawReindex%, SawDelete%, SawRemove%, SawFailureRestore%, SawFailureLog%
+	Local InDeleteCase%, Stage%, CommitBranch%, CommitIndent%
+	Local SawMark%, SawCommit%, SawTotalAccounts%, SawDMCounter%, SawBannedCounter%, SawAccountLabel%, SawDMLabel%, SawBannedLabel%, SawReindexStart%, SawReindexStep%, SawDelete%, SawRemove%, SawFailureRestore%, SawFailureLog%
 	Local Line$, Trimmed$
 	If F = Null Then Return False
 
@@ -40,7 +40,7 @@ Function AccountWindowDeleteCommitsBeforeLiveTeardown%(Path$)
 		If Trimmed$ = "Case Accounts\DeleteButton" Then InDeleteCase = True
 		If InDeleteCase And Trimmed$ = "Case Updates\LockButton" Then Exit
 		If InDeleteCase
-			If Stage < 2 And (Trimmed$ = "Delete A" Or Instr(Trimmed$, "Accounts\TotalAccounts = Accounts\TotalAccounts - 1") > 0 Or Instr(Trimmed$, "RemoveGadgetItem Accounts\List") > 0)
+			If Stage < 2 And (Trimmed$ = "Delete A" Or Instr(Trimmed$, "Accounts\TotalAccounts =") > 0 Or Instr(Trimmed$, "Accounts\TotalDMs =") > 0 Or Instr(Trimmed$, "Accounts\TotalBanned =") > 0 Or Instr(Trimmed$, "SetGadgetText(") > 0 Or Instr(Trimmed$, "Ac2.Account = After A") > 0 Or Instr(Trimmed$, "Ac2\ListID =") > 0 Or Instr(Trimmed$, "RemoveGadgetItem Accounts\List") > 0)
 				CloseFile F
 				Return False
 			EndIf
@@ -50,16 +50,22 @@ Function AccountWindowDeleteCommitsBeforeLiveTeardown%(Path$)
 			ElseIf Stage = 1 And Trimmed$ = "If SaveAccounts()"
 				SawCommit = True
 				Stage = 2
-				SuccessStage = 1
-			ElseIf Stage = 2 And Trimmed$ = "Else"
-				SuccessStage = 0
-				FailureStage = 1
-			ElseIf SuccessStage = 1
-				If Instr(Trimmed$, "Accounts\TotalAccounts = Accounts\TotalAccounts - 1") > 0 Then SawCounters = True
-				If Trimmed$ = "Ac2.Account = After A" Then SawReindex = True
+				CommitBranch = 1
+				CommitIndent = LeadingTabs(Line$)
+			ElseIf CommitBranch = 1 And Trimmed$ = "Else" And LeadingTabs(Line$) = CommitIndent
+				CommitBranch = 2
+			ElseIf CommitBranch = 1
+				If Instr(Trimmed$, "Accounts\TotalAccounts = Accounts\TotalAccounts - 1") > 0 Then SawTotalAccounts = True
+				If Instr(Trimmed$, "Accounts\TotalDMs = Accounts\TotalDMs - 1") > 0 Then SawDMCounter = True
+				If Instr(Trimmed$, "Accounts\TotalBanned = Accounts\TotalBanned - 1") > 0 Then SawBannedCounter = True
+				If Instr(Trimmed$, "SetGadgetText(Accounts\AccountsLabel") > 0 Then SawAccountLabel = True
+				If Instr(Trimmed$, "SetGadgetText(Accounts\DMLabel") > 0 Then SawDMLabel = True
+				If Instr(Trimmed$, "SetGadgetText(Accounts\BannedLabel") > 0 Then SawBannedLabel = True
+				If Trimmed$ = "Ac2.Account = After A" Then SawReindexStart = True
+				If Trimmed$ = "Ac2\ListID = Ac2\ListID - 1" Then SawReindexStep = True
 				If Trimmed$ = "Delete A" Then SawDelete = True
 				If Instr(Trimmed$, "RemoveGadgetItem Accounts\List") > 0 Then SawRemove = True
-			ElseIf FailureStage = 1
+			ElseIf CommitBranch = 2
 				If Trimmed$ = "A\PendingDelete = False" Then SawFailureRestore = True
 				If Instr(Trimmed$, "Could not delete account") > 0 Then SawFailureLog = True
 			EndIf
@@ -67,15 +73,32 @@ Function AccountWindowDeleteCommitsBeforeLiveTeardown%(Path$)
 	Wend
 
 	CloseFile F
-	Return SawMark And SawCommit And SawCounters And SawReindex And SawDelete And SawRemove And SawFailureRestore And SawFailureLog
+	Return SawMark And SawCommit And SawTotalAccounts And SawDMCounter And SawBannedCounter And SawAccountLabel And SawDMLabel And SawBannedLabel And SawReindexStart And SawReindexStep And SawDelete And SawRemove And SawFailureRestore And SawFailureLog
+
+End Function
+
+Function IsAccountRecordWrite%(Trimmed$)
+
+	If Trimmed$ = "WriteString F, A\User$" Then Return True
+	If Trimmed$ = "WriteString F, A\Pass$" Then Return True
+	If Trimmed$ = "WriteString F, A\Email$" Then Return True
+	If Trimmed$ = "WriteByte F, A\IsDM" Then Return True
+	If Trimmed$ = "WriteByte F, A\IsBanned" Then Return True
+	If Trimmed$ = "WriteString F, A\Ignore$" Then Return True
+	If Trimmed$ = "WriteByte F, Chars" Then Return True
+	If Trimmed$ = "WriteActorInstance(F, A\Character[i])" Then Return True
+	If Trimmed$ = "WriteString F, A\QuestLog[i]\EntryName$[j]" Then Return True
+	If Trimmed$ = "WriteString F, A\QuestLog[i]\EntryStatus$[j]" Then Return True
+	If Trimmed$ = "WriteString F, A\ActionBar[i]\Slots$[j]" Then Return True
+	Return False
 
 End Function
 
 Function PendingDeleteIsExcludedFromFlatFileSave%(Path$)
 
 	Local F.BBStream = OpenContractFile(Path$)
-	Local InSave%, Stage%, GuardIndent%
-	Local SawField%, SawGuard%, SawUserWrite%, SawPassWrite%, SawCharsWrite%, SawGuardEnd%
+	Local InSave%, Stage%, GuardIndent%, GuardActive%
+	Local SawField%, SawGuard%, SawUserWrite%, SawPassWrite%, SawEmailWrite%, SawDMWrite%, SawBannedWrite%, SawIgnoreWrite%, SawCharsWrite%, SawActorWrite%, SawQuestNameWrite%, SawQuestStatusWrite%, SawActionBarWrite%, SawGuardEnd%
 	Local Line$, Trimmed$
 	If F = Null Then Return False
 
@@ -89,14 +112,30 @@ Function PendingDeleteIsExcludedFromFlatFileSave%(Path$)
 			If Stage = 1 And Trimmed$ = "If A\PendingDelete = False"
 				SawGuard = True
 				GuardIndent = LeadingTabs(Line$)
+				GuardActive = True
 				Stage = 2
 			EndIf
 			If Stage = 2
-				If Trimmed$ = "WriteString F, A\User$" And LeadingTabs(Line$) = GuardIndent + 1 Then SawUserWrite = True
-				If Trimmed$ = "WriteString F, A\Pass$" And LeadingTabs(Line$) = GuardIndent + 1 Then SawPassWrite = True
-				If Trimmed$ = "WriteByte F, Chars" And LeadingTabs(Line$) = GuardIndent + 1 Then SawCharsWrite = True
-				If Trimmed$ = "EndIf" And LeadingTabs(Line$) = GuardIndent
+				If IsAccountRecordWrite%(Trimmed$)
+					If GuardActive = False Or LeadingTabs(Line$) <= GuardIndent
+						CloseFile F
+						Return False
+					EndIf
+				EndIf
+				If Trimmed$ = "WriteString F, A\User$" Then SawUserWrite = True
+				If Trimmed$ = "WriteString F, A\Pass$" Then SawPassWrite = True
+				If Trimmed$ = "WriteString F, A\Email$" Then SawEmailWrite = True
+				If Trimmed$ = "WriteByte F, A\IsDM" Then SawDMWrite = True
+				If Trimmed$ = "WriteByte F, A\IsBanned" Then SawBannedWrite = True
+				If Trimmed$ = "WriteString F, A\Ignore$" Then SawIgnoreWrite = True
+				If Trimmed$ = "WriteByte F, Chars" Then SawCharsWrite = True
+				If Trimmed$ = "WriteActorInstance(F, A\Character[i])" Then SawActorWrite = True
+				If Trimmed$ = "WriteString F, A\QuestLog[i]\EntryName$[j]" Then SawQuestNameWrite = True
+				If Trimmed$ = "WriteString F, A\QuestLog[i]\EntryStatus$[j]" Then SawQuestStatusWrite = True
+				If Trimmed$ = "WriteString F, A\ActionBar[i]\Slots$[j]" Then SawActionBarWrite = True
+				If GuardActive And Trimmed$ = "EndIf" And LeadingTabs(Line$) = GuardIndent
 					SawGuardEnd = True
+					GuardActive = False
 					Stage = 3
 				EndIf
 			EndIf
@@ -105,7 +144,7 @@ Function PendingDeleteIsExcludedFromFlatFileSave%(Path$)
 	Wend
 
 	CloseFile F
-	Return SawField And SawGuard And SawUserWrite And SawPassWrite And SawCharsWrite And SawGuardEnd
+	Return SawField And SawGuard And SawUserWrite And SawPassWrite And SawEmailWrite And SawDMWrite And SawBannedWrite And SawIgnoreWrite And SawCharsWrite And SawActorWrite And SawQuestNameWrite And SawQuestStatusWrite And SawActionBarWrite And SawGuardEnd
 
 End Function
 

--- a/src/Tests/Modules/AccountWindowDeleteDurabilityTest.bb
+++ b/src/Tests/Modules/AccountWindowDeleteDurabilityTest.bb
@@ -1,0 +1,118 @@
+Strict
+EnableGC
+
+; The Accounts window lives in Server.bb and cannot be Included into an
+; isolated test build. These bounded source contracts make the flat-file
+; deletion transaction explicit: a marked account is omitted from the pending
+; atomic write, and the live account/UI state changes only after that write
+; commits.
+
+Function LeadingTabs%(Line$)
+	Local Count%, Pos% = 1
+	While Pos <= Len(Line$)
+		If Mid$(Line$, Pos, 1) <> Chr$(9) Then Exit
+		Count = Count + 1
+		Pos = Pos + 1
+	Wend
+	Return Count
+
+End Function
+
+Function OpenContractFile.BBStream(Path$)
+
+	Local F.BBStream = ReadFile(Path$)
+	If F = Null Then F = ReadFile("..\" + Path$)
+	Return F
+
+End Function
+
+Function AccountWindowDeleteCommitsBeforeLiveTeardown%(Path$)
+
+	Local F.BBStream = OpenContractFile(Path$)
+	Local InDeleteCase%, Stage%, SuccessStage%, FailureStage%
+	Local SawMark%, SawCommit%, SawCounters%, SawReindex%, SawDelete%, SawRemove%, SawFailureRestore%, SawFailureLog%
+	Local Line$, Trimmed$
+	If F = Null Then Return False
+
+	While Not Eof(F)
+		Line$ = ReadLine$(F)
+		Trimmed$ = Trim$(Line$)
+		If Trimmed$ = "Case Accounts\DeleteButton" Then InDeleteCase = True
+		If InDeleteCase And Trimmed$ = "Case Updates\LockButton" Then Exit
+		If InDeleteCase
+			If Stage < 2 And (Trimmed$ = "Delete A" Or Instr(Trimmed$, "Accounts\TotalAccounts = Accounts\TotalAccounts - 1") > 0 Or Instr(Trimmed$, "RemoveGadgetItem Accounts\List") > 0)
+				CloseFile F
+				Return False
+			EndIf
+			If Stage = 0 And Trimmed$ = "A\PendingDelete = True"
+				SawMark = True
+				Stage = 1
+			ElseIf Stage = 1 And Trimmed$ = "If SaveAccounts()"
+				SawCommit = True
+				Stage = 2
+				SuccessStage = 1
+			ElseIf Stage = 2 And Trimmed$ = "Else"
+				SuccessStage = 0
+				FailureStage = 1
+			ElseIf SuccessStage = 1
+				If Instr(Trimmed$, "Accounts\TotalAccounts = Accounts\TotalAccounts - 1") > 0 Then SawCounters = True
+				If Trimmed$ = "Ac2.Account = After A" Then SawReindex = True
+				If Trimmed$ = "Delete A" Then SawDelete = True
+				If Instr(Trimmed$, "RemoveGadgetItem Accounts\List") > 0 Then SawRemove = True
+			ElseIf FailureStage = 1
+				If Trimmed$ = "A\PendingDelete = False" Then SawFailureRestore = True
+				If Instr(Trimmed$, "Could not delete account") > 0 Then SawFailureLog = True
+			EndIf
+		EndIf
+	Wend
+
+	CloseFile F
+	Return SawMark And SawCommit And SawCounters And SawReindex And SawDelete And SawRemove And SawFailureRestore And SawFailureLog
+
+End Function
+
+Function PendingDeleteIsExcludedFromFlatFileSave%(Path$)
+
+	Local F.BBStream = OpenContractFile(Path$)
+	Local InSave%, Stage%, GuardIndent%
+	Local SawField%, SawGuard%, SawUserWrite%, SawPassWrite%, SawCharsWrite%, SawGuardEnd%
+	Local Line$, Trimmed$
+	If F = Null Then Return False
+
+	While Not Eof(F)
+		Line$ = ReadLine$(F)
+		Trimmed$ = Trim$(Line$)
+		If Trimmed$ = "Field PendingDelete" Then SawField = True
+		If Trimmed$ = "Function SaveAccounts()" Then InSave = True
+		If InSave
+			If Stage = 0 And Trimmed$ = "For A.Account = Each Account" Then Stage = 1
+			If Stage = 1 And Trimmed$ = "If A\PendingDelete = False"
+				SawGuard = True
+				GuardIndent = LeadingTabs(Line$)
+				Stage = 2
+			EndIf
+			If Stage = 2
+				If Trimmed$ = "WriteString F, A\User$" And LeadingTabs(Line$) = GuardIndent + 1 Then SawUserWrite = True
+				If Trimmed$ = "WriteString F, A\Pass$" And LeadingTabs(Line$) = GuardIndent + 1 Then SawPassWrite = True
+				If Trimmed$ = "WriteByte F, Chars" And LeadingTabs(Line$) = GuardIndent + 1 Then SawCharsWrite = True
+				If Trimmed$ = "EndIf" And LeadingTabs(Line$) = GuardIndent
+					SawGuardEnd = True
+					Stage = 3
+				EndIf
+			EndIf
+			If Trimmed$ = "End Function" Then Exit
+		EndIf
+	Wend
+
+	CloseFile F
+	Return SawField And SawGuard And SawUserWrite And SawPassWrite And SawCharsWrite And SawGuardEnd
+
+End Function
+
+Test testAccountWindowDeletionDoesNotTearDownBeforeSaveCommit()
+	Assert(AccountWindowDeleteCommitsBeforeLiveTeardown%("Server.bb") = True)
+End Test
+
+Test testPendingAccountDeletionIsExcludedFromFlatFileSave()
+	Assert(PendingDeleteIsExcludedFromFlatFileSave%("Modules\AccountsServer.bb") = True)
+End Test


### PR DESCRIPTION
## Outcome

Server administrators no longer see an account deleted unless the corresponding Accounts.dat change commits. A failed atomic save keeps the account, counters, list entry, and list IDs live, so restart state agrees with the running server.

## Technical changes

- Mark a GUI-selected Account as pending deletion while SaveAccounts writes the prospective flat-file state.
- Exclude marked accounts from that attempted serialization.
- Finalize counters, list reindexing, UI removal, and Delete only after commit success; clear the marker and log on failure.
- Add a focused bounded source-contract regression test, strengthened after review to bind every teardown mutation and every account-record writer.

Fixes #709

## Acceptance evidence

- Pending GUI deletion is omitted from the flat-file writer: strengthened source audit exit 0.
- No live teardown precedes SaveAccounts commit; failure restores the marker: strengthened source audit exit 0.
- The focused contract binds counters, labels, list reindexing, delete/UI removal, and identity/character/quest/action-bar serialization.
- MySQL keeps SaveAccounts returning true, so its existing successful deletion path remains unchanged.

## RED and GREEN

- RED: missing pending marker, commit gate, rollback, and serialization guard probe exited 1 before implementation.
- GREEN: the required-shape probe exited 0 after implementation; the reviewer-requested stronger audit also exited 0.

## Verification

- git diff --check origin/develop...HEAD: exit 0.
- bash scripts/gen_packet_index.sh --check: exit 0.
- bash scripts/gen_bvm_reference.sh --check: exit 0.
- ./compile.sh -t and ./test.sh AccountWindowDeleteDurabilityTest: exit 1 only because this isolated Linux worktree cannot fetch the pinned BlitzForge revision and has no compiler/BlitzForge/bin/blitzcc. CI runs the native Windows compiler/test suite.

## Compatibility and rollback

Accounts.dat layout is unchanged for non-pending accounts. The pending marker is in-memory only. Revert this PR to restore the prior behavior.

## Deferred

Do not change client-driven character deletion, password operations, account creation, MySQL persistence, or protocol documentation.

## Independent review

Fresh review ACCEPTed exact head 5467b75fa9c3acd62e073d6424daeef4c789fff7. The prior review requested stronger lexical coverage; its test-only correction is included in this head.