### PR TITLE
fix(server): bound SourceSP cleanup counters

### DIFF
--- a/src/Modules/GameServer.bb
+++ b/src/Modules/GameServer.bb
@@ -227,7 +227,7 @@ Function KillActor(A.ActorInstance, Killer.ActorInstance)
 		EndIf
 		; Remove from spawn point if attached to one. Same Null guard --
 		; if AInstance is gone, the Spawned counter is already orphaned.
-		If A\SourceSP > -1
+		If A\SourceSP > -1 And A\SourceSP <= 999
 			AInstance.AreaInstance = Object.AreaInstance(A\ServerArea)
 			If AInstance <> Null
 				AInstance\Spawned[A\SourceSP] = AInstance\Spawned[A\SourceSP] - 1
@@ -1346,7 +1346,7 @@ Function SetArea(A.ActorInstance, Ar.Area, Instance, Waypoint = -1, Portal = 0, 
 	; If the new area is different to the old
 	If Ar\Instances[Instance] <> OldAr
 		; If this actor still belongs to a spawnpoint, remove him
-		If A\SourceSP > -1
+		If A\SourceSP > -1 And A\SourceSP <= 999
 			If OldAr <> Null Then OldAr\Spawned[A\SourceSP] = OldAr\Spawned[A\SourceSP] - 1
 			A\SourceSP = -1
 		EndIf

--- a/src/Modules/GameServer.bb
+++ b/src/Modules/GameServer.bb
@@ -227,10 +227,12 @@ Function KillActor(A.ActorInstance, Killer.ActorInstance)
 		EndIf
 		; Remove from spawn point if attached to one. Same Null guard --
 		; if AInstance is gone, the Spawned counter is already orphaned.
-		If A\SourceSP > -1 And A\SourceSP <= 999
+		If A\SourceSP > -1
 			AInstance.AreaInstance = Object.AreaInstance(A\ServerArea)
 			If AInstance <> Null
-				AInstance\Spawned[A\SourceSP] = AInstance\Spawned[A\SourceSP] - 1
+				If A\SourceSP <= 999
+					AInstance\Spawned[A\SourceSP] = AInstance\Spawned[A\SourceSP] - 1
+				EndIf
 			EndIf
 		EndIf
 		FreeActorScripts(A)
@@ -1346,8 +1348,10 @@ Function SetArea(A.ActorInstance, Ar.Area, Instance, Waypoint = -1, Portal = 0, 
 	; If the new area is different to the old
 	If Ar\Instances[Instance] <> OldAr
 		; If this actor still belongs to a spawnpoint, remove him
-		If A\SourceSP > -1 And A\SourceSP <= 999
-			If OldAr <> Null Then OldAr\Spawned[A\SourceSP] = OldAr\Spawned[A\SourceSP] - 1
+		If A\SourceSP > -1
+			If A\SourceSP <= 999
+				If OldAr <> Null Then OldAr\Spawned[A\SourceSP] = OldAr\Spawned[A\SourceSP] - 1
+			EndIf
 			A\SourceSP = -1
 		EndIf
 

--- a/src/Modules/ScriptingCommands.bb
+++ b/src/Modules/ScriptingCommands.bb
@@ -1024,7 +1024,7 @@ Function BVM_SETLEADER(Param1%, Param2%)
 				; Skip the spawn-count decrement if the actor's area
 				; lookup is Null (mid-warp / freed zone) -- the counter
 				; is already orphaned in that case.
-				If Actor\SourceSP > -1
+				If Actor\SourceSP > -1 And Actor\SourceSP <= 999
 					AInstance.AreaInstance = Object.AreaInstance(Actor\ServerArea)
 					If AInstance <> Null
 						AInstance\Spawned[Actor\SourceSP] = AInstance\Spawned[Actor\SourceSP] - 1

--- a/src/Modules/ScriptingCommands.bb
+++ b/src/Modules/ScriptingCommands.bb
@@ -1024,10 +1024,12 @@ Function BVM_SETLEADER(Param1%, Param2%)
 				; Skip the spawn-count decrement if the actor's area
 				; lookup is Null (mid-warp / freed zone) -- the counter
 				; is already orphaned in that case.
-				If Actor\SourceSP > -1 And Actor\SourceSP <= 999
+				If Actor\SourceSP > -1
 					AInstance.AreaInstance = Object.AreaInstance(Actor\ServerArea)
 					If AInstance <> Null
-						AInstance\Spawned[Actor\SourceSP] = AInstance\Spawned[Actor\SourceSP] - 1
+						If Actor\SourceSP <= 999
+							AInstance\Spawned[Actor\SourceSP] = AInstance\Spawned[Actor\SourceSP] - 1
+						EndIf
 					EndIf
 					Actor\SourceSP = -1
 				EndIf

--- a/src/Tests/Modules/SourceSPCleanupBoundsTest.bb
+++ b/src/Tests/Modules/SourceSPCleanupBoundsTest.bb
@@ -7,47 +7,95 @@ EnableGC
 ; The server and BVM modules cannot be included in a standalone Strict test;
 ; bind the bounded source shape instead.
 
-Function SourceSPCleanupGuardsAreBounded%(Path$, Subject$, ExpectedCount%)
+Function LeadingTabs%(Line$)
+	Local Count%, Pos% = 1
+	While Pos <= Len(Line$)
+		If Mid$(Line$, Pos, 1) <> Chr$(9) Then Exit
+		Count = Count + 1
+		Pos = Pos + 1
+	Wend
+	Return Count
+End Function
+
+Function SourceSPPositiveCleanupGuardCount%(Path$, Subject$)
 	Local F.BBStream = ReadFile(Path$)
 	Local GuardPrefix$ = "If " + Subject$ + "\SourceSP > -1"
-	Local BoundNeedle$ = "And " + Subject$ + "\SourceSP <= 999"
 	Local Count%, Line$
 	If F = Null Then F = ReadFile("..\" + Path$)
 	If F = Null Then Return False
 	While Not Eof(F)
 		Line$ = ReadLine$(F)
-		If Instr(Line$, GuardPrefix$) > 0
-			If Instr(Line$, BoundNeedle$) = 0
+		If Instr(Line$, GuardPrefix$) > 0 Then Count = Count + 1
+	Wend
+	CloseFile F
+	Return Count
+End Function
+
+Function SourceSPCleanupDecrementsAreBounded%(Path$, Subject$, ExpectedCount%)
+	Local F.BBStream = ReadFile(Path$)
+	Local BoundIndent% = -1, Count%, Line$
+	Local BoundNeedle$ = "If " + Subject$ + "\SourceSP <= 999"
+	Local DecrementNeedle$ = "\Spawned[" + Subject$ + "\SourceSP] ="
+	If F = Null Then F = ReadFile("..\" + Path$)
+	If F = Null Then Return False
+	While Not Eof(F)
+		Line$ = ReadLine$(F)
+		If Instr(Line$, BoundNeedle$) > 0 Then BoundIndent = LeadingTabs(Line$)
+		If Instr(Line$, DecrementNeedle$) > 0
+			If BoundIndent < 0 Or LeadingTabs(Line$) <= BoundIndent
 				CloseFile F
 				Return False
 			EndIf
 			Count = Count + 1
+		EndIf
+		If BoundIndent >= 0 And Instr(Line$, "EndIf") > 0 And LeadingTabs(Line$) <= BoundIndent Then BoundIndent = -1
+	Wend
+	CloseFile F
+	Return Count = ExpectedCount
+End Function
+
+Function SourceSPCleanupDetachesAfterBound%(Path$, Subject$, ExpectedCount%)
+	Local F.BBStream = ReadFile(Path$)
+	Local OuterIndent% = -1, BoundIndent% = -1, BoundClosed%, Count%, Line$
+	Local OuterNeedle$ = "If " + Subject$ + "\SourceSP > -1"
+	Local BoundNeedle$ = "If " + Subject$ + "\SourceSP <= 999"
+	Local DetachNeedle$ = Subject$ + "\SourceSP = -1"
+	If F = Null Then F = ReadFile("..\" + Path$)
+	If F = Null Then Return False
+	While Not Eof(F)
+		Line$ = ReadLine$(F)
+		If Instr(Line$, OuterNeedle$) > 0
+			OuterIndent = LeadingTabs(Line$)
+			BoundIndent = -1
+			BoundClosed = False
+		EndIf
+		If OuterIndent >= 0 And Instr(Line$, BoundNeedle$) > 0 Then BoundIndent = LeadingTabs(Line$)
+		If BoundIndent >= 0 And Instr(Line$, "EndIf") > 0 And LeadingTabs(Line$) <= BoundIndent
+			BoundIndent = -1
+			BoundClosed = True
+		EndIf
+		If Instr(Line$, DetachNeedle$) > 0
+			If OuterIndent < 0 Or BoundClosed = False Or LeadingTabs(Line$) <= OuterIndent
+				CloseFile F
+				Return False
+			EndIf
+			Count = Count + 1
+			OuterIndent = -1
 		EndIf
 	Wend
 	CloseFile F
 	Return Count = ExpectedCount
 End Function
 
-Function SourceSPCleanupDetachCount%(Path$, DetachNeedle$)
-	Local F.BBStream = ReadFile(Path$)
-	Local Count%, Line$
-	If F = Null Then F = ReadFile("..\" + Path$)
-	If F = Null Then Return -1
-	While Not Eof(F)
-		Line$ = ReadLine$(F)
-		If Instr(Line$, DetachNeedle$) > 0 Then Count = Count + 1
-	Wend
-	CloseFile F
-	Return Count
-End Function
-
 Test testGameServerBoundsEverySourceSpawnCleanupGuard()
-	Assert(SourceSPCleanupGuardsAreBounded%("Modules\GameServer.bb", "A", 2) = True)
-	; The death path frees the actor; the cross-area path must still detach it.
-	Assert(SourceSPCleanupDetachCount%("Modules\GameServer.bb", "A\SourceSP = -1") = 1)
+	Assert(SourceSPPositiveCleanupGuardCount%("Modules\GameServer.bb", "A") = 2)
+	Assert(SourceSPCleanupDecrementsAreBounded%("Modules\GameServer.bb", "A", 2) = True)
+	; The death path frees the actor; the cross-area path must detach after its bound ends.
+	Assert(SourceSPCleanupDetachesAfterBound%("Modules\GameServer.bb", "A", 1) = True)
 End Test
 
 Test testSetLeaderBoundsSourceSpawnCleanupGuard()
-	Assert(SourceSPCleanupGuardsAreBounded%("Modules\ScriptingCommands.bb", "Actor", 1) = True)
-	Assert(SourceSPCleanupDetachCount%("Modules\ScriptingCommands.bb", "Actor\SourceSP = -1") = 1)
+	Assert(SourceSPPositiveCleanupGuardCount%("Modules\ScriptingCommands.bb", "Actor") = 1)
+	Assert(SourceSPCleanupDecrementsAreBounded%("Modules\ScriptingCommands.bb", "Actor", 1) = True)
+	Assert(SourceSPCleanupDetachesAfterBound%("Modules\ScriptingCommands.bb", "Actor", 1) = True)
 End Test

--- a/src/Tests/Modules/SourceSPCleanupBoundsTest.bb
+++ b/src/Tests/Modules/SourceSPCleanupBoundsTest.bb
@@ -1,0 +1,53 @@
+Strict
+EnableGC
+
+; Regression contract for SourceSP cleanup paths. SourceSP originates in
+; project data and scripts, so every fixed AreaInstance\Spawned[999] access
+; must retain the existing non-negative check and also reject values above 999.
+; The server and BVM modules cannot be included in a standalone Strict test;
+; bind the bounded source shape instead.
+
+Function SourceSPCleanupGuardsAreBounded%(Path$, Subject$, ExpectedCount%)
+	Local F.BBStream = ReadFile(Path$)
+	Local GuardPrefix$ = "If " + Subject$ + "\SourceSP > -1"
+	Local BoundNeedle$ = "And " + Subject$ + "\SourceSP <= 999"
+	Local Count%, Line$
+	If F = Null Then F = ReadFile("..\" + Path$)
+	If F = Null Then Return False
+	While Not Eof(F)
+		Line$ = ReadLine$(F)
+		If Instr(Line$, GuardPrefix$) > 0
+			If Instr(Line$, BoundNeedle$) = 0
+				CloseFile F
+				Return False
+			EndIf
+			Count = Count + 1
+		EndIf
+	Wend
+	CloseFile F
+	Return Count = ExpectedCount
+End Function
+
+Function SourceSPCleanupDetachCount%(Path$, DetachNeedle$)
+	Local F.BBStream = ReadFile(Path$)
+	Local Count%, Line$
+	If F = Null Then F = ReadFile("..\" + Path$)
+	If F = Null Then Return -1
+	While Not Eof(F)
+		Line$ = ReadLine$(F)
+		If Instr(Line$, DetachNeedle$) > 0 Then Count = Count + 1
+	Wend
+	CloseFile F
+	Return Count
+End Function
+
+Test testGameServerBoundsEverySourceSpawnCleanupGuard()
+	Assert(SourceSPCleanupGuardsAreBounded%("Modules\GameServer.bb", "A", 2) = True)
+	; The death path frees the actor; the cross-area path must still detach it.
+	Assert(SourceSPCleanupDetachCount%("Modules\GameServer.bb", "A\SourceSP = -1") = 1)
+End Test
+
+Test testSetLeaderBoundsSourceSpawnCleanupGuard()
+	Assert(SourceSPCleanupGuardsAreBounded%("Modules\ScriptingCommands.bb", "Actor", 1) = True)
+	Assert(SourceSPCleanupDetachCount%("Modules\ScriptingCommands.bb", "Actor\SourceSP = -1") = 1)
+End Test


### PR DESCRIPTION
## Outcome
Server cleanup now ignores corrupt SourceSP values above 999 instead of indexing past a fixed spawn-occupancy array during actor death, cross-area warp, or BVM leader conversion. The existing cross-area and BVM detach behavior remains intact.

## Technical changes
- Retained each existing positive SourceSP cleanup branch.
- Added an inner SourceSP 0..999 guard only around each fixed-array decrement.
- Added a focused source-contract regression that binds all three decrements, the outer cleanup branches, and detach ordering.

Fixes #780

## Acceptance criteria and evidence
- All three cleanup decrements run only inside SourceSP 0..999 guards: final portable review regression reports GameServer outer=2, inner=2, detach=1 and ScriptingCommands outer=1, inner=1, detach=1.
- Existing behavior is preserved: actor death still frees the actor; cross-area and BVM cleanup retain SourceSP = -1 after their inner bounds close.
- Regression coverage: SourceSPCleanupBoundsTest now rejects both unbounded decrements and resets accidentally nested inside the upper-bound guard.
- No BVM dispatch, protocol, spawn scheduling, or save-format changes: three-file diff only.

## Baseline, RED, and GREEN
- BASELINE: test.sh SpawnTrackingTest exited 1 before test execution because compiler/BlitzForge/bin/blitzcc is unavailable.
- BASELINE source probe: GameServer expected 2 bounded guards and observed 0; ScriptingCommands expected 1 and observed 0.
- Initial RED: portable mirror reported SOURCE_SP_CLEANUP_CONTRACT_RED with GameServer bounded=0/2 and ScriptingCommands bounded=0/1.
- Initial GREEN: portable mirror reported FINAL_SOURCE_CONTRACT_GREEN with GameServer bounded=2/2 and ScriptingCommands bounded=1/1.
- Review-cycle RED: strengthened regression found inner_bound=0 for both surfaces on the first head, proving the reviewer-reported detach regression.
- Review-cycle GREEN: FINAL_REVIEW_REGRESSION_GREEN reports all outer, inner-bound, and detach counts at their required values.
- Final local checks: git diff --cached --check, bash scripts/gen_packet_index.sh --check, and bash scripts/gen_bvm_reference.sh --check exited 0. The BVM generator printed its two known DEAD-API warnings.
- Local compiled test remains unavailable: test.sh SourceSPCleanupBoundsTest exits 1 before execution because blitzcc is absent after a 60-second narrow submodule initialization timeout and a shallow retry could not resolve the pinned revision.

## Compatibility, risks, rollback, and deferred work
Valid SourceSP values preserve existing behavior. Invalid positive values skip only the unsafe decrement while still following the pre-existing free or detach behavior. Roll back by reverting these commits. Deferred: broader spawn scheduling behavior and unrelated Loom source-build documentation.

## Independent review
First review requested changes because the initial guard placement skipped two pre-existing detach assignments. The exact review feedback was implemented and regression-tested; fresh independent review of exact head c147d2a34856b40ebaf4f1258984d1ed3b54c6dc returned ACCEPT; it confirmed all three bounds, preserved detach behavior, permitted scope, and local generator/whitespace evidence. Local compiled test execution remains unavailable pending CI.