### PR TITLE
fix(fui): safely drain teardown resource pools

### DIFF
--- a/src/Modules/F-UI.bb
+++ b/src/Modules/F-UI.bb
@@ -16970,13 +16970,17 @@ Function FUI_Destroy(  )
 	Delete Each ComboBox
 	Delete Each ComboBoxItem
 	Delete Each GroupBox
-	For img.ImageBox = Each ImageBox
+	Local img.ImageBox = First ImageBox
+	Local imgNext.ImageBox = Null
+	While img <> Null
+		imgNext = After img
 		If img\Image <> Null
 			FreeImage img\Image
 			img\Image = Null
 		EndIf
 		Delete img
-	Next
+		img = imgNext
+	Wend
 	Delete Each Label
 	Delete Each ListBox
 	Delete Each ListBoxItem
@@ -16988,17 +16992,25 @@ Function FUI_Destroy(  )
 	Delete Each TextBox
 	Delete Each TreeView
 	Delete Each Node
-	For view.View = Each View
+	Local view.View = First View
+	Local viewNext.View = Null
+	While view <> Null
+		viewNext = After view
 		FreeEntity view\Cam
 		
 		Delete view
-	Next
-	For m.Mesh = Each Mesh
+		view = viewNext
+	Wend
+	Local m.Mesh = First Mesh
+	Local mNext.Mesh = Null
+	While m <> Null
+		mNext = After m
 		If m\Mesh <> Null FreeEntity m\Mesh
 			m\Mesh = Null
 		
 		Delete m
-	Next
+		m = mNext
+	Wend
 	
 	If ICON_NEW <> Null
 		FreeImage ICON_NEW

--- a/src/Tests/Modules/FUIDestroyIteratorTest.bb
+++ b/src/Tests/Modules/FUIDestroyIteratorTest.bb
@@ -1,0 +1,55 @@
+Strict
+EnableGC
+
+; FUI_Destroy owns resource pools whose current nodes are freed during cleanup.
+; Each bounded loop must save After before freeing/deleting its current node.
+
+Function FUIDestroySectionUsesAfterCursor%(Path$, LegacyFor$, FirstCursor$, NextDeclaration$, WhileCursor$, Capture$, FirstCleanup$, DeleteNode$, Advance$)
+	Local F.BBStream = ReadFile(Path$)
+	Local InDestroy%, Stage%
+	Local Line$
+	If F = Null Then F = ReadFile("..\" + Path$)
+	If F = Null Then F = ReadFile("..\..\" + Path$)
+	If F = Null Then Return False
+
+	While Not Eof(F)
+		Line$ = ReadLine$(F)
+		If Instr(Line$, "Function FUI_Destroy(  )") > 0 Then InDestroy = True
+		If InDestroy = True
+			If Instr(Line$, LegacyFor$) > 0 Then
+				CloseFile F
+				Return False
+			EndIf
+			If Stage < 4 And (Instr(Line$, FirstCleanup$) > 0 Or Instr(Line$, DeleteNode$) > 0)
+				CloseFile F
+				Return False
+			EndIf
+			If Stage = 0 And Instr(Line$, FirstCursor$) > 0 Then Stage = 1
+			If Stage = 1 And Instr(Line$, NextDeclaration$) > 0 Then Stage = 2
+			If Stage = 2 And Instr(Line$, WhileCursor$) > 0 Then Stage = 3
+			If Stage = 3 And Instr(Line$, Capture$) > 0 Then Stage = 4
+			If Stage = 4 And Instr(Line$, FirstCleanup$) > 0 Then Stage = 5
+			If Stage = 5 And Instr(Line$, DeleteNode$) > 0 Then Stage = 6
+			If Stage = 6 And Instr(Line$, Advance$) > 0 Then
+				CloseFile F
+				Return True
+			EndIf
+			If Instr(Line$, "End Function") > 0 Then Exit
+		EndIf
+	Wend
+
+	CloseFile F
+	Return False
+End Function
+
+Test testFUIDestroyImageBoxesCaptureNextBeforeFreeAndDelete()
+	Assert(FUIDestroySectionUsesAfterCursor%("Modules\F-UI.bb", "For img.ImageBox = Each ImageBox", "Local img.ImageBox = First ImageBox", "Local imgNext.ImageBox = Null", "While img <> Null", "imgNext = After img", "FreeImage img\Image", "Delete img", "img = imgNext") = True)
+End Test
+
+Test testFUIDestroyViewsCaptureNextBeforeFreeAndDelete()
+	Assert(FUIDestroySectionUsesAfterCursor%("Modules\F-UI.bb", "For view.View = Each View", "Local view.View = First View", "Local viewNext.View = Null", "While view <> Null", "viewNext = After view", "FreeEntity view\Cam", "Delete view", "view = viewNext") = True)
+End Test
+
+Test testFUIDestroyMeshesCaptureNextBeforeFreeAndDelete()
+	Assert(FUIDestroySectionUsesAfterCursor%("Modules\F-UI.bb", "For m.Mesh = Each Mesh", "Local m.Mesh = First Mesh", "Local mNext.Mesh = Null", "While m <> Null", "mNext = After m", "FreeEntity m\Mesh", "Delete m", "m = mNext") = True)
+End Test


### PR DESCRIPTION
## Outcome

F-UI teardown no longer loses ImageBox, View, or Mesh nodes when several resources are cleaned up together. This prevents incomplete cleanup and iterator corruption across Project Manager, GUE, and RC Terrain Editor shutdown paths.

## Technical changes

- Replace the three destructive `FUI_Destroy` `For Each` resource-pool loops with `First` / `After` / `While` cursor walks.
- Preserve existing `FreeImage`, `FreeEntity`, nulling, and `Delete` operations; only cursor sequencing changes.
- Add `FUIDestroyIteratorTest.bb`, a bounded source contract for ImageBox, View, and Mesh cleanup order.

Fixes #729

## Acceptance criteria and evidence

- Successor captured before resource cleanup: source contract green (exit 0) for all three pools.
- Successor advanced after delete: source contract green (exit 0) for all three pools.
- Legacy destructive loops absent from bounded `FUI_Destroy` sections: scoped static scan passed.
- Existing cleanup operations retained: reviewed diff preserves each resource-specific free/delete path.

## TDD and verification

- Baseline: `./test.sh FUIDestroyIteratorTest` exit 1 because `compiler/BlitzForge/bin/blitzcc` is absent; the three-loop source probe observed all legacy loops and exited 1.
- RED: after adding the focused contract, the mirrored bounded contract exited 1 with `ImageBox`, `View`, and `Mesh` legacy-iterator findings.
- GREEN: the same bounded contract exited 0 after the cursor changes; `git diff --check` exited 0.
- Native limitation: normal `git submodule update --init compiler/BlitzForge` timed out after 60s; `--depth 1` retry exited 128 (`Unable to find current revision`). Exact-head CI is required for compiler/runtime proof.

## Compatibility, risk, rollback, and deferred work

No public API, data format, or protocol changes. Risk is limited to cleanup sequencing; existing frees/deletes stay in place. Rollback is a single revert. Other F-UI loops, GUE dialogs, Loom toasts, protocol docs, and generated artifacts are deliberately out of scope.

## Independent review

ACCEPT — a fresh independent review of exact head 55641ad1ff6df6d17bd6b06eb83f0906306a08e5 found the cleanup ordering, bounded contract, scope, and compatibility fit valid. Local native execution remains unavailable; Build and test CI is still required.