### PR TITLE
fix(persistence): verify SafeWrite backup and promotion copies

### DIFF
--- a/src/Modules/Logging.bb
+++ b/src/Modules/Logging.bb
@@ -30,9 +30,9 @@ Function SafeWriteOpen$(FinalPath$)
 	Return Temp$
 End Function
 
-; Returns True on success, False on any failure (in which case the caller
-; should treat the save as not having happened — the production file is
-; still the previous version, and the temp has been cleaned up).
+; Returns True on success, False on any failure. A failed copy keeps the
+; verified recovery artifacts in place so the caller can treat the save as
+; not having happened rather than silently accepting a truncated file.
 Function SafeWriteCommit%(TempPath$, FinalPath$, F)
 	If F <> 0 Then CloseFile(F)
 
@@ -42,7 +42,8 @@ Function SafeWriteCommit%(TempPath$, FinalPath$, F)
 		WriteLog(MainLog, "SafeWriteCommit: temp missing for " + FinalPath$)
 		Return False
 	EndIf
-	If FileSize(TempPath$) = 0
+	Local TempSize = FileSize(TempPath$)
+	If TempSize = 0
 		WriteLog(MainLog, "SafeWriteCommit: temp empty for " + FinalPath$ + ", refusing to promote")
 		DeleteFile(TempPath$)
 		Return False
@@ -50,18 +51,36 @@ Function SafeWriteCommit%(TempPath$, FinalPath$, F)
 
 	; Demote the current production file to .bak (one cycle of backup).
 	Local Bak$ = FinalPath$ + ".bak"
+	Local FinalSize = FileSize(FinalPath$)
+	Local BakTemp$ = Bak$ + ".tmp"
 	If FileType(FinalPath$) = 1
+		; Stage the new backup separately so an old .bak survives until the
+		; replacement has been copied and verified.
+		If FileType(BakTemp$) = 1 Then DeleteFile(BakTemp$)
+		CopyFile(FinalPath$, BakTemp$)
+		If FileType(BakTemp$) <> 1 Or FileSize(BakTemp$) <> FinalSize
+			WriteLog(MainLog, "SafeWriteCommit: backup staging failed for " + FinalPath$)
+			Return False
+		EndIf
+
 		If FileType(Bak$) = 1 Then DeleteFile(Bak$)
-		CopyFile(FinalPath$, Bak$)
+		CopyFile(BakTemp$, Bak$)
+		If FileType(Bak$) <> 1 Or FileSize(Bak$) <> FinalSize
+			WriteLog(MainLog, "SafeWriteCommit: backup verification failed for " + FinalPath$)
+			Return False
+		EndIf
+		DeleteFile(BakTemp$)
 		DeleteFile(FinalPath$)
 	EndIf
 
 	; Promote the temp into production.
 	CopyFile(TempPath$, FinalPath$)
-	If FileType(FinalPath$) <> 1
+	If FileType(FinalPath$) <> 1 Or FileSize(FinalPath$) <> TempSize
 		; Promotion failed catastrophically — try to roll back from .bak.
 		WriteLog(MainLog, "SafeWriteCommit: promote failed for " + FinalPath$ + ", rolling back from " + Bak$)
-		If FileType(Bak$) = 1 Then CopyFile(Bak$, FinalPath$)
+		If FileType(Bak$) = 1
+			If FileSize(Bak$) = FinalSize Then CopyFile(Bak$, FinalPath$)
+		EndIf
 		Return False
 	EndIf
 	DeleteFile(TempPath$)

--- a/src/Modules/Logging.bb
+++ b/src/Modules/Logging.bb
@@ -83,6 +83,10 @@ Function SafeWriteCommit%(TempPath$, FinalPath$, F)
 		EndIf
 		DeleteFile(BakTemp$)
 		DeleteFile(FinalPath$)
+		If FileType(FinalPath$) = 1
+			WriteLog(MainLog, "SafeWriteCommit: production cleanup failed for " + FinalPath$)
+			Return False
+		EndIf
 	EndIf
 
 	; Promote the temp into production.

--- a/src/Modules/Logging.bb
+++ b/src/Modules/Logging.bb
@@ -56,14 +56,26 @@ Function SafeWriteCommit%(TempPath$, FinalPath$, F)
 	If FileType(FinalPath$) = 1
 		; Stage the new backup separately so an old .bak survives until the
 		; replacement has been copied and verified.
-		If FileType(BakTemp$) = 1 Then DeleteFile(BakTemp$)
+		If FileType(BakTemp$) = 1
+			DeleteFile(BakTemp$)
+			If FileType(BakTemp$) = 1
+				WriteLog(MainLog, "SafeWriteCommit: backup staging cleanup failed for " + FinalPath$)
+				Return False
+			EndIf
+		EndIf
 		CopyFile(FinalPath$, BakTemp$)
 		If FileType(BakTemp$) <> 1 Or FileSize(BakTemp$) <> FinalSize
 			WriteLog(MainLog, "SafeWriteCommit: backup staging failed for " + FinalPath$)
 			Return False
 		EndIf
 
