### PR TITLE
fix(loom): reject stale scenery brushes after catalog rebuild

### DIFF
--- a/src/Modules/Loom/ZoneViewport.bb
+++ b/src/Modules/Loom/ZoneViewport.bb
@@ -1211,6 +1211,17 @@ Function Loom_AddSceneryAtClick(zoneHandle, localX, localY)
     Local py# = VPPickY#
     Local pz# = VPPickZ#
 
+    ; Media deletion rebuilds the catalog, so a previously selected brush ID
+    ; can outlive its MeshEntry. Validate the catalog before loading or
+    ; allocating anything: BlitzForge And is eager and cannot guard mEnt\Scale.
+    Local mEnt.MeshEntry = Meshes_GetByID(ScnBrushMeshID)
+    If mEnt = Null
+        ScnBrushMeshID = 0
+        ScnBrushName$ = ""
+        Toast_Show("Selected scenery mesh is no longer available; pick another mesh", "warning")
+        Return
+    EndIf
+
     Local en = GetMesh(ScnBrushMeshID, False)
     If en = 0
         Toast_Show("Could not load mesh " + Str(ScnBrushMeshID), "warning")
@@ -1219,8 +1230,7 @@ Function Loom_AddSceneryAtClick(zoneHandle, localX, localY)
 
     ; Brush scale mirrors GUE's place-from-browser: mesh's catalog scale * 0.05.
     Local sc# = 1.0
-    Local mEnt.MeshEntry = Meshes_GetByID(ScnBrushMeshID)
-    If mEnt <> Null And mEnt\Scale# > 0.0 Then sc# = mEnt\Scale# * 0.05
+    If mEnt\Scale# > 0.0 Then sc# = mEnt\Scale# * 0.05
     If sc# <= 0.0 Then sc# = 1.0
 
     ; --- Create + fully initialize every serialized field ---

--- a/src/Tests/Modules/LoomSceneryBrushCatalogTest.bb
+++ b/src/Tests/Modules/LoomSceneryBrushCatalogTest.bb
@@ -33,7 +33,7 @@ Function StaleSceneryBrushIsRejected%(Path$)
 				EndIf
 			Case 2
 				If Trimmed$ = "ScnBrushMeshID = 0" Then SawBrushIDReset = True
-				If Trimmed$ = "ScnBrushName$ = \"\"" Then SawBrushNameReset = True
+				If Trimmed$ = "ScnBrushName$ = " + Chr$(34) + Chr$(34) Then SawBrushNameReset = True
 				If Trimmed$ = "Return"
 					If SawBrushIDReset = False Or SawBrushNameReset = False
 						CloseFile F

--- a/src/Tests/Modules/LoomSceneryBrushCatalogTest.bb
+++ b/src/Tests/Modules/LoomSceneryBrushCatalogTest.bb
@@ -9,7 +9,7 @@ EnableGC
 Function StaleSceneryBrushIsRejected%(Path$)
 	Local F.BBStream = ReadFile(Path$)
 	Local Line$, Trimmed$
