### PR TITLE
fix(rust-server): preserve quest bytes on character reload

### DIFF
--- a/server-rs/crates/rcce-server/src/characters.rs
+++ b/server-rs/crates/rcce-server/src/characters.rs
@@ -29,6 +29,20 @@ const Q_FRAGMENT_AT: usize = 700;
 /// S known-spells fragment threshold (`Len(OldPa$ + Pa$) > 1000`).
 const S_FRAGMENT_AT: usize = 1000;
 
+/// Quest names are framed with a one-byte byte count on both live and reload
+/// packets, so retain only the bytes that fit that protocol field.
+pub(crate) fn quest_name_to_bytes(name: &str) -> &[u8] {
+    let bytes = name.as_bytes();
+    &bytes[..bytes.len().min(u8::MAX as usize)]
+}
+
+/// Blitz quest statuses are byte strings, including three leading flag bytes.
+/// Rust stores those flags as Latin-1 chars, so send each char's low byte and
+/// bound the result to the u16 byte count used by the quest wire format.
+pub(crate) fn quest_status_to_bytes(status: &str) -> Vec<u8> {
+    status.chars().take(u16::MAX as usize).map(|c| c as u32 as u8).collect()
+}
+
 fn read_field(r: &mut MsgReader) -> Option<Vec<u8>> {
     let n = r.u8()? as usize;
     Some(r.bytes(n)?.to_vec())
@@ -337,11 +351,13 @@ pub fn handle_fetch_character(
         if q.name.is_empty() {
             continue;
         }
+        let name = quest_name_to_bytes(&q.name);
+        let status = quest_status_to_bytes(&q.status);
         num = num.wrapping_add(1);
-        qbuf.push(q.name.len().min(255) as u8);
-        qbuf.extend_from_slice(q.name.as_bytes());
-        qbuf.extend_from_slice(&(q.status.len() as u16).to_le_bytes());
-        qbuf.extend_from_slice(q.status.as_bytes());
+        qbuf.push(name.len() as u8);
+        qbuf.extend_from_slice(name);
+        qbuf.extend_from_slice(&(status.len() as u16).to_le_bytes());
+        qbuf.extend_from_slice(&status);
         if qbuf.len() > Q_FRAGMENT_AT {
             out.push((P_FETCH_CHARACTER, prefixed(b"Q", &qbuf)));
             qbuf.clear();
@@ -372,6 +388,7 @@ fn prefixed(tag: &[u8], body: &[u8]) -> Vec<u8> {
 mod tests {
     use super::*;
     use rcce_server_accounts::store::Account;
+    use rcce_server_core::character::Character;
     use std::path::PathBuf;
 
     const MD5: &str = "5d41402abc4b2a76b9719d911017c592";
@@ -406,6 +423,25 @@ mod tests {
         let mut v = vec![b.len() as u8];
         v.extend_from_slice(b);
         v
+    }
+
+    fn fetch_quest_packet(name: &str, status: &str) -> Vec<u8> {
+        let mut store = tmp_store("fetchquest");
+        let mut account = Account::new("hero", MD5, "h@x.com").unwrap();
+        let mut record = CharacterRecord::new(Character::blank());
+        record.quests[0].name = name.into();
+        record.quests[0].status = status.into();
+        account.characters.push(record);
+        store.push(account);
+
+        let mut throttle = LoginThrottle::new();
+        let mut fetch = field(b"hero");
+        fetch.extend_from_slice(&field(MD5.as_bytes()));
+        fetch.push(0u8);
+        handle_fetch_character(&fetch, &mut store, &mut throttle, &spell_catalog(), 1, 0)
+            .into_iter()
+            .find_map(|(_, payload)| payload.starts_with(b"Q").then_some(payload))
+            .expect("one quest must produce one Q packet")
     }
 
     fn config_for(dir: PathBuf) -> ServerConfig {
@@ -677,6 +713,47 @@ mod tests {
         assert_eq!(last.1[0], b'F');
         assert_eq!(&last.1[1..3], &[0, 0]); // num quests
         assert_eq!(&last.1[3..5], &[0, 0]); // spells done
+    }
+
+    #[test]
+    fn fetch_character_quest_status_uses_legacy_low_bytes() {
+        let packet = fetch_quest_packet("Flags", "\u{ff}\u{e1}d");
+        let mut offset = 1usize; // Q tag
+        let name_len = packet[offset] as usize;
+        offset += 1 + name_len;
+        let status_len =
+            u16::from_le_bytes(packet[offset..offset + 2].try_into().unwrap()) as usize;
+        offset += 2;
+
+        assert_eq!(status_len, 3, "prefix must describe legacy status bytes");
+        assert_eq!(&packet[offset..offset + status_len], &[0xff, 0xe1, b'd']);
+        assert_eq!(
+            offset + status_len,
+            packet.len(),
+            "Q record must end at its declared status length"
+        );
+    }
+
+    #[test]
+    fn fetch_character_quest_name_payload_matches_u8_prefix() {
+        let name = "N".repeat(256);
+        let packet = fetch_quest_packet(&name, "ok");
+        let mut offset = 1usize; // Q tag
+        let name_len = packet[offset] as usize;
+        offset += 1;
+
+        assert_eq!(name_len, 255);
+        assert_eq!(&packet[offset..offset + name_len], &name.as_bytes()[..255]);
+        offset += name_len;
+        let status_len =
+            u16::from_le_bytes(packet[offset..offset + 2].try_into().unwrap()) as usize;
+        offset += 2;
+        assert_eq!(&packet[offset..offset + status_len], b"ok");
+        assert_eq!(
+            offset + status_len,
+            packet.len(),
+            "Q record must not retain bytes beyond its name prefix"
+        );
     }
 
     /// Byte-exact `S`(spells) sub-packet against the real shipped `Spells.dat`

--- a/server-rs/crates/rcce-server/src/scripts.rs
+++ b/server-rs/crates/rcce-server/src/scripts.rs
@@ -289,28 +289,16 @@ impl ScriptHost<'_> {
         }
     }
 
-    /// Send a `P_QuestLog` packet to the actor's player, if online. `'N'`/`'U'`
-    /// carry `[u8 nameLen][name][u16 statusLen][status]`; `'D'` carries the raw
-    /// name (`ScriptingCommands.bb:2211-2213`). The status is a Blitz byte string
-    /// (3 flag bytes + description) held as Latin-1 chars; the wire form is each
-    /// char's low byte (`quest_status_to_bytes`), so the 3 flag bytes + ASCII
-    /// description encode faithfully.
+    /// Send a `P_QuestLog` packet to the actor's player, if online.
     fn send_quest_log(&mut self, rid: u16, sub: u8, name: &str, status: &str) {
         let Some(peer) = self.world.peer_for_runtime(rid) else {
             return;
         };
-        let mut p = vec![sub];
-        if sub == b'D' {
-            p.extend_from_slice(name.as_bytes());
-        } else {
-            let nb = quest_name_to_bytes(name);
-            let sb = quest_status_to_bytes(status);
-            p.push(nb.len() as u8);
-            p.extend_from_slice(nb);
-            p.extend_from_slice(&(sb.len() as u16).to_le_bytes());
-            p.extend_from_slice(&sb);
-        }
-        self.out.push(Outgoing::peer(peer, world::P_QUEST_LOG, p));
+        self.out.push(Outgoing::peer(
+            peer,
+            world::P_QUEST_LOG,
+            quest_log_payload(sub, name, status),
+        ));
     }
 
     /// Broadcast `P_NameChange` for an actor (`SetName`/`SetTag`,
@@ -567,6 +555,24 @@ impl ScriptHost<'_> {
             .map(|a| if banned { a.is_banned } else { a.is_dm })
             .unwrap_or(false)
     }
+}
+
+/// Build a live `P_QuestLog` payload. `N`/`U` carry a one-byte name length and
+/// `D` carries a raw name, but all forms use the same capped name bytes so a
+/// client can delete exactly the entry it was shown.
+fn quest_log_payload(sub: u8, name: &str, status: &str) -> Vec<u8> {
+    let name = quest_name_to_bytes(name);
+    let mut payload = vec![sub];
+    if sub == b'D' {
+        payload.extend_from_slice(name);
+    } else {
+        let status = quest_status_to_bytes(status);
+        payload.push(name.len() as u8);
+        payload.extend_from_slice(name);
+        payload.extend_from_slice(&(status.len() as u16).to_le_bytes());
+        payload.extend_from_slice(&status);
+    }
+    payload
 }
 
 /// Build a quest status: 3 flag bytes (`Param4/5/6`, Latin-1) + description.
@@ -1417,6 +1423,17 @@ mod tests {
             v.extend_from_slice(&7u32.to_le_bytes());
             v
         });
+    }
+
+    #[test]
+    fn quest_log_wire_payload_caps_delete_name_like_new() {
+        let name = "N".repeat(256);
+        let new = quest_log_payload(b'N', &name, "ok");
+        assert_eq!(new[1], 255);
+        assert_eq!(&new[2..257], &name.as_bytes()[..255]);
+
+        let delete = quest_log_payload(b'D', &name, "");
+        assert_eq!(&delete[1..], &name.as_bytes()[..255]);
     }
 
     #[test]

