### PR TITLE
fix(editors): safely clear RC Terrain Editor Type lists

### DIFF
--- a/src/Tests/Modules/RCTerrainEditorCleanupIteratorTest.bb
+++ b/src/Tests/Modules/RCTerrainEditorCleanupIteratorTest.bb
@@ -1,0 +1,87 @@
+Strict
+EnableGC
+
+; RC Terrain Editor clears several Type lists during startup, load, reset, and
+; save paths.  These are standalone source contracts because the tool pulls in
+; the editor and renderer graph; each owned direct cleanup must save After
+; before Delete so a multi-record list cannot advance through a freed node.
+Function DirectCleanupUsesAfterCursor%(Path$, Start$, EndMarker$, LegacyFor$, FirstCursor$, NextCursor$, WhileCursor$, Capture$, DeleteNode$, Advance$)
+	Local F.BBStream = ReadFile(Path$)
+	Local InSection%, Stage%
+	Local Line$
+	If F = Null Then F = ReadFile("..\\" + Path$)
+	If F = Null Then F = ReadFile("..\\..\\" + Path$)
+	If F = Null Then Return False
+
+	While Not Eof(F)
+		Line$ = ReadLine$(F)
+		If InSection = False And Instr(Line$, Start$) > 0 Then InSection = True
+		If InSection = True
+			If Instr(Line$, LegacyFor$) > 0 Then
+				CloseFile F
+				Return False
+			EndIf
+			If Stage < 4 And Instr(Line$, DeleteNode$) > 0 Then
+				CloseFile F
+				Return False
+			EndIf
+			If Stage = 0 And Instr(Line$, FirstCursor$) > 0 Then Stage = 1
+			If Stage = 1 And Instr(Line$, NextCursor$) > 0 Then Stage = 2
+			If Stage = 2 And Instr(Line$, WhileCursor$) > 0 Then Stage = 3
+			If Stage = 3 And Instr(Line$, Capture$) > 0 Then Stage = 4
+			If Stage = 4 And Instr(Line$, DeleteNode$) > 0 Then Stage = 5
+			If Stage = 5 And Instr(Line$, Advance$) > 0 Then Stage = 6
+			If Instr(Line$, EndMarker$) > 0 Then
+				CloseFile F
+				Return Stage = 6
+			EndIf
+		EndIf
+	Wend
+
+	CloseFile F
+	Return False
+End Function
+
+Function ModelBrushCleanupUsesAfterCursor%(Start$, EndMarker$)
+	Return DirectCleanupUsesAfterCursor%("Tools\\RC Terrain Editor.bb", Start$, EndMarker$, "For mbr.modelbrush=Each ModelBrush", "mbr.modelbrush=First ModelBrush", "mbrNext.modelbrush=Null", "While mbr<>Null", "mbrNext=After mbr", "Delete mbr", "mbr=mbrNext")
+End Function
+
+Function AutoUndoCleanupUsesAfterCursor%(Start$, EndMarker$)
+	Return DirectCleanupUsesAfterCursor%("Tools\\RC Terrain Editor.bb", Start$, EndMarker$, "For au.autoundo=Each autoundo", "au.autoundo=First autoundo", "auNext.autoundo=Null", "While au<>Null", "auNext=After au", "Delete au", "au=auNext")
+End Function
+
+Function SceneryCleanupUsesAfterCursor%(Start$, EndMarker$)
+	Return DirectCleanupUsesAfterCursor%("Tools\\RC Terrain Editor.bb", Start$, EndMarker$, "For scn.scenery=Each scenery", "scn.scenery=First scenery", "scnNext.scenery=Null", "While scn<>Null", "scnNext=After scn", "Delete scn", "scn=scnNext")
+End Function
+
+Test testStartupModelBrushCleanupCapturesNextBeforeDelete()
+	Assert(ModelBrushCleanupUsesAfterCursor%("Global totaldrops", "updatemodelbrushlist()") = True)
+End Test
+
+Test testModelBrushAddCleanupCapturesNextBeforeDelete()
+	Assert(ModelBrushCleanupUsesAfterCursor%("Case GUI_MBWIN_ADD", "Case GUI_MBWIN_LOAD") = True)
+End Test
+
+Test testImportedAreaUndoCleanupCapturesNextBeforeDelete()
+	Assert(AutoUndoCleanupUsesAfterCursor%("If Instr( Lower$(importmap$), " + Chr$(34) + ".dat" + Chr$(34) + ", 1 ) > 1", "ElseIf Instr( Lower$(importmap$), " + Chr$(34) + ".rct" + Chr$(34) + ", 1 ) > 1") = True)
+End Test
+
+Test testTerrainLoadUndoCleanupCapturesNextBeforeDelete()
+	Assert(AutoUndoCleanupUsesAfterCursor%("If sf$<>" + Chr$(34) + Chr$(34), "unloadtrees(False)") = True)
+End Test
+
+Test testNewMapUndoCleanupCapturesNextBeforeDelete()
+	Assert(AutoUndoCleanupUsesAfterCursor%("Function newmap(sg%,flagit=0,ask=1)", "UNLOADAREA()") = True)
+End Test
+
+Test testRemoveUndoDataCapturesNextBeforeDelete()
+	Assert(AutoUndoCleanupUsesAfterCursor%("Function RemoveUndoData()", "End Function") = True)
+End Test
+
+Test testAreaSaveSceneryCleanupCapturesNextBeforeDelete()
+	Assert(SceneryCleanupUsesAfterCursor%("Function SaveAreaRCTE(Name$)", "For dm.dropmodel=Each dropmodel") = True)
+End Test
+
+Test testAreaSaveFinalSceneryCleanupCapturesNextBeforeDelete()
+	Assert(SceneryCleanupUsesAfterCursor%("Delete Each area", "End Function") = True)
+End Test

