### PR TITLE
fix(editors): safely drain MediaDialogs event queues

### DIFF
--- a/src/Modules/MediaDialogs.bb
+++ b/src/Modules/MediaDialogs.bb
@@ -103,8 +103,11 @@ Function ChooseMeshDialog(MeshType = MeshDialog_All, InitialFolder$ = "", XPos =
 	Result = 0
 	While Result = 0
 
-		For E.Event = Each Event
-			Select E\EventID
+		Local MeshDialogEvent.Event = First Event
+		Local NextMeshDialogEvent.Event = Null
+		While MeshDialogEvent <> Null
+			NextMeshDialogEvent = After MeshDialogEvent
+			Select MeshDialogEvent\EventID
 				; Selected folder changed
 				Case LMeshFolder
 					Name$ = FUI_SendMessage(LMeshFolder, M_GETTEXT)
@@ -124,7 +127,7 @@ Function ChooseMeshDialog(MeshType = MeshDialog_All, InitialFolder$ = "", XPos =
 					EndIf
 				; Window closed
 				Case WMeshDialog
-					If Lower$(E\EventData$) = "closed" Then Result = -1
+					If Lower$(MeshDialogEvent\EventData$) = "closed" Then Result = -1
 				; Cancel hit
 				Case BMeshDialogCancel
 					Result = -1
@@ -132,8 +135,9 @@ Function ChooseMeshDialog(MeshType = MeshDialog_All, InitialFolder$ = "", XPos =
 				Case BMeshDialogOK
 					Result = FUI_SendMessageI(FUI_SendMessage(LMeshDialog, M_GETINDEX), M_GETDATA) + 1
 			End Select
-			Delete E
-		Next
+			Delete MeshDialogEvent
+			MeshDialogEvent = NextMeshDialogEvent
+		Wend
 
 		If Mesh <> 0 Then TurnEntity Mesh, 0, 0.5, 0
 		FUI_Update()
@@ -186,8 +190,11 @@ Function ChooseTextureDialog(InitialFolder$ = "", XPos = -1, YPos = -1)
 	Result = 0
 	While Result = 0
 
-		For E.Event = Each Event
-			Select E\EventID
+		Local TextureDialogEvent.Event = First Event
+		Local NextTextureDialogEvent.Event = Null
+		While TextureDialogEvent <> Null
+			NextTextureDialogEvent = After TextureDialogEvent
+			Select TextureDialogEvent\EventID
 				; Selected folder changed
 				Case LTextureFolder
 					Name$ = FUI_SendMessage(LTextureFolder, M_GETTEXT)
@@ -203,7 +210,7 @@ Function ChooseTextureDialog(InitialFolder$ = "", XPos = -1, YPos = -1)
 					UnloadTexture(ID)
 				; Window closed
 				Case WTextureDialog
-					If Lower$(E\EventData$) = "closed" Then Result = -1
+					If Lower$(TextureDialogEvent\EventData$) = "closed" Then Result = -1
 				; Cancel hit
 				Case BTextureDialogCancel
 					Result = -1
@@ -211,8 +218,9 @@ Function ChooseTextureDialog(InitialFolder$ = "", XPos = -1, YPos = -1)
 				Case BTextureDialogOK
 					Result = FUI_SendMessageI(FUI_SendMessage(LTextureDialog, M_GETINDEX), M_GETDATA) + 1
 			End Select
-			Delete E
-		Next
+			Delete TextureDialogEvent
+			TextureDialogEvent = NextTextureDialogEvent
+		Wend
 
 		FUI_Update()
 		Flip(0)
@@ -252,8 +260,11 @@ Function ChooseSoundDialog(SoundType = SoundDialog_All, InitialFolder$ = "", XPo
 	Result = 0
 	While Result = 0
 
-		For E.Event = Each Event
-			Select E\EventID
+		Local SoundDialogEvent.Event = First Event
+		Local NextSoundDialogEvent.Event = Null
+		While SoundDialogEvent <> Null
+			NextSoundDialogEvent = After SoundDialogEvent
+			Select SoundDialogEvent\EventID
 				; Selected folder changed
 				Case LSoundFolder
 					Name$ = FUI_SendMessage(LSoundFolder, M_GETTEXT)
@@ -280,7 +291,7 @@ Function ChooseSoundDialog(SoundType = SoundDialog_All, InitialFolder$ = "", XPo
 					If Sound <> 0 Then FreeSound(Sound) : Sound = 0
 				; Window closed
 				Case WSoundDialog
-					If Lower$(E\EventData$) = "closed" Then Result = -1
+					If Lower$(SoundDialogEvent\EventData$) = "closed" Then Result = -1
 				; Cancel hit
 				Case BSoundDialogCancel
 					Result = -1
@@ -288,8 +299,9 @@ Function ChooseSoundDialog(SoundType = SoundDialog_All, InitialFolder$ = "", XPo
 				Case BSoundDialogOK
 					Result = FUI_SendMessageI(FUI_SendMessage(LSoundDialog, M_GETINDEX), M_GETDATA) + 1
 			End Select
-			Delete E
-		Next
+			Delete SoundDialogEvent
+			SoundDialogEvent = NextSoundDialogEvent
+		Wend
 
 		FUI_Update()
 		Flip(0)
@@ -329,8 +341,11 @@ Function ChooseMusicDialog(InitialFolder$ = "", XPos = -1, YPos = -1)
 	Result = 0
 	While Result = 0
 
-		For E.Event = Each Event
-			Select E\EventID
+		Local MusicDialogEvent.Event = First Event
+		Local NextMusicDialogEvent.Event = Null
+		While MusicDialogEvent <> Null
+			NextMusicDialogEvent = After MusicDialogEvent
+			Select MusicDialogEvent\EventID
 				; Selected folder changed
 				Case LMusicFolder
 					Name$ = FUI_SendMessage(LMusicFolder, M_GETTEXT)
@@ -357,7 +372,7 @@ Function ChooseMusicDialog(InitialFolder$ = "", XPos = -1, YPos = -1)
 					Chan = 0
 				; Window closed
 				Case WMusicDialog
-					If Lower$(E\EventData$) = "closed" Then Result = -1
+					If Lower$(MusicDialogEvent\EventData$) = "closed" Then Result = -1
 				; Cancel hit
 				Case BMusicDialogCancel
 					Result = -1
@@ -365,8 +380,9 @@ Function ChooseMusicDialog(InitialFolder$ = "", XPos = -1, YPos = -1)
 				Case BMusicDialogOK
 					Result = FUI_SendMessageI(FUI_SendMessage(LMusicDialog, M_GETINDEX), M_GETDATA) + 1
 			End Select
-			Delete E
-		Next
+			Delete MusicDialogEvent
+			MusicDialogEvent = NextMusicDialogEvent
+		Wend
 
 		FUI_Update()
 		Flip(0)

--- a/src/Tests/Modules/MediaDialogsEventIteratorTest.bb
+++ b/src/Tests/Modules/MediaDialogsEventIteratorTest.bb
@@ -1,0 +1,56 @@
+Strict
+EnableGC
+
+; MediaDialogs owns four modal loops that delete each handled F-UI Event. Each
+; loop must capture the successor first so a queued follow-up action is not
+; skipped after the current Event is deleted.
+Function MediaDialogsEventDrainUsesAfterCursor%(FunctionMarker$, LegacyFor$, FirstCursor$, NextDeclaration$, WhileCursor$, Capture$, DeleteEvent$, Advance$)
+	Local F.BBStream = ReadFile("Modules\\MediaDialogs.bb")
+	Local Line$
+	Local Stage%
+	If F = Null Then F = ReadFile("..\\Modules\\MediaDialogs.bb")
+	If F = Null Then F = ReadFile("..\\..\\Modules\\MediaDialogs.bb")
+	If F = Null Then Return False
+
+	While Not Eof(F)
+		Line$ = ReadLine$(F)
+		If Stage = 0 And Instr(Line$, FunctionMarker$) > 0 Then Stage = 1
+		If Stage > 0 And Instr(Line$, LegacyFor$) > 0 Then
+			CloseFile F
+			Return False
+		EndIf
+		If Stage = 1 And Instr(Line$, FirstCursor$) > 0 Then Stage = 2
+		If Stage = 2 And Instr(Line$, NextDeclaration$) > 0 Then Stage = 3
+		If Stage = 3 And Instr(Line$, WhileCursor$) > 0 Then Stage = 4
+		If Stage = 4 And Instr(Line$, Capture$) > 0 Then Stage = 5
+		If Stage < 5 And Instr(Line$, DeleteEvent$) > 0 Then
+			CloseFile F
+			Return False
+		EndIf
+		If Stage = 5 And Instr(Line$, DeleteEvent$) > 0 Then Stage = 6
+		If Stage = 6 And Instr(Line$, Advance$) > 0 Then
+			CloseFile F
+			Return True
+		EndIf
+		If Stage > 0 And Instr(Line$, "End Function") > 0 Then Exit
+	Wend
+
+	CloseFile F
+	Return False
+End Function
+
+Test testChooseMeshDialogCapturesNextEventBeforeDelete()
+	Assert(MediaDialogsEventDrainUsesAfterCursor%("Function ChooseMeshDialog", "For E.Event = Each Event", "Local MeshDialogEvent.Event = First Event", "Local NextMeshDialogEvent.Event = Null", "While MeshDialogEvent <> Null", "NextMeshDialogEvent = After MeshDialogEvent", "Delete MeshDialogEvent", "MeshDialogEvent = NextMeshDialogEvent") = True)
+End Test
+
+Test testChooseTextureDialogCapturesNextEventBeforeDelete()
+	Assert(MediaDialogsEventDrainUsesAfterCursor%("Function ChooseTextureDialog", "For E.Event = Each Event", "Local TextureDialogEvent.Event = First Event", "Local NextTextureDialogEvent.Event = Null", "While TextureDialogEvent <> Null", "NextTextureDialogEvent = After TextureDialogEvent", "Delete TextureDialogEvent", "TextureDialogEvent = NextTextureDialogEvent") = True)
+End Test
+
+Test testChooseSoundDialogCapturesNextEventBeforeDelete()
+	Assert(MediaDialogsEventDrainUsesAfterCursor%("Function ChooseSoundDialog", "For E.Event = Each Event", "Local SoundDialogEvent.Event = First Event", "Local NextSoundDialogEvent.Event = Null", "While SoundDialogEvent <> Null", "NextSoundDialogEvent = After SoundDialogEvent", "Delete SoundDialogEvent", "SoundDialogEvent = NextSoundDialogEvent") = True)
+End Test
+
+Test testChooseMusicDialogCapturesNextEventBeforeDelete()
+	Assert(MediaDialogsEventDrainUsesAfterCursor%("Function ChooseMusicDialog", "For E.Event = Each Event", "Local MusicDialogEvent.Event = First Event", "Local NextMusicDialogEvent.Event = Null", "While MusicDialogEvent <> Null", "NextMusicDialogEvent = After MusicDialogEvent", "Delete MusicDialogEvent", "MusicDialogEvent = NextMusicDialogEvent") = True)
+End Test


### PR DESCRIPTION
## Outcome

GUE media chooser dialogs now safely drain every queued UI action instead of advancing through a deleted event cursor.

## Technical changes

- Replaced the deleting `For Each Event` loops in the mesh, texture, sound, and music chooser dialogs with typed `First` / `After` / `While` walks.
- Added a focused source-contract regression test for the four capture-before-delete sequences.

Fixes #761

## Acceptance evidence

| Criterion | Evidence |
| --- | --- |
| Legacy traversal rejected | Baseline found `unsafe_for_each=4 unsafe_delete=4` in `MediaDialogs.bb`. |
| RED observed | Focused source probe exited 1 with `RED_EXPECTED: all four MediaDialogs loops still use deleting For Each traversal; focused after-cursor contract is absent`. |
| Safe traversal implemented | GREEN source probe exited 0 with `GREEN: four MediaDialogs source contracts use capture-before-delete after-cursor walks; diff check is clean`. |
| Regression test added | `src/Tests/Modules/MediaDialogsEventIteratorTest.bb` binds each function's first/capture/delete/advance sequence and rejects its legacy loop. |

## Verification

- `git diff --check` — exit 0.
- Focused GREEN source-contract probe — exit 0 (four functions verified).
- `./test.sh MediaDialogsEventIteratorTest` — exit 1 because `compiler/BlitzForge/bin/blitzcc` is absent locally. A narrow `git submodule update --init compiler/BlitzForge` timed out after 60s; the safe shallow retry exited 128: `Unable to find current revision in submodule path 'compiler/BlitzForge'`. Exact-head Windows CI will provide native test proof.

## Compatibility and rollback

No protocol, persisted data, or UI semantic change: this preserves each existing `Select` body and only makes traversal safe. Roll back with a revert of `c45aebda`.

## Deferred

F-UI internals, other dialogs, and generated artifacts remain out of scope.

## Independent review

ACCEPT — a fresh reviewer inspected `c45aebda41ea3d397b42c26aa6eb4967e3d723d9`, confirmed the two-file scope, four baseline loops, RED-to-GREEN source contract, preserved `Select` bodies and `FUI_CreateEvent` calls, and no added security, concurrency, or performance cost. Native local execution remains blocked by the absent compiler binary.