### PR TITLE
Fix recursive F-UI Region child teardown iteration

### DIFF
--- a/src/Modules/F-UI.bb
+++ b/src/Modules/F-UI.bb
@@ -17750,96 +17750,168 @@ Function FUI_DeleteGadget( ID )
 	EndIf
 	reg.Region = Object.Region( ID )
 	If reg <> Null
-		For reg2.Region = Each Region
-			If reg2\Parent = ID
-				FUI_DeleteGadget( Handle( reg2 ) )
+		Local regionChild.Region = First Region
+		While regionChild <> Null
+			If regionChild\Parent = ID
+				FUI_DeleteGadget( Handle( regionChild ) )
+				regionChild = First Region
+			Else
+				regionChild = After regionChild
 			EndIf
-		Next
-		For Tab.Tab = Each Tab
-			If Tab\Parent = ID
-				FUI_DeleteGadget( Handle( Tab ) )
+		Wend
+		Local regionTab.Tab = First Tab
+		While regionTab <> Null
+			If regionTab\Parent = ID
+				FUI_DeleteGadget( Handle( regionTab ) )
+				regionTab = First Tab
+			Else
+				regionTab = After regionTab
 			EndIf
-		Next
-		For pan.Panel = Each Panel
-			If pan\Parent = ID
-				FUI_DeleteGadget( Handle( pan ) )
+		Wend
+		Local regionPanel.Panel = First Panel
+		While regionPanel <> Null
+			If regionPanel\Parent = ID
+				FUI_DeleteGadget( Handle( regionPanel ) )
+				regionPanel = First Panel
+			Else
+				regionPanel = After regionPanel
 			EndIf
-		Next
-		For btn.Button = Each Button
-			If btn\Parent = ID
-				FUI_DeleteGadget( Handle( btn ) )
+		Wend
+		Local regionButton.Button = First Button
+		While regionButton <> Null
+			If regionButton\Parent = ID
+				FUI_DeleteGadget( Handle( regionButton ) )
+				regionButton = First Button
+			Else
+				regionButton = After regionButton
 			EndIf
-		Next
-		For chk.CheckBox = Each CheckBox
-			If chk\Parent = ID
-				FUI_DeleteGadget( Handle( chk ) )
+		Wend
+		Local regionCheckBox.CheckBox = First CheckBox
+		While regionCheckBox <> Null
+			If regionCheckBox\Parent = ID
+				FUI_DeleteGadget( Handle( regionCheckBox ) )
+				regionCheckBox = First CheckBox
+			Else
+				regionCheckBox = After regionCheckBox
 			EndIf
-		Next
-		For cbo.ComboBox = Each ComboBox
-			If cbo\Parent = ID
-				FUI_DeleteGadget( Handle( cbo ) )
+		Wend
+		Local regionComboBox.ComboBox = First ComboBox
+		While regionComboBox <> Null
+			If regionComboBox\Parent = ID
+				FUI_DeleteGadget( Handle( regionComboBox ) )
+				regionComboBox = First ComboBox
+			Else
+				regionComboBox = After regionComboBox
 			EndIf
-		Next
-		For grp.GroupBox = Each GroupBox
-			If grp\Parent = ID
-				FUI_DeleteGadget( Handle( grp ) )
+		Wend
+		Local regionGroupBox.GroupBox = First GroupBox
+		While regionGroupBox <> Null
+			If regionGroupBox\Parent = ID
+				FUI_DeleteGadget( Handle( regionGroupBox ) )
+				regionGroupBox = First GroupBox
+			Else
+				regionGroupBox = After regionGroupBox
 			EndIf
-		Next
-		For img.ImageBox = Each ImageBox
-			If img\Parent = ID
-				FUI_DeleteGadget( Handle( img ) )
+		Wend
+		Local regionImageBox.ImageBox = First ImageBox
+		While regionImageBox <> Null
+			If regionImageBox\Parent = ID
+				FUI_DeleteGadget( Handle( regionImageBox ) )
+				regionImageBox = First ImageBox
+			Else
+				regionImageBox = After regionImageBox
 			EndIf
