### PR TITLE
Fix Loom script-search hit cleanup iterator safety

### DIFF
--- a/src/Modules/Loom/ScriptSearch.bb
+++ b/src/Modules/Loom/ScriptSearch.bb
@@ -106,10 +106,13 @@ Type ScriptSearch
 
 
     Method clearHits()
-        Local h.ScriptSearchHit
-        For h = Each ScriptSearchHit
+        Local h.ScriptSearchHit = First ScriptSearchHit
+        Local nextHit.ScriptSearchHit = Null
+        While h <> Null
+            nextHit = After h
             Delete h
-        Next
+            h = nextHit
+        Wend
         self\hitCount = 0
         self\scrollOffset = 0
     End Method

--- a/src/Tests/Modules/LoomScriptSearchIteratorTest.bb
+++ b/src/Tests/Modules/LoomScriptSearchIteratorTest.bb
@@ -1,0 +1,59 @@
+Strict
+EnableGC
+
+; Source-contract regression for Loom's Ctrl+F result cleanup. ScriptSearch
+; lives in the editor graph, so bind the bounded cleanup order from source.
+
+Function ClearHitsUsesAfterCursor%(Path$)
+	Local F.BBStream = ReadFile(Path$)
+	Local Line$, Trimmed$
+	Local InMethod%, Stage%, SawHitCount%, SawScrollOffset%
+	If F = Null Then F = ReadFile("..\" + Path$)
+	If F = Null Then F = ReadFile("..\..\" + Path$)
+	If F = Null Then Return False
+
+	While Not Eof(F)
+		Line$ = ReadLine$(F)
+		Trimmed$ = Trim$(Line$)
+		If Trimmed$ = "Method clearHits()" Then InMethod = True
+		If InMethod = False Then Continue
+
+		If Trimmed$ = "For h = Each ScriptSearchHit"
+			CloseFile F
+			Return False
+		EndIf
+		If Trimmed$ = "Delete h" And Stage < 4
+			CloseFile F
+			Return False
+		EndIf
+
+		Select Stage
+			Case 0
+				If Trimmed$ = "Local h.ScriptSearchHit = First ScriptSearchHit" Then Stage = 1
+			Case 1
+				If Trimmed$ = "Local nextHit.ScriptSearchHit = Null" Then Stage = 2
+			Case 2
+				If Trimmed$ = "While h <> Null" Then Stage = 3
+			Case 3
+				If Trimmed$ = "nextHit = After h" Then Stage = 4
+			Case 4
+				If Trimmed$ = "Delete h" Then Stage = 5
+			Case 5
+				If Trimmed$ = "h = nextHit" Then Stage = 6
+		End Select
+
+		If Trimmed$ = "self\hitCount = 0" Then SawHitCount = True
+		If Trimmed$ = "self\scrollOffset = 0" Then SawScrollOffset = True
+		If Trimmed$ = "End Method"
+			CloseFile F
+			Return Stage = 6 And SawHitCount And SawScrollOffset
+		EndIf
+	Wend
+
+	CloseFile F
+	Return False
+End Function
+
+Test testScriptSearchClearHitsCapturesSuccessorBeforeDeleting()
+	Assert(ClearHitsUsesAfterCursor%("Modules\Loom\ScriptSearch.bb") = True)
+End Test


### PR DESCRIPTION
## Outcome

Loom Ctrl+F now drains old search-hit records without invalidating the Blitz iterator, preventing stale or skipped results during modal open, close, and refresh.

## Technical changes

- Replace the deleting `For Each ScriptSearchHit` loop with a `First` / pre-captured `After` / `While` traversal.
- Preserve `hitCount` and `scrollOffset` reset behavior.
- Add a bounded source-contract test that rejects the legacy loop and enforces capture → delete → advance ordering.

Fixes #739

## Acceptance evidence

- Safe successor capture before deletion: `FINAL: clearHits captures successor before Delete and preserves resets` (exit 0).
- Legacy deleting `For Each` was observed at baseline and the new contract was RED for that exact condition.
- Reset assignments remain after the drain and are bound by the focused contract.

## Verification

- Baseline: source probe reported `BASELINE: 1 unsafe clearHits For Each/Delete loop` (expected exit 1).
- RED: source probe reported `RED: legacy deleting For Each remains in ScriptSearch.clearHits` (expected exit 1).
- GREEN/final: bounded ordering contract exit 0.
- `bash scripts/gen_packet_index.sh --check` — exit 0.
- `bash scripts/gen_bvm_reference.sh --check` — exit 0; two known DEAD-API warnings only.
- `git diff --check origin/develop...HEAD` — exit 0.
- `./test.sh LoomScriptSearchIteratorTest` is UNVERIFIED locally: `compiler/BlitzForge/bin/blitzcc` is absent. A narrow `git submodule update --init compiler/BlitzForge` timed out after 55 seconds, so exact-head CI must provide native test proof.

## Compatibility, risk, rollback

No query, rendering, keyboard, or public API behavior changes. The change only makes cleanup traversal safe. Rollback is a revert of commit `17b9b2cf`.

## Independent review

Pending fresh review of this exact head.

Reviewer verdict: ACCEPT — fresh independent review accepted exact head `17b9b2cf8aa82d14c5cf6bb570676ceb32121a78`. The reviewer confirmed successor capture before delete, reset preservation, bounded scope, regression-contract quality, and no documentation/security/performance/concurrency concern. CI was in progress at review time.