### PR TITLE
fix(loom): guard stale spawn actor metadata in viewport

### DIFF
--- a/src/Modules/Loom/ZoneViewport.bb
+++ b/src/Modules/Loom/ZoneViewport.bb
@@ -1002,7 +1002,9 @@ Function Loom_LoadZoneMarkers(Ar.Area)
                     spawnMeshCount = spawnMeshCount + 1
                     PositionEntity sEn, Ar\WaypointX#[waypointIdx], VPSceneYOff# + Ar\WaypointY#[waypointIdx], Ar\WaypointZ#[waypointIdx]
                     Local A2.Actor = ActorList(Ar\SpawnActor[i])
-                    If A2 <> Null And A2\Scale# > 0.0 Then spawnScale# = A2\Scale#
+                    If A2 <> Null Then
+                        If A2\Scale# > 0.0 Then spawnScale# = A2\Scale#
+                    EndIf
                 Else
                     ; Fallback marker cube (centered -> lift by half-size).
                     sEn = CreateCube()

--- a/src/Tests/Modules/LoomSpawnActorScaleGuardTest.bb
+++ b/src/Tests/Modules/LoomSpawnActorScaleGuardTest.bb
@@ -1,0 +1,31 @@
+Strict
+EnableGC
+
+Function FileContains%(Path$, Needle$)
+	Local F.BBStream = ReadFile(Path$)
+	Local Line$
+	If F = Null Then F = ReadFile("..\" + Path$)
+	If F = Null Then F = ReadFile("..\..\" + Path$)
+	If F = Null Then Return False
+
+	While Not Eof(F)
+		Line$ = ReadLine$(F)
+		If Instr(Line$, Needle$) > 0
+			CloseFile F
+			Return True
+		EndIf
+	Wend
+
+	CloseFile F
+	Return False
+End Function
+
+Test testSpawnMarkerScaleGuardsStaleActorMetadata()
+	Local Source$ = "Modules\Loom\ZoneViewport.bb"
+
+	Assert(FileContains%(Source$, "Local spawnScale# = VP_MARKER_SIZE#") = True)
+	Assert(FileContains%(Source$, "Local A2.Actor = ActorList(Ar\SpawnActor[i])") = True)
+	Assert(FileContains%(Source$, "                    If A2 <> Null Then") = True)
+	Assert(FileContains%(Source$, "                        If A2\Scale# > 0.0 Then spawnScale# = A2\Scale#") = True)
+	Assert(FileContains%(Source$, "If A2 <> Null And A2\Scale# > 0.0 Then spawnScale# = A2\Scale#") = False)
+End Test

--- a/src/Tests/Modules/LoomSpawnActorScaleGuardTest.bb
+++ b/src/Tests/Modules/LoomSpawnActorScaleGuardTest.bb
@@ -27,30 +27,30 @@ End Function
 Function HasSafeSpawnMarkerScaleGuard%(Path$)
 	Local F.BBStream = ReadFile(Path$)
 	Local Line$
-	Local Step = 0
+	Local Stage = 0
 	If F = Null Then F = ReadFile("..\" + Path$)
 	If F = Null Then F = ReadFile("..\..\" + Path$)
 	If F = Null Then Return False
 
 	While Not Eof(F)
 		Line$ = ReadLine$(F)
-		Select Step
+		Select Stage
 			Case 0
-				If Instr(Line$, "Local spawnScale# = VP_MARKER_SIZE#") > 0 Then Step = 1
+				If Instr(Line$, "Local spawnScale# = VP_MARKER_SIZE#") > 0 Then Stage = 1
 			Case 1
-				If Instr(Line$, "Local A2.Actor = ActorList(Ar\SpawnActor[i])") > 0 Then Step = 2
+				If Instr(Line$, "Local A2.Actor = ActorList(Ar\SpawnActor[i])") > 0 Then Stage = 2
 			Case 2
 				If Trim$(Line$) <> "If A2 <> Null Then"
 					CloseFile F
 					Return False
 				EndIf
-				Step = 3
+				Stage = 3
 			Case 3
 				If Trim$(Line$) <> "If A2\Scale# > 0.0 Then spawnScale# = A2\Scale#"
 					CloseFile F
 					Return False
 				EndIf
-				Step = 4
+				Stage = 4
 			Case 4
 				CloseFile F
 				Return Trim$(Line$) = "EndIf"

--- a/src/Tests/Modules/LoomSpawnActorScaleGuardTest.bb
+++ b/src/Tests/Modules/LoomSpawnActorScaleGuardTest.bb
@@ -1,19 +1,60 @@
 Strict
 EnableGC
 
-Function FileContains%(Path$, Needle$)
+Function FileOccurrenceCount%(Path$, Needle$)
 	Local F.BBStream = ReadFile(Path$)
 	Local Line$
+	Local Count = 0
+	If F = Null Then F = ReadFile("..\" + Path$)
+	If F = Null Then F = ReadFile("..\..\" + Path$)
+	If F = Null Then Return -1
+
+	While Not Eof(F)
+		Line$ = ReadLine$(F)
+		Local Start = 1
+		Local Found = Instr(Line$, Needle$, Start)
+		While Found > 0
+			Count = Count + 1
+			Start = Found + Len(Needle$)
+			Found = Instr(Line$, Needle$, Start)
+		Wend
+	Wend
+
+	CloseFile F
+	Return Count
+End Function
+
+Function HasSafeSpawnMarkerScaleGuard%(Path$)
+	Local F.BBStream = ReadFile(Path$)
+	Local Line$
+	Local Step = 0
 	If F = Null Then F = ReadFile("..\" + Path$)
 	If F = Null Then F = ReadFile("..\..\" + Path$)
 	If F = Null Then Return False
 
 	While Not Eof(F)
 		Line$ = ReadLine$(F)
-		If Instr(Line$, Needle$) > 0
-			CloseFile F
-			Return True
-		EndIf
+		Select Step
+			Case 0
+				If Instr(Line$, "Local spawnScale# = VP_MARKER_SIZE#") > 0 Then Step = 1
+			Case 1
+				If Instr(Line$, "Local A2.Actor = ActorList(Ar\SpawnActor[i])") > 0 Then Step = 2
+			Case 2
+				If Trim$(Line$) <> "If A2 <> Null Then"
+					CloseFile F
+					Return False
+				EndIf
+				Step = 3
+			Case 3
+				If Trim$(Line$) <> "If A2\Scale# > 0.0 Then spawnScale# = A2\Scale#"
+					CloseFile F
+					Return False
+				EndIf
+				Step = 4
+			Case 4
+				CloseFile F
+				Return Trim$(Line$) = "EndIf"
+		End Select
 	Wend
 
 	CloseFile F
@@ -23,9 +64,9 @@ End Function
 Test testSpawnMarkerScaleGuardsStaleActorMetadata()
 	Local Source$ = "Modules\Loom\ZoneViewport.bb"
 
-	Assert(FileContains%(Source$, "Local spawnScale# = VP_MARKER_SIZE#") = True)
-	Assert(FileContains%(Source$, "Local A2.Actor = ActorList(Ar\SpawnActor[i])") = True)
-	Assert(FileContains%(Source$, "                    If A2 <> Null Then") = True)
-	Assert(FileContains%(Source$, "                        If A2\Scale# > 0.0 Then spawnScale# = A2\Scale#") = True)
-	Assert(FileContains%(Source$, "If A2 <> Null And A2\Scale# > 0.0 Then spawnScale# = A2\Scale#") = False)
+	Assert(HasSafeSpawnMarkerScaleGuard%(Source$) = True)
+	; The required nested assignment contains both references. Any additional
+	; A2 scale access would be outside this bounded guard contract.
+	Assert(FileOccurrenceCount%(Source$, "A2\Scale#") = 2)
+	Assert(FileOccurrenceCount%(Source$, "If A2 <> Null And A2\Scale# > 0.0 Then spawnScale# = A2\Scale#") = 0)
 End Test


### PR DESCRIPTION
## Outcome
Opening a zone with a stale or missing actor-template entry no longer evaluates that entry’s scale field in Loom’s spawn-marker renderer.

## Technical changes
- Replaced the eager `A2 <> Null And A2\Scale# > 0.0` condition with nested guards in `Loom_LoadZoneMarkers`.
- Added `LoomSpawnActorScaleGuardTest.bb`, a bounded source contract for default scale → lookup → null guard → positive override → guard close; it also permits exactly the two scale references in that guarded override.

Fixes #774

## Acceptance evidence
- Default `VP_MARKER_SIZE#`, `ActorList` lookup, standalone null guard, and contained positive-scale override are present; the eager form is absent.
- Missing/stale metadata skips the field read and retains the existing default scale.
- No mesh/cube/waypoint, area-format, protocol, generated-artifact, or actor-loading behavior changed.

## RED → GREEN
- RED: original behavior failed portable contract with `old=0 outer=1 inner=1` (`eager condition remains and nested guard is absent`).
- GREEN: final bounded contract reported `ordered guard complete, scale_reads=2, eager=0`.
- Review-driven RED: original test lacked a bounded scanner; CI then exposed `Step` as reserved; the corrected `Stage` scanner is covered by the final Windows suite.

## Verification
- Local: `git diff --check`, `bash -n test.sh`, `bash scripts/gen_packet_index.sh --check`, and `bash scripts/gen_bvm_reference.sh --check` exited `0` (two known BVM DEAD-API warnings only).
- Local native limitation: `./test.sh LoomSpawnActorScaleGuardTest` exits `1` before execution because this Linux worktree lacks `compiler/BlitzForge/bin/blitzcc`.
- Exact head `d9e198286ef7301ff9cdafea43a594c979b2d3b4`: CI `Build and test` passed in 7m42s; `Rust server (Linux)` passed in 1m29s; zero legacy status contexts.

## Compatibility, risk, rollback
Valid positive scales still override the default. Only a stale/missing metadata lookup changes, from eager field access to fail-closed default behavior. Roll back by reverting the three commits in this PR.

## Deferred
No data migration is needed; actor loading, area files, and unrelated Loom viewport behavior remain out of scope.

## Independent review
- Review 1: `REQUEST_CHANGES` — strengthened the source contract to bind ordering and reject additional unguarded scale access.
- Review 2: `REQUEST_CHANGES` — Windows CI identified reserved identifier `Step`; renamed it `Stage`.
- Final fresh review of `d9e19828`: `ACCEPT`; it confirmed scope, guard correctness, exact scale-reference count, test fit, and no docs/security/performance/concurrency cost. CI evidence above is separate and green.