### PR TITLE
fix(GUE): drain modal events with after cursors

### DIFF
--- a/src/GUE.bb
+++ b/src/GUE.bb
@@ -8984,15 +8984,19 @@ Function ScaleEntireZoneDialog()
 	Repeat
 
 		; Events
-		For E.Event = Each Event
-			Select E\EventID
+		Local ScaleEvent.Event = First Event
+		Local NextScaleEvent.Event = Null
+		While ScaleEvent <> Null
+			NextScaleEvent = After ScaleEvent
+			Select ScaleEvent\EventID
 				Case BCancel
 					Done = 2
 				Case BDone
 					Done = 1
 			End Select
-			Delete(E)
-		Next
+			Delete(ScaleEvent)
+			ScaleEvent = NextScaleEvent
+		Wend
 
 		; Render
 		FUI_Update()
@@ -10398,11 +10402,14 @@ Function GenerateGamePatch()
 	Repeat
 		FUI_Update()
 		Flip(0)
-		For E.Event = Each Event
-			Select E\EventID
+		Local QuitEvent.Event = First Event
+		Local NextQuitEvent.Event = Null
+		While QuitEvent <> Null
+			NextQuitEvent = After QuitEvent
+			Select QuitEvent\EventID
 				; Window closed
 				Case W
-					If Lower$(E\EventData$) = "closed"
+					If Lower$(QuitEvent\EventData$) = "closed"
 						FUI_DeleteGadget(W)
 						Return
 					EndIf
@@ -10411,8 +10418,9 @@ Function GenerateGamePatch()
 					FUI_DeleteGadget(W)
 					Return
 			End Select
-			Delete(E)
-		Next
+			Delete(QuitEvent)
+			QuitEvent = NextQuitEvent
+		Wend
 	Forever
 
 End Function

--- a/src/Tests/Modules/GUEEventIteratorTest.bb
+++ b/src/Tests/Modules/GUEEventIteratorTest.bb
@@ -1,0 +1,48 @@
+Strict
+EnableGC
+
+; GUE consumes F-UI Event objects in two modal loops. The current event must
+; save its successor before Delete so a burst of queued events is fully drained.
+
+Function GUEEventDrainUsesAfterCursor%(Path$, FunctionMarker$, LegacyFor$, FirstCursor$, NextDeclaration$, WhileCursor$, Capture$, DeleteEvent$, Advance$)
+	Local F.BBStream = ReadFile(Path$)
+	Local Stage%
+	Local Line$
+	If F = Null Then F = ReadFile("..\\" + Path$)
+	If F = Null Then F = ReadFile("..\\..\\" + Path$)
+	If F = Null Then Return False
+
+	While Not Eof(F)
+		Line$ = ReadLine$(F)
+		If Stage = 0 And Instr(Line$, FunctionMarker$) > 0 Then Stage = 1
+		If Stage > 0 And Instr(Line$, LegacyFor$) > 0 Then
+			CloseFile F
+			Return False
+		EndIf
+		If Stage = 1 And Instr(Line$, FirstCursor$) > 0 Then Stage = 2
+		If Stage = 2 And Instr(Line$, NextDeclaration$) > 0 Then Stage = 3
+		If Stage = 3 And Instr(Line$, WhileCursor$) > 0 Then Stage = 4
+		If Stage = 4 And Instr(Line$, Capture$) > 0 Then Stage = 5
+		If Stage < 5 And Instr(Line$, DeleteEvent$) > 0 Then
+			CloseFile F
+			Return False
+		EndIf
+		If Stage = 5 And Instr(Line$, DeleteEvent$) > 0 Then Stage = 6
+		If Stage = 6 And Instr(Line$, Advance$) > 0 Then
+			CloseFile F
+			Return True
+		EndIf
+		If Stage > 0 And Instr(Line$, "End Function") > 0 Then Exit
+	Wend
+
+	CloseFile F
+	Return False
+End Function
+
+Test testScaleEntireZoneDialogCapturesNextEventBeforeDelete()
+	Assert(GUEEventDrainUsesAfterCursor%("GUE.bb", "Function ScaleEntireZoneDialog()", "For E.Event = Each Event", "Local ScaleEvent.Event = First Event", "Local NextScaleEvent.Event = Null", "While ScaleEvent <> Null", "NextScaleEvent = After ScaleEvent", "Delete(ScaleEvent)", "ScaleEvent = NextScaleEvent") = True)
+End Test
+
+Test testGenerateGamePatchCapturesNextEventBeforeDelete()
+	Assert(GUEEventDrainUsesAfterCursor%("GUE.bb", "Function GenerateGamePatch()", "For E.Event = Each Event", "Local QuitEvent.Event = First Event", "Local NextQuitEvent.Event = Null", "While QuitEvent <> Null", "NextQuitEvent = After QuitEvent", "Delete(QuitEvent)", "QuitEvent = NextQuitEvent") = True)
+End Test


### PR DESCRIPTION
## Outcome

GUE now drains every queued F-UI event safely in two modal UI flows, avoiding iterator traversal through a just-deleted event. Cancel/OK and patch-window close/Done behavior are unchanged.

## Changes

- Replaced the deleting `For Each Event` drains in `ScaleEntireZoneDialog` and `GenerateGamePatch` with typed `First` / `After` / `While` cursor walks.
- Added `GUEEventIteratorTest.bb`, a bounded source-contract regression that rejects the legacy loops and requires capture-before-delete/advance ordering in both functions.

Fixes #727

## Acceptance evidence

| Criterion | Evidence |
| --- | --- |
| Both drains capture and advance safely | Green bounded source contract requires the two `First` / `After` / `While` sequences and legacy-loop absence. |
| Existing UI outcomes stay intact | The original `Select` cases and early returns remain in place; only traversal variables changed. |
| Regression coverage exists | New focused `GUEEventIteratorTest.bb` pins each bounded section and ordering. |

## Baseline, RED, GREEN, and final verification

- Baseline: `rg -n -U 'For E.Event = Each Event[\s\S]{0,500}?Delete\(E)' src/GUE.bb` found both unsafe loops; bounded baseline probe exited `0` with `BASELINE_UNSAFE_LOOPS_PRESENT`.
- RED: the new-contract source probe exited `1` with `RED: GUEEventIteratorTest contract would fail because both safe cursor sequences are absent`.
- GREEN: the bounded after-cursor source contract exited `0`; `git diff --check` exited `0`.
- Native focused check: `./test.sh GUEEventIteratorTest` exited `1` before test execution because `compiler/BlitzForge/bin/blitzcc` is absent. Narrow submodule initialization timed out after 60 seconds; a `--depth 1` retry exited `128` (`Unable to find current revision`). Exact-head CI is required for native compiler proof.

## Compatibility, risks, rollback, and deferred work

No F-UI event IDs, payloads, generated docs, or behavior outside the two modal drains changed. Risk is confined to retaining legacy modal-flow behavior while changing cursor safety. Rollback is reverting commit `55968192`. The separate Rust build-documentation and contributor-CI-documentation findings are deliberately deferred.

## Independent review

ACCEPT — fresh independent reviewer inspected exact head `5596819296af0a0bb69ed404b5bfb9a2f88a8530` against `d9eaee53`, confirmed both capture-before-delete/advance sequences, bounded test quality, scope, compatibility, and no correctness, security, performance, concurrency, or documentation findings. Native CI remained pending at review time.