### PR TITLE
fix(server): release stale legacy login throttle records

### DIFF
--- a/docs/protocol/index.md
+++ b/docs/protocol/index.md
@@ -37,18 +37,18 @@ pages is a per-iteration documentation task — see CONTRIBUTING.md.
 
 | ID | Packet | Direction | Server handler | Client handler | Detail |
 |---|---|---|---|---|---|
-| 1 | `P_CreateAccount` | C→S | [ServerNet.bb:2461](../../src/Modules/ServerNet.bb#L2461) | — | [P_CreateAccount](packets/P_CreateAccount.md) |
-| 2 | `P_VerifyAccount` | C→S | [ServerNet.bb:2517](../../src/Modules/ServerNet.bb#L2517) | — | [P_VerifyAccount](packets/P_VerifyAccount.md) |
-| 3 | `P_FetchCharacter` | C→S | [ServerNet.bb:2728](../../src/Modules/ServerNet.bb#L2728) | — | — |
-| 4 | `P_CreateCharacter` | C→S | [ServerNet.bb:2852](../../src/Modules/ServerNet.bb#L2852) | — | — |
-| 5 | `P_DeleteCharacter` | C→S | [ServerNet.bb:3068](../../src/Modules/ServerNet.bb#L3068) | — | — |
-| 6 | `P_ChangePassword` | C→S | [ServerNet.bb:2652](../../src/Modules/ServerNet.bb#L2652) | — | [P_ChangePassword](packets/P_ChangePassword.md) |
-| 7 | `P_FetchActors` | C→S | [ServerNet.bb:2353](../../src/Modules/ServerNet.bb#L2353) | — | — |
+| 1 | `P_CreateAccount` | C→S | [ServerNet.bb:2462](../../src/Modules/ServerNet.bb#L2462) | — | [P_CreateAccount](packets/P_CreateAccount.md) |
+| 2 | `P_VerifyAccount` | C→S | [ServerNet.bb:2518](../../src/Modules/ServerNet.bb#L2518) | — | [P_VerifyAccount](packets/P_VerifyAccount.md) |
+| 3 | `P_FetchCharacter` | C→S | [ServerNet.bb:2729](../../src/Modules/ServerNet.bb#L2729) | — | — |
+| 4 | `P_CreateCharacter` | C→S | [ServerNet.bb:2853](../../src/Modules/ServerNet.bb#L2853) | — | — |
+| 5 | `P_DeleteCharacter` | C→S | [ServerNet.bb:3069](../../src/Modules/ServerNet.bb#L3069) | — | — |
+| 6 | `P_ChangePassword` | C→S | [ServerNet.bb:2653](../../src/Modules/ServerNet.bb#L2653) | — | [P_ChangePassword](packets/P_ChangePassword.md) |
+| 7 | `P_FetchActors` | C→S | [ServerNet.bb:2354](../../src/Modules/ServerNet.bb#L2354) | — | — |
 | 8 | `P_FetchItems` | Unused | — | — | — |
 | 9 | `P_ChangeArea` | Both | [ServerNet.bb:819](../../src/Modules/ServerNet.bb#L819) | [ClientNet.bb:1642](../../src/Modules/ClientNet.bb#L1642) | — |
-| 10 | `P_FetchUpdateFiles` | C→S | [ServerNet.bb:2338](../../src/Modules/ServerNet.bb#L2338) | — | — |
+| 10 | `P_FetchUpdateFiles` | C→S | [ServerNet.bb:2339](../../src/Modules/ServerNet.bb#L2339) | — | — |
 | 11 | `P_NewActor` | S→C | — | [ClientNet.bb:1601](../../src/Modules/ClientNet.bb#L1601) | — |
-| 12 | `P_StartGame` | C→S | [ServerNet.bb:2218](../../src/Modules/ServerNet.bb#L2218) | — | — |
+| 12 | `P_StartGame` | C→S | [ServerNet.bb:2219](../../src/Modules/ServerNet.bb#L2219) | — | — |
 | 13 | `P_ActorGone` | S→C | — | [ClientNet.bb:1561](../../src/Modules/ClientNet.bb#L1561) | — |
 | 14 | `P_StandardUpdate` | Both | [ServerNet.bb:1914](../../src/Modules/ServerNet.bb#L1914) | [ClientNet.bb:1501](../../src/Modules/ClientNet.bb#L1501) | [P_StandardUpdate](packets/P_StandardUpdate.md) |
 | 15 | `P_InventoryUpdate` | Both | [ServerNet.bb:1717](../../src/Modules/ServerNet.bb#L1717) | [ClientNet.bb:1282](../../src/Modules/ClientNet.bb#L1282) | [P_InventoryUpdate](packets/P_InventoryUpdate.md) |

--- a/src/Modules/AccountsServer.bb
+++ b/src/Modules/AccountsServer.bb
@@ -81,6 +81,25 @@ Function LoginAttemptFind.LoginAttempt(FromID)
 	Return Null
 End Function
 
+; Release the transient throttle record when its peer disconnects.
+Function LoginAttemptForget(FromID)
+	LA.LoginAttempt = LoginAttemptFind(FromID)
+	If LA <> Null Then Delete LA
+End Function
+
+; Drop expired records during later auth activity so disconnected peers cannot
+; accumulate in the per-login lookup list forever.
+Function LoginAttemptPruneExpired()
+	Local LA.LoginAttempt = First LoginAttempt
+	Local LANext.LoginAttempt = Null
+	Local NowMs = MilliSecs()
+	While LA <> Null
+		LANext = After LA
+		If NowMs - LA\WindowStart >= LoginAttemptWindowMs Then Delete LA
+		LA = LANext
+	Wend
+End Function
+
 ; Returns True if a fresh P_VerifyAccount from FromID should be processed.
 ; False if the source has tripped the failure threshold within the window.
 Function LoginAttemptOk%(FromID)
@@ -96,6 +115,7 @@ End Function
 ; failure increments it (creating a fresh entry / opening a new window if
 ; the previous one expired).
 Function LoginAttemptRecord(FromID, Success)
+	LoginAttemptPruneExpired()
 	LA.LoginAttempt = LoginAttemptFind(FromID)
 	If Success
 		If LA <> Null Then Delete LA

--- a/src/Modules/ServerNet.bb
+++ b/src/Modules/ServerNet.bb
@@ -2004,6 +2004,7 @@ Function UpdateNetwork()
 				Else
 					M\FromID = RCE_LastDisconnectedPeer()	
 				EndIf
+				LoginAttemptForget(M\FromID)
 				; Find which actor instance he was
 				AI.ActorInstance = FindActorInstanceFromRNID(M\FromID)
 				If AI <> Null

--- a/src/Tests/Modules/AccountsServerTest.bb
+++ b/src/Tests/Modules/AccountsServerTest.bb
@@ -184,6 +184,28 @@ Function CreateAccountRepliesAfterAtomicSave%(Path$)
 	Return False
 End Function
 
+Function DisconnectReleasesLoginAttempt%(Path$)
+	Local F.BBStream = ReadFile(Path$)
+	Local Stage%
+	Local Line$
+	If F = Null Then F = ReadFile("..\" + Path$)
+	If F = Null Then Return False
+
+	While Not Eof(F)
+		Line$ = ReadLine$(F)
+		If Instr(Line$, "Case RCE_PlayerTimedOut, RCE_PlayerHasLeft, RCE_PlayerKicked") > 0 Then Stage = 1
+		If Stage = 1 And Trim$(Line$) = "EndIf" Then Stage = 2
+		If Stage = 2 And Instr(Line$, "LoginAttemptForget(M\FromID)") > 0 Then Stage = 3
+		If Stage = 3 And Instr(Line$, "AI.ActorInstance = FindActorInstanceFromRNID(M\FromID)") > 0
+			CloseFile F
+			Return True
+		EndIf
+	Wend
+
+	CloseFile F
+	Return False
+End Function
+
 Test testFindAccountByListIDReturnsMatchingAccount()
 	Local firstAccount.Account = New Account()
 	firstAccount\User$ = "first"
@@ -259,4 +281,49 @@ End Test
 
 Test testCreateAccountSendsFailureWhenAtomicSaveFails()
 	Assert(CreateAccountRepliesAfterAtomicSave%("Modules\ServerNet.bb") = True)
+End Test
+
+Test testLoginAttemptForgetReleasesOnlyTheDisconnectedPeer()
+	LoginAttemptRecord(41, False)
+	LoginAttemptRecord(42, False)
+
+	LoginAttemptForget(41)
+
+	Assert(LoginAttemptFind(41) = Null)
+	Assert(LoginAttemptFind(42) <> Null)
+	Delete Each LoginAttempt
+End Test
+
+Test testLoginAttemptThresholdAndSuccessfulResetRemainUnchanged()
+	Local i%
+	For i = 1 To LoginAttemptMaxFailures
+		LoginAttemptRecord(41, False)
+	Next
+	Assert(LoginAttemptOk(41) = False)
+
+	LoginAttemptRecord(41, True)
+	Assert(LoginAttemptOk(41) = True)
+	Delete Each LoginAttempt
+End Test
+
+Test testLoginAttemptRecordPrunesExpiredRecords()
+	Local expired.LoginAttempt = New LoginAttempt()
+	expired\FromID = 41
+	expired\Failures = LoginAttemptMaxFailures
+	expired\WindowStart = MilliSecs() - LoginAttemptWindowMs
+
+	Local active.LoginAttempt = New LoginAttempt()
+	active\FromID = 42
+	active\Failures = 1
+	active\WindowStart = MilliSecs()
+
+	LoginAttemptRecord(42, False)
+	Assert(LoginAttemptFind(41) = Null)
+	Assert(LoginAttemptFind(42) = active)
+	Assert(active\Failures = 2)
+	Delete Each LoginAttempt
+End Test
+
+Test testDisconnectPathReleasesTheResolvedLoginAttempt()
+	Assert(DisconnectReleasesLoginAttempt%("Modules\ServerNet.bb") = True)
 End Test

--- a/src/Tests/Modules/AccountsServerTest.bb
+++ b/src/Tests/Modules/AccountsServerTest.bb
@@ -194,9 +194,13 @@ Function DisconnectReleasesLoginAttempt%(Path$)
 	While Not Eof(F)
 		Line$ = ReadLine$(F)
 		If Instr(Line$, "Case RCE_PlayerTimedOut, RCE_PlayerHasLeft, RCE_PlayerKicked") > 0 Then Stage = 1
-		If Stage = 1 And Trim$(Line$) = "EndIf" Then Stage = 2
-		If Stage = 2 And Instr(Line$, "LoginAttemptForget(M\FromID)") > 0 Then Stage = 3
-		If Stage = 3 And Instr(Line$, "AI.ActorInstance = FindActorInstanceFromRNID(M\FromID)") > 0
+		If Stage = 1 And Instr(Line$, "If (M\MessageType = RCE_PlayerKicked)") > 0 Then Stage = 2
+		If Stage = 2 And Instr(Line$, "M\FromID = RCE_IntFromStr(M\MessageData$)") > 0 Then Stage = 3
+		If Stage = 3 And Trim$(Line$) = "Else" Then Stage = 4
+		If Stage = 4 And Instr(Line$, "M\FromID = RCE_LastDisconnectedPeer()") > 0 Then Stage = 5
+		If Stage = 5 And Trim$(Line$) = "EndIf" Then Stage = 6
+		If Stage = 6 And Instr(Line$, "LoginAttemptForget(M\FromID)") > 0 Then Stage = 7
+		If Stage = 7 And Instr(Line$, "AI.ActorInstance = FindActorInstanceFromRNID(M\FromID)") > 0
 			CloseFile F
 			Return True
 		EndIf


### PR DESCRIPTION
## Outcome
Legacy servers now discard failed-login throttle state when an unauthenticated peer departs and prune expired records during later auth activity, preventing historical peer IDs from accumulating in the login lookup path.

## Technical changes
- Added `LoginAttemptForget` and cursor-safe `LoginAttemptPruneExpired` in `AccountsServer.bb`.
- Prune expired records before each login-result record; retain existing threshold and successful-reset behavior.
- Release the resolved peer record in timeout, leave, and kick handling.
- Added focused behavior/source-contract coverage and regenerated the protocol handler index.

Fixes #784

## Acceptance criteria and evidence
- Five failures remain throttled and a success clears state: `testLoginAttemptThresholdAndSuccessfulResetRemainUnchanged`.
- Disconnect cleanup is ordered after peer-ID resolution and before actor lookup: `testDisconnectPathReleasesTheResolvedLoginAttempt` plus portable source contract.
- Expired records are physically removed while an active peer record remains live: `testLoginAttemptRecordPrunesExpiredRecords`.
- Generated packet-handler references are current: `bash scripts/gen_packet_index.sh --check` -> exit 0.

## RED -> GREEN
- RED: portable source contract returned exit 1 with `expected_missing_cleanup=1` before implementation because the helpers and disconnect call were absent.
- GREEN: portable source contracts reported `accounts_contract=pass forget=1 prune=1 cursor_safe=1 record_prunes=1` and `disconnect_contract=pass cleanup_after_peer_resolution=1`.

## Baseline and final verification
- Baseline: `./test.sh AccountsServerTest` -> exit 1 before execution because `compiler/BlitzForge/bin/blitzcc` is absent in this Linux worktree.
- Final: `git diff --check`, `bash scripts/gen_packet_index.sh --check`, and `bash scripts/gen_bvm_reference.sh --check` -> exit 0 (BVM emitted only the two known DEAD-API warnings).
- Native focused test remains UNVERIFIED locally; exact-head Windows CI is required for runnable Blitz proof.

## Compatibility, risk, rollback, and deferred work
No packet framing, reply bytes, persistence format, client behavior, Rust server, or toolchain behavior changes. The lookup prune is O(n) only when an auth result is recorded; rollback is reverting this isolated commit.

## Independent review
Fresh independent reviewer verdict: ACCEPT for exact head `79f5b6151459d5525269f7f8988047334ca35dba`; it confirmed both peer-resolution branches precede cleanup, prune deletion is cursor-safe, threshold/reset coverage remains, and generated docs are current. Native focused proof remains CI-gated.