### PR TITLE
fix(architect): safely drain modal event queues

### DIFF
--- a/src/Modules/Architect_Gui_Shell_Fui.bb
+++ b/src/Modules/Architect_Gui_Shell_Fui.bb
@@ -244,10 +244,13 @@ Function FUI_Confirm(msg$,ys$,no$)
     FUI_SendMessage(gui_controlswindow,m_open)
 	TClose = False
 	Repeat
-		 For e.Event = Each Event
-		 	Select e\EventID
+		Local ArchitectEvent.Event = First Event
+		Local ArchitectNextEvent.Event = Null
+		While ArchitectEvent <> Null
+			ArchitectNextEvent = After ArchitectEvent
+			Select ArchitectEvent\EventID
 		 		Case GUI_CONTROLSWINDOW
-		 			Select e\EventData
+				Select ArchitectEvent\EventData
 		 				Case "Closed"
 		 					TClose = True
                             Return  -1
@@ -262,8 +265,9 @@ Function FUI_Confirm(msg$,ys$,no$)
               
                     Return  -1
 		 	End Select
-		 	Delete e
-		 Next
+			Delete ArchitectEvent
+			ArchitectEvent = ArchitectNextEvent
+		Wend
 		 If KeyHit( 1 ) Then TClose = True
 		 ;#Region Rendering	
 			CameraProjMode( App\Cam, False )
@@ -300,18 +304,22 @@ Function ControlsWindow( )
 	FUI_CenterWindow( GUI_CONTROLSWINDOW )
 	TClose = False
 	Repeat
-		 For e.Event = Each Event
-		 	Select e\EventID
+		Local ArchitectEvent.Event = First Event
+		Local ArchitectNextEvent.Event = Null
+		While ArchitectEvent <> Null
+			ArchitectNextEvent = After ArchitectEvent
+			Select ArchitectEvent\EventID
 		 		Case GUI_CONTROLSWINDOW
-		 			Select e\EventData
+				Select ArchitectEvent\EventData
 		 				Case "Closed"
 		 					TClose = True
 		 			End Select
 		 		Case GUI_CONTROLSWINDOW_BUTTON_OK
 		 			tClose = True
 		 	End Select
-		 	Delete e
-		 Next
+			Delete ArchitectEvent
+			ArchitectEvent = ArchitectNextEvent
+		Wend
 		 If KeyHit( 1 ) Then TClose = True
 		 ;#Region Rendering	
 			CameraProjMode( App\Cam, False )
@@ -349,18 +357,22 @@ Function AboutWindow( )
   	    FUI_CenterWindow( GUI_ABOUTWINDOW )
 		TClose = False
 		Repeat
-		 For e.Event = Each Event
-		 	Select e\EventID
+		Local ArchitectEvent.Event = First Event
+		Local ArchitectNextEvent.Event = Null
+		While ArchitectEvent <> Null
+			ArchitectNextEvent = After ArchitectEvent
+			Select ArchitectEvent\EventID
 		 		Case GUI_ABOUTWINDOW
-		 			Select e\EventData
+				Select ArchitectEvent\EventData
 		 			Case "Closed"
 		 			TClose = True
 		 			End Select
 		 		Case GUI_ABOUTWINDOW_BUTTON_OK
 		 			tClose = True
 		 	End Select
-		 	Delete e
-		 Next
+			Delete ArchitectEvent
+			ArchitectEvent = ArchitectNextEvent
+		Wend
 		 If KeyHit( 1 ) Then TClose = True
 		 ;#Region Rendering	
 			CameraProjMode( App\Cam, False )

--- a/src/Tests/Modules/ArchitectGuiShellFuiEventIteratorTest.bb
+++ b/src/Tests/Modules/ArchitectGuiShellFuiEventIteratorTest.bb
@@ -4,51 +4,47 @@ EnableGC
 ; RC Architect deletes handled F-UI Events in three modal dialogs. Each walk
 ; must retain the successor before deleting the current Event so a queued
 ; follow-up input is not skipped.
-Function ArchitectModalEventDrainUsesAfterCursor%(FunctionMarker$, LegacyFor$, FirstCursor$, NextDeclaration$, WhileCursor$, Capture$, DeleteEvent$, Advance$)
-	Local F.BBStream
+Function ArchitectModalEventDrainsUseAfterCursor%()
+	Local F.BBStream = ReadFile("Modules\\Architect_Gui_Shell_Fui.bb")
 	Local Line$
