### PR TITLE
fix(editors): safely drain Gubbin mesh-name modal events

### DIFF
--- a/src/Tests/Modules/GubbinToolEventIteratorTest.bb
+++ b/src/Tests/Modules/GubbinToolEventIteratorTest.bb
@@ -20,7 +20,7 @@ Function GubbinEventQueueUsesAfterCursor%()
 				CloseFile F
 				Return False
 			EndIf
-			If Stage < 4 And Instr(Line$, "Delete(E)") > 0 Then
+			If Stage < 4 And Instr(Line$, "Delete E") > 0 Then
 				CloseFile F
 				Return False
 			EndIf
@@ -28,7 +28,7 @@ Function GubbinEventQueueUsesAfterCursor%()
 			If Stage = 1 And Instr(Line$, "ENext.Event = Null") > 0 Then Stage = 2
 			If Stage = 2 And Instr(Line$, "While E <> Null") > 0 Then Stage = 3
 			If Stage = 3 And Instr(Line$, "ENext = After E") > 0 Then Stage = 4
-			If Stage = 4 And Instr(Line$, "Delete(E)") > 0 Then Stage = 5
+			If Stage = 4 And Instr(Line$, "Delete E") > 0 Then Stage = 5
 			If Stage = 5 And Instr(Line$, "E = ENext") > 0 Then Stage = 6
 			If Instr(Line$, "If MouseDown(1) And PreviewMesh <> 0") > 0
 				CloseFile F
@@ -41,6 +41,47 @@ Function GubbinEventQueueUsesAfterCursor%()
 	Return False
 End Function
 
+Function GubbinMeshNameDialogUsesAfterCursor%()
+	Local F.BBStream = ReadFile("Tools\\Gubbin Tool.bb")
+	Local InDialog%, Stage%
+	Local Line$
+	If F = Null Then F = ReadFile("..\\Tools\\Gubbin Tool.bb")
+	If F = Null Then F = ReadFile("..\\..\\Tools\\Gubbin Tool.bb")
+	If F = Null Then Return False
+
+	While Not Eof(F)
+		Line$ = ReadLine$(F)
+		If Instr(Line$, "Function MeshNameDialog$()") > 0 Then InDialog = True
+		If InDialog = True
+			If Instr(Line$, "For E.Event = Each Event") > 0 Then
+				CloseFile F
+				Return False
+			EndIf
+			If Stage < 4 And Instr(Line$, "Delete E") > 0 Then
+				CloseFile F
+				Return False
+			EndIf
+			If Stage = 0 And Instr(Line$, "E.Event = First Event") > 0 Then Stage = 1
+			If Stage = 1 And Instr(Line$, "ENext.Event = Null") > 0 Then Stage = 2
+			If Stage = 2 And Instr(Line$, "While E <> Null") > 0 Then Stage = 3
+			If Stage = 3 And Instr(Line$, "ENext = After E") > 0 Then Stage = 4
+			If Stage = 4 And Instr(Line$, "Delete E") > 0 Then Stage = 5
+			If Stage = 5 And Instr(Line$, "E = ENext") > 0 Then Stage = 6
+			If Instr(Line$, "; Render") > 0
+				CloseFile F
+				Return Stage = 6
+			EndIf
+		EndIf
+	Wend
+
+	CloseFile F
+	Return False
+End Function
+
 Test testGubbinEventQueueCapturesNextBeforeDelete()
 	Assert(GubbinEventQueueUsesAfterCursor%() = True)
+End Test
+
+Test testGubbinMeshNameDialogCapturesNextBeforeDelete()
+	Assert(GubbinMeshNameDialogUsesAfterCursor%() = True)
 End Test

--- a/src/Tests/Modules/GubbinToolEventIteratorTest.bb
+++ b/src/Tests/Modules/GubbinToolEventIteratorTest.bb
@@ -20,7 +20,7 @@ Function GubbinEventQueueUsesAfterCursor%()
 				CloseFile F
 				Return False
 			EndIf
-			If Stage < 4 And Instr(Line$, "Delete E") > 0 Then
+			If Stage < 4 And (Instr(Line$, "Delete(E)") > 0 Or Instr(Line$, "Delete E") > 0) Then
 				CloseFile F
 				Return False
 			EndIf
