### PR TITLE
ci: exercise Windows Rust release packaging

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -119,6 +119,22 @@ jobs:
           restore-keys: |
             cargo-${{ runner.os }}-
 
+      # Exercise the Windows release wrapper, including its copies to the
+      # shipped bin paths; crate-level tests below cannot cover that contract.
+      - name: Package Rust apps for Windows
+        shell: cmd
+        run: |
+          call compile.bat -e -t -r
+          if errorlevel 1 exit /b %errorlevel%
+          if not exist bin\ClientRS.exe (
+            echo ClientRS.exe missing after Rust packaging
+            exit /b 1
+          )
+          if not exist bin\ServerRS.exe (
+            echo ServerRS.exe missing after Rust packaging
+            exit /b 1
+          )
+
       - name: Run Rust client tests (logic crates)
         shell: bash
         working-directory: client-rs

--- a/src/Tests/Modules/RustToolchainPolicyTest.bb
+++ b/src/Tests/Modules/RustToolchainPolicyTest.bb
@@ -93,6 +93,12 @@ Test testExplicitRustBuildsRejectMissingCargo()
 	Assert(FileContainsSequenceBefore%("compile.bat", "if errorlevel 1 (", "Cannot build ClientRS.exe/ServerRS.exe.", "exit /b 1", ")") = True)
 End Test
 
+Test testWindowsCIExercisesRustReleasePackaging()
+	Assert(FileContainsSequenceBefore%(".github\workflows\ci.yml", "- name: Package Rust apps for Windows", "call compile.bat -e -t -r", "if errorlevel 1 exit /b %errorlevel%", "- name: Run Rust client tests (logic crates)") = True)
+	Assert(FileContains%(".github\workflows\ci.yml", "if not exist bin\ClientRS.exe (") = True)
+	Assert(FileContains%(".github\workflows\ci.yml", "if not exist bin\ServerRS.exe (") = True)
+End Test
+
 Test testRustServerContainerBuilderKeepsDeclaredToolchainAndLockfile()
 	Assert(FileContains%("server-rs\Dockerfile", "FROM rust:1.85.0-bookworm AS build") = True)
 	Assert(FileContains%("server-rs\Dockerfile", "RUN cargo build --release --locked --bin rcce-server") = True)


### PR DESCRIPTION
## Outcome
Windows pull-request CI now exercises the actual Rust release-packaging path, so a broken wrapper or missing copied executable is caught before a source builder encounters it.

## Changes
- Adds a named Windows CMD CI step after the Rust cache: `compile.bat -e -t -r`.
- Propagates wrapper failures and requires `bin\ClientRS.exe` plus `bin\ServerRS.exe`.
- Adds a strict `RustToolchainPolicyTest.bb` contract for the command, error propagation, and both output checks.

Fixes #763

## Acceptance evidence
- CI command and output checks: workflow lines 124-136.
- Regression contract: `RustToolchainPolicyTest.bb` lines 96-100.
- `GREEN: Windows Rust packaging contract present` from the portable source-contract mirror.

## TDD and verification
- Baseline: `./test.sh RustToolchainPolicyTest` exited 1 because `compiler/BlitzForge/bin/blitzcc` was absent; source scans for the wrapper command and both artifact checks each exited 1 (absent).
- RED: focused portable contract mirror exited 1 with `RED: missing Windows Rust packaging contract: step-name release-command client-artifact server-artifact`.
- GREEN: portable contract mirror, `git diff --check`, `bash scripts/gen_packet_index.sh --check`, and `bash scripts/gen_bvm_reference.sh --check` all exited 0. The BVM check emitted its two known DEAD-API warnings only.
- Native local Blitz compilation remains unavailable after narrow submodule initialization because `compiler/BlitzForge/bin/blitzcc` is absent; exact-head Windows CI is the required compiled proof.

## Compatibility, risk, rollback
No production code, network protocol, persistence format, release behavior, or Linux CI changes. Risk is additional Windows CI time and intentional failure when packaging is broken. Roll back by reverting this one commit.

## Deferred
No release/deployment changes, no Rust implementation changes, and no Windows artifact upload policy are included.

## Independent review
Fresh independent reviewer verdict: **ACCEPT** for exact head `f078d6b942136da6046792e4926ea5d28958cb8d`. It confirmed the two-file scope, wrapper placement after setup/cache, failure propagation, both executable checks, and the regression contract. No required changes. Exact-head CI remains the final merge gate.