-	Local Stage% = 0
-	F = ReadFile("Modules\\Architect_Gui_Shell_Fui.bb")
+	Local Active%, Stage%, Finished%
 	If F = Null Then F = ReadFile("..\\Modules\\Architect_Gui_Shell_Fui.bb")
 	If F = Null Then F = ReadFile("..\\..\\Modules\\Architect_Gui_Shell_Fui.bb")
 	If F = Null Then Return False
-	Stage = 0
 
 	While Not Eof(F)
 		Line$ = ReadLine$(F)
-		If Stage = 0 And Left$(Line$, Len(FunctionMarker$)) = FunctionMarker$ Then Stage = 1
-		If Stage > 0 And Instr(Line$, LegacyFor$) > 0 Then
+		If Left$(Line$, Len("Function FUI_Confirm")) = "Function FUI_Confirm" Then Active = 1 : Stage = 1
+		If Left$(Line$, Len("Function ControlsWindow")) = "Function ControlsWindow" Then Active = 2 : Stage = 1
+		If Left$(Line$, Len("Function AboutWindow")) = "Function AboutWindow" Then Active = 3 : Stage = 1
+		If Active = 0 Then Continue
+		If Instr(Line$, "For e.Event = Each Event") > 0 Then
 			CloseFile F
 			Return False
 		EndIf
-		If Stage = 1 And Instr(Line$, FirstCursor$) > 0 Then Stage = 2
-		If Stage = 2 And Instr(Line$, NextDeclaration$) > 0 Then Stage = 3
-		If Stage = 3 And Instr(Line$, WhileCursor$) > 0 Then Stage = 4
-		If Stage = 4 And Instr(Line$, Capture$) > 0 Then Stage = 5
-		If Stage < 5 And Instr(Line$, DeleteEvent$) > 0 Then
+		If Stage = 1 And Instr(Line$, "Local ArchitectEvent.Event = First Event") > 0 Then Stage = 2
+		If Stage = 2 And Instr(Line$, "Local ArchitectNextEvent.Event = Null") > 0 Then Stage = 3
+		If Stage = 3 And Instr(Line$, "While ArchitectEvent <> Null") > 0 Then Stage = 4
+		If Stage = 4 And Instr(Line$, "ArchitectNextEvent = After ArchitectEvent") > 0 Then Stage = 5
+		If Stage < 5 And Instr(Line$, "Delete ArchitectEvent") > 0 Then
 			CloseFile F
 			Return False
 		EndIf
-		If Stage = 5 And Instr(Line$, DeleteEvent$) > 0 Then Stage = 6
-		If Stage = 6 And Instr(Line$, Advance$) > 0 Then
-			CloseFile F
-			Return True
+		If Stage = 5 And Instr(Line$, "Delete ArchitectEvent") > 0 Then Stage = 6
+		If Stage = 6 And Instr(Line$, "ArchitectEvent = ArchitectNextEvent") > 0 Then
+			Finished = Finished + 1
+			Active = 0
 		EndIf
-		If Stage > 0 And Instr(Line$, "End Function") > 0 Then Exit
+		If Active > 0 And Instr(Line$, "End Function") > 0 Then
+			CloseFile F
+			Return False
+		EndIf
 	Wend
 
 	CloseFile F
-	Return False
+	Return Finished = 3
 End Function
 
-Test testFUIConfirmCapturesNextEventBeforeDelete()
-	Assert(ArchitectModalEventDrainUsesAfterCursor%("Function FUI_Confirm", "For e.Event = Each Event", "Local ArchitectEvent.Event = First Event", "Local ArchitectNextEvent.Event = Null", "While ArchitectEvent <> Null", "ArchitectNextEvent = After ArchitectEvent", "Delete ArchitectEvent", "ArchitectEvent = ArchitectNextEvent") = True)
-End Test
-
-Test testControlsWindowCapturesNextEventBeforeDelete()
-	Assert(ArchitectModalEventDrainUsesAfterCursor%("Function ControlsWindow", "For e.Event = Each Event", "Local ArchitectEvent.Event = First Event", "Local ArchitectNextEvent.Event = Null", "While ArchitectEvent <> Null", "ArchitectNextEvent = After ArchitectEvent", "Delete ArchitectEvent", "ArchitectEvent = ArchitectNextEvent") = True)
-End Test
-
-Test testAboutWindowCapturesNextEventBeforeDelete()
-	Assert(ArchitectModalEventDrainUsesAfterCursor%("Function AboutWindow", "For e.Event = Each Event", "Local ArchitectEvent.Event = First Event", "Local ArchitectNextEvent.Event = Null", "While ArchitectEvent <> Null", "ArchitectNextEvent = After ArchitectEvent", "Delete ArchitectEvent", "ArchitectEvent = ArchitectNextEvent") = True)
+Test testArchitectModalEventDrainsCaptureNextBeforeDelete()
+	Assert(ArchitectModalEventDrainsUseAfterCursor%() = True)
 End Test

