### PR TITLE
fix(client): safely sweep Interface3D chat nodes

### DIFF
--- a/src/Modules/Interface3D.bb
+++ b/src/Modules/Interface3D.bb
@@ -1602,7 +1602,10 @@ Function UpdateInterface()
 	If First Dialog = Null And First TextInput = Null And MouseDown(2) = False Then InDialog = False : FlushMouse()
 
 	;- Update chat bubbles
-	For Bubble.Bubble = Each Bubble
+	Local Bubble.Bubble = First Bubble
+	Local BNext.Bubble = Null
+	While Bubble <> Null
+		BNext = After Bubble
 		; Position above character's head
 		AI.ActorInstance = Bubble\ActorInstance
 		If AI <> Null
@@ -1632,7 +1635,8 @@ Function UpdateInterface()
 			FreeEntity(Bubble\EN)
 			Delete(Bubble)
 		EndIf
-	Next
+		Bubble = BNext
+	Wend
 
 	; Update quest log window
 	If QuestLogVisible = True
@@ -3051,13 +3055,17 @@ EndIf
 
 ;Increased Chat fader timer from 10 to 15 seconds cysis145
 	; Make current chat text disappear after 15 seconds
-	For CC.CurrentChat = Each CurrentChat
+	Local CC.CurrentChat = First CurrentChat
+	Local CCNext.CurrentChat = Null
+	While CC <> Null
+		CCNext = After CC
 		If MilliSecs() - CC\Timer > 15000
 			Delete(CC)
 			; Remove from display
 			If HistoryMode = False Then UpdateChatTextDisplay()
 		EndIf
