### PR TITLE
fix(build): fail explicit Rust builds without Cargo

### DIFF
--- a/compile.bat
+++ b/compile.bat
@@ -125,8 +125,9 @@ if not %BUILD_RUST%==1 goto skip_rust
 echo Compiling RealmCrafter CE Rust apps (client-rs + server-rs)...
 where cargo >nul 2>nul
 if errorlevel 1 (
-    echo   cargo not found on PATH -- install Rust from https://rustup.rs to build the Rust apps. Skipping ClientRS.exe/ServerRS.exe.
-    goto skip_rust
+    echo   cargo not found on PATH -- install Rust from https://rustup.rs to build the Rust apps. Cannot build ClientRS.exe/ServerRS.exe.
+    endlocal
+    exit /b 1
 )
 rem Rust client (client-rs) -> bin\ClientRS.exe
 cd /d "%ROOTDIR%\client-rs"

--- a/compile.sh
+++ b/compile.sh
@@ -150,7 +150,8 @@ fi
 if [[ "${BUILD_RUST}" -eq 1 ]]; then
   echo "Compiling RealmCrafter CE Rust apps (client-rs + server-rs)..."
   if ! command -v cargo >/dev/null 2>&1; then
-    echo "  cargo not found on PATH -- install Rust from https://rustup.rs to build the Rust apps. Skipping ClientRS/ServerRS." >&2
+    echo "  cargo not found on PATH -- install Rust from https://rustup.rs to build the Rust apps. Cannot build ClientRS/ServerRS." >&2
+    exit 1
   else
     mkdir -p "${ROOTDIR}/bin"
     # Rust client (client-rs) -> bin/ClientRS

--- a/src/Tests/Modules/RustToolchainPolicyTest.bb
+++ b/src/Tests/Modules/RustToolchainPolicyTest.bb
@@ -37,6 +37,33 @@ Function FileOccurrenceCount%(Path$, Needle$)
 	Return Count
 End Function
 