-	Local Stage%, SawBrushIDReset%, SawBrushNameReset%
+	Local InPlacement%, Stage%, SawBrushIDReset%, SawBrushNameReset%
 	If F = Null Then F = ReadFile("..\" + Path$)
 	If F = Null Then F = ReadFile("..\..\" + Path$)
 	If F = Null Then Return False
@@ -17,13 +17,24 @@ Function StaleSceneryBrushIsRejected%(Path$)
 	While Not Eof(F)
 		Line$ = ReadLine$(F)
 		Trimmed$ = Trim$(Line$)
+		If Instr(Trimmed$, "Function Loom_AddSceneryAtClick") > 0 Then InPlacement = True
+		If InPlacement = False Then Continue
+		If Trimmed$ = "End Function"
+			CloseFile F
+			Return False
+		EndIf
 		If Instr(Trimmed$, "If mEnt <> Null And") > 0
 			CloseFile F
 			Return False
 		EndIf
 		Select Stage
 			Case 0
-				If Instr(Trimmed$, "Local mEnt.MeshEntry = Meshes_GetByID(ScnBrushMeshID)") > 0 Then Stage = 1
+				If Instr(Trimmed$, "Local mEnt.MeshEntry = Meshes_GetByID(ScnBrushMeshID)") > 0
+					Stage = 1
+				ElseIf Instr(Trimmed$, "GetMesh(") > 0 Or Instr(Trimmed$, "New Scenery") > 0
+					CloseFile F
+					Return False
+				EndIf
 			Case 1
 				If Trimmed$ = "If mEnt = Null"
 					Stage = 2

--- a/src/Tests/Modules/LoomSceneryBrushCatalogTest.bb
+++ b/src/Tests/Modules/LoomSceneryBrushCatalogTest.bb
@@ -1,0 +1,63 @@
+Strict
+EnableGC
+
+; Loom's mesh picker stores an engine mesh ID, but media deletion rebuilds the
+; catalog. A stale brush must be rejected before placement asks GetMesh for it
+; or creates a Scenery record. BlitzForge And is eager, so scale access also
+; needs a separate guard after the catalog entry is known live.
+
+Function StaleSceneryBrushIsRejected%(Path$)
+	Local F.BBStream = ReadFile(Path$)
+	Local Line$, Trimmed$
+	Local Stage%, SawBrushIDReset%, SawBrushNameReset%
+	If F = Null Then F = ReadFile("..\" + Path$)
+	If F = Null Then F = ReadFile("..\..\" + Path$)
+	If F = Null Then Return False
+
+	While Not Eof(F)
+		Line$ = ReadLine$(F)
+		Trimmed$ = Trim$(Line$)
+		If Instr(Trimmed$, "If mEnt <> Null And") > 0
+			CloseFile F
+			Return False
+		EndIf
+		Select Stage
+			Case 0
+				If Instr(Trimmed$, "Local mEnt.MeshEntry = Meshes_GetByID(ScnBrushMeshID)") > 0 Then Stage = 1
+			Case 1
+				If Trimmed$ = "If mEnt = Null"
+					Stage = 2
+				ElseIf Instr(Trimmed$, "GetMesh(") > 0 Or Instr(Trimmed$, "New Scenery") > 0
+					CloseFile F
+					Return False
+				EndIf
+			Case 2
+				If Trimmed$ = "ScnBrushMeshID = 0" Then SawBrushIDReset = True
+				If Trimmed$ = "ScnBrushName$ = \"\"" Then SawBrushNameReset = True
+				If Trimmed$ = "Return"
+					If SawBrushIDReset = False Or SawBrushNameReset = False
+						CloseFile F
+						Return False
+					EndIf
+					Stage = 3
+				ElseIf Instr(Trimmed$, "GetMesh(") > 0 Or Instr(Trimmed$, "New Scenery") > 0
+					CloseFile F
+					Return False
+				EndIf
+			Case 3
+				If Instr(Trimmed$, "Local en = GetMesh(ScnBrushMeshID, False)") > 0 Then Stage = 4
+			Case 4
+				If Trimmed$ = "If mEnt\Scale# > 0.0 Then sc# = mEnt\Scale# * 0.05"
+					CloseFile F
+					Return True
+				EndIf
+		End Select
+	Wend
+
+	CloseFile F
+	Return False
+End Function
+
+Test testStaleSceneryBrushIsRejectedBeforePlacement()
+	Assert(StaleSceneryBrushIsRejected%("Modules\Loom\ZoneViewport.bb") = True)
+End Test


### PR DESCRIPTION
## Outcome
Loom now safely clears a scenery brush removed from the media catalog instead of dereferencing its missing catalog entry during World-mode placement.

## Technical changes
- Look up the selected brush before GetMesh or Scenery allocation.
- On a stale catalog ID, clear its ID/name, show a recovery toast, and return.
- Preserve valid positive-scale placement.
- Add a function-bounded source-contract regression.

Fixes #713

## Acceptance and TDD evidence
- Baseline unsafe predicate existed at ZoneViewport.bb:1223.
- RED safe-shape probe exited 1: lookup line 1222, load line 1214, null guard 0, unsafe guard 1.
- GREEN final probe exited 0: lookup 1217, reset ID 1219, reset name 1220, return 1222, load 1225, new 1237, unsafe 0, nested 1.
- The regression rejects eager And, GetMesh, or New Scenery before lookup/guard return.

## Verification
- git diff --check origin/develop...HEAD: exit 0.
- bash -n test.sh: exit 0.
- ./test.sh LoomSceneryBrushCatalogTest: exit 1 only because the checkout lacks compiler/BlitzForge/bin/blitzcc; CI is the executable-test authority.

## Compatibility, rollback, deferred work
Only invalid stale local brush selection changes to a recoverable no-op; valid placement is unchanged. Rollback is reverting these commits. Media delete semantics and unrelated scenery editing are excluded.

## Independent review
Fresh review of exact head dec9405828512f93e4c40ba7f2275958991c7355: ACCEPT for correctness, scope, and regression coverage.