-		If FileType(Bak$) = 1 Then DeleteFile(Bak$)
+		If FileType(Bak$) = 1
+			DeleteFile(Bak$)
+			If FileType(Bak$) = 1
+				WriteLog(MainLog, "SafeWriteCommit: backup cleanup failed for " + FinalPath$)
+				Return False
+			EndIf
+		EndIf
 		CopyFile(BakTemp$, Bak$)
 		If FileType(Bak$) <> 1 Or FileSize(Bak$) <> FinalSize
 			WriteLog(MainLog, "SafeWriteCommit: backup verification failed for " + FinalPath$)

--- a/src/Tests/Modules/SafeWriteTest.bb
+++ b/src/Tests/Modules/SafeWriteTest.bb
@@ -78,16 +78,17 @@ Function SafeWriteCommitUsesVerifiedBackupAndPromotion%()
 		If Stage = 12 And Instr(Line$, "CopyFile(BakTemp$, Bak$)") > 0 Then Stage = 13
 		If Stage = 13 And Instr(Line$, "If FileType(Bak$) <> 1 Or FileSize(Bak$) <> FinalSize") > 0 Then Stage = 14
 		If Stage = 14 And Instr(Line$, "DeleteFile(FinalPath$)") > 0 Then Stage = 15
-		If Stage = 15 And Instr(Line$, "CopyFile(TempPath$, FinalPath$)") > 0 Then Stage = 16
-		If Stage = 16 And Instr(Line$, "If FileType(FinalPath$) <> 1 Or FileSize(FinalPath$) <> TempSize") > 0 Then Stage = 17
-		If Stage = 17 And Trim$(Line$) = "If FileType(Bak$) = 1" Then Stage = 18
-		If Stage = 18 And Instr(Line$, "If FileSize(Bak$) = FinalSize Then CopyFile(Bak$, FinalPath$)") > 0 Then Stage = 19
-		If Stage = 19 And Instr(Line$, "DeleteFile(TempPath$)") > 0 Then Stage = 20
+		If Stage = 15 And Trim$(Line$) = "If FileType(FinalPath$) = 1" Then Stage = 16
+		If Stage = 16 And Instr(Line$, "CopyFile(TempPath$, FinalPath$)") > 0 Then Stage = 17
+		If Stage = 17 And Instr(Line$, "If FileType(FinalPath$) <> 1 Or FileSize(FinalPath$) <> TempSize") > 0 Then Stage = 18
+		If Stage = 18 And Trim$(Line$) = "If FileType(Bak$) = 1" Then Stage = 19
+		If Stage = 19 And Instr(Line$, "If FileSize(Bak$) = FinalSize Then CopyFile(Bak$, FinalPath$)") > 0 Then Stage = 20
+		If Stage = 20 And Instr(Line$, "DeleteFile(TempPath$)") > 0 Then Stage = 21
 		If Instr(Line$, "End Function") > 0 Then Exit
 	Wend
 
 	CloseFile(F)
-	Return Stage = 20
+	Return Stage = 21
 End Function
 
 ; SafeWriteOpen is a pure helper: it just appends .tmp to the final path.

--- a/src/Tests/Modules/SafeWriteTest.bb
+++ b/src/Tests/Modules/SafeWriteTest.bb
@@ -67,19 +67,27 @@ Function SafeWriteCommitUsesVerifiedBackupAndPromotion%()
 		If Stage = 1 And Instr(Line$, "Local TempSize = FileSize(TempPath$)") > 0 Then Stage = 2
 		If Stage = 2 And Instr(Line$, "Local FinalSize = FileSize(FinalPath$)") > 0 Then Stage = 3
 		If Stage = 3 And Instr(Line$, "Local BakTemp$ = Bak$ + " + Chr$(34) + ".tmp" + Chr$(34)) > 0 Then Stage = 4
