### PR TITLE
fix(client): reject truncated P_ChangeArea payloads

### DIFF
--- a/src/Modules/ClientNet.bb
+++ b/src/Modules/ClientNet.bb
@@ -1682,6 +1682,21 @@ Function UpdateNetwork()
 
 			; I have gone into a new area
 			Case P_ChangeArea
+				; The fixed prefix ends with the one-byte area-name length. Do not
+				; let Mid$ zero-fill an incomplete zone transition and tear down the active area.
+				If Len(M\MessageData$) < 25
+					WriteLog(MainLog, "P_ChangeArea: truncated header, dropping")
+					Delete M
+					M = MNext
+					Continue
+				EndIf
+				NameLen = RCE_IntFromStr(Mid$(M\MessageData$, 25, 1))
+				If Len(M\MessageData$) < 25 + NameLen
+					WriteLog(MainLog, "P_ChangeArea: truncated area name, dropping")
+					Delete M
+					M = MNext
+					Continue
+				EndIf
 				; Retrieve info for new zone
 				OldAreaName$ = AreaName$
 				OldAreaID = CurrentAreaID
@@ -1707,29 +1722,24 @@ Function UpdateNetwork()
 				If Gravity# < -2.0 Then Gravity# = -2.0
 				If Gravity# > 2.0 Then Gravity# = 2.0
 				CurrentAreaID = RCE_IntFromStr(Mid$(M\MessageData$, 20, 4))
-				NameLen = RCE_IntFromStr(Mid$(M\MessageData$, 25, 1))
 				AreaName$ = Mid$(M\MessageData$, 26, NameLen)
-				
 				;Actor Shadows Cysis145
 				If AreaName$ <> OldAreaName$
 					For A.ActorInstance = Each ActorInstance
-      					FreeShadowCaster% (A\EN)
-   					Next
+					FreeShadowCaster% (A\EN)
+					Next
 				EndIf
-				
 				If AreaName$ = OldAreaName$
 					For A.ActorInstance = Each ActorInstance
-      					FreeShadowCaster% (A\EN)
-   					Next
+					FreeShadowCaster% (A\EN)
+					Next
 				EndIf
-
 				; Going to new zone or instance
 				If OldAreaID <> CurrentAreaID
 					; Remove scripted emitters
 					For SEm.ScriptedEmitter = Each ScriptedEmitter
 						If SEm\AttachedToPlayer = False Then RP_FreeEmitter(SEm\EN, True, False)
 					Next
-
 					; Remove all in-flight projectiles
 					Local AreaProjI.ProjectileInstance = First ProjectileInstance
 					Local AreaProjINext.ProjectileInstance = Null
@@ -1738,10 +1748,8 @@ Function UpdateNetwork()
 						FreeProjectileInstance(AreaProjI)
 						AreaProjI = AreaProjINext
 					Wend
-
 					; Save radar state
 					If OldAreaName$ <> "" Then Save_Radar_Fog(RadarPath$ + Me\Name$ + "-" + OldAreaName$ + ".rdr")
-
 					; Remove old actor instances
 					; After-cursor walk: SafeFreeActorInstance Deletes A
 					; via FreeActorInstance. The original For-Each form
@@ -1756,7 +1764,6 @@ Function UpdateNetwork()
 						Acac = AcacNext
 					Wend
 				EndIf
-
 				; Remove dropped loot -- After-cursor walk for the same
 				; reason as above.
 				Local DItemR.DroppedItem = First DroppedItem
@@ -1767,7 +1774,6 @@ Function UpdateNetwork()
 					Delete DItemR
 					DItemR = DItemRNext
 				Wend
-
 				; Unload old and load new zone if necessary
 				If AreaName$ <> OldAreaName$
 					UnloadArea()
