### PR TITLE
Fix F-UI window child teardown iterator safety

### DIFF
--- a/src/Modules/F-UI.bb
+++ b/src/Modules/F-UI.bb
@@ -17512,96 +17512,168 @@ Function FUI_DeleteGadget( ID )
 	
 	win.Window = Object.Window( ID )
 	If win <> Null
-		For reg.Region = Each Region
+		Local reg.Region = First Region
+		While reg <> Null
 			If reg\Owner = win
 				FUI_DeleteGadget( Handle( reg ) )
+				reg = First Region
+			Else
+				reg = After reg
 			EndIf
-		Next
-		For Tab.Tab = Each Tab
+		Wend
+		Local Tab.Tab = First Tab
+		While Tab <> Null
 			If Tab\Owner = win
 				FUI_DeleteGadget( Handle( Tab ) )
+				Tab = First Tab
+			Else
+				Tab = After Tab
 			EndIf
-		Next
-		For pan.Panel = Each Panel
+		Wend
+		Local pan.Panel = First Panel
+		While pan <> Null
 			If pan\Owner = win
 				FUI_DeleteGadget( Handle( pan ) )
+				pan = First Panel
+			Else
+				pan = After pan
 			EndIf
-		Next
-		For btn.Button = Each Button
+		Wend
+		Local btn.Button = First Button
+		While btn <> Null
 			If btn\Owner = win
 				FUI_DeleteGadget( Handle( btn ) )
+				btn = First Button
+			Else
+				btn = After btn
 			EndIf
-		Next
-		For chk.CheckBox = Each CheckBox
+		Wend
+		Local chk.CheckBox = First CheckBox
+		While chk <> Null
 			If chk\Owner = win
 				FUI_DeleteGadget( Handle( chk ) )
+				chk = First CheckBox
+			Else
+				chk = After chk
 			EndIf
-		Next
-		For cbo.ComboBox = Each ComboBox
+		Wend
+		Local cbo.ComboBox = First ComboBox
+		While cbo <> Null
 			If cbo\Owner = win
 				FUI_DeleteGadget( Handle( cbo ) )
+				cbo = First ComboBox
+			Else
+				cbo = After cbo
 			EndIf
-		Next
-		For grp.GroupBox = Each GroupBox
+		Wend
+		Local grp.GroupBox = First GroupBox
+		While grp <> Null
 			If grp\Owner = win
 				FUI_DeleteGadget( Handle( grp ) )
+				grp = First GroupBox
+			Else
+				grp = After grp
 			EndIf
-		Next
-		For img.ImageBox = Each ImageBox
+		Wend
+		Local img.ImageBox = First ImageBox
+		While img <> Null
 			If img\Owner = win
 				FUI_DeleteGadget( Handle( img ) )
+				img = First ImageBox
+			Else
+				img = After img
 			EndIf
-		Next
-		For lbl.Label = Each Label
+		Wend
+		Local lbl.Label = First Label
+		While lbl <> Null
 			If lbl\Owner = win
 				FUI_DeleteGadget( Handle( lbl ) )
+				lbl = First Label
+			Else
+				lbl = After lbl
 			EndIf
-		Next
-		For lst.ListBox = Each ListBox
+		Wend
+		Local lst.ListBox = First ListBox
+		While lst <> Null
 			If lst\Owner = win
 				FUI_DeleteGadget( Handle( lst ) )
+				lst = First ListBox
+			Else
+				lst = After lst
 			EndIf
-		Next
-		For prg.ProgressBar = Each ProgressBar
+		Wend
+		Local prg.ProgressBar = First ProgressBar
+		While prg <> Null
 			If prg\Owner = win
 				FUI_DeleteGadget( Handle( prg ) )
+				prg = First ProgressBar
+			Else
+				prg = After prg
 			EndIf
-		Next
-		For rad.Radio = Each Radio
+		Wend
+		Local rad.Radio = First Radio
+		While rad <> Null
 			If rad\Owner = win
 				FUI_DeleteGadget( Handle( rad ) )