--- a/server-rs/crates/rcce-server/src/scripts.rs
+++ b/server-rs/crates/rcce-server/src/scripts.rs
@@ -17,6 +17,7 @@ use rcce_server_accounts::store::AccountStore;
 use rcce_server_core::record::CharacterRecord;
 use rcce_server_core::ActorCatalog;
 
+use crate::characters::{quest_name_to_bytes, quest_status_to_bytes};
 use crate::spawn::SpawnManager;
 use crate::state::{clamp_attribute_max, Outgoing};
 use crate::world::{self, World};
@@ -302,7 +303,7 @@ impl ScriptHost<'_> {
         if sub == b'D' {
             p.extend_from_slice(name.as_bytes());
         } else {
-            let nb = name.as_bytes();
+            let nb = quest_name_to_bytes(name);
             let sb = quest_status_to_bytes(status);
             p.push(nb.len() as u8);
             p.extend_from_slice(nb);
@@ -566,12 +567,6 @@ impl ScriptHost<'_> {
             .map(|a| if banned { a.is_banned } else { a.is_dm })
             .unwrap_or(false)
     }
-}
-
-/// Blitz byte-string form of a quest status — Latin-1 low byte per char, so the
-/// 3 leading flag bytes (0..255) and an ASCII description encode faithfully.
-fn quest_status_to_bytes(s: &str) -> Vec<u8> {
-    s.chars().map(|c| c as u32 as u8).collect()
 }
 
 /// Build a quest status: 3 flag bytes (`Param4/5/6`, Latin-1) + description.