@@ -1799,7 +1805,6 @@ Function UpdateNetwork()
 					Load_Radar(Me\Name$ + "-" + AreaName$, Radar\X#, Radar\Y#, Radar\Width#, Radar\Height#, Not Outdoors, "Radar_Border.png", "Radar_Player.png")
 					If ShowRadar = False Then Hide_Radar()
 				EndIf
-
 				; Update settings
 				SetWeather(RCE_IntFromStr(Mid$(M\MessageData$, 24, 1)))
 				PlayerTarget = 0
@@ -1807,30 +1812,25 @@ Function UpdateNetwork()
 				PositionEntity(Me\CollisionEN, Me\X#, Y# + 5.0, Me\Z#)
 				RotateEntity(Me\CollisionEN, 0.0, Yaw#, 0.0)
 				ResetEntity(Me\CollisionEN)
-				
 				;Shadow [###]
 				PositionEntity(Cam, 0.0, Y# + 10.0, 0.0)
 				ResetEntity(Cam)
 				;UpdateShadows Cam
-				
-				
 				PositionEntity(Cam, Me\X#, Y# + 10.0, Me\Z#)
 				ResetEntity(Cam)
 				MoveMouse GraphicsWidth() / 2, GraphicsHeight() / 2
 				ZonedMS = MilliSecs()
-
 				; If the new zone is different to the old
 				If AreaName$ <> OldAreaName$
 					WriteLog(MainLog, "Entered zone: " + AreaName$)
 				Else
 					WriteLog(MainLog, "Reloaded current zone")
 				EndIf
-
 				;we are done, let the server know the it can resume paying attention to standard updates for our player actor again
 				;RCE_Send(Connection, RN_Host, P_ChangeArea, M\MessageData$, True)
 				;resume processing standard updates from the server
 				Me\IgnoreUpdate = 0
-	
+
 			; Host disconnected
 			Case P_KickedPlayer
 				RCE_Disconnect()

--- a/src/Tests/Modules/ClientNetChangeAreaWireBoundsTest.bb
+++ b/src/Tests/Modules/ClientNetChangeAreaWireBoundsTest.bb
@@ -17,6 +17,34 @@ Function ChangeAreaDeclaredNamePresent%(PayloadLen%, NameLen%)
 	Return True
 End Function
 
+Function ChangeAreaStateMutation%(Line$)
+	If Instr(Line$, "OldAreaName$ = AreaName$") > 0 Then Return True
+	If Instr(Line$, "OldAreaID = CurrentAreaID") > 0 Then Return True
+	If Instr(Line$, "Me\\") > 0 Then Return True
+	If Instr(Line$, "Y# = RCE_FloatFromStr#") > 0 Then Return True
+	If Instr(Line$, "Yaw# = RCE_FloatFromStr#") > 0 Then Return True
+	If Instr(Line$, "PvPEnabled =") > 0 Then Return True
+	If Instr(Line$, "Grav =") > 0 Then Return True
+	If Instr(Line$, "CurrentAreaID =") > 0 Then Return True
+	If Instr(Line$, "AreaName$ = Mid$(M\\MessageData$") > 0 Then Return True
+	If Instr(Line$, "FreeShadowCaster%") > 0 Then Return True
+	If Instr(Line$, "RP_FreeEmitter(") > 0 Then Return True
+	If Instr(Line$, "FreeProjectileInstance(") > 0 Then Return True
+	If Instr(Line$, "SafeFreeActorInstance(") > 0 Then Return True
+	If Instr(Line$, "FreeEntity DItemR\\EN") > 0 Then Return True
+	If Instr(Line$, "Delete DItemR") > 0 Then Return True
+	If Instr(Line$, "UnloadArea()") > 0 Then Return True
+	If Instr(Line$, "LoadArea(AreaName$") > 0 Then Return True
+	If Instr(Line$, "SetWeather(") > 0 Then Return True
+	If Instr(Line$, "PlayerTarget =") > 0 Then Return True
+	If Instr(Line$, "AttackTarget =") > 0 Then Return True
+	If Instr(Line$, "PositionEntity(Cam") > 0 Then Return True
+	If Instr(Line$, "RotateEntity(Cam") > 0 Then Return True
+	If Instr(Line$, "ResetEntity(Cam)") > 0 Then Return True
+	If Instr(Line$, "ZonedMS =") > 0 Then Return True
+	Return False
+End Function
+
 Function ChangeAreaGuardsPrecedeStateMutation%(Path$)
 	Local F.BBStream = ReadFile(Path$)
 	Local InCase%, Stage%
@@ -29,6 +57,10 @@ Function ChangeAreaGuardsPrecedeStateMutation%(Path$)
 		If Instr(Line$, "Case P_ChangeArea") > 0 Then InCase = True
 		If InCase = True And Instr(Line$, "Case P_KickedPlayer") > 0 Then Exit
 		If InCase = True
+			If Stage < 11 And ChangeAreaStateMutation%(Line$)
+				CloseFile F
+				Return False
+			EndIf
 			If Stage = 0 And Instr(Line$, "If Len(M\\MessageData$) < 25") > 0
 				Stage = 1
 			EndIf

--- a/src/Tests/Modules/ClientNetChangeAreaWireBoundsTest.bb
+++ b/src/Tests/Modules/ClientNetChangeAreaWireBoundsTest.bb
@@ -1,0 +1,69 @@
+Strict
+EnableGC
+
+; P_ChangeArea has a fixed 25-byte prefix that ends with the one-byte area-name
+; length, followed by the corresponding name bytes. The dispatcher owns world teardown,
+; so malformed packets must be rejected before they change local zone state.
+
+Const ChangeAreaHeaderBytes% = 25
+
+Function ChangeAreaFixedHeaderPresent%(PayloadLen%)
+	If PayloadLen < ChangeAreaHeaderBytes Then Return False
+	Return True
+End Function
+
+Function ChangeAreaDeclaredNamePresent%(PayloadLen%, NameLen%)
+	If PayloadLen < ChangeAreaHeaderBytes + NameLen Then Return False
+	Return True
+End Function
+
+Function ChangeAreaGuardsPrecedeStateMutation%(Path$)
+	Local F.BBStream = ReadFile(Path$)
+	Local InCase%, Stage%
+	Local Line$
+	If F = Null Then F = ReadFile("..\\" + Path$)
+	If F = Null Then Return False
+
+	While Not Eof(F)
+		Line$ = ReadLine$(F)
+		If Instr(Line$, "Case P_ChangeArea") > 0 Then InCase = True
+		If InCase = True And Instr(Line$, "Case P_KickedPlayer") > 0 Then Exit
+		If InCase = True
+			If Stage = 0 And Instr(Line$, "If Len(M\\MessageData$) < 25") > 0
+				Stage = 1
+			EndIf
+			If Stage = 1 And Instr(Line$, "P_ChangeArea: truncated header, dropping") > 0 Then Stage = 2
+			If Stage = 2 And Trim$(Line$) = "Delete M" Then Stage = 3
+			If Stage = 3 And Trim$(Line$) = "M = MNext" Then Stage = 4
+			If Stage = 4 And Trim$(Line$) = "Continue" Then Stage = 5
+			If Stage = 5 And Instr(Line$, "NameLen = RCE_IntFromStr(Mid$(M\\MessageData$, 25, 1))") > 0 Then Stage = 6
+			If Stage = 6 And Instr(Line$, "If Len(M\\MessageData$) < 25 + NameLen") > 0 Then Stage = 7
+			If Stage = 7 And Instr(Line$, "P_ChangeArea: truncated area name, dropping") > 0 Then Stage = 8
+			If Stage = 8 And Trim$(Line$) = "Delete M" Then Stage = 9
+			If Stage = 9 And Trim$(Line$) = "M = MNext" Then Stage = 10
+			If Stage = 10 And Trim$(Line$) = "Continue" Then Stage = 11
+			If Stage = 11 And Instr(Line$, "OldAreaName$ = AreaName$") > 0
+				CloseFile F
+				Return True
+			EndIf
+		EndIf
+	Wend
+
+	CloseFile F
+	Return False
+End Function
+
+Test testChangeAreaRejectsTruncatedFixedHeader()
+	Assert(ChangeAreaFixedHeaderPresent%(24) = False)
+	Assert(ChangeAreaFixedHeaderPresent%(25) = True)
+End Test
+
+Test testChangeAreaRejectsTruncatedDeclaredName()
+	Assert(ChangeAreaDeclaredNamePresent%(25, 0) = True)
+	Assert(ChangeAreaDeclaredNamePresent%(26, 1) = True)
+	Assert(ChangeAreaDeclaredNamePresent%(25, 1) = False)
+End Test
+
+Test testChangeAreaGuardsPrecedeZoneStateMutation()
+	Assert(ChangeAreaGuardsPrecedeStateMutation%("Modules\\ClientNet.bb") = True)
+End Test

--- a/src/Tests/Modules/ClientNetChangeAreaWireBoundsTest.bb
+++ b/src/Tests/Modules/ClientNetChangeAreaWireBoundsTest.bb
@@ -20,18 +20,18 @@ End Function
 Function ChangeAreaStateMutation%(Line$)
 	If Instr(Line$, "OldAreaName$ = AreaName$") > 0 Then Return True
 	If Instr(Line$, "OldAreaID = CurrentAreaID") > 0 Then Return True
-	If Instr(Line$, "Me\\") > 0 Then Return True
+	If Instr(Line$, "Me\") > 0 Then Return True
 	If Instr(Line$, "Y# = RCE_FloatFromStr#") > 0 Then Return True
 	If Instr(Line$, "Yaw# = RCE_FloatFromStr#") > 0 Then Return True
 	If Instr(Line$, "PvPEnabled =") > 0 Then Return True
 	If Instr(Line$, "Grav =") > 0 Then Return True
 	If Instr(Line$, "CurrentAreaID =") > 0 Then Return True
-	If Instr(Line$, "AreaName$ = Mid$(M\\MessageData$") > 0 Then Return True
+	If Instr(Line$, "AreaName$ = Mid$(M\MessageData$") > 0 Then Return True
 	If Instr(Line$, "FreeShadowCaster%") > 0 Then Return True
 	If Instr(Line$, "RP_FreeEmitter(") > 0 Then Return True
 	If Instr(Line$, "FreeProjectileInstance(") > 0 Then Return True
 	If Instr(Line$, "SafeFreeActorInstance(") > 0 Then Return True
-	If Instr(Line$, "FreeEntity DItemR\\EN") > 0 Then Return True
+	If Instr(Line$, "FreeEntity DItemR\EN") > 0 Then Return True
 	If Instr(Line$, "Delete DItemR") > 0 Then Return True
 	If Instr(Line$, "UnloadArea()") > 0 Then Return True
 	If Instr(Line$, "LoadArea(AreaName$") > 0 Then Return True
@@ -49,7 +49,7 @@ Function ChangeAreaGuardsPrecedeStateMutation%(Path$)
 	Local F.BBStream = ReadFile(Path$)
 	Local InCase%, Stage%
 	Local Line$
-	If F = Null Then F = ReadFile("..\\" + Path$)
+	If F = Null Then F = ReadFile("..\" + Path$)
 	If F = Null Then Return False
 
 	While Not Eof(F)
@@ -61,15 +61,15 @@ Function ChangeAreaGuardsPrecedeStateMutation%(Path$)
 				CloseFile F
 				Return False
 			EndIf
-			If Stage = 0 And Instr(Line$, "If Len(M\\MessageData$) < 25") > 0
+			If Stage = 0 And Instr(Line$, "If Len(M\MessageData$) < 25") > 0
 				Stage = 1
 			EndIf
 			If Stage = 1 And Instr(Line$, "P_ChangeArea: truncated header, dropping") > 0 Then Stage = 2
 			If Stage = 2 And Trim$(Line$) = "Delete M" Then Stage = 3
 			If Stage = 3 And Trim$(Line$) = "M = MNext" Then Stage = 4
 			If Stage = 4 And Trim$(Line$) = "Continue" Then Stage = 5
-			If Stage = 5 And Instr(Line$, "NameLen = RCE_IntFromStr(Mid$(M\\MessageData$, 25, 1))") > 0 Then Stage = 6
-			If Stage = 6 And Instr(Line$, "If Len(M\\MessageData$) < 25 + NameLen") > 0 Then Stage = 7
+			If Stage = 5 And Instr(Line$, "NameLen = RCE_IntFromStr(Mid$(M\MessageData$, 25, 1))") > 0 Then Stage = 6
+			If Stage = 6 And Instr(Line$, "If Len(M\MessageData$) < 25 + NameLen") > 0 Then Stage = 7
 			If Stage = 7 And Instr(Line$, "P_ChangeArea: truncated area name, dropping") > 0 Then Stage = 8
 			If Stage = 8 And Trim$(Line$) = "Delete M" Then Stage = 9
 			If Stage = 9 And Trim$(Line$) = "M = MNext" Then Stage = 10
@@ -97,5 +97,5 @@ Test testChangeAreaRejectsTruncatedDeclaredName()
 End Test
 
 Test testChangeAreaGuardsPrecedeZoneStateMutation()
-	Assert(ChangeAreaGuardsPrecedeStateMutation%("Modules\\ClientNet.bb") = True)
+	Assert(ChangeAreaGuardsPrecedeStateMutation%("Modules\ClientNet.bb") = True)
 End Test


### PR DESCRIPTION
## Outcome

Malformed zone-transition packets are discarded before they can overwrite client zone state or unload the active world.

## Technical changes

- Validate the complete 25-byte `P_ChangeArea` prefix, then its declared area-name bytes, before decoding or changing state.
- Safely delete and advance malformed messages before continuing the network queue.
- Add a focused source-contract regression test that rejects pre-guard zone decoders, writes, teardown, and loads.

Fixes #800

## Acceptance evidence

- Fixed-prefix and declared-name guards occur before zone state/teardown sinks: portable ordering contract printed `CHANGE_AREA_ORDERING_CONTRACT_GREEN` (exit 0).
- Boundary model passed: 24 rejected, 25 accepted, 25 with a declared name byte rejected, 26 with one name byte accepted (`CHANGE_AREA_LENGTH_MODEL_GREEN`).
- The predicates use `<`, so zero-length names and trailing bytes remain accepted.

## RED -> GREEN

- RED: before the production guard, the portable contract exited 1 with `CHANGE_AREA_SOURCE_CONTRACT_RED missing fixed-header guard`.
- GREEN: after the guard, the portable source contract printed `CHANGE_AREA_SOURCE_CONTRACT_GREEN` (exit 0); the strengthened ordering mirror printed `CHANGE_AREA_ORDERING_CONTRACT_GREEN` (exit 0).

## Verification

- `git diff --check` -> exit 0.
- `bash scripts/gen_packet_index.sh --check` -> exit 0.
- `bash scripts/gen_bvm_reference.sh --check` -> exit 0; two existing DEAD-API warnings only.
- `./test.sh ClientNetChangeAreaWireBoundsTest` -> exit 1 before test execution locally because `compiler/BlitzForge/bin/blitzcc` is unavailable. Exact-head Windows CI is running this native test.

## Compatibility, rollback, and follow-up

No packet schema changes. Complete existing packets keep their parser, including zero-length names and trailing bytes. Roll back by reverting commits `56650f26`, `f38732af`, and `242f5b7b`.

## Independent review

Fresh exact-head review verdict: **ACCEPT** for `242f5b7b4fa046d9eb55281b9fe6cdd437fe3f70`. It confirmed the queue cursor flow, ordering contract, compatibility, and narrow scope. Exact-head CI remains the final merge gate.