### PR TITLE
docs: expose the shipped Loom source-build target

### DIFF
--- a/ReadMe.md
+++ b/ReadMe.md
@@ -111,11 +111,15 @@ publish.bat            :: produce a redistributable release
 
 Useful flags (both platforms): `-b` rebuild BlitzForge, `-e` skip engine, `-t` skip tools.
 
+The standard engine build also compiles `src/Loom.bb` to `bin/Loom(.exe)`.
+Launch Loom (Beta) from Project Manager: choose a project, switch to the Engine
+tab, and select **Loom (Beta)**.
+
 ## Repository layout
 
 ```
 rcce2/
-├── src/                        # Engine source (BlitzBasic): Client, Server, GUE, Project Manager, Tests
+├── src/                        # Engine source (BlitzBasic): Client, Server, GUE, Loom (Beta), Project Manager, Tests
 ├── data/                       # Default game project (worlds, scripts, assets)
 ├── compiler/BlitzForge/        # Modernized Blitz3D compiler + runtime (submodule)
 ├── extras/vscode-blitz-forge/  # VS Code language extension (submodule)

--- a/docs/start.md
+++ b/docs/start.md
@@ -30,6 +30,7 @@ The main source entrypoints live under `src/`:
 - `src/Client.bb` - game client
 - `src/Server.bb` - game server
 - `src/GUE.bb` - Game Unified Editor
+- `src/Loom.bb` - Loom (Beta) editor
 - `src/Project Manager.bb` - launcher and packaging entrypoint
 - `src/Modules/` - shared engine and editor modules
 - `src/Tests/` - Blitz test sources compiled by the test runners
@@ -86,9 +87,12 @@ Successful builds produce the main applications from the repo root:
 - `bin/Client(.exe)`
 - `bin/Server(.exe)`
 - `bin/GUE(.exe)`
+- `bin/Loom(.exe)`
 
 Use Project Manager when you want the normal launcher flow. Use the binaries in
-`bin/` when you want to run the client, server, or editor directly.
+`bin/` when you want to run the client, server, or editor directly. To launch
+Loom (Beta), open Project Manager, choose a project, switch to the Engine tab,
+and select **Loom (Beta)**.
 
 ## Run Tests
 

--- a/src/Tests/Modules/ReadMeMacOSInstallTest.bb
+++ b/src/Tests/Modules/ReadMeMacOSInstallTest.bb
@@ -51,3 +51,16 @@ Test testContributorGeneratedDocsGuidanceMatchesCI()
 	Assert(FileContains%(".github\workflows\ci.yml", "bash scripts/gen_packet_index.sh --check") = True)
 	Assert(FileContains%(".github\workflows\ci.yml", "bash scripts/gen_bvm_reference.sh --check") = True)
 End Test
+
+Test testPublicSourceBuildOnboardingListsLoomAsShippedBeta()
+	Assert(FileContains%("ReadMe.md", "src/Loom.bb") = True)
+	Assert(FileContains%("ReadMe.md", "bin/Loom(.exe)") = True)
+	Assert(FileContains%("ReadMe.md", "Loom (Beta)") = True)
+	Assert(FileContains%("ReadMe.md", "Launch Loom (Beta) from Project Manager") = True)
+	Assert(FileContains%("docs/start.md", "src/Loom.bb") = True)
+	Assert(FileContains%("docs/start.md", "bin/Loom(.exe)") = True)
+	Assert(FileContains%("docs/start.md", "Loom (Beta)") = True)
+	Assert(FileContains%("docs/start.md", "Loom (Beta), open Project Manager") = True)
+	Assert(FileContains%("ReadMe.md", "Loom replacement for GUE") = False)
+	Assert(FileContains%("docs/start.md", "Loom replacement for GUE") = False)
+End Test


### PR DESCRIPTION
## Outcome
Source builders can now discover the shipped Loom (Beta) editor after a standard build, including its source entrypoint, generated binary, and supported Project Manager launch route.

## Technical changes
- Add Loom entrypoint/output and beta-launch guidance to `ReadMe.md` and `docs/start.md`.
- Add a focused public-onboarding source contract.

Fixes #794

## Acceptance criteria and evidence
- Both public pages name `src/Loom.bb`, `bin/Loom(.exe)`, and Loom (Beta): portable source-contract mirror GREEN, 10/10 assertions.
- Both pages retain the Project Manager route and reject a replacement claim: same mirror includes two route assertions and two negative assertions.
- Scope is limited to `ReadMe.md`, `docs/start.md`, and `src/Tests/Modules/ReadMeMacOSInstallTest.bb`.

## RED -> GREEN
- RED: portable mirror reported `SOURCE_CONTRACT_RED: 2/8 assertions satisfied` before the docs update.
- GREEN: portable mirror reported `SOURCE_CONTRACT_GREEN: 10/10 assertions satisfied` after the docs and contract update.

## Verification
- Baseline: `./test.sh ReadMeMacOSInstallTest` exited 1 before test execution because `compiler/BlitzForge/bin/blitzcc` is absent in this isolated worktree; a bounded `git submodule update --init compiler/BlitzForge` also timed out while cloning.
- Final local: portable mirror 10/10 GREEN; `git diff --check` exit 0; `bash scripts/gen_packet_index.sh --check` exit 0; `bash scripts/gen_bvm_reference.sh --check` exit 0 (two known DEAD-API warnings).
- Native focused test remains unverified locally for the compiler-binary limitation above; CI is the exact-head native proof.

## Compatibility, risk, and rollback
Documentation/test-only change. It preserves binary names, build scripts, GUE, and Loom behavior. Roll back by reverting `30386e2e`.

## Deferred
No Loom roadmap, save behavior, GUE, CI/toolchain, protocol, release, or deployment changes.

## Independent review
ACCEPT — fresh reviewer verified exact head `30386e2e`, the three-file scope, documented build and Project Manager route, 10/10 portable contract evidence, and absence of replacement/deferred-feature claims. Native focused compilation remains unverified locally because `compiler/BlitzForge/bin/blitzcc` is absent.