--- a/src/Tools/RC Terrain Editor.bb
+++ b/src/Tools/RC Terrain Editor.bb
@@ -519,9 +519,13 @@ sceneryID=-1
 
 ;EnableDirectInput 1
 
-For mbr.modelbrush=Each ModelBrush
+mbr.modelbrush=First ModelBrush
+mbrNext.modelbrush=Null
+While mbr<>Null
+	mbrNext=After mbr
 	Delete mbr
-Next
+	mbr=mbrNext
+Wend
 updatemodelbrushlist() 
 POSITIONWINDOWS()
 InitFPS()
@@ -1653,9 +1657,13 @@ Function LOADWORK(sf$="")
 						FreeEntity dm\ent
 						Delete dm
 					Next
-					For au.autoundo=Each autoundo
-						Delete au
-					Next
+						au.autoundo=First autoundo
+						auNext.autoundo=Null
+						While au<>Null
+							auNext=After au
+							Delete au
+							au=auNext
+						Wend
 					unloadtrees(False)
 					loadworkpath$ = ""
 					LoadAreaTE(importmap$)
@@ -1704,9 +1712,13 @@ Function LOADWORK(sf$="")
 				FreeEntity dm\ent
 				Delete dm
 			Next
-			For au.autoundo=Each autoundo
+			au.autoundo=First autoundo
+			auNext.autoundo=Null
+			While au<>Null
+				auNext=After au
 				Delete au
-			Next
+				au=auNext
+			Wend
 			unloadtrees(False)
 		EndIf
 		
@@ -2072,9 +2084,13 @@ Function newmap(sg%,flagit=0,ask=1)
 			Delete dm
 		Next
 		
-		For au.autoundo=Each autoundo
+		au.autoundo=First autoundo
+		auNext.autoundo=Null
+		While au<>Null
+			auNext=After au
 			Delete au
-		Next
+			au=auNext
+		Wend
 		
 		UNLOADAREA()
 		If flagit=0 And layer(1) <> 0
@@ -3108,9 +3124,13 @@ Wend
 End Function
 
 Function RemoveUndoData()
-For au.autoundo=Each autoundo
-Delete au
-Next
+au.autoundo=First autoundo
+auNext.autoundo=Null
+While au<>Null
+	auNext=After au
+	Delete au
+	au=auNext
+Wend
 
 End Function
 
