### PR TITLE
fix(GUE): safely drain media-dialog events

### DIFF
--- a/src/GUE.bb
+++ b/src/GUE.bb
@@ -6764,11 +6764,14 @@ Function MeshDialog()
 		FUI_Update()
 		Flip(0)
 
-		For E.Event = Each Event
-			Select E\EventID
+		Local MeshEvent.Event = First Event
+		Local NextMeshEvent.Event = Null
+		While MeshEvent <> Null
+			NextMeshEvent = After MeshEvent
+			Select MeshEvent\EventID
 				; Window closed
 				Case W
-					If Lower$(E\EventData$) = "closed"
+					If Lower$(MeshEvent\EventData$) = "closed"
 						IsAnim = FUI_SendMessage(BAnimated, M_GETCHECKED)
 						IsEncrypted = False;FUI_SendMessage(BEncrypted, M_GETCHECKED)
 						Result = IsAnim Or (IsEncrypted * 2)
@@ -6780,9 +6783,10 @@ Function MeshDialog()
 					IsEncrypted = False;FUI_SendMessage(BEncrypted, M_GETCHECKED)
 					Result = IsAnim Or (IsEncrypted * 2)
 					Closed = True
-			End Select
-			Delete E
-		Next
+				End Select
+			Delete MeshEvent
+			MeshEvent = NextMeshEvent
+		Wend
 	Until Closed = True
 
 	FUI_DeleteGadget(W)
@@ -6813,11 +6817,14 @@ Function TextureDialog()
 		FUI_Update()
 		Flip(0)
 
-		For E.Event = Each Event
-			Select E\EventID
+		Local TextureEvent.Event = First Event
+		Local NextTextureEvent.Event = Null
+		While TextureEvent <> Null
+			NextTextureEvent = After TextureEvent
+			Select TextureEvent\EventID
 				; Window closed
 				Case W
-					If Lower$(E\EventData$) = "closed"
+					If Lower$(TextureEvent\EventData$) = "closed"
 						Result = FUI_SendMessageI(BColour, M_GETCHECKED) + (FUI_SendMessageI(BAlpha, M_GETCHECKED) * 2)
 						Result = Result + (FUI_SendMessageI(BMasked, M_GETCHECKED) * 4)
 						Result = Result + (FUI_SendMessageI(BMipmap, M_GETCHECKED) * 8)
@@ -6834,9 +6841,10 @@ Function TextureDialog()
 					Result = Result + (FUI_SendMessageI(BClampU, M_GETCHECKED) * 16) + (FUI_SendMessageI(BClampV, M_GETCHECKED) * 32)
 					Result = Result + (FUI_SendMessageI(BSphere, M_GETCHECKED) * 64) + (FUI_SendMessageI(BCube, M_GETCHECKED) * 128)
 					Closed = True
-			End Select
-			Delete E
-		Next
+				End Select
+			Delete TextureEvent
+			TextureEvent = NextTextureEvent
+		Wend
 	Until Closed = True
 
 	FUI_DeleteGadget(W)
@@ -6860,11 +6868,14 @@ Function SoundDialog()
 		FUI_Update()
 		Flip(0)
 
-		For E.Event = Each Event
-			Select E\EventID
+		Local SoundEvent.Event = First Event
+		Local NextSoundEvent.Event = Null
+		While SoundEvent <> Null
+			NextSoundEvent = After SoundEvent
+			Select SoundEvent\EventID
 				; Window closed
 				Case W
-					If Lower$(E\EventData$) = "closed"
+					If Lower$(SoundEvent\EventData$) = "closed"
 						Result = FUI_SendMessage(B3D, M_GETCHECKED)
 						Closed = True
 					EndIf
@@ -6872,9 +6883,10 @@ Function SoundDialog()
 				Case BDone
 					Result = FUI_SendMessage(B3D, M_GETCHECKED)
 					Closed = True
-			End Select
-			Delete E
-		Next
+				End Select
+			Delete SoundEvent
+			SoundEvent = NextSoundEvent
+		Wend
 	Until Closed = True
 
 	FUI_DeleteGadget(W)

--- a/src/Tests/Modules/GUEEventIteratorTest.bb
+++ b/src/Tests/Modules/GUEEventIteratorTest.bb
@@ -1,7 +1,7 @@
 Strict
 EnableGC
 
