### PR TITLE
docs(loom): describe shipped World mode accurately

### DIFF
--- a/docs/loom/README.md
+++ b/docs/loom/README.md
@@ -47,7 +47,7 @@ A full-featured GUE replacement with thread navigation, search, and a custom-dra
 
 What it deliberately still can't do:
 
-- **Render zones in 3D.** The 3D mesh loader is locked into GUE's UI substrate — see [decisions/004-deferred-3d-viewport.md](decisions/004-deferred-3d-viewport.md).
+- **Terrain sculpting, water-volume editing, weather/environment editing, or scenery texture painting.** The Zone viewport's World mode renders the focused zone's real terrain, scenery, and water through the shared `LoadAreaData` loader; it falls back to schematic mode when a zone has no visual `.dat`. These remaining editing surfaces are separate subsystems — see [roadmap.md](roadmap.md) and [decisions/004-deferred-3d-viewport.md](decisions/004-deferred-3d-viewport.md).
 - **Walk-in playtest.** Requires server-side feature work (out-of-band player spawn API) — see roadmap "Deferred."
 - **Multi-cursor / collaboration.** Out of scope indefinitely.
 

--- a/docs/loom/architecture.md
+++ b/docs/loom/architecture.md
@@ -255,7 +255,7 @@ See [decisions/001-custom-draw-not-fui.md](decisions/001-custom-draw-not-fui.md)
 
 The *data-only* halves of the area I/O were carved out of `ClientAreas.bb` into the shared `Modules/AreaLoader.bb` precisely so Loom can use them without that coupling: `LoadAreaData` (the reader, ADR-004 Phase B) and now `SaveArea` (the whole-visual-area writer, ADR-007 "Phase D"). GUE `Include`s `AreaLoader.bb` before `ClientAreas.bb`, so its own `LoadAreaData`/`SaveArea` calls resolve to the shared definitions unchanged.
 