-		If Stage = 4 And Instr(Line$, "CopyFile(FinalPath$, BakTemp$)") > 0 Then Stage = 5
-		If Stage = 5 And Instr(Line$, "If FileType(BakTemp$) <> 1 Or FileSize(BakTemp$) <> FinalSize") > 0 Then Stage = 6
-		If Stage = 6 And Instr(Line$, "CopyFile(BakTemp$, Bak$)") > 0 Then Stage = 7
-		If Stage = 7 And Instr(Line$, "If FileType(Bak$) <> 1 Or FileSize(Bak$) <> FinalSize") > 0 Then Stage = 8
-		If Stage = 8 And Instr(Line$, "DeleteFile(FinalPath$)") > 0 Then Stage = 9
-		If Stage = 9 And Instr(Line$, "CopyFile(TempPath$, FinalPath$)") > 0 Then Stage = 10
-		If Stage = 10 And Instr(Line$, "If FileType(FinalPath$) <> 1 Or FileSize(FinalPath$) <> TempSize") > 0 Then Stage = 11
-		If Stage = 11 And Instr(Line$, "DeleteFile(TempPath$)") > 0 Then Stage = 12
+		If Stage = 4 And Trim$(Line$) = "If FileType(BakTemp$) = 1" Then Stage = 5
+		If Stage = 5 And Trim$(Line$) = "DeleteFile(BakTemp$)" Then Stage = 6
+		If Stage = 6 And Trim$(Line$) = "If FileType(BakTemp$) = 1" Then Stage = 7
+		If Stage = 7 And Instr(Line$, "CopyFile(FinalPath$, BakTemp$)") > 0 Then Stage = 8
+		If Stage = 8 And Instr(Line$, "If FileType(BakTemp$) <> 1 Or FileSize(BakTemp$) <> FinalSize") > 0 Then Stage = 9
+		If Stage = 9 And Trim$(Line$) = "If FileType(Bak$) = 1" Then Stage = 10
+		If Stage = 10 And Trim$(Line$) = "DeleteFile(Bak$)" Then Stage = 11
+		If Stage = 11 And Trim$(Line$) = "If FileType(Bak$) = 1" Then Stage = 12
+		If Stage = 12 And Instr(Line$, "CopyFile(BakTemp$, Bak$)") > 0 Then Stage = 13
+		If Stage = 13 And Instr(Line$, "If FileType(Bak$) <> 1 Or FileSize(Bak$) <> FinalSize") > 0 Then Stage = 14
+		If Stage = 14 And Instr(Line$, "DeleteFile(FinalPath$)") > 0 Then Stage = 15
+		If Stage = 15 And Instr(Line$, "CopyFile(TempPath$, FinalPath$)") > 0 Then Stage = 16
+		If Stage = 16 And Instr(Line$, "If FileType(FinalPath$) <> 1 Or FileSize(FinalPath$) <> TempSize") > 0 Then Stage = 17
+		If Stage = 17 And Trim$(Line$) = "If FileType(Bak$) = 1" Then Stage = 18
+		If Stage = 18 And Instr(Line$, "If FileSize(Bak$) = FinalSize Then CopyFile(Bak$, FinalPath$)") > 0 Then Stage = 19
+		If Stage = 19 And Instr(Line$, "DeleteFile(TempPath$)") > 0 Then Stage = 20
 		If Instr(Line$, "End Function") > 0 Then Exit
 	Wend
 
 	CloseFile(F)
-	Return Stage = 12
+	Return Stage = 20
 End Function
 
 ; SafeWriteOpen is a pure helper: it just appends .tmp to the final path.

--- a/src/Tests/Modules/SafeWriteTest.bb
+++ b/src/Tests/Modules/SafeWriteTest.bb
@@ -14,11 +14,13 @@ Global testDir$ = CurrentDir$()
 Global ProductionPath$ = testDir$ + "safewrite_test.dat"
 Global TempPathExpected$ = ProductionPath$ + ".tmp"
 Global BakPath$ = ProductionPath$ + ".bak"
+Global BakTempPath$ = BakPath$ + ".tmp"
 
 Function CleanupTestFiles()
 	If FileType(ProductionPath$) = 1 Then DeleteFile(ProductionPath$)
 	If FileType(TempPathExpected$) = 1 Then DeleteFile(TempPathExpected$)
 	If FileType(BakPath$) = 1 Then DeleteFile(BakPath$)
+	If FileType(BakTempPath$) = 1 Then DeleteFile(BakTempPath$)
 End Function
 
 ; Helper: write payload to path and close the handle. We close locally
@@ -44,6 +46,40 @@ Function ReadFileString$(path$)
 	Local payload$ = ReadString(s)
 	CloseFile(s)
 	Return payload$