-; GUE consumes F-UI Event objects in two modal loops. The current event must
+; GUE consumes F-UI Event objects in several modal loops. The current event must
 ; save its successor before Delete so a burst of queued events is fully drained.
 
 Function GUEEventDrainUsesAfterCursor%(Path$, FunctionMarker$, LegacyFor$, FirstCursor$, NextDeclaration$, WhileCursor$, Capture$, DeleteEvent$, Advance$)
@@ -45,4 +45,16 @@ End Test
 
 Test testGenerateGamePatchCapturesNextEventBeforeDelete()
 	Assert(GUEEventDrainUsesAfterCursor%("GUE.bb", "Function GenerateGamePatch()", "For E.Event = Each Event", "Local QuitEvent.Event = First Event", "Local NextQuitEvent.Event = Null", "While QuitEvent <> Null", "NextQuitEvent = After QuitEvent", "Delete(QuitEvent)", "QuitEvent = NextQuitEvent") = True)
+End Test
+
+Test testMeshDialogCapturesNextEventBeforeDelete()
+	Assert(GUEEventDrainUsesAfterCursor%("GUE.bb", "Function MeshDialog()", "For E.Event = Each Event", "Local MeshEvent.Event = First Event", "Local NextMeshEvent.Event = Null", "While MeshEvent <> Null", "NextMeshEvent = After MeshEvent", "Delete MeshEvent", "MeshEvent = NextMeshEvent") = True)
+End Test
+
+Test testTextureDialogCapturesNextEventBeforeDelete()
+	Assert(GUEEventDrainUsesAfterCursor%("GUE.bb", "Function TextureDialog()", "For E.Event = Each Event", "Local TextureEvent.Event = First Event", "Local NextTextureEvent.Event = Null", "While TextureEvent <> Null", "NextTextureEvent = After TextureEvent", "Delete TextureEvent", "TextureEvent = NextTextureEvent") = True)
+End Test
+
+Test testSoundDialogCapturesNextEventBeforeDelete()
+	Assert(GUEEventDrainUsesAfterCursor%("GUE.bb", "Function SoundDialog()", "For E.Event = Each Event", "Local SoundEvent.Event = First Event", "Local NextSoundEvent.Event = Null", "While SoundEvent <> Null", "NextSoundEvent = After SoundEvent", "Delete SoundEvent", "SoundEvent = NextSoundEvent") = True)
 End Test


### PR DESCRIPTION
## Outcome

GUE now drains queued modal events safely in the Mesh, Texture, and Sound option dialogs, preventing bursty UI input from skipping queued events.

## Changes

- Replace three deleting `For Each Event` loops with typed `First` / `After` / `While` cursors.
- Extend the existing focused source-contract test for all three dialogs.

Fixes #757

## Acceptance evidence

- Each target captures its successor before deleting the current event, then advances; legacy deleting `For Each` forms are rejected.
- Existing modal `Select` result branches and F-UI event semantics are unchanged.

## TDD and verification

- Baseline: three unsafe loops observed at `src/GUE.bb:6767`, `:6816`, and `:6863`.
- RED: bounded baseline source-contract exited 1 for all three missing cursor drains.
- GREEN: bounded contract reports all three GREEN; ordered capture → delete → advance is verified; `git diff --check` exits 0.
- Native local limitation: `./test.sh GUEEventIteratorTest` exits 1 before execution because `compiler/BlitzForge/bin/blitzcc` is absent. Narrow normal submodule initialization timed out at 60 seconds; a safe shallow retry exited 128 because the pinned revision was unavailable. Exact-head CI supplied native proof.
- Exact-head CI: Build and test SUCCESS (2m56s); Rust server (Linux) SUCCESS (1m37s); API reports zero legacy status contexts.

## Compatibility, risk, rollback, and deferred work

No event IDs, payloads, F-UI internals, or non-target GUE flows changed. Risk is limited to traversal correctness; rollback is reverting commit `a39290ac`. Deferred: unrelated GUE loops and the independent Rust CI/docs findings.

## Independent review

ACCEPT — fresh review of exact head `a39290ac` found no correctness, scope, test-fit, repository-fit, docs, security, performance, concurrency-isolation, or hidden-cost findings.