@@ -3165,9 +3185,13 @@ Function SaveAreaRCTE(Name$)
 	ChangeDir thispath$
 	fileExists = FileType(thispath$+"data\areas\"+Name$+".dat")
 	
-	For scn.scenery=Each scenery
+	scn.scenery=First scenery
+	scnNext.scenery=Null
+	While scn<>Null
+		scnNext=After scn
 		Delete scn
-	Next
+		scn=scnNext
+	Wend
 	
 	For dm.dropmodel=Each dropmodel
 		EntityType dm\ent,3
@@ -3216,9 +3240,13 @@ Function SaveAreaRCTE(Name$)
 	
 	
 	Delete Each area
-	For scn.scenery=Each scenery
+	scn.scenery=First scenery
+	scnNext.scenery=Null
+	While scn<>Null
+		scnNext=After scn
 		Delete scn
-	Next
+		scn=scnNext
+	Wend
 
 End Function
 
@@ -4496,9 +4524,13 @@ Next
 ;-------
 Case GUI_MBWIN_ADD 
 checked.window=Null 
-For mbr.modelbrush=Each ModelBrush
-Delete mbr
-Next
+mbr.modelbrush=First ModelBrush
+mbrNext.modelbrush=Null
+While mbr<>Null
+	mbrNext=After mbr
+	Delete mbr
+	mbr=mbrNext
+Wend
 updatemodelbrushlist() 
 
 ;-------


### PR DESCRIPTION
## Outcome

RC Terrain Editor now clears all eight owned direct Type-list cleanup paths without advancing through a deleted node, preventing skipped cleanup or cursor corruption when a list has multiple records.

## Technical changes

- Replace the two `ModelBrush`, four direct `autoundo`, and two `scenery` live-deleting `For Each` loops with `First` / `After` / `While` walks.
- Add `RCTerrainEditorCleanupIteratorTest.bb`, a bounded source-contract regression suite that checks every sequence, cleanup ordering, and legacy-loop absence.
- Keep nested `Undo()` and every `dropmodel` loop out of scope because they need a distinct ownership audit.

Fixes #743

## Acceptance evidence

- Eight owned loops now capture their successor before `Delete` and advance after it.
- The new contract covers startup, Model Brush Add, both load branches, new map, `RemoveUndoData`, and both area-save cleanup points.
- No file format, protocol, UI feature, or editor serialization behavior changes.

## Baseline, RED, GREEN, final verification

- Baseline: `BASELINE: 8 owned unsafe direct-delete loops (Undo excluded)` (expected source probe exit 1). A broad scan found the separate out-of-scope nested `Undo()` loop as the ninth occurrence.
- RED: bounded source contract reported all eight retained legacy `For ... = Each` loops (expected exit 1).
- GREEN: bounded source contract reported all eight cleanup paths green and `GREEN_SOURCE_CONTRACT unexpected=0`.
- `git diff --check`, `bash scripts/gen_packet_index.sh --check`, and `bash scripts/gen_bvm_reference.sh --check` exited 0; BVM emitted only the two known DEAD-API warnings.
- Local native `./test.sh RCTerrainEditorCleanupIteratorTest` is UNVERIFIED: exit 1 because `compiler/BlitzForge/bin/blitzcc` is absent after a 55-second narrow submodule-init attempt. Exact-head CI supplied native proof: Build and test passed in 2m39s; Rust server (Linux) passed in 1m37s; direct check-runs were `completed/success`; legacy status contexts: 0.

## Compatibility, risk, rollback, follow-up

Risk is limited to traversal mechanics; each loop deletes the same nodes in the same order. Revert `575b9f6e` to restore the prior implementation. Deferred: nested `Undo()` and `dropmodel` cleanup ownership audit.

## Independent review

Fresh independent review returned **ACCEPT** for exact head `575b9f6e451f4afb92571f0f0cf75463fdd9d6b5`: all eight owned paths capture before delete and advance after it; excluded paths remain untouched; the bounded contract matches established iterator-test patterns; no docs, protocol, serialization, security, performance, concurrency, or hidden-cost concern was found.