+Function FileContainsSequenceBefore%(Path$, StartNeedle$, FirstNeedle$, SecondNeedle$, EndNeedle$)
+	Local F.BBStream = ReadFile(Path$)
+	Local Line$
+	Local Stage = 0
+	If F = Null Then F = ReadFile("..\" + Path$)
+	If F = Null Then F = ReadFile("..\..\" + Path$)
+	If F = Null Then Return False
+	While Not Eof(F)
+		Line$ = ReadLine$(F)
+		If Stage = 0
+			If Instr(Line$, StartNeedle$) > 0 Then Stage = 1
+		Else
+			If Stage = 1 And Instr(Line$, FirstNeedle$) > 0 Then Stage = 2
+			If Stage = 2 And Instr(Line$, SecondNeedle$) > 0
+				CloseFile F
+				Return True
+			EndIf
+			If Instr(Line$, EndNeedle$) > 0
+				CloseFile F
+				Return False
+			EndIf
+		EndIf
+	Wend
+	CloseFile F
+	Return False
+End Function
+
 Test testDeclaredMSRVIsPinnedWithClippy()
 	Assert(FileContains%("rust-toolchain.toml", "channel = " + Chr$(34) + "1.85.0" + Chr$(34)) = True)
 	Assert(FileContains%("rust-toolchain.toml", "components = [" + Chr$(34) + "clippy" + Chr$(34) + "]") = True)
@@ -60,12 +87,10 @@ Test testOptInReleaseBuildsKeepBothLockfilesLocked()
 End Test
 
 Test testExplicitRustBuildsRejectMissingCargo()
-	Assert(FileContains%("compile.sh", "Cannot build ClientRS/ServerRS.") = True)
 	Assert(FileContains%("compile.sh", "Skipping ClientRS/ServerRS.") = False)
-	Assert(FileContains%("compile.sh", "exit 1") = True)
-	Assert(FileContains%("compile.bat", "Cannot build ClientRS.exe/ServerRS.exe.") = True)
 	Assert(FileContains%("compile.bat", "Skipping ClientRS.exe/ServerRS.exe.") = False)
-	Assert(FileContains%("compile.bat", "exit /b 1") = True)
+	Assert(FileContainsSequenceBefore%("compile.sh", "if ! command -v cargo >/dev/null 2>&1; then", "Cannot build ClientRS/ServerRS.", "exit 1", "  else") = True)
+	Assert(FileContainsSequenceBefore%("compile.bat", "if errorlevel 1 (", "Cannot build ClientRS.exe/ServerRS.exe.", "exit /b 1", ")") = True)
 End Test
 
 Test testRustServerContainerBuilderKeepsDeclaredToolchainAndLockfile()

--- a/src/Tests/Modules/RustToolchainPolicyTest.bb
+++ b/src/Tests/Modules/RustToolchainPolicyTest.bb
@@ -59,6 +59,15 @@ Test testOptInReleaseBuildsKeepBothLockfilesLocked()
 	Assert(FileContains%("compile.bat", "cargo build --release --locked --bin rcce-server") = True)
 End Test
 
+Test testExplicitRustBuildsRejectMissingCargo()
+	Assert(FileContains%("compile.sh", "Cannot build ClientRS/ServerRS.") = True)
+	Assert(FileContains%("compile.sh", "Skipping ClientRS/ServerRS.") = False)
+	Assert(FileContains%("compile.sh", "exit 1") = True)
+	Assert(FileContains%("compile.bat", "Cannot build ClientRS.exe/ServerRS.exe.") = True)
+	Assert(FileContains%("compile.bat", "Skipping ClientRS.exe/ServerRS.exe.") = False)
+	Assert(FileContains%("compile.bat", "exit /b 1") = True)
+End Test
+
 Test testRustServerContainerBuilderKeepsDeclaredToolchainAndLockfile()
 	Assert(FileContains%("server-rs\Dockerfile", "FROM rust:1.85.0-bookworm AS build") = True)
 	Assert(FileContains%("server-rs\Dockerfile", "RUN cargo build --release --locked --bin rcce-server") = True)


### PR DESCRIPTION
## Outcome

Explicit Rust builds now fail clearly when Cargo is unavailable instead of reporting success without creating `ClientRS` or `ServerRS` artifacts.

## Technical changes

- Exit nonzero from the Unix and Windows `--rust` branches after the existing installation guidance when Cargo is unavailable.
- Keep successful locked client/server Cargo commands unchanged.
- Add a focused Rust build-policy source contract.

Fixes #737

## Acceptance evidence

| Criterion | Evidence |
| --- | --- |
| Unix explicit build rejects missing Cargo | Controlled Cargo-free `./compile.sh -e -t -r` changed from exit `0` to `1`; final output says `Cannot build ClientRS/ServerRS.` |
| Windows branch has matching contract | `compile.bat` now emits `Cannot build ClientRS.exe/ServerRS.exe.` then `exit /b 1`; focused source contract pins the bounded guard |
| Successful builds remain locked | Existing `RustToolchainPolicyTest` assertions retain both `cargo build --release --locked` commands |

## TDD and verification

- Baseline: controlled Cargo-free Unix build exited `0` and printed `Skipping ClientRS/ServerRS.`; the native focused test could not start because `compiler/BlitzForge/bin/blitzcc` is absent locally.
- RED: the first bounded source-contract mirror exited `1` on the two legacy `Skipping` messages.
- GREEN: controlled Cargo-free Unix build exits `1`; guard-bounded source-contract mirrors exit `0`.
- Final local commands (all exit `0` unless noted): `bash -n compile.sh test.sh scripts/gen_packet_index.sh scripts/gen_bvm_reference.sh`; `bash scripts/gen_packet_index.sh --check`; `bash scripts/gen_bvm_reference.sh --check` (two known DEAD-API warnings); `git diff --check`.
- Native caveat: `./test.sh RustToolchainPolicyTest` exits `1` before test execution because `compiler/BlitzForge/bin/blitzcc` is unavailable. Exact-head CI supplied executable proof: Build and test SUCCESS (2m34s); Rust server (Linux) SUCCESS (1m23s); zero legacy status contexts.

## Compatibility, risk, rollback

The intentional compatibility change is that callers explicitly requesting `--rust` now see a failure when Cargo is missing rather than a false-success no-op. Cargo commands, lockfile policy, CI, runtime behavior, and non-Rust build modes are unchanged. Roll back with the two-commit revert if optional-skip semantics are required.

## Independent review

Fresh final review at `26a47e8de4c5b00a06615477c430761003b5aceb`: **ACCEPT**. The first review requested a stronger guard-bound test; the follow-up commit added it and received this fresh verdict.