+End Function
+
+; Filesystem copy failures are difficult to inject portably in a Blitz test,
+; so bind the fail-closed ordering in the real helper. This must keep the
+; verified backup ahead of production deletion and the verified promotion
+; ahead of temp cleanup.
+Function SafeWriteCommitUsesVerifiedBackupAndPromotion%()
+	Local F.BBStream = ReadFile("Modules\Logging.bb")
+	Local Line$
+	Local Stage%
+	If F = Null Then F = ReadFile("..\Modules\Logging.bb")
+	If F = Null Then F = ReadFile("..\..\Modules\Logging.bb")
+	If F = Null Then Return False
+
+	While Not Eof(F)
+		Line$ = ReadLine$(F)
+		If Instr(Line$, "Function SafeWriteCommit%(TempPath$, FinalPath$, F)") > 0 Then Stage = 1
+		If Stage = 0 Then Continue
+		If Stage = 1 And Instr(Line$, "Local TempSize = FileSize(TempPath$)") > 0 Then Stage = 2
+		If Stage = 2 And Instr(Line$, "Local FinalSize = FileSize(FinalPath$)") > 0 Then Stage = 3
+		If Stage = 3 And Instr(Line$, "Local BakTemp$ = Bak$ + " + Chr$(34) + ".tmp" + Chr$(34)) > 0 Then Stage = 4
+		If Stage = 4 And Instr(Line$, "CopyFile(FinalPath$, BakTemp$)") > 0 Then Stage = 5
+		If Stage = 5 And Instr(Line$, "If FileType(BakTemp$) <> 1 Or FileSize(BakTemp$) <> FinalSize") > 0 Then Stage = 6
+		If Stage = 6 And Instr(Line$, "CopyFile(BakTemp$, Bak$)") > 0 Then Stage = 7
+		If Stage = 7 And Instr(Line$, "If FileType(Bak$) <> 1 Or FileSize(Bak$) <> FinalSize") > 0 Then Stage = 8
+		If Stage = 8 And Instr(Line$, "DeleteFile(FinalPath$)") > 0 Then Stage = 9
+		If Stage = 9 And Instr(Line$, "CopyFile(TempPath$, FinalPath$)") > 0 Then Stage = 10
+		If Stage = 10 And Instr(Line$, "If FileType(FinalPath$) <> 1 Or FileSize(FinalPath$) <> TempSize") > 0 Then Stage = 11
+		If Stage = 11 And Instr(Line$, "DeleteFile(TempPath$)") > 0 Then Stage = 12
+		If Instr(Line$, "End Function") > 0 Then Exit
+	Wend
+
+	CloseFile(F)
+	Return Stage = 12
 End Function
 
 ; SafeWriteOpen is a pure helper: it just appends .tmp to the final path.
@@ -186,4 +222,8 @@ Test testSafeWriteAbortRemovesTemp()
 	Assert(FileType(temp$) <> 1)
 
 	CleanupTestFiles()
+End Test
+
+Test testSafeWriteCommitVerifiesBackupAndPromotionCopies()
+	Assert(SafeWriteCommitUsesVerifiedBackupAndPromotion() = True)
 End Test


### PR DESCRIPTION
## Outcome
Save callers now retain a verified recovery copy before replacing production data and reject incomplete promotions instead of accepting a potentially truncated save.

## Technical changes
- Stage, size-check, and then install the `.bak` recovery copy before deleting production.
- Verify each existing recovery/production target is actually removed before copying into it; verify promoted final size; restore only a size-verified backup on failure.
- Add a focused SafeWrite source contract that pins cleanup, verification, rollback, and temp-cleanup ordering.

Fixes #776

## Acceptance criteria and evidence
- Backup verification before production deletion: staged `.bak.tmp` and `.bak` must be absent after deletion, then present at the expected size before `DeleteFile(FinalPath$)`.
- Promotion verification: `SafeWriteCommit%` requires `FileSize(FinalPath$) = TempSize` before deleting `.tmp`.
- Failure behavior: each failed cleanup/verification logs and returns `False`; promotion failure copies back only a size-verified backup.
- Regression coverage: `SafeWriteTest.bb` checks the complete ordered contract including rollback; existing runtime happy/empty/missing-temp tests remain in the focused suite.

## RED → GREEN
- RED: the original ordered-contract probe exited 1 because `Local TempSize = FileSize(TempPath$)` was absent. Review-driven extensions also went RED for missing backup and production cleanup guards.
- GREEN: the final probe exited 0 with `GREEN: SafeWrite copy integrity ordering is present`.

## Verification
- Baseline and final focused native command: `./test.sh SafeWriteTest` exited 1 before and after because `compiler/BlitzForge/bin/blitzcc` is unavailable in this worktree; native execution is delegated to CI.
- `git diff --check`, `bash scripts/gen_packet_index.sh --check`, and `bash scripts/gen_bvm_reference.sh --check` each exited 0 (the last has two known DEAD-API warnings).

## Compatibility, risk, rollback
- No save formats, public signatures, or callers change.
- Risk: fail-closed behavior can report a save failure when filesystem cleanup/copy is incomplete; it preserves existing data instead of accepting corruption.
- Rollback: revert commits `70d136b6`, `e7073354`, and `0b0b2723`; detected failure leaves `.bak`, staged backup, or `.tmp` recovery evidence.

## Independent review
- Final exact-head review: `ACCEPT` for `0b0b272393aab0a74d5886679c248495f0d05f31` after two review-driven failure-path fixes.