-		Next
-		For lbl.Label = Each Label
-			If lbl\Parent = ID
-				FUI_DeleteGadget( Handle( lbl ) )
+		Wend
+		Local regionLabel.Label = First Label
+		While regionLabel <> Null
+			If regionLabel\Parent = ID
+				FUI_DeleteGadget( Handle( regionLabel ) )
+				regionLabel = First Label
+			Else
+				regionLabel = After regionLabel
 			EndIf
-		Next
-		For lst.ListBox = Each ListBox
-			If lst\Parent = ID
-				FUI_DeleteGadget( Handle( lst ) )
+		Wend
+		Local regionListBox.ListBox = First ListBox
+		While regionListBox <> Null
+			If regionListBox\Parent = ID
+				FUI_DeleteGadget( Handle( regionListBox ) )
+				regionListBox = First ListBox
+			Else
+				regionListBox = After regionListBox
 			EndIf
-		Next
-		For prg.ProgressBar = Each ProgressBar
-			If prg\Parent = ID
-				FUI_DeleteGadget( Handle( prg ) )
+		Wend
+		Local regionProgressBar.ProgressBar = First ProgressBar
+		While regionProgressBar <> Null
+			If regionProgressBar\Parent = ID
+				FUI_DeleteGadget( Handle( regionProgressBar ) )
+				regionProgressBar = First ProgressBar
+			Else
+				regionProgressBar = After regionProgressBar
 			EndIf
-		Next
-		For rad.Radio = Each Radio
-			If rad\Parent = ID
-				FUI_DeleteGadget( Handle( rad ) )
+		Wend
+		Local regionRadio.Radio = First Radio
+		While regionRadio <> Null
+			If regionRadio\Parent = ID
+				FUI_DeleteGadget( Handle( regionRadio ) )
+				regionRadio = First Radio
+			Else
+				regionRadio = After regionRadio
 			EndIf
-		Next
-		For scroll.ScrollBar = Each ScrollBar
-			If scroll\Parent = ID
-				FUI_DeleteGadget( Handle( scroll ) )
+		Wend
+		Local regionScrollBar.ScrollBar = First ScrollBar
+		While regionScrollBar <> Null
+			If regionScrollBar\Parent = ID
+				FUI_DeleteGadget( Handle( regionScrollBar ) )
+				regionScrollBar = First ScrollBar
+			Else
+				regionScrollBar = After regionScrollBar
 			EndIf
-		Next
-		For sld.Slider = Each Slider
-			If sld\Parent = ID
-				FUI_DeleteGadget( Handle( sld ) )
+		Wend
+		Local regionSlider.Slider = First Slider
+		While regionSlider <> Null
+			If regionSlider\Parent = ID
+				FUI_DeleteGadget( Handle( regionSlider ) )
+				regionSlider = First Slider
+			Else
+				regionSlider = After regionSlider
 			EndIf
-		Next
-		For spn.Spinner = Each Spinner
-			If spn\Parent = ID
-				FUI_DeleteGadget( Handle( spn ) )
+		Wend
+		Local regionSpinner.Spinner = First Spinner
+		While regionSpinner <> Null
+			If regionSpinner\Parent = ID
+				FUI_DeleteGadget( Handle( regionSpinner ) )
+				regionSpinner = First Spinner
+			Else
+				regionSpinner = After regionSpinner
 			EndIf
-		Next
-		For txt.TextBox = Each TextBox
-			If txt\Parent = ID
-				FUI_DeleteGadget( Handle( txt ) )
+		Wend
+		Local regionTextBox.TextBox = First TextBox
+		While regionTextBox <> Null
+			If regionTextBox\Parent = ID
+				FUI_DeleteGadget( Handle( regionTextBox ) )
+				regionTextBox = First TextBox
+			Else
+				regionTextBox = After regionTextBox
 			EndIf
-		Next
-		For tree.TreeView = Each TreeView
-			If tree\Parent = ID
-				FUI_DeleteGadget( Handle( tree ) )
+		Wend
+		Local regionTreeView.TreeView = First TreeView
+		While regionTreeView <> Null
+			If regionTreeView\Parent = ID
+				FUI_DeleteGadget( Handle( regionTreeView ) )
+				regionTreeView = First TreeView
+			Else
+				regionTreeView = After regionTreeView
 			EndIf