--- a/src/Tests/Modules/ArchitectGuiShellFuiEventIteratorTest.bb
+++ b/src/Tests/Modules/ArchitectGuiShellFuiEventIteratorTest.bb
@@ -1,0 +1,52 @@
+Strict
+EnableGC
+
+; RC Architect deletes handled F-UI Events in three modal dialogs. Each walk
+; must retain the successor before deleting the current Event so a queued
+; follow-up input is not skipped.
+Function ArchitectModalEventDrainUsesAfterCursor%(FunctionMarker$, LegacyFor$, FirstCursor$, NextDeclaration$, WhileCursor$, Capture$, DeleteEvent$, Advance$)
+	Local F.BBStream = ReadFile("Modules\\Architect_Gui_Shell_Fui.bb")
+	Local Line$
+	Local Stage%
+	If F = Null Then F = ReadFile("..\\Modules\\Architect_Gui_Shell_Fui.bb")
+	If F = Null Then F = ReadFile("..\\..\\Modules\\Architect_Gui_Shell_Fui.bb")
+	If F = Null Then Return False
+
+	While Not Eof(F)
+		Line$ = ReadLine$(F)
+		If Stage = 0 And Instr(Line$, FunctionMarker$) > 0 Then Stage = 1
+		If Stage > 0 And Instr(Line$, LegacyFor$) > 0 Then
+			CloseFile F
+			Return False
+		EndIf
+		If Stage = 1 And Instr(Line$, FirstCursor$) > 0 Then Stage = 2
+		If Stage = 2 And Instr(Line$, NextDeclaration$) > 0 Then Stage = 3
+		If Stage = 3 And Instr(Line$, WhileCursor$) > 0 Then Stage = 4
+		If Stage = 4 And Instr(Line$, Capture$) > 0 Then Stage = 5
+		If Stage < 5 And Instr(Line$, DeleteEvent$) > 0 Then
+			CloseFile F
+			Return False
+		EndIf
+		If Stage = 5 And Instr(Line$, DeleteEvent$) > 0 Then Stage = 6
+		If Stage = 6 And Instr(Line$, Advance$) > 0 Then
+			CloseFile F
+			Return True
+		EndIf
+		If Stage > 0 And Instr(Line$, "End Function") > 0 Then Exit
+	Wend
+
+	CloseFile F
+	Return False
+End Function
+
+Test testFUIConfirmCapturesNextEventBeforeDelete()
+	Assert(ArchitectModalEventDrainUsesAfterCursor%("Function FUI_Confirm", "For e.Event = Each Event", "Local ArchitectEvent.Event = First Event", "Local ArchitectNextEvent.Event = Null", "While ArchitectEvent <> Null", "ArchitectNextEvent = After ArchitectEvent", "Delete ArchitectEvent", "ArchitectEvent = ArchitectNextEvent") = True)
+End Test
+
+Test testControlsWindowCapturesNextEventBeforeDelete()
+	Assert(ArchitectModalEventDrainUsesAfterCursor%("Function ControlsWindow", "For e.Event = Each Event", "Local ArchitectEvent.Event = First Event", "Local ArchitectNextEvent.Event = Null", "While ArchitectEvent <> Null", "ArchitectNextEvent = After ArchitectEvent", "Delete ArchitectEvent", "ArchitectEvent = ArchitectNextEvent") = True)
+End Test
+
+Test testAboutWindowCapturesNextEventBeforeDelete()
+	Assert(ArchitectModalEventDrainUsesAfterCursor%("Function AboutWindow", "For e.Event = Each Event", "Local ArchitectEvent.Event = First Event", "Local ArchitectNextEvent.Event = Null", "While ArchitectEvent <> Null", "ArchitectNextEvent = After ArchitectEvent", "Delete ArchitectEvent", "ArchitectEvent = ArchitectNextEvent") = True)
+End Test

--- a/src/Tests/Modules/ArchitectGuiShellFuiEventIteratorTest.bb
+++ b/src/Tests/Modules/ArchitectGuiShellFuiEventIteratorTest.bb
@@ -5,9 +5,10 @@ EnableGC
 ; must retain the successor before deleting the current Event so a queued
 ; follow-up input is not skipped.
 Function ArchitectModalEventDrainUsesAfterCursor%(FunctionMarker$, LegacyFor$, FirstCursor$, NextDeclaration$, WhileCursor$, Capture$, DeleteEvent$, Advance$)