@@ -28,7 +28,7 @@ Function GubbinEventQueueUsesAfterCursor%()
 			If Stage = 1 And Instr(Line$, "ENext.Event = Null") > 0 Then Stage = 2
 			If Stage = 2 And Instr(Line$, "While E <> Null") > 0 Then Stage = 3
 			If Stage = 3 And Instr(Line$, "ENext = After E") > 0 Then Stage = 4
-			If Stage = 4 And Instr(Line$, "Delete E") > 0 Then Stage = 5
+			If Stage = 4 And (Instr(Line$, "Delete(E)") > 0 Or Instr(Line$, "Delete E") > 0) Then Stage = 5
 			If Stage = 5 And Instr(Line$, "E = ENext") > 0 Then Stage = 6
 			If Instr(Line$, "If MouseDown(1) And PreviewMesh <> 0") > 0
 				CloseFile F

--- a/src/Tools/Gubbin Tool.bb
+++ b/src/Tools/Gubbin Tool.bb
@@ -605,7 +605,10 @@ Function MeshNameDialog$()
 		EndIf
 
 		; Events
-		For E.Event = Each Event
+		E.Event = First Event
+		ENext.Event = Null
+		While E <> Null
+			ENext = After E
 			Select E\EventID
 				; Window closed
 				Case W
@@ -625,7 +628,8 @@ Function MeshNameDialog$()
 					EndIf
 			End Select
 			Delete E
-		Next
+			E = ENext
+		Wend
 
 		; Render
 		FUI_Update()


### PR DESCRIPTION
## Outcome

Gubbin’s mesh-duplication name dialog now drains every queued UI event safely, so a modal interaction cannot advance through an event that it just deleted.

## Technical changes

- Replace the dialog’s destructive `For Each Event` loop with the established `First` / `After` / `While` traversal.
- Preserve the complete close, cancel, OK, duplicate-name, render, and return paths.
- Extend the focused Gubbin iterator source-contract test to cover the modal loop and correct its existing delete-spelling matcher.

Fixes #747

## Acceptance criteria and evidence

| Criterion | Evidence |
| --- | --- |
| No live cursor deletion in `MeshNameDialog$` | RED probe detected legacy `For Each` traversal; final bounded probe reports `safe=True` and `legacy_for_each=False`. |
| Successor captured before delete and then advanced | Final bounded probe verified `First`, `After`, `Delete`, and advance ordering. |
| Existing modal actions retained | Diff changes only traversal mechanics around the existing `Select E\EventID` body. |
| Regression contract covers the modal | `GubbinToolEventIteratorTest.bb` now rejects the legacy loop and asserts safe ordering before render. |

## TDD and verification

- BASELINE: `git diff --check` → exit 0; the modal source probe exited 1 with `mesh_name_dialog_legacy_destructive_loop=True`.
- RED: new modal contract exited 1 with `mesh_name_dialog_safe_after_cursor=False legacy_for_each=True ordered=False`.
- GREEN: final bounded contract exited 0 with `FINAL_MODAL_CONTRACT safe=True contract=True`.
- Final local gates (exit 0): `git diff --check`; `bash scripts/gen_packet_index.sh --check`; `bash scripts/gen_bvm_reference.sh --check` (two known DEAD-API warnings); `bash -n test.sh scripts/gen_packet_index.sh scripts/gen_bvm_reference.sh`.
- Native caveat: `./test.sh GubbinToolEventIteratorTest` exits 1 before execution because `compiler/BlitzForge/bin/blitzcc` is absent in this Linux worktree. Exact-head CI is required for executable Blitz proof.

## Compatibility, risk, rollback, and deferred work

Behavioral actions and event ordering are retained; only post-delete traversal is made safe. Revert commit `48f23fba` to restore the previous loop if required. Other Gubbin dialogs and F-UI internals are intentionally out of scope.

## Independent review

Fresh re-review at exact head `84e3623dc518f632aba97c5b467c534bf9474b7a`: **ACCEPT**. The initial review correctly caught a main-pump matcher spelling defect; the test-only follow-up accepts both established delete spellings and received a fresh ACCEPT verdict.