### PR TITLE
fix(GUE): safely reconcile unmatched water during zone load

### DIFF
--- a/src/GUE.bb
+++ b/src/GUE.bb
@@ -4888,7 +4888,10 @@ Cls
 					ClearTextureFilters() : TextureFilter("m_", 1 + 4) : TextureFilter("a_", 1 + 2)
 
 					; Match client water with server water
-					For W.Water = Each Water
+					Local W.Water = First Water
+					Local WNext.Water = Null
+					While W <> Null
+						WNext = After W
 						For SW.ServerWater = Each ServerWater
 							If SW\Area = CurrentArea
 								If SW\Width# = W\ScaleX# And SW\Depth# = W\ScaleZ#
@@ -4909,7 +4912,8 @@ Cls
 							FreeEntity(W\EN)
 							Delete(W)
 						EndIf
-					Next
+						W = WNext
+					Wend
 
 					; Load meshes for server side parts
 					For i = 0 To 149

--- a/src/GUE.bb
+++ b/src/GUE.bb
@@ -4888,7 +4888,7 @@ Cls
 					ClearTextureFilters() : TextureFilter("m_", 1 + 4) : TextureFilter("a_", 1 + 2)
 
 					; Match client water with server water
-					Local W.Water = First Water
+					W = First Water
 					Local WNext.Water = Null
 					While W <> Null
 						WNext = After W