+				rad = First Radio
+			Else
+				rad = After rad
 			EndIf
-		Next
-		For scroll.ScrollBar = Each ScrollBar
+		Wend
+		Local scroll.ScrollBar = First ScrollBar
+		While scroll <> Null
 			If scroll\Owner = win
 				FUI_DeleteGadget( Handle( scroll ) )
+				scroll = First ScrollBar
+			Else
+				scroll = After scroll
 			EndIf
-		Next
-		For sld.Slider = Each Slider
+		Wend
+		Local sld.Slider = First Slider
+		While sld <> Null
 			If sld\Owner = win
 				FUI_DeleteGadget( Handle( sld ) )
+				sld = First Slider
+			Else
+				sld = After sld
 			EndIf
-		Next
-		For spn.Spinner = Each Spinner
+		Wend
+		Local spn.Spinner = First Spinner
+		While spn <> Null
 			If spn\Owner = win
 				FUI_DeleteGadget( Handle( spn ) )
+				spn = First Spinner
+			Else
+				spn = After spn
 			EndIf
-		Next
-		For txt.TextBox = Each TextBox
+		Wend
+		Local txt.TextBox = First TextBox
+		While txt <> Null
 			If txt\Owner = win
 				FUI_DeleteGadget( Handle( txt ) )
+				txt = First TextBox
+			Else
+				txt = After txt
 			EndIf
-		Next
-		For tree.TreeView = Each TreeView
+		Wend
+		Local tree.TreeView = First TreeView
+		While tree <> Null
 			If tree\Owner = win
 				FUI_DeleteGadget( Handle( tree ) )
+				tree = First TreeView
+			Else
+				tree = After tree
 			EndIf
-		Next
-		For view.View = Each View
+		Wend
+		Local view.View = First View
+		While view <> Null
 			If view\Owner = win
 				FUI_DeleteGadget( Handle( view ) )
+				view = First View
+			Else
+				view = After view
 			EndIf
-		Next
+		Wend
 		
 		FreeEntity win\Mesh
 		Delete win

