### PR TITLE
fix(rust-server): release stale login throttle records

### DIFF
--- a/server-rs/crates/rcce-server-accounts/src/throttle.rs
+++ b/server-rs/crates/rcce-server-accounts/src/throttle.rs
@@ -33,6 +33,11 @@ impl LoginThrottle {
         Self::default()
     }
 
+    /// Drop a peer's history when its connection ends.
+    pub fn forget(&mut self, peer: u32) {
+        self.entries.remove(&peer);
+    }
+
     /// `LoginAttemptOk%` — true if a fresh attempt from `peer` should be
     /// processed. False once the peer has tripped the failure threshold inside
     /// the current window.
@@ -51,8 +56,10 @@ impl LoginThrottle {
     /// counter; failure increments it (opening a fresh window if the prior one
     /// closed).
     pub fn record(&mut self, peer: u32, success: bool, now_ms: u64) {
+        self.entries
+            .retain(|_, entry| now_ms.saturating_sub(entry.window_start_ms) < WINDOW_MS);
         if success {
-            self.entries.remove(&peer);
+            self.forget(peer);
             return;
         }
         match self.entries.get_mut(&peer) {
@@ -131,5 +138,15 @@ mod tests {
         }
         assert!(!t.ok(1, 0));
         assert!(t.ok(2, 0));
+    }
+
+    #[test]
+    fn later_failure_prunes_expired_peer_entries() {
+        let mut t = LoginThrottle::new();
+        t.record(1, false, 0);
+        t.record(2, false, WINDOW_MS);
+
+        assert!(!t.entries.contains_key(&1));
+        assert!(t.entries.contains_key(&2));
     }
 }

--- a/server-rs/crates/rcce-server/src/state.rs
+++ b/server-rs/crates/rcce-server/src/state.rs
@@ -36,10 +36,39 @@ fn clamp_coord(v: f32) -> f32 {
 #[cfg(test)]
 mod tests {
     use super::ServerState;
+    use crate::config::ServerConfig;
+    use rcce_server_accounts::store::AccountStore;
+    use rcce_server_accounts::throttle::MAX_FAILURES;
+    use rcce_server_core::ActorCatalog;
+    use std::path::PathBuf;
 
     #[test]
     fn missing_defender_resistance_is_neutral() {
         assert_eq!(ServerState::defender_resistance(&[150], 9), 100);
+    }
+
+    #[test]
+    fn disconnect_releases_failed_login_throttle_record() {
+        let config = ServerConfig {
+            port: 25000,
+            allow_account_creation: true,
+            max_account_chars: 4,
+            start_gold: 0,
+            start_reputation: 0,
+            attribute_assignment: 0,
+            data_dir: PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../../../data"),
+        };
+        let accounts =
+            AccountStore::load(std::env::temp_dir().join("rcce-throttle-disconnect-test.dat")).unwrap();
+        let mut state = ServerState::new(config, accounts, ActorCatalog::default());
+        for _ in 0..MAX_FAILURES {
+            state.throttle.record(7, false, 0);
+        }
+        assert!(!state.throttle.ok(7, 0));
+
+        state.on_disconnect(7);
+
+        assert!(state.throttle.ok(7, 0));
     }
 }
 
@@ -633,6 +662,7 @@ impl ServerState {
     /// the indices.
     pub fn on_disconnect(&mut self, peer_id: u32) -> Vec<(u32, u8, Vec<u8>)> {
         let mut out = Vec::new();
+        self.throttle.forget(peer_id);
         // Leave any party + drop per-peer tick state.
         if let Some(pid) = self.party_of.remove(&peer_id) {
             // Recompute the roster after this peer leaves, then notify survivors.


### PR DESCRIPTION
## Outcome
Disconnected or long-expired Rust-server login attempts no longer accumulate indefinitely in the in-memory throttle map. Login rejection behavior for a live peer is unchanged.

## Technical changes
- Forget a peer's `LoginThrottle` history at the start of `ServerState::on_disconnect`.
- Prune expired throttle entries whenever a login result is recorded.
- Add direct regression coverage for both cleanup boundaries.

Fixes #782

## Acceptance criteria and evidence
- Five failures still block a live peer: retained `trips_after_max_failures` coverage passes.
- Successful login still resets a peer: retained `success_resets_counter` coverage passes.
- Disconnect releases a failed peer: `state::tests::disconnect_releases_failed_login_throttle_record` RED -> GREEN.
- Later activity removes expired peers: `throttle::tests::later_failure_prunes_expired_peer_entries` RED -> GREEN.
- Packet framing and replies are untouched: two-file internal-state diff only.

## Baseline, RED, and final verification
- Baseline: `rustup run 1.85.0 cargo test -p rcce-server-accounts` -> 30 passed, 0 failed; `cargo test -p rcce-server --lib` -> 158 passed, 0 failed.
- RED: both new focused tests failed with exit 101 because the old map retained stale entries.
- GREEN: both focused tests passed.
- Final: `rustup run 1.85.0 cargo test --workspace --locked` -> passed (26 + 1 + 159 + 5 + 3 + 31 + 41 + 1 tests); `cargo clippy --workspace --all-targets --locked -- -D warnings` -> exit 0; `git diff --check` -> exit 0.

## Compatibility, risk, rollback, deferred work
Internal-only retention cleanup; no protocol, persistence, client, toolchain, or CI-package change. Rollback is a revert of this commit. Rust 1.85 `rustfmt` is unavailable locally, so formatting verification is limited to review and `git diff --check`; CI does not run a Rustfmt gate. No deferred behavior change.

## Independent review
ACCEPT — fresh review of exact head `c24358826c17f7dd2dcd30e83b6bc52809188dea` found the two-file scope correct, both cleanup boundaries directly covered, and no protocol/persistence/client/security/concurrency regression. The O(n) expired-entry prune runs only when a login result is recorded and is acceptable for bounded retention.