-		Next
-		For view.View = Each View
-			If view\Parent = ID
-				FUI_DeleteGadget( Handle( view ) )
+		Wend
+		Local regionView.View = First View
+		While regionView <> Null
+			If regionView\Parent = ID
+				FUI_DeleteGadget( Handle( regionView ) )
+				regionView = First View
+			Else
+				regionView = After regionView
 			EndIf
-		Next
+		Wend
 		FreeEntity reg\Mesh
 		Delete reg
 		

--- a/src/Tests/Modules/FUIRegionDeleteIteratorTest.bb
+++ b/src/Tests/Modules/FUIRegionDeleteIteratorTest.bb
@@ -1,0 +1,71 @@
+Strict
+EnableGC
+
+; A Region owns child F-UI gadgets. FUI_DeleteGadget can recursively remove
+; arbitrary later nodes, so Region teardown must restart its Type-list walk
+; after deleting a child and advance with After only when the child survives.
+
+Function RegionChildTeardownUsesRestartWalk%(Path$, Start$, LegacyFor$, FirstCursor$, WhileCursor$, ParentCheck$, DeleteChild$, Restart$, Advance$)
+	Local F.BBStream = ReadFile(Path$)
+	Local InRegion%, InWalk%, Stage%
+	Local Line$
+	If F = Null Then F = ReadFile("..\" + Path$)
+	If F = Null Then F = ReadFile("..\..\" + Path$)
+	If F = Null Then Return False
+
+	While Not Eof(F)
+		Line$ = ReadLine$(F)
+		If Instr(Line$, "Function FUI_DeleteGadget( ID )") > 0 Then InRegion = True
+		If InRegion = True And InWalk = False And Instr(Line$, Start$) > 0 Then InWalk = True
+		If InWalk = True
+			If Instr(Line$, LegacyFor$) > 0
+				CloseFile F
+				Return False
+			EndIf
+			If Stage < 6 And Instr(Line$, Advance$) > 0
+				CloseFile F
+				Return False
+			EndIf
+			If Stage = 0 And Instr(Line$, FirstCursor$) > 0 Then Stage = 1
+			If Stage = 1 And Instr(Line$, WhileCursor$) > 0 Then Stage = 2
+			If Stage = 2 And Instr(Line$, ParentCheck$) > 0 Then Stage = 3
+			If Stage = 3 And Instr(Line$, DeleteChild$) > 0 Then Stage = 4
+			If Stage = 4 And Instr(Line$, Restart$) > 0 Then Stage = 5
+			If Stage = 5 And Instr(Line$, "Else") > 0 Then Stage = 6
+			If Stage = 6 And Instr(Line$, Advance$) > 0 Then Stage = 7
+			If Stage = 7 And Instr(Line$, "EndIf") > 0 Then Stage = 8
+			If Stage = 8 And Instr(Line$, "Wend") > 0
+				CloseFile F
+				Return True
+			EndIf
+		EndIf
+	Wend
+
+	CloseFile F
+	Return False
+End Function
+
+Function AssertRegionChildTeardown%(Start$, LegacyFor$, FirstCursor$, WhileCursor$, ParentCheck$, DeleteChild$, Restart$, Advance$)
+	Return RegionChildTeardownUsesRestartWalk%("Modules\F-UI.bb", Start$, LegacyFor$, FirstCursor$, WhileCursor$, ParentCheck$, DeleteChild$, Restart$, Advance$)
+End Function
+
+Test testFUIRegionChildTeardownsRestartAfterRecursiveDelete()
+	Assert(AssertRegionChildTeardown%("reg.Region = Object.Region( ID )", "For reg2.Region = Each Region", "Local regionChild.Region = First Region", "While regionChild <> Null", "If regionChild\Parent = ID", "FUI_DeleteGadget( Handle( regionChild ) )", "regionChild = First Region", "regionChild = After regionChild") = True)
+	Assert(AssertRegionChildTeardown%("reg.Region = Object.Region( ID )", "For Tab.Tab = Each Tab", "Local regionTab.Tab = First Tab", "While regionTab <> Null", "If regionTab\Parent = ID", "FUI_DeleteGadget( Handle( regionTab ) )", "regionTab = First Tab", "regionTab = After regionTab") = True)
+	Assert(AssertRegionChildTeardown%("reg.Region = Object.Region( ID )", "For pan.Panel = Each Panel", "Local regionPanel.Panel = First Panel", "While regionPanel <> Null", "If regionPanel\Parent = ID", "FUI_DeleteGadget( Handle( regionPanel ) )", "regionPanel = First Panel", "regionPanel = After regionPanel") = True)
+	Assert(AssertRegionChildTeardown%("reg.Region = Object.Region( ID )", "For btn.Button = Each Button", "Local regionButton.Button = First Button", "While regionButton <> Null", "If regionButton\Parent = ID", "FUI_DeleteGadget( Handle( regionButton ) )", "regionButton = First Button", "regionButton = After regionButton") = True)
+	Assert(AssertRegionChildTeardown%("reg.Region = Object.Region( ID )", "For chk.CheckBox = Each CheckBox", "Local regionCheckBox.CheckBox = First CheckBox", "While regionCheckBox <> Null", "If regionCheckBox\Parent = ID", "FUI_DeleteGadget( Handle( regionCheckBox ) )", "regionCheckBox = First CheckBox", "regionCheckBox = After regionCheckBox") = True)
+	Assert(AssertRegionChildTeardown%("reg.Region = Object.Region( ID )", "For cbo.ComboBox = Each ComboBox", "Local regionComboBox.ComboBox = First ComboBox", "While regionComboBox <> Null", "If regionComboBox\Parent = ID", "FUI_DeleteGadget( Handle( regionComboBox ) )", "regionComboBox = First ComboBox", "regionComboBox = After regionComboBox") = True)
+	Assert(AssertRegionChildTeardown%("reg.Region = Object.Region( ID )", "For grp.GroupBox = Each GroupBox", "Local regionGroupBox.GroupBox = First GroupBox", "While regionGroupBox <> Null", "If regionGroupBox\Parent = ID", "FUI_DeleteGadget( Handle( regionGroupBox ) )", "regionGroupBox = First GroupBox", "regionGroupBox = After regionGroupBox") = True)
+	Assert(AssertRegionChildTeardown%("reg.Region = Object.Region( ID )", "For img.ImageBox = Each ImageBox", "Local regionImageBox.ImageBox = First ImageBox", "While regionImageBox <> Null", "If regionImageBox\Parent = ID", "FUI_DeleteGadget( Handle( regionImageBox ) )", "regionImageBox = First ImageBox", "regionImageBox = After regionImageBox") = True)
+	Assert(AssertRegionChildTeardown%("reg.Region = Object.Region( ID )", "For lbl.Label = Each Label", "Local regionLabel.Label = First Label", "While regionLabel <> Null", "If regionLabel\Parent = ID", "FUI_DeleteGadget( Handle( regionLabel ) )", "regionLabel = First Label", "regionLabel = After regionLabel") = True)
+	Assert(AssertRegionChildTeardown%("reg.Region = Object.Region( ID )", "For lst.ListBox = Each ListBox", "Local regionListBox.ListBox = First ListBox", "While regionListBox <> Null", "If regionListBox\Parent = ID", "FUI_DeleteGadget( Handle( regionListBox ) )", "regionListBox = First ListBox", "regionListBox = After regionListBox") = True)
+	Assert(AssertRegionChildTeardown%("reg.Region = Object.Region( ID )", "For prg.ProgressBar = Each ProgressBar", "Local regionProgressBar.ProgressBar = First ProgressBar", "While regionProgressBar <> Null", "If regionProgressBar\Parent = ID", "FUI_DeleteGadget( Handle( regionProgressBar ) )", "regionProgressBar = First ProgressBar", "regionProgressBar = After regionProgressBar") = True)
+	Assert(AssertRegionChildTeardown%("reg.Region = Object.Region( ID )", "For rad.Radio = Each Radio", "Local regionRadio.Radio = First Radio", "While regionRadio <> Null", "If regionRadio\Parent = ID", "FUI_DeleteGadget( Handle( regionRadio ) )", "regionRadio = First Radio", "regionRadio = After regionRadio") = True)
+	Assert(AssertRegionChildTeardown%("reg.Region = Object.Region( ID )", "For scroll.ScrollBar = Each ScrollBar", "Local regionScrollBar.ScrollBar = First ScrollBar", "While regionScrollBar <> Null", "If regionScrollBar\Parent = ID", "FUI_DeleteGadget( Handle( regionScrollBar ) )", "regionScrollBar = First ScrollBar", "regionScrollBar = After regionScrollBar") = True)
+	Assert(AssertRegionChildTeardown%("reg.Region = Object.Region( ID )", "For sld.Slider = Each Slider", "Local regionSlider.Slider = First Slider", "While regionSlider <> Null", "If regionSlider\Parent = ID", "FUI_DeleteGadget( Handle( regionSlider ) )", "regionSlider = First Slider", "regionSlider = After regionSlider") = True)
+	Assert(AssertRegionChildTeardown%("reg.Region = Object.Region( ID )", "For spn.Spinner = Each Spinner", "Local regionSpinner.Spinner = First Spinner", "While regionSpinner <> Null", "If regionSpinner\Parent = ID", "FUI_DeleteGadget( Handle( regionSpinner ) )", "regionSpinner = First Spinner", "regionSpinner = After regionSpinner") = True)
+	Assert(AssertRegionChildTeardown%("reg.Region = Object.Region( ID )", "For txt.TextBox = Each TextBox", "Local regionTextBox.TextBox = First TextBox", "While regionTextBox <> Null", "If regionTextBox\Parent = ID", "FUI_DeleteGadget( Handle( regionTextBox ) )", "regionTextBox = First TextBox", "regionTextBox = After regionTextBox") = True)
+	Assert(AssertRegionChildTeardown%("reg.Region = Object.Region( ID )", "For tree.TreeView = Each TreeView", "Local regionTreeView.TreeView = First TreeView", "While regionTreeView <> Null", "If regionTreeView\Parent = ID", "FUI_DeleteGadget( Handle( regionTreeView ) )", "regionTreeView = First TreeView", "regionTreeView = After regionTreeView") = True)
+	Assert(AssertRegionChildTeardown%("reg.Region = Object.Region( ID )", "For view.View = Each View", "Local regionView.View = First View", "While regionView <> Null", "If regionView\Parent = ID", "FUI_DeleteGadget( Handle( regionView ) )", "regionView = First View", "regionView = After regionView") = True)
+End Test


### PR DESCRIPTION
## Outcome
Closing a Region now removes every nested F-UI child safely instead of advancing through a cursor that recursive teardown can invalidate.

## Technical changes
- Replace the Region branchs 18 recursive `For Each` child loops with restart-on-delete walks.
- Add an 18-assertion strict source-contract regression for each child family.

Fixes #759

## Acceptance evidence
- Region has 0 legacy `For Each` loops, 18 restart paths, 18 non-delete `After` paths, and 18 recursive delete paths.
- The regression file contains 18 focused assertions that reject the legacy loops and require the safe ordering.

## Baseline, RED, and GREEN
- BASELINE: source probe found 18 unsafe Region recursive `For Each` loops.
- RED: the portable source-contract mirror exited 1 with `unsafe Region loops=18 (expected 0)`.
- GREEN: the same mirror exited 0 with `legacy=0 restart=18 advance=18 delete=18`; the regression source contains 18 assertions.
- `git diff --check`, `bash scripts/gen_packet_index.sh --check`, and `bash scripts/gen_bvm_reference.sh --check` exited 0 (the latter prints two known DEAD-API warnings).

## Verification limit
`./test.sh FUIRegionDeleteIteratorTest` exits 1 locally because `compiler/BlitzForge/bin/blitzcc` is absent. Narrow normal submodule initialization timed out after 60s; a shallow retry reported it could not resolve the pinned revision. Exact-head Windows CI is therefore required for compiled proof.

## Compatibility, risk, and rollback
No protocol, serialized format, or public API changes. Restart-on-delete is the repository-established safe pattern for recursive teardown; its small teardown-time cost is intentional. Roll back with a revert of this two-file commit.

## Independent review
ACCEPT — a fresh independent review of exact head `9a14061fb08dbf26c7fb3776170b42328893f4d3` found no required changes.

## Deferred
No unrelated F-UI branches were changed.