### PR TITLE
test: stabilize Unix test runner order

### DIFF
--- a/src/Tests/Modules/UnixTestRunnerOrderTest.bb
+++ b/src/Tests/Modules/UnixTestRunnerOrderTest.bb
@@ -8,6 +8,8 @@ EnableGC
 Function FileContains%(Path$, Needle$)
 	Local F.BBStream = ReadFile(Path$)
 	Local Line$
+	If F = Null Then F = ReadFile("../" + Path$)
+	If F = Null Then F = ReadFile("../../" + Path$)
 	If F = Null Then F = ReadFile("..\\" + Path$)
 	If F = Null Then F = ReadFile("..\\..\\" + Path$)
 	If F = Null Then Return False
@@ -26,6 +28,8 @@ Function FileContainsSequence%(Path$, FirstNeedle$, SecondNeedle$, ThirdNeedle$)
 	Local F.BBStream = ReadFile(Path$)
 	Local Line$
 	Local Stage = 0
+	If F = Null Then F = ReadFile("../" + Path$)
+	If F = Null Then F = ReadFile("../../" + Path$)
 	If F = Null Then F = ReadFile("..\\" + Path$)
 	If F = Null Then F = ReadFile("..\\..\\" + Path$)
 	If F = Null Then Return False

--- a/src/Tests/Modules/UnixTestRunnerOrderTest.bb
+++ b/src/Tests/Modules/UnixTestRunnerOrderTest.bb
@@ -1,0 +1,52 @@
+Strict
+EnableGC
+
+; Source-contract regression for the Unix runner's contributor-visible test
+; ordering. This stays standalone because the runner is a shell entry point,
+; not a Blitz module that a Strict test can Include.
+
+Function FileContains%(Path$, Needle$)
+	Local F.BBStream = ReadFile(Path$)
+	Local Line$
+	If F = Null Then F = ReadFile("..\\" + Path$)
+	If F = Null Then F = ReadFile("..\\..\\" + Path$)
+	If F = Null Then Return False
+	While Not Eof(F)
+		Line$ = ReadLine$(F)
+		If Instr(Line$, Needle$) > 0
+			CloseFile F
+			Return True
+		EndIf
+	Wend
+	CloseFile F
+	Return False
+End Function
+
+Function FileContainsSequence%(Path$, FirstNeedle$, SecondNeedle$, ThirdNeedle$)
+	Local F.BBStream = ReadFile(Path$)
+	Local Line$
+	Local Stage = 0
+	If F = Null Then F = ReadFile("..\\" + Path$)
+	If F = Null Then F = ReadFile("..\\..\\" + Path$)
+	If F = Null Then Return False
+	While Not Eof(F)
+		Line$ = ReadLine$(F)
+		If Stage = 0 And Instr(Line$, FirstNeedle$) > 0 Then Stage = 1
+		If Stage = 1 And Instr(Line$, SecondNeedle$) > 0 Then Stage = 2
+		If Stage = 2 And Instr(Line$, ThirdNeedle$) > 0
+			CloseFile F
+			Return True
+		EndIf
+	Wend
+	CloseFile F
+	Return False
+End Function
+
+Test testUnixRunnerSortsNulDelimitedDiscoveryBeforeExecution()
+	Assert(FileContains%("test.sh", "export LC_ALL=C") = True)
+	Assert(FileContainsSequence%("test.sh", "find " + Chr$(34) + "${TESTDIR}" + Chr$(34) + " -type f -name '*.bb' -print0", "for ((i = 1; i < ${#FILES[@]}; i++)); do", "for f in " + Chr$(34) + "${FILES[@]}" + Chr$(34) + "; do") = True)
+End Test
+
+Test testUnixRunnerRetainsTheExistingFileExecutionLoop()
+	Assert(FileContains%("test.sh", "for f in " + Chr$(34) + "${FILES[@]}" + Chr$(34) + "; do") = True)
+End Test

--- a/test.sh
+++ b/test.sh
@@ -11,6 +11,9 @@
 #                          ItemsTest stack-overflow flake locally)
 set -uo pipefail
 
+# Keep discovery and failure reporting stable across contributor locales.
+export LC_ALL=C
+
 ROOTDIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 BLITZPATH="${ROOTDIR}/compiler/BlitzForge"
 
@@ -48,6 +51,19 @@ while IFS= read -r -d '' f; do
     FILES+=("${f}")
   fi
 done < <(find "${TESTDIR}" -type f -name '*.bb' -print0)
+
+# Bash 3 (the macOS system shell) has arrays but no mapfile, while BSD sort
+# lacks GNU sort's NUL-delimited mode. Sort the already NUL-safely collected
+# paths in place so names containing whitespace or newlines remain intact.
+for ((i = 1; i < ${#FILES[@]}; i++)); do
+  current="${FILES[i]}"
+  j=$((i - 1))
+  while ((j >= 0)) && [[ "${FILES[j]}" > "${current}" ]]; do
+    FILES[j + 1]="${FILES[j]}"
+    j=$((j - 1))
+  done
+  FILES[j + 1]="${current}"
+done
 
 TOTAL="${#FILES[@]}"
 


### PR DESCRIPTION
## Outcome

Unix contributors now see test execution and failure summaries in one reproducible lexical order, independent of filesystem traversal and locale.

## Changes

- Keep NUL-delimited `find` discovery and current filter/no-match behavior.
- Export `LC_ALL=C` and sort the collected array in-place using Bash 3-compatible logic, avoiding unsupported BSD `sort -z` on macOS.
- Add a focused Strict source-contract test that pins the discovery → sort → execution sequence.

Fixes #767

## Acceptance evidence

- **Deterministic order:** `bash -n test.sh` exited 0; an executed Bash 3-compatible ordering probe returned `src/Tests/ExampleTest.bb` first and verified no descending pair.
- **NUL safety and placement:** source probes confirmed `find ... -print0`, `export LC_ALL=C`, the array sort, and the contract sequence before `for f in "${FILES[@]}"`.
- **Existing runner behavior:** filtering/no-match logic and compiler invocation are unchanged by the two-file diff.

## RED → GREEN

- **RED:** required lexical-order source probe exited 1 before implementation. A portability review then replaced the initial GNU-only `sort -z` approach; the Bash 3-compatible array-sort probe also exited 1 before that correction.
- **GREEN:** `bash -n test.sh` exited 0; the final portable ordering probe exited 0; `git diff --check HEAD` exited 0.

## Baseline and final verification

- **Baseline:** `bash -n test.sh` exited 0; unsorted discovery began with `src/Tests/Helpers/List/ListTest.bb`, while lexical reference began with `src/Tests/ExampleTest.bb`.
- **Final:** `bash -n test.sh` exited 0; portable array ordering probe exited 0 and began with `src/Tests/ExampleTest.bb`; `git diff --check origin/develop...HEAD` exited 0.
- **Native limitation:** `./test.sh UnixTestRunnerOrderTest` exits 1 here because `compiler/BlitzForge/bin/blitzcc` is absent. Exact-head CI is required for native test execution.

## Compatibility, risk, and rollback

No compiler invocation, test set, data format, protocol, or Windows runner behavior changes. The sort is intentionally implemented in Bash arrays to keep macOS Bash 3 and whitespace/newline-safe paths supported. Rollback is a normal revert of this single commit.

## Independent review

Fresh independent re-review: ACCEPT for `a42fba7bc02af6d91506da401b1e6ca91e4501af`; it exercised a fake compiler fixture for stable C-locale ordering, whitespace/newline-safe paths, filtering, and no-match behavior.