### PR TITLE
fix(editors): safely drain Gubbin event queue

### DIFF
--- a/src/Tests/Modules/GubbinToolEventIteratorTest.bb
+++ b/src/Tests/Modules/GubbinToolEventIteratorTest.bb
@@ -1,0 +1,46 @@
+Strict
+EnableGC
+
+; The Gubbin Tool owns this event queue and deletes each event after handling
+; it.  The bounded source contract keeps the traversal from advancing through
+; a freed Event when more than one UI action is queued in the same tick.
+Function GubbinEventQueueUsesAfterCursor%()
+	Local F.BBStream = ReadFile("Tools\\Gubbin Tool.bb")
+	Local InEventPump%, Stage%
+	Local Line$
+	If F = Null Then F = ReadFile("..\\Tools\\Gubbin Tool.bb")
+	If F = Null Then F = ReadFile("..\\..\\Tools\\Gubbin Tool.bb")
+	If F = Null Then Return False
+
+	While Not Eof(F)
+		Line$ = ReadLine$(F)
+		If InEventPump = False And Instr(Line$, "; Process events") > 0 Then InEventPump = True
+		If InEventPump = True
+			If Instr(Line$, "For E.Event = Each Event") > 0 Then
+				CloseFile F
+				Return False
+			EndIf
+			If Stage < 4 And Instr(Line$, "Delete(E)") > 0 Then
+				CloseFile F
+				Return False
+			EndIf
+			If Stage = 0 And Instr(Line$, "E.Event = First Event") > 0 Then Stage = 1
+			If Stage = 1 And Instr(Line$, "ENext.Event = Null") > 0 Then Stage = 2
+			If Stage = 2 And Instr(Line$, "While E <> Null") > 0 Then Stage = 3
+			If Stage = 3 And Instr(Line$, "ENext = After E") > 0 Then Stage = 4
+			If Stage = 4 And Instr(Line$, "Delete(E)") > 0 Then Stage = 5
+			If Stage = 5 And Instr(Line$, "E = ENext") > 0 Then Stage = 6
+			If Instr(Line$, "If MouseDown(1) And PreviewMesh <> 0") > 0
+				CloseFile F
+				Return Stage = 6
+			EndIf
+		EndIf
+	Wend
+
+	CloseFile F
+	Return False
+End Function
+
+Test testGubbinEventQueueCapturesNextBeforeDelete()
+	Assert(GubbinEventQueueUsesAfterCursor%() = True)
+End Test

--- a/src/Tools/Gubbin Tool.bb
+++ b/src/Tools/Gubbin Tool.bb
@@ -140,7 +140,10 @@ Const BaseFramerate# = 30.0
 Repeat
 
 	; Process events
-	For E.Event = Each Event
+	E.Event = First Event
+	ENext.Event = Null
+	While E <> Null
+		ENext = After E
 		Select E\EventID
 
 			; Apply all changes
@@ -351,7 +354,8 @@ Repeat
 
 		End Select
 		Delete(E)
-	Next
+		E = ENext
+	Wend
 
 	; Gubbin mesh control
 	If MouseDown(1) And PreviewMesh <> 0


### PR DESCRIPTION
## Outcome

Gubbin Tool now drains every queued UI event through a safe cursor walk, so deleting one event cannot corrupt or skip the next queued action.

## Technical changes

- Replaced the destructive `For E.Event = Each Event` loop with `First` / `After` / `While`.
- Captures `ENext` before `Delete(E)` and advances to it after existing event handling.
- Added a bounded Strict source-contract regression for the Gubbin event pump.

Fixes #745

## Acceptance evidence

| Criterion | Evidence |
| --- | --- |
| Capture successor before deletion | RED source probe exited 1 on legacy `For Each`; GREEN reached stage 6 on `E -> ENext -> After -> Delete -> advance`. |
| Preserve event actions | Diff changes only traversal around the unchanged `Select E\EventID` body. |
| Reject future cursor regressions | `GubbinToolEventIteratorTest.bb` rejects the legacy loop and deletion before capture. |

## Verification

- Baseline: `bash scripts/gen_packet_index.sh --check`, `bash scripts/gen_bvm_reference.sh --check`, and `git diff --check` each exited 0; legacy loop was present.
- RED: focused source-contract probe exited 1: `legacy destructive For Each event traversal remains`.
- GREEN: focused source-contract probe exited 0 at stage 6; `git diff --check`, packet-index check, and BVM-reference check each exited 0.
- Local native test: `./test.sh GubbinToolEventIteratorTest` exited 1 before compilation because `compiler/BlitzForge/bin/blitzcc` is unavailable. A narrow `git submodule update --init compiler/BlitzForge` timed out at 60 seconds; the safe shallow retry exited 128 (`Unable to find current revision`). GitHub Actions is the required compiled-test proof.

## Compatibility, risk, rollback

Event meanings and queue order remain unchanged. The risk is limited to the cursor mechanics; rollback is reverting commit `6f22ecde`. Other editor event loops and F-UI internals are explicitly out of scope.

## Independent review

Fresh independent review returned **ACCEPT** for exact head `6f22ecde6f2b4cd9adb43837ff0f50d31d77de44`: it confirmed the scope, cursor order, unchanged action body, regression coverage, repository fit, and no docs/security/performance/concurrency concerns.