-Concrete consequence: **Loom cannot render the 3D zone mesh.** Zone composer shows zone metadata as text + portal-target chips; the Atlas surface gives a 2D spatial view from the portal graph topology. See [decisions/004-deferred-3d-viewport.md](decisions/004-deferred-3d-viewport.md) for the path to fixing this (extract `GetFilename$` to a shared helper; either rewrite `LoadArea`'s data path with the GUI side ripped out, or build a Loom-side mesh loader).
+Concrete consequence: **Loom can render the 3D zone mesh in World mode.** `ZoneViewport.bb` loads the focused zone's real terrain, scenery, and water through `LoadAreaData`, overlays the schematic markers at their true coordinates, and soft-falls back to schematic mode when no visual `.dat` exists. World-mode entity editing and scenery placement write through the shared area save path; terrain sculpting, water-volume editing, weather/environment editing, and scenery texture painting remain separate deferred surfaces. See [decisions/004-deferred-3d-viewport.md](decisions/004-deferred-3d-viewport.md) for the shipped extraction and viewport history.
 
 ## Data-model gotchas
 

--- a/docs/loom/roadmap.md
+++ b/docs/loom/roadmap.md
@@ -72,7 +72,7 @@ Shipped, next, and deferred. Read this when picking what to build next.
 
 All six original "next up" roadmap items are shipped, plus eight scope-expanded surfaces (palette, search-within-category, entity creation, deletion, discard, conscience ribbon, broken-ref finder, keyboard nav, atlas, ref-field editing, timeline scrubber, recents, tools tab). Loom is now in **beta** — every primary GUE workflow has a Loom equivalent.
 
-Beta vs alpha distinction: alpha was read-only browsing; beta covers full editing parity with GUE. Out-of-scope items (3D viewport, walk-in playtest, multi-cursor) remain in the deferred list below.
+Beta vs alpha distinction: alpha was read-only browsing; beta covers full editing parity with GUE. Out-of-scope items (walk-in playtest and multi-cursor) remain in the deferred list below; the zone viewport's World mode is shipped, while its remaining terrain, water, weather, and texture-painting follow-ups are listed separately.
 
 ## Next up
 

--- a/src/Tests/Modules/LoomBetaLabelTest.bb
+++ b/src/Tests/Modules/LoomBetaLabelTest.bb
@@ -43,6 +43,8 @@ End Test
 
 Test testLoomGuidanceIdentifiesTheShippedWorldMode()
 	Assert(FileContains%("docs\\loom\\README.md", "World mode renders the focused zone's real terrain, scenery, and water") = True)
+	Assert(FileContains%("docs\\loom\\README.md", "falls back to schematic mode when a zone has no visual `.dat`") = True)
+	Assert(FileContains%("docs\\loom\\README.md", "Terrain sculpting, water-volume editing, weather/environment editing, or scenery texture painting.") = True)
 	Assert(FileContains%("docs\\loom\\architecture.md", "Loom can render the 3D zone mesh in World mode") = True)
 	Assert(FileContains%("docs\\loom\\roadmap.md", "Out-of-scope items (walk-in playtest and multi-cursor) remain in the deferred list below") = True)
 	Assert(FileContains%("docs\\loom\\README.md", "Render zones in 3D.") = False)

--- a/src/Tests/Modules/LoomBetaLabelTest.bb
+++ b/src/Tests/Modules/LoomBetaLabelTest.bb
@@ -40,3 +40,12 @@ Test testCurrentFacingGuidanceCannotRegressToAlpha()
 	Assert(FileContains%("CLAUDE.md", "## Loom (alpha redesigned editor)") = False)
 	Assert(FileContains%("CLAUDE.md", "Read-only in the alpha; editing is a beta concern") = False)
 End Test
+
+Test testLoomGuidanceIdentifiesTheShippedWorldMode()
+	Assert(FileContains%("docs\\loom\\README.md", "World mode renders the focused zone's real terrain, scenery, and water") = True)
+	Assert(FileContains%("docs\\loom\\architecture.md", "Loom can render the 3D zone mesh in World mode") = True)
+	Assert(FileContains%("docs\\loom\\roadmap.md", "Out-of-scope items (walk-in playtest and multi-cursor) remain in the deferred list below") = True)
+	Assert(FileContains%("docs\\loom\\README.md", "Render zones in 3D.") = False)
+	Assert(FileContains%("docs\\loom\\architecture.md", "Loom cannot render the 3D zone mesh.") = False)
+	Assert(FileContains%("docs\\loom\\roadmap.md", "Out-of-scope items (3D viewport, walk-in playtest, multi-cursor)") = False)
+End Test


### PR DESCRIPTION
## Outcome

Loom's user-facing documentation now describes the shipped World-mode viewport instead of directing users away from it as a GUE-only future capability.

Fixes #719

## Technical changes

- Corrected the stale World-mode description in the Loom README and architecture guide.
- Removed the internally stale beta-roadmap summary that listed the shipped viewport as out of scope.
- Preserved the real deferred boundaries: terrain sculpting, water-volume editing, weather/environment editing, scenery texture painting, walk-in playtest, and collaboration.
- Added a focused `LoomBetaLabelTest` source contract for the shipped wording, schematic fallback, all remaining viewport deferrals, and legacy-denial rejection.

## Acceptance evidence

| Criterion | Evidence |
| --- | --- |
| Current docs identify shipped World mode | Bounded source contract requires real terrain/scenery/water wording in the README and World-mode rendering in architecture. |
| Schematic fallback remains documented | Contract requires the no-visual-`.dat` schematic fallback wording. |
| Deferred work remains explicit | Contract requires terrain/water/weather/texture-painting wording; docs retain walk-in playtest and collaboration. |
| Old denials cannot return | Contract rejects all three bounded legacy claims. |

## TDD and verification

- Baseline: `./test.sh LoomBetaLabelTest` exited `1` because `compiler/BlitzForge/bin/blitzcc` is absent; baseline source scan found all three stale claims.
- RED: after adding the new contract, the bounded Python source probe exited `1` with six expected mismatches (three required shipped statements absent and three legacy statements present).
- GREEN: the bounded contract exited `0` after the doc correction; its strengthened 11 assertions also exited `0` after review follow-up; `rg` found the bounded legacy claims absent; `git diff --check` exited `0`.
- Native limitation: narrow `git submodule update --init compiler/BlitzForge` timed out after 60 seconds. A safe `--depth 1` retry exited `128` (`Unable to find current revision`), so the focused native Blitz test remains for CI.

## Compatibility, risk, rollback, and deferred work

Docs/test-only change; no runtime, save-format, protocol, or compatibility impact. Revert commits `754652cf` and `54972a13` to roll back. This deliberately does not claim the remaining terrain/water/weather/texture-painting or playtest/collaboration work is shipped.

## Independent review

- Review cycle 1: `REQUEST_CHANGES` — missing regression assertions for schematic fallback and the four remaining viewport deferrals.
- Fresh review of exact head `54972a13a7b11986dfb43a43b6bad87f5782129a`: `ACCEPT`. The reviewer independently ran the strengthened 11-assertion contract and `git diff --check`; native compiler limitation remains documented.