-	Local F.BBStream = ReadFile("Modules\\Architect_Gui_Shell_Fui.bb")
+	Local F.BBStream
 	Local Line$
 	Local Stage% = 0
+	F = ReadFile("Modules\\Architect_Gui_Shell_Fui.bb")
 	If F = Null Then F = ReadFile("..\\Modules\\Architect_Gui_Shell_Fui.bb")
 	If F = Null Then F = ReadFile("..\\..\\Modules\\Architect_Gui_Shell_Fui.bb")
 	If F = Null Then Return False

--- a/src/Tests/Modules/ArchitectGuiShellFuiEventIteratorTest.bb
+++ b/src/Tests/Modules/ArchitectGuiShellFuiEventIteratorTest.bb
@@ -14,7 +14,7 @@ Function ArchitectModalEventDrainUsesAfterCursor%(FunctionMarker$, LegacyFor$, F
 
 	While Not Eof(F)
 		Line$ = ReadLine$(F)
-		If Stage = 0 And Instr(Line$, FunctionMarker$) > 0 Then Stage = 1
+		If Stage = 0 And Left$(Line$, Len(FunctionMarker$)) = FunctionMarker$ Then Stage = 1
 		If Stage > 0 And Instr(Line$, LegacyFor$) > 0 Then
 			CloseFile F
 			Return False

--- a/src/Tests/Modules/ArchitectGuiShellFuiEventIteratorTest.bb
+++ b/src/Tests/Modules/ArchitectGuiShellFuiEventIteratorTest.bb
@@ -7,7 +7,7 @@ EnableGC
 Function ArchitectModalEventDrainUsesAfterCursor%(FunctionMarker$, LegacyFor$, FirstCursor$, NextDeclaration$, WhileCursor$, Capture$, DeleteEvent$, Advance$)
 	Local F.BBStream = ReadFile("Modules\\Architect_Gui_Shell_Fui.bb")
 	Local Line$
-	Local Stage%
+	Local Stage% = 0
 	If F = Null Then F = ReadFile("..\\Modules\\Architect_Gui_Shell_Fui.bb")
 	If F = Null Then F = ReadFile("..\\..\\Modules\\Architect_Gui_Shell_Fui.bb")
 	If F = Null Then Return False

--- a/src/Tests/Modules/ArchitectGuiShellFuiEventIteratorTest.bb
+++ b/src/Tests/Modules/ArchitectGuiShellFuiEventIteratorTest.bb
@@ -11,6 +11,7 @@ Function ArchitectModalEventDrainUsesAfterCursor%(FunctionMarker$, LegacyFor$, F
 	If F = Null Then F = ReadFile("..\\Modules\\Architect_Gui_Shell_Fui.bb")
 	If F = Null Then F = ReadFile("..\\..\\Modules\\Architect_Gui_Shell_Fui.bb")
 	If F = Null Then Return False
+	Stage = 0
 
 	While Not Eof(F)
 		Line$ = ReadLine$(F)


### PR DESCRIPTION
## Outcome
RC Architect modal dialogs now keep walking the F-UI event queue safely after deleting an event, so a queued follow-up input is not skipped.

## Changes
- Replace unsafe deleting For Each Event loops in FUI_Confirm, ControlsWindow, and AboutWindow with First / After / While cursor walks.
- Add a single-read, bounded source-contract regression test for all three function bodies.

Fixes #769

## Acceptance evidence
- RED: three focused probes exited 1 for the legacy loops.
- GREEN: three final source-contract mirrors exited 0 for First -> After -> Delete -> advance order.
- Final local checks: git diff --check, scripts/gen_packet_index.sh --check, and scripts/gen_bvm_reference.sh --check all exited 0; BVM reference emitted only the known BVM_SETOWNER/BVM_SCENERYOWNER warnings.
- Exact-head CI: Build and test SUCCESS (6m55s); Rust server (Linux) SUCCESS (1m27s); zero legacy status contexts.
- Native local test execution remains unavailable because compiler/BlitzForge/bin/blitzcc is absent after narrow submodule initialization.

## Compatibility and rollback
No wire, persisted-data, F-UI-internal, or event-semantics change. Existing close/result/render paths remain unchanged. Roll back by reverting the PR commits.

## Independent review
Fresh review: ACCEPT at a07e88e. It confirmed the two-file scope, cursor ordering, preserved FUI_Confirm early returns, bounded test coverage, exact-head CI, and no legacy statuses.