-	Next
+		CC = CCNext
+	Wend
 	
 	;If ( ControlDown(29) Or ControlDown(157) ) And ControlDown(199) ; Ctrl + Home [#@#]
 	;	ToggleDebugBannerVisibility()

--- a/src/Tests/Modules/Interface3DIteratorTest.bb
+++ b/src/Tests/Modules/Interface3DIteratorTest.bb
@@ -1,0 +1,53 @@
+Strict
+EnableGC
+
+; Source-contract regression for UpdateInterface cleanup loops. Blitz3D's
+; For Each cursor cannot safely advance after its current node is deleted, so
+; both bounded sections must capture After before cleanup and advance via it.
+
+Function CleanupSectionUsesAfterCursor%(Path$, StartMarker$, EndMarker$, LegacyFor$, FirstCursor$, NextDeclaration$, WhileCursor$, Capture$, FirstCleanup$, Cleanup$, Advance$)
+	Local F.BBStream = ReadFile(Path$)
+	Local Stage%
+	Local Line$
+	If F = Null Then F = ReadFile("..\" + Path$)
+	If F = Null Then F = ReadFile("..\..\" + Path$)
+	If F = Null Then Return False
+	While Not Eof(F)
+		Line$ = ReadLine$(F)
+		If Stage = 0 And Instr(Line$, StartMarker$) > 0 Then Stage = 1
+		If Stage > 0 And Instr(Line$, LegacyFor$) > 0 Then
+			CloseFile F
+			Return False
+		EndIf
+		If Stage = 1
+			If Instr(Line$, FirstCursor$) > 0 Then Stage = 2
+		ElseIf Stage = 2
+			If Instr(Line$, NextDeclaration$) > 0 Then Stage = 3
+		ElseIf Stage = 3
+			If Instr(Line$, WhileCursor$) > 0 Then Stage = 4
+		ElseIf Stage = 4
+			If Instr(Line$, Capture$) > 0 Then Stage = 5
+		ElseIf Stage = 5
+			If FirstCleanup$ = "" Then Stage = 6
+			If Instr(Line$, FirstCleanup$) > 0 Then Stage = 6
+		ElseIf Stage = 6
+			If Instr(Line$, Cleanup$) > 0 Then Stage = 7
+		ElseIf Stage = 7
+			If Instr(Line$, Advance$) > 0 Then
+				CloseFile F
+				Return True
+			EndIf
+		EndIf
+		If Stage > 0 And Instr(Line$, EndMarker$) > 0 Then Exit
+	Wend
+	CloseFile F
+	Return False
+End Function
+
+Test testBubbleCleanupCapturesNextBeforeDeletingBubble()
+	Assert(CleanupSectionUsesAfterCursor%("Modules\Interface3D.bb", "Update chat bubbles", "; Update quest log window", "For Bubble.Bubble = Each Bubble", "Local Bubble.Bubble = First Bubble", "Local BNext.Bubble = Null", "While Bubble <> Null", "BNext = After Bubble", "FreeEntity(Bubble\EN)", "Delete(Bubble)", "Bubble = BNext") = True)
+End Test
+
+Test testCurrentChatCleanupCapturesNextBeforeDeletingCurrentChat()
+	Assert(CleanupSectionUsesAfterCursor%("Modules\Interface3D.bb", "; Make current chat text disappear after 15 seconds", ";If ( ControlDown", "For CC.CurrentChat = Each CurrentChat", "Local CC.CurrentChat = First CurrentChat", "Local CCNext.CurrentChat = Null", "While CC <> Null", "CCNext = After CC", "", "Delete(CC)", "CC = CCNext") = True)
+End Test

--- a/src/Tests/Modules/Interface3DIteratorTest.bb
+++ b/src/Tests/Modules/Interface3DIteratorTest.bb
@@ -19,6 +19,16 @@ Function CleanupSectionUsesAfterCursor%(Path$, StartMarker$, EndMarker$, LegacyF
 			CloseFile F
 			Return False
 		EndIf
+		If Stage > 0 And Stage < 5
+			If FirstCleanup$ <> "" And Instr(Line$, FirstCleanup$) > 0 Then
+				CloseFile F
+				Return False
+			EndIf
+			If Instr(Line$, Cleanup$) > 0 Then
+				CloseFile F
+				Return False
+			EndIf
+		EndIf
 		If Stage = 1
 			If Instr(Line$, FirstCursor$) > 0 Then Stage = 2
 		ElseIf Stage = 2


### PR DESCRIPTION
## Outcome

Chat bubbles and expired chat-history entries can now be cleaned up safely in bursts, without deleting the active Blitz3D iterator cursor.

## Technical changes

- Replace the two deleting `For Each` loops in `UpdateInterface` with documented `First` / `After` / `While` walks.
- Add a bounded regression contract for both Bubble and CurrentChat cleanup sections.

Fixes #723

## Acceptance evidence

- Bubble: the source contract verifies `BNext = After Bubble` precedes `FreeEntity`/`Delete`, and `Bubble = BNext` follows cleanup.
- CurrentChat: the source contract verifies `CCNext = After CC` precedes `Delete`, and `CC = CCNext` follows cleanup.
- Both contracts reject the legacy deleting `For Each` loops and cleanup before cursor capture.

## TDD and verification

- Baseline: the two legacy loops were present; `./test.sh Interface3DIteratorTest` exited 1 because `compiler/BlitzForge/bin/blitzcc` is not supplied locally.
- RED: bounded source probe exited 1 with `expected RED: bounded cleanup sections still use deleting For Each loops`.
- GREEN/final: bounded source contract exited 0 and reported both safe orderings; `bash scripts/gen_packet_index.sh --check`, `bash scripts/gen_bvm_reference.sh --check`, and `git diff --check origin/develop...HEAD` exited 0. The BVM check retains two known dead-command warnings only.
- Native test caveat: narrow submodule initialization succeeded (`--depth 1`, exit 0), but still supplies no `bin/blitzcc`; Windows Build and test CI is required for native execution.

## Compatibility, risk, rollback, and follow-up

The existing positioning, fading, stale-actor cleanup, and 15-second expiry predicates are unchanged. Risk is low because only iterator traversal changes, using the repository-documented idiom. Rollback is a single revert. No deferred follow-up.

## Independent review

`ACCEPT` — fresh review of exact head `8ec0f08408ec809f6c56aa29323baed097fde818` confirmed scope, after-cursor ordering, legacy-loop rejection, and pre-capture cleanup rejection.
