### PR TITLE
docs: correct generated-doc CI guidance

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -192,7 +192,7 @@ Two doc artifacts are generated from source; do not edit by hand. After touching
   ./scripts/gen_packet_index.sh
   ```
 
-Both scripts accept `--check` mode (exit non-zero if the doc is stale) for use in pre-commit hooks or CI; neither is yet wired into the GitHub Actions workflow.
+Both scripts accept `--check` mode (exit non-zero if the doc is stale) for use in pre-commit hooks or CI. Both checks run in the GitHub Actions workflow.
 
 Per-packet detail pages under [`docs/protocol/packets/`](docs/protocol/packets/) are hand-written and incrementally filled. Adding one is a good first PR — pick an under-documented packet from the index table where the "Detail" column shows `—`.
 

--- a/src/Tests/Modules/ReadMeMacOSInstallTest.bb
+++ b/src/Tests/Modules/ReadMeMacOSInstallTest.bb
@@ -48,4 +48,6 @@ Test testContributorGeneratedDocsGuidanceMatchesCI()
 	Assert(FileContains%("CONTRIBUTING.md", "./scripts/gen_bvm_reference.sh") = True)
 	Assert(FileContains%("CONTRIBUTING.md", "Both checks run in the GitHub Actions workflow") = True)
 	Assert(FileContains%("CONTRIBUTING.md", "neither is yet wired into the GitHub Actions workflow") = False)
+	Assert(FileContains%(".github\workflows\ci.yml", "bash scripts/gen_packet_index.sh --check") = True)
+	Assert(FileContains%(".github\workflows\ci.yml", "bash scripts/gen_bvm_reference.sh --check") = True)
 End Test

--- a/src/Tests/Modules/ReadMeMacOSInstallTest.bb
+++ b/src/Tests/Modules/ReadMeMacOSInstallTest.bb
@@ -42,3 +42,10 @@ Test testSourceBuildOnboardingDoesNotAdvertiseTheMacOSBootstrapForLinux()
 	Assert(FileContains%("CONTRIBUTING.md", "# macOS / Linux (alpha)") = False)
 	Assert(FileContains%("CONTRIBUTING.md", "macOS equivalent") = True)
 End Test
+
+Test testContributorGeneratedDocsGuidanceMatchesCI()
+	Assert(FileContains%("CONTRIBUTING.md", "./scripts/gen_packet_index.sh") = True)
+	Assert(FileContains%("CONTRIBUTING.md", "./scripts/gen_bvm_reference.sh") = True)
+	Assert(FileContains%("CONTRIBUTING.md", "Both checks run in the GitHub Actions workflow") = True)
+	Assert(FileContains%("CONTRIBUTING.md", "neither is yet wired into the GitHub Actions workflow") = False)
+End Test


### PR DESCRIPTION
## Outcome

Contributors now see that generated packet and BVM reference freshness is enforced in GitHub Actions, so they know regenerated documentation is required before a PR can pass.

## Technical changes

- Correct the stale `CONTRIBUTING.md` sentence about generated-doc `--check` enforcement.
- Extend the focused onboarding source-contract test to require both local generator commands, the CI statement, absence of the retired denial, and both exact workflow checks.

Fixes #741

## Acceptance evidence

- `CONTRIBUTING.md` now names the two local generators and states: `Both checks run in the GitHub Actions workflow`.
- The focused contract rejects the prior `neither is yet wired` wording and binds `bash scripts/gen_packet_index.sh --check` plus `bash scripts/gen_bvm_reference.sh --check` in `.github/workflows/ci.yml`.

## Baseline, RED, GREEN, final verification

- Baseline: `BASELINE: 1 stale generated-doc CI claim(s)` (expected exit 1).
- RED: bounded contract reported the missing CI wording and present stale claim (expected exit 1).
- GREEN: bounded contract confirmed both local generators, CI enforcement wording, stale-wording rejection, and both workflow checks (exit 0).
- `bash scripts/gen_packet_index.sh --check` — exit 0.
- `bash scripts/gen_bvm_reference.sh --check` — exit 0; only the two known DEAD-API warnings.
- `git diff --check` — exit 0 before commit.
- Local `./test.sh ReadMeMacOSInstallTest` is UNVERIFIED: exit 1 because `compiler/BlitzForge/bin/blitzcc` is absent. Exact-head CI supplied native proof: Build and test passed in 2m43s; Rust server (Linux) passed in 1m28s.

## Compatibility, risk, rollback

No workflow, generator, runtime, or public API behavior changes. Risk is limited to a bounded docs/test contract. Roll back by reverting `db48df39` and `13bea15e`.

## Independent review

- First independent review requested assertions for both workflow commands; commit `13bea15e` added them.
- Fresh independent review returned ACCEPT for exact head `13bea15e3f91ea870954e7ac76a8106939ed08b4`, confirming scope, docs/workflow correctness, regression quality, and no security, performance, concurrency, or compatibility concerns.