### PR TITLE
Fix Windows publish argument and copy-failure handling

### DIFF
--- a/publish.bat
+++ b/publish.bat
@@ -4,7 +4,7 @@ setlocal
 set "ROOTDIR=%~dp0"
 if "%ROOTDIR:~-1%"=="\" set "ROOTDIR=%ROOTDIR:~0,-1%"
 
-call "%ROOTDIR%\compile.bat" || (
+call "%ROOTDIR%\compile.bat" %* || (
     echo Compilation failed; aborting publish.
     endlocal
     exit /b 1
@@ -16,14 +16,23 @@ if exist "%ROOTDIR%\release" rmdir /S /Q "%ROOTDIR%\release"
 
 mkdir "%ROOTDIR%\release"
 
-xcopy /E /Y /I "%ROOTDIR%\bin" "%ROOTDIR%\release\bin"
-xcopy /E /Y /I "%ROOTDIR%\bin\ReShade.ini.example" "%ROOTDIR%\release\bin\ReShade.ini"
-xcopy /Y "%ROOTDIR%\Project Manager.exe" "%ROOTDIR%\release\"
-xcopy /E /Y /I "%ROOTDIR%\data" "%ROOTDIR%\release\data"
-xcopy /E /Y /I "%ROOTDIR%\res" "%ROOTDIR%\release\res"
-xcopy /E /Y /I "%ROOTDIR%\docs" "%ROOTDIR%\release\docs"
-xcopy /E /Y /I "%ROOTDIR%\extras\Freemake" "%ROOTDIR%\release\extras\Freemake"
+call :CopyRequired /E /Y /I "%ROOTDIR%\bin" "%ROOTDIR%\release\bin" || exit /b 1
+call :CopyRequired /E /Y /I "%ROOTDIR%\bin\ReShade.ini.example" "%ROOTDIR%\release\bin\ReShade.ini" || exit /b 1
+call :CopyRequired /Y "%ROOTDIR%\Project Manager.exe" "%ROOTDIR%\release\" || exit /b 1
+call :CopyRequired /E /Y /I "%ROOTDIR%\data" "%ROOTDIR%\release\data" || exit /b 1
+call :CopyRequired /E /Y /I "%ROOTDIR%\res" "%ROOTDIR%\release\res" || exit /b 1
+call :CopyRequired /E /Y /I "%ROOTDIR%\docs" "%ROOTDIR%\release\docs" || exit /b 1
+call :CopyRequired /E /Y /I "%ROOTDIR%\extras\Freemake" "%ROOTDIR%\release\extras\Freemake" || exit /b 1
 
 if exist "%ROOTDIR%\release\res\Recent.dat" del "%ROOTDIR%\release\res\Recent.dat"
 
 endlocal
+exit /b 0
+
+:CopyRequired
+xcopy %*
+if errorlevel 1 (
+    echo Copy failed; aborting publish.
+    exit /b 1
+)
+exit /b 0

--- a/src/Tests/Modules/PublishBatchContractTest.bb
+++ b/src/Tests/Modules/PublishBatchContractTest.bb
@@ -55,17 +55,63 @@ Function RecentCleanupFollowsRequiredCopies%(Path$)
 	Return False
 End Function
 
+Function CompileForwardingFailsClosed%(Path$)
+	Local F.BBStream = ReadFile(Path$)
+	Local Line$
+	Local Stage% = 0
+	If F = Null Then F = ReadFile("..\" + Path$)
+	If F = Null Then F = ReadFile("..\..\" + Path$)
+	If F = Null Then Return False
+	While Not Eof(F)
+		Line$ = ReadLine$(F)
+		If Stage = 0 And Instr(Line$, "call " + Chr$(34) + "%ROOTDIR%\compile.bat" + Chr$(34) + " %* || (") > 0 Then Stage = 1
+		If Stage = 1 And Instr(Line$, "echo Compilation failed; aborting publish.") > 0 Then Stage = 2
+		If Stage = 2 And Instr(Line$, "endlocal") > 0 Then Stage = 3
+		If Stage = 3 And Instr(Line$, "exit /b 1") > 0
+			CloseFile F
+			Return True
+		EndIf
+	Wend
+	CloseFile F
+	Return False
+End Function
+
+Function CopyRequiredFailsClosed%(Path$)
+	Local F.BBStream = ReadFile(Path$)
+	Local Line$
+	Local Stage% = 0
+	If F = Null Then F = ReadFile("..\" + Path$)
+	If F = Null Then F = ReadFile("..\..\" + Path$)
+	If F = Null Then Return False
+	While Not Eof(F)
+		Line$ = ReadLine$(F)
+		If Stage = 0 And Instr(Line$, ":CopyRequired") > 0 Then Stage = 1
+		If Stage = 1 And Instr(Line$, "xcopy %*") > 0 Then Stage = 2
+		If Stage = 2 And Instr(Line$, "if errorlevel 1 (") > 0 Then Stage = 3
+		If Stage = 3 And Instr(Line$, "Copy failed; aborting publish.") > 0 Then Stage = 4
+		If Stage = 4 And Instr(Line$, "exit /b 1") > 0
+			CloseFile F
+			Return True
+		EndIf
+	Wend
+	CloseFile F
+	Return False
+End Function
+
 Test testPublishForwardsRequestedBuildFlags()
-	Assert(FileContains%("publish.bat", "call " + Chr$(34) + "%ROOTDIR%\compile.bat" + Chr$(34) + " %* || (") = True)
+	Assert(CompileForwardingFailsClosed%("publish.bat") = True)
 End Test
 
 Test testPublishFailsWhenARequiredPayloadCopyFails()
 	Assert(FileOccurrenceCount%("publish.bat", "call :CopyRequired ") = 7)
-	Assert(FileOccurrenceCount%("publish.bat", " || exit /b 1") = 7)
-	Assert(FileContains%("publish.bat", ":CopyRequired") = True)
-	Assert(FileContains%("publish.bat", "xcopy %*") = True)
-	Assert(FileContains%("publish.bat", "if errorlevel 1 (") = True)
-	Assert(FileContains%("publish.bat", "Copy failed; aborting publish.") = True)
+	Assert(FileContains%("publish.bat", "call :CopyRequired /E /Y /I " + Chr$(34) + "%ROOTDIR%\bin" + Chr$(34) + " " + Chr$(34) + "%ROOTDIR%\release\bin" + Chr$(34) + " || exit /b 1") = True)
+	Assert(FileContains%("publish.bat", "call :CopyRequired /E /Y /I " + Chr$(34) + "%ROOTDIR%\bin\ReShade.ini.example" + Chr$(34) + " " + Chr$(34) + "%ROOTDIR%\release\bin\ReShade.ini" + Chr$(34) + " || exit /b 1") = True)
+	Assert(FileContains%("publish.bat", "call :CopyRequired /Y " + Chr$(34) + "%ROOTDIR%\Project Manager.exe" + Chr$(34) + " " + Chr$(34) + "%ROOTDIR%\release\" + Chr$(34) + " || exit /b 1") = True)
+	Assert(FileContains%("publish.bat", "call :CopyRequired /E /Y /I " + Chr$(34) + "%ROOTDIR%\data" + Chr$(34) + " " + Chr$(34) + "%ROOTDIR%\release\data" + Chr$(34) + " || exit /b 1") = True)
+	Assert(FileContains%("publish.bat", "call :CopyRequired /E /Y /I " + Chr$(34) + "%ROOTDIR%\res" + Chr$(34) + " " + Chr$(34) + "%ROOTDIR%\release\res" + Chr$(34) + " || exit /b 1") = True)
+	Assert(FileContains%("publish.bat", "call :CopyRequired /E /Y /I " + Chr$(34) + "%ROOTDIR%\docs" + Chr$(34) + " " + Chr$(34) + "%ROOTDIR%\release\docs" + Chr$(34) + " || exit /b 1") = True)
+	Assert(FileContains%("publish.bat", "call :CopyRequired /E /Y /I " + Chr$(34) + "%ROOTDIR%\extras\Freemake" + Chr$(34) + " " + Chr$(34) + "%ROOTDIR%\release\extras\Freemake" + Chr$(34) + " || exit /b 1") = True)
+	Assert(CopyRequiredFailsClosed%("publish.bat") = True)
 End Test
 
 Test testPublishKeepsRecentProjectStateOutOfTheRelease()

--- a/src/Tests/Modules/PublishBatchContractTest.bb
+++ b/src/Tests/Modules/PublishBatchContractTest.bb
@@ -1,0 +1,74 @@
+Strict
+EnableGC
+
+; publish.bat is a committed contributor/release interface. Keep this source
+; contract standalone so it does not require the compiler or runtime graph.
+
+Function FileContains%(Path$, Needle$)
+	Local F.BBStream = ReadFile(Path$)
+	Local Line$
+	If F = Null Then F = ReadFile("..\" + Path$)
+	If F = Null Then F = ReadFile("..\..\" + Path$)
+	If F = Null Then Return False
+	While Not Eof(F)
+		Line$ = ReadLine$(F)
+		If Instr(Line$, Needle$) > 0
+			CloseFile F
+			Return True
+		EndIf
+	Wend
+	CloseFile F
+	Return False
+End Function
+
+Function FileOccurrenceCount%(Path$, Needle$)
+	Local F.BBStream = ReadFile(Path$)
+	Local Line$
+	Local Count% = 0
+	If F = Null Then F = ReadFile("..\" + Path$)
+	If F = Null Then F = ReadFile("..\..\" + Path$)
+	If F = Null Then Return 0
+	While Not Eof(F)
+		Line$ = ReadLine$(F)
+		If Instr(Line$, Needle$) > 0 Then Count = Count + 1
+	Wend
+	CloseFile F
+	Return Count
+End Function
+
+Function RecentCleanupFollowsRequiredCopies%(Path$)
+	Local F.BBStream = ReadFile(Path$)
+	Local Line$
+	Local CopyCount% = 0
+	If F = Null Then F = ReadFile("..\" + Path$)
+	If F = Null Then F = ReadFile("..\..\" + Path$)
+	If F = Null Then Return False
+	While Not Eof(F)
+		Line$ = ReadLine$(F)
+		If Instr(Line$, "call :CopyRequired ") > 0 Then CopyCount = CopyCount + 1
+		If Instr(Line$, "if exist " + Chr$(34) + "%ROOTDIR%\release\res\Recent.dat" + Chr$(34) + " del ") > 0
+			CloseFile F
+			Return CopyCount = 7
+		EndIf
+	Wend
+	CloseFile F
+	Return False
+End Function
+
+Test testPublishForwardsRequestedBuildFlags()
+	Assert(FileContains%("publish.bat", "call " + Chr$(34) + "%ROOTDIR%\compile.bat" + Chr$(34) + " %* || (") = True)
+End Test
+
+Test testPublishFailsWhenARequiredPayloadCopyFails()
+	Assert(FileOccurrenceCount%("publish.bat", "call :CopyRequired ") = 7)
+	Assert(FileOccurrenceCount%("publish.bat", " || exit /b 1") = 7)
+	Assert(FileContains%("publish.bat", ":CopyRequired") = True)
+	Assert(FileContains%("publish.bat", "xcopy %*") = True)
+	Assert(FileContains%("publish.bat", "if errorlevel 1 (") = True)
+	Assert(FileContains%("publish.bat", "Copy failed; aborting publish.") = True)
+End Test
+
+Test testPublishKeepsRecentProjectStateOutOfTheRelease()
+	Assert(FileContains%("publish.bat", "if exist " + Chr$(34) + "%ROOTDIR%\release\res\Recent.dat" + Chr$(34) + " del " + Chr$(34) + "%ROOTDIR%\release\res\Recent.dat" + Chr$(34)) = True)
+	Assert(RecentCleanupFollowsRequiredCopies%("publish.bat") = True)
+End Test


### PR DESCRIPTION
## Outcome

Windows contributors can now use `publish.bat -b` without silently dropping the requested BlitzForge rebuild, and packaging stops instead of producing a partial release when a required payload copy fails.

## Technical changes

- Forward `%*` from `publish.bat` to `compile.bat`.
- Route all seven required payload copies through a local `:CopyRequired` helper that propagates `xcopy` failures.
- Preserve the existing compile failure gate and `release\res\Recent.dat` cleanup.
- Add a standalone Blitz source-contract regression test for forwarding, each required copy path, fail-closed ordering, and cleanup order.

Fixes #721

## Acceptance criteria and evidence

1. Build flags are forwarded and compilation remains fail-closed: the contract follows the forwarded compile call through its error message, `endlocal`, and nonzero exit.
2. Each required `bin`, `ReShade.ini.example`, `Project Manager.exe`, `data`, `res`, `docs`, and `extras\Freemake` copy uses `call :CopyRequired ... || exit /b 1`; the contract binds every full statement.
3. The helper executes `xcopy %*`, tests `if errorlevel 1`, reports the failure, and returns nonzero; the contract pins that order.
4. `Recent.dat` cleanup remains after all seven required copies.

## Verification

- Baseline source probe: exit `1`; absent `%*` forwarding and all seven copies unguarded.
- RED: focused source-contract probe exit `1` with `AssertionError: publish does not forward caller build flags`.
- GREEN: strengthened focused source contract exit `0`; `bash scripts/gen_packet_index.sh --check` exit `0`; `bash scripts/gen_bvm_reference.sh --check` exit `0` with only two known dead-implementation warnings; `git diff --check` exit `0`.
- Native focused command: `./test.sh PublishBatchContractTest` exit `1` before compilation because the Linux worktree has no `compiler/BlitzForge/bin/blitzcc` after successful narrow submodule initialization. Exact-head Windows CI remains the native proof.

## Compatibility, risk, rollback, deferred work

Successful invocations retain the release layout. Invalid/missing required inputs now fail nonzero rather than reporting an incomplete package as successful. Rollback is reverting commits `79d30f14` and `3171cde2`. No release/deployment occurred. Unix packaging and broader packaging cleanup are deliberately out of scope.

## Independent review

Fresh reviewer verdict for exact head `3171cde2bc60533f34fab6f2dea809bad1c1b9b8`: **ACCEPT**. It independently verified the full seven-path contract, helper ordering, cleanup ordering, scope, and generated checks. CI was pending at review time.