### PR DESCRIPTION
## Outcome

Character selection/reconnect now restores quest status flags as the legacy byte strings that the stock client expects, instead of UTF-8-expanded bytes. Oversize persisted quest names no longer desynchronize the reload stream.

## Technical changes

- Centralize capped quest-name and legacy low-byte quest-status encoding in the Rust server crate.
- Reuse that encoding for live `P_QuestLog` updates and `P_FetchCharacter` `Q` reload records.
- Add byte-level reload regressions for `ff e1 64` status bytes and a 256-byte quest name.

Fixes #753

## Acceptance evidence

| Criterion | Evidence |
| --- | --- |
| Legacy flag bytes survive reload | `fetch_character_quest_status_uses_legacy_low_bytes` asserts u16 length 3 and payload `ff e1 64`. |
| Name prefix matches payload | `fetch_character_quest_name_payload_matches_u8_prefix` asserts a 256-byte name emits exactly 255 bytes and a complete following status field. |
| Live/reload parity | Both paths import `characters::{quest_name_to_bytes, quest_status_to_bytes}`. |

## TDD and verification

- BASELINE: `PATH=/home/ryan/.cargo/bin:$PATH cargo test -p rcce-server fetch_character -- --nocapture` → 2 passed, 0 failed before the regression tests.
- RED: `cargo test -p rcce-server fetch_character_ -- --nocapture` → 0 passed, 2 failed: status prefix was 5 instead of 3; the 256-byte record desynchronized its parser.
- GREEN: the same focused command → 2 passed, 0 failed.
- Final: `cargo test --workspace --locked` → all workspace tests passed; `cargo clippy --workspace --all-targets --locked -- -D warnings` → exit 0; `git diff --check origin/develop...HEAD` → exit 0.
- Local limitation: the declared 1.85 toolchain lacks `rustfmt`; Docker is installed as a Windows shim but unavailable to this WSL distro, so the CI formatter/container smoke validation remains exact-head CI work.

## Compatibility, risk, rollback

No packet schema changes. The reload path now matches the existing live encoding; oversize names are capped to the protocol’s existing u8 capacity. Roll back by reverting commit `b273cd404803a4c36b8425dadd0cf5e07d64d41f`.

## Deferred

Quest gameplay semantics, Blitz client changes, and unrelated server paths are out of scope.

## Independent review

ACCEPT — fresh cycle-2 review of exact head 157429148ff0b2ecc0a9da7acaa3b614b4b6e8ba. The first review requested a capped DeleteQuest payload; the follow-up commit and direct N/D boundary regression addressed it.