--- a/src/Tests/Modules/FUIWindowDeleteIteratorTest.bb
+++ b/src/Tests/Modules/FUIWindowDeleteIteratorTest.bb
@@ -1,0 +1,72 @@
+Strict
+EnableGC
+
+; FUI_DeleteGadget recursively tears down every child owned by a Window. A
+; recursive delete can remove nodes beyond the current Type-list cursor, so
+; each bounded walk must restart after delete and use After only when it keeps
+; the current node.
+
+Function WindowChildTeardownUsesRestartWalk%(Path$, LegacyFor$, FirstCursor$, WhileCursor$, OwnerCheck$, DeleteChild$, Restart$, Advance$)
+	Local F.BBStream = ReadFile(Path$)
+	Local InWindow%, Stage%
+	Local Line$
+	If F = Null Then F = ReadFile("..\" + Path$)
+	If F = Null Then F = ReadFile("..\..\" + Path$)
+	If F = Null Then Return False
+
+	While Not Eof(F)
+		Line$ = ReadLine$(F)
+		If Instr(Line$, "Function FUI_DeleteGadget( ID )") > 0 Then InWindow = True
+		If InWindow = True
+			If Instr(Line$, "mnut.MenuTitle = Object.MenuTitle( ID )") > 0 Then Exit
+			If Instr(Line$, LegacyFor$) > 0
+				CloseFile F
+				Return False
+			EndIf
+			If Stage < 6 And Instr(Line$, Advance$) > 0
+				CloseFile F
+				Return False
+			EndIf
+			If Stage = 0 And Instr(Line$, FirstCursor$) > 0 Then Stage = 1
+			If Stage = 1 And Instr(Line$, WhileCursor$) > 0 Then Stage = 2
+			If Stage = 2 And Instr(Line$, OwnerCheck$) > 0 Then Stage = 3
+			If Stage = 3 And Instr(Line$, DeleteChild$) > 0 Then Stage = 4
+			If Stage = 4 And Instr(Line$, Restart$) > 0 Then Stage = 5
+			If Stage = 5 And Instr(Line$, "Else") > 0 Then Stage = 6
+			If Stage = 6 And Instr(Line$, Advance$) > 0 Then Stage = 7
+			If Stage = 7 And Instr(Line$, "EndIf") > 0 Then Stage = 8
+			If Stage = 8 And Instr(Line$, "Wend") > 0
+				CloseFile F
+				Return True
+			EndIf
+		EndIf
+	Wend
+
+	CloseFile F
+	Return False
+End Function
+
+Function AssertWindowChildTeardown%(LegacyFor$, FirstCursor$, WhileCursor$, OwnerCheck$, DeleteChild$, Restart$, Advance$)
+	Return WindowChildTeardownUsesRestartWalk%("Modules\F-UI.bb", LegacyFor$, FirstCursor$, WhileCursor$, OwnerCheck$, DeleteChild$, Restart$, Advance$)
+End Function
+
+Test testFUIWindowChildTeardownsRestartAfterRecursiveDelete()
+	Assert(AssertWindowChildTeardown%("For reg.Region = Each Region", "Local reg.Region = First Region", "While reg <> Null", "If reg\Owner = win", "FUI_DeleteGadget( Handle( reg ) )", "reg = First Region", "reg = After reg") = True)
+	Assert(AssertWindowChildTeardown%("For Tab.Tab = Each Tab", "Local Tab.Tab = First Tab", "While Tab <> Null", "If Tab\Owner = win", "FUI_DeleteGadget( Handle( Tab ) )", "Tab = First Tab", "Tab = After Tab") = True)
+	Assert(AssertWindowChildTeardown%("For pan.Panel = Each Panel", "Local pan.Panel = First Panel", "While pan <> Null", "If pan\Owner = win", "FUI_DeleteGadget( Handle( pan ) )", "pan = First Panel", "pan = After pan") = True)
+	Assert(AssertWindowChildTeardown%("For btn.Button = Each Button", "Local btn.Button = First Button", "While btn <> Null", "If btn\Owner = win", "FUI_DeleteGadget( Handle( btn ) )", "btn = First Button", "btn = After btn") = True)
+	Assert(AssertWindowChildTeardown%("For chk.CheckBox = Each CheckBox", "Local chk.CheckBox = First CheckBox", "While chk <> Null", "If chk\Owner = win", "FUI_DeleteGadget( Handle( chk ) )", "chk = First CheckBox", "chk = After chk") = True)
+	Assert(AssertWindowChildTeardown%("For cbo.ComboBox = Each ComboBox", "Local cbo.ComboBox = First ComboBox", "While cbo <> Null", "If cbo\Owner = win", "FUI_DeleteGadget( Handle( cbo ) )", "cbo = First ComboBox", "cbo = After cbo") = True)
+	Assert(AssertWindowChildTeardown%("For grp.GroupBox = Each GroupBox", "Local grp.GroupBox = First GroupBox", "While grp <> Null", "If grp\Owner = win", "FUI_DeleteGadget( Handle( grp ) )", "grp = First GroupBox", "grp = After grp") = True)
+	Assert(AssertWindowChildTeardown%("For img.ImageBox = Each ImageBox", "Local img.ImageBox = First ImageBox", "While img <> Null", "If img\Owner = win", "FUI_DeleteGadget( Handle( img ) )", "img = First ImageBox", "img = After img") = True)
+	Assert(AssertWindowChildTeardown%("For lbl.Label = Each Label", "Local lbl.Label = First Label", "While lbl <> Null", "If lbl\Owner = win", "FUI_DeleteGadget( Handle( lbl ) )", "lbl = First Label", "lbl = After lbl") = True)
+	Assert(AssertWindowChildTeardown%("For lst.ListBox = Each ListBox", "Local lst.ListBox = First ListBox", "While lst <> Null", "If lst\Owner = win", "FUI_DeleteGadget( Handle( lst ) )", "lst = First ListBox", "lst = After lst") = True)
+	Assert(AssertWindowChildTeardown%("For prg.ProgressBar = Each ProgressBar", "Local prg.ProgressBar = First ProgressBar", "While prg <> Null", "If prg\Owner = win", "FUI_DeleteGadget( Handle( prg ) )", "prg = First ProgressBar", "prg = After prg") = True)
+	Assert(AssertWindowChildTeardown%("For rad.Radio = Each Radio", "Local rad.Radio = First Radio", "While rad <> Null", "If rad\Owner = win", "FUI_DeleteGadget( Handle( rad ) )", "rad = First Radio", "rad = After rad") = True)
+	Assert(AssertWindowChildTeardown%("For scroll.ScrollBar = Each ScrollBar", "Local scroll.ScrollBar = First ScrollBar", "While scroll <> Null", "If scroll\Owner = win", "FUI_DeleteGadget( Handle( scroll ) )", "scroll = First ScrollBar", "scroll = After scroll") = True)
+	Assert(AssertWindowChildTeardown%("For sld.Slider = Each Slider", "Local sld.Slider = First Slider", "While sld <> Null", "If sld\Owner = win", "FUI_DeleteGadget( Handle( sld ) )", "sld = First Slider", "sld = After sld") = True)
+	Assert(AssertWindowChildTeardown%("For spn.Spinner = Each Spinner", "Local spn.Spinner = First Spinner", "While spn <> Null", "If spn\Owner = win", "FUI_DeleteGadget( Handle( spn ) )", "spn = First Spinner", "spn = After spn") = True)
+	Assert(AssertWindowChildTeardown%("For txt.TextBox = Each TextBox", "Local txt.TextBox = First TextBox", "While txt <> Null", "If txt\Owner = win", "FUI_DeleteGadget( Handle( txt ) )", "txt = First TextBox", "txt = After txt") = True)
+	Assert(AssertWindowChildTeardown%("For tree.TreeView = Each TreeView", "Local tree.TreeView = First TreeView", "While tree <> Null", "If tree\Owner = win", "FUI_DeleteGadget( Handle( tree ) )", "tree = First TreeView", "tree = After tree") = True)
+	Assert(AssertWindowChildTeardown%("For view.View = Each View", "Local view.View = First View", "While view <> Null", "If view\Owner = win", "FUI_DeleteGadget( Handle( view ) )", "view = First View", "view = After view") = True)
+End Test


### PR DESCRIPTION
## Outcome

Closing complex F-UI/GUE editor windows now safely tears down every owned child gadget instead of advancing a Blitz Type-list cursor through recursive deletes.

## Changes

- Replaced the 18 Window-child `For Each` teardown loops in `FUI_DeleteGadget` with restart-on-delete walks.
- Added a bounded source-contract regression test for all 18 child families; it rejects legacy loops and premature `After` advancement.

Fixes #735

## Acceptance evidence

- All 18 bounded loops start at `First`, recurse on an owned child, restart from `First`, and call `After` only in the non-delete branch.
- The focused source contract has 18 assertions, one per child Type family.

## TDD and verification

- Baseline: 18 unsafe child `For Each` loops; both generated-doc checks exited 0 (BVM emitted two expected DEAD-API warnings).
- RED: the mirrored bounded contract found 18 legacy loops and exited 1.
- GREEN: mirrored contract verified 18 restart-safe walks and 18 assertions; both generated-doc checks and `git diff --check` exited 0.
- Native focused test: `./test.sh FUIWindowDeleteIteratorTest` exited 1 because `compiler/BlitzForge/bin/blitzcc` is absent. A narrow `git submodule update --init compiler/BlitzForge` timed out after 55 seconds, so the native suite remains an explicit CI gate.

## Risk and rollback

This changes only Window teardown traversal sequencing; ownership, rendering, child ordering, non-Window branches, and generated artifacts are unchanged. Roll back with the single implementation-and-test commit if needed.

## Review

Independent review: ACCEPT. Fresh reviewer inspected the exact head against `origin/develop`, confirmed all 18 restart-safe walks and the bounded contract, and found no correctness, scope, docs, security, performance, or concurrency-isolation issues.