### PR TITLE
fix(loom): safely drain expired toast notifications

### DIFF
--- a/src/Modules/Loom/Toasts.bb
+++ b/src/Modules/Loom/Toasts.bb
@@ -110,13 +110,16 @@ Type Toasts
     // -------------------------------------------------------------------------
     Method render(sw%, sh%)
         // Garbage-collect expired
-        Local t.Toast
-        For t = Each Toast
+        Local t.Toast = First Toast
+        Local nextToast.Toast = Null
+        While t <> Null
+            nextToast = After t
             If (MilliSecs() - t\CreatedAt) >= TOAST_TTL_MS
                 Delete t
                 self\count = self\count - 1
             EndIf
-        Next
+            t = nextToast
+        Wend
 
         If self\count = 0 Then Return
 

--- a/src/Tests/Modules/LoomToastIteratorTest.bb
+++ b/src/Tests/Modules/LoomToastIteratorTest.bb
@@ -1,0 +1,54 @@
+Strict
+EnableGC
+
+// Toasts.bb is part of Loom's renderer graph, so this source contract binds
+// the expiry sweep's deletion-safe traversal without loading the editor.
+
+Function ToastExpirySweepUsesAfterCursor%(Path$)
+	Local F.BBStream = ReadFile(Path$)
+	Local Line$, Trimmed$
+	Local InRender%, Stage%
+	If F = Null Then F = ReadFile("..\" + Path$)
+	If F = Null Then F = ReadFile("..\..\" + Path$)
+	If F = Null Then Return False
+
+	While Not Eof(F)
+		Line$ = ReadLine$(F)
+		Trimmed$ = Trim$(Line$)
+		If Trimmed$ = "Method render(sw%, sh%)" Then InRender = True
+		If InRender = False Then Continue
+		If Trimmed$ = "For t = Each Toast"
+			CloseFile F
+			Return False
+		EndIf
+		Select Stage
+			Case 0
+				If Trimmed$ = "Local t.Toast = First Toast" Then Stage = 1
+			Case 1
+				If Trimmed$ = "Local nextToast.Toast = Null" Then Stage = 2
+			Case 2
+				If Trimmed$ = "While t <> Null" Then Stage = 3
+			Case 3
+				If Trimmed$ = "nextToast = After t" Then Stage = 4
+			Case 4
+				If Trimmed$ = "If (MilliSecs() - t\CreatedAt) >= TOAST_TTL_MS" Then Stage = 5
+			Case 5
+				If Trimmed$ = "Delete t" Then Stage = 6
+			Case 6
+				If Trimmed$ = "self\count = self\count - 1" Then Stage = 7
+			Case 7
+				If Trimmed$ = "t = nextToast" Then Stage = 8
+		End Select
+		If Trimmed$ = "End Method"
+			CloseFile F
+			Return Stage = 8
+		EndIf
+	Wend
+
+	CloseFile F
+	Return False
+End Function
+
+Test testExpiredToastsCaptureTheSuccessorBeforeDeletion()
+	Assert(ToastExpirySweepUsesAfterCursor%("Modules\Loom\Toasts.bb") = True)
+End Test


### PR DESCRIPTION
## Outcome
Expired Loom notifications are now drained reliably, so adjacent expired toasts cannot be skipped or leave the notification count out of sync.

## Technical changes
- Replaced the destructive expiry `For Each` in `Toasts::render` with the established `First` / `After` / `While` traversal.
- Added `LoomToastIteratorTest.bb`, a bounded source-contract regression test that rejects the legacy loop and requires successor capture before deletion, count update, and advance.

Fixes #731

## Acceptance criteria and evidence
- Successor captured before deletion: required by the new source contract; GREEN replay completed stage 8.
- Consecutive expired entries are traversable: successor is captured before the TTL predicate, then used after any deletion.
- Legacy destructive loop absent: GREEN probe confirmed no `For t = Each Toast` in the expiry pass.
- Regression coverage: `src/Tests/Modules/LoomToastIteratorTest.bb` binds the full order.

## Baseline, RED, and GREEN
- Baseline: `src/Modules/Loom/Toasts.bb:114-119` used `For t = Each Toast` with `Delete t`; local focused runner exited 1 before test execution because `compiler/BlitzForge/bin/blitzcc` is absent.
- RED: bounded source-contract probe exited 1 with `RED_EXPECTED: expiry sweep lacks the required successor-capture traversal`.
- GREEN: bounded replay exited 0 (`SOURCE_CONTRACT_REPLAY_GREEN stage=8`); `git diff --check`, `bash scripts/gen_packet_index.sh --check`, `bash scripts/gen_bvm_reference.sh --check`, and `bash -n test.sh` exited 0. The BVM check emitted two existing dead-command warnings.

## Compatibility, risk, rollback, and deferred work
- TTL, rendering order, cap, toast style, and public interfaces are unchanged.
- Low risk: this follows the repository-standard `After` cursor pattern for delete-current loops.
- Rollback: revert commit `03a64930`.
- Deferred: unrelated Loom and toast rendering behavior is intentionally out of scope.

## Independent review
ACCEPT — fresh independent review of exact head 03a64930d6d0dae988ef15d0d80690eecc9e76cc found the scope, cursor ordering, regression contract, compatibility, and repository fit acceptable.