--- a/src/Tests/Modules/GUEWaterMatchIteratorTest.bb
+++ b/src/Tests/Modules/GUEWaterMatchIteratorTest.bb
@@ -1,0 +1,55 @@
+Strict
+EnableGC
+
+; Source-contract regression for the zone-load water reconciliation loop. GUE
+; pulls the full editor graph, so pin the bounded cleanup ordering directly.
+
+Function SectionLine%(Path$, SectionStart$, SectionEnd$, Needle$)
+	Local F.BBStream = ReadFile(Path$)
+	Local Line$
+	Local LineNumber% = 0
+	Local InSection% = False
+	If F = Null Then F = ReadFile("..\" + Path$)
+	If F = Null Then F = ReadFile("..\..\" + Path$)
+	If F = Null Then Return 0
+	While Not Eof(F)
+		LineNumber = LineNumber + 1
+		Line = ReadLine$(F)
+		If InSection = False
+			If Instr(Line$, SectionStart$) > 0 Then InSection = True
+		Else
+			If Instr(Line$, SectionEnd$) > 0
+				CloseFile F
+				Return 0
+			EndIf
+			If Instr(Line$, Needle$) > 0
+				CloseFile F
+				Return LineNumber
+			EndIf
+		EndIf
+	Wend
+	CloseFile F
+	Return 0
+End Function
+
+Test testGUEWaterReconciliationCapturesTheSuccessorBeforeCleanup()
+	Local SectionStart$ = "; Match client water with server water"
+	Local SectionEnd$ = "; Load meshes for server side parts"
+	Assert(SectionLine%("GUE.bb", SectionStart$, SectionEnd$, "For W.Water = Each Water") = 0)
+
+	Local FirstLine% = SectionLine%("GUE.bb", SectionStart$, SectionEnd$, "Local W.Water = First Water")
+	Local CaptureLine% = SectionLine%("GUE.bb", SectionStart$, SectionEnd$, "WNext = After W")
+	Local UnloadLine% = SectionLine%("GUE.bb", SectionStart$, SectionEnd$, "UnloadTexture(W\TexID)")
+	Local FreeTextureLine% = SectionLine%("GUE.bb", SectionStart$, SectionEnd$, "FreeTexture(W\TexHandle)")
+	Local FreeEntityLine% = SectionLine%("GUE.bb", SectionStart$, SectionEnd$, "FreeEntity(W\EN)")
+	Local DeleteLine% = SectionLine%("GUE.bb", SectionStart$, SectionEnd$, "Delete(W)")
+	Local AdvanceLine% = SectionLine%("GUE.bb", SectionStart$, SectionEnd$, "W = WNext")
+
+	Assert(FirstLine > 0)
+	Assert(CaptureLine > FirstLine)
+	Assert(UnloadLine > CaptureLine)
+	Assert(FreeTextureLine > UnloadLine)
+	Assert(FreeEntityLine > FreeTextureLine)
+	Assert(DeleteLine > FreeEntityLine)
+	Assert(AdvanceLine > DeleteLine)
+End Test

--- a/src/Tests/Modules/GUEWaterMatchIteratorTest.bb
+++ b/src/Tests/Modules/GUEWaterMatchIteratorTest.bb
@@ -37,7 +37,7 @@ Test testGUEWaterReconciliationCapturesTheSuccessorBeforeCleanup()
 	Local SectionEnd$ = "; Load meshes for server side parts"
 	Assert(SectionLine%("GUE.bb", SectionStart$, SectionEnd$, "For W.Water = Each Water") = 0)
 
-	Local FirstLine% = SectionLine%("GUE.bb", SectionStart$, SectionEnd$, "Local W.Water = First Water")
+	Local FirstLine% = SectionLine%("GUE.bb", SectionStart$, SectionEnd$, "W = First Water")
 	Local CaptureLine% = SectionLine%("GUE.bb", SectionStart$, SectionEnd$, "WNext = After W")
 	Local UnloadLine% = SectionLine%("GUE.bb", SectionStart$, SectionEnd$, "UnloadTexture(W\TexID)")
 	Local FreeTextureLine% = SectionLine%("GUE.bb", SectionStart$, SectionEnd$, "FreeTexture(W\TexHandle)")


### PR DESCRIPTION
## Outcome

GUE now removes unmatched client-side water records without invalidating the live Water traversal, so a zone load cannot skip later cleanup entries after deleting the current one.

## Technical changes

- Replaced the bounded `For Each Water` reconciliation loop with a `First` / `After` / `While` cursor walk.
- Reused the pre-existing GUE `W` local for the cursor; this resolves the prior exact-head CI compile error from redeclaring it.
- Preserved the Water-to-ServerWater matching predicates and existing `UnloadTexture` → `FreeTexture` → `FreeEntity` → `Delete` cleanup order.
- Added `GUEWaterMatchIteratorTest.bb`, a bounded source contract for legacy-loop rejection and cursor/cleanup ordering.

Fixes #733

## Acceptance evidence

- No `For W.Water = Each Water` remains in the reconciliation section.
- The source contract requires successor capture before cleanup and cursor advance after deletion.
- The scoped source probe recorded RED exit `1` on the legacy loop, then GREEN exit `0` with lines `first=2 capture=5 unload=21 free_texture=22 free_entity=23 delete=24 advance=26`.

## Verification

- Baseline: `bash scripts/gen_packet_index.sh --check`, `bash scripts/gen_bvm_reference.sh --check`, and `git diff --check` all exited `0` (the BVM checker emitted its two known dead-command warnings).
- Final local: both generated-doc checks and `git diff --check` exited `0`; the scoped source-contract probe exited `0`.
- Exact-head CI is pending. The prior head failed compilation solely because it redeclared existing GUE local `W`; commit `376054c5` reuses that local and requires fresh CI/review.
- Native focused test: `./test.sh GUEWaterMatchIteratorTest` exited `1` before execution because `compiler/BlitzForge/bin/blitzcc` is absent. A normal `git submodule update --init compiler/BlitzForge` timed out at 60 seconds while cloning; a safe shallow retry then exited `128` with `Unable to find current revision`. Exact-head CI is therefore required for native proof.

## Compatibility, risk, and rollback

No serialized data, matching rules, or rendering behavior changes. The loop preserves the existing cleanup sequence; rollback is reverting commits `5a92f90b` and `376054c5`.

## Deferred

Other GUE cleanup loops and all Water/ServerWater matching semantics are intentionally out of scope.

## Independent review

Fresh independent reviewer verdict: `ACCEPT` for exact head `376054c5`.