### PR TITLE
docs: expose optional Rust source-build targets

### DIFF
--- a/ReadMe.md
+++ b/ReadMe.md
@@ -96,6 +96,7 @@ git submodule update --init --recursive
 ```bat
 compile.bat            :: build engine + tools
 compile.bat -b         :: also rebuild the BlitzForge toolchain
+compile.bat -r         :: also build optional Rust client + server (bin\ClientRS.exe + bin\ServerRS.exe; requires Cargo)
 publish.bat            :: produce a redistributable release
 ```
 
@@ -109,7 +110,7 @@ publish.bat            :: produce a redistributable release
 ./publish.sh                    # produce a redistributable release
 ```
 
-Useful flags (both platforms): `-b` rebuild BlitzForge, `-e` skip engine, `-t` skip tools.
+Useful flags (both platforms): `-b` rebuild BlitzForge, `-e` skip engine, `-t` skip tools, and `-r` / `--rust` also build the optional Rust client and server (requires Cargo).
 
 The standard engine build also compiles `src/Loom.bb` to `bin/Loom(.exe)`.
 Launch Loom (Beta) from Project Manager: choose a project, switch to the Engine

--- a/docs/start.md
+++ b/docs/start.md
@@ -48,6 +48,7 @@ Use the batch scripts from the repository root:
 ```bat
 compile.bat
 compile.bat -b
+compile.bat -r
 publish.bat
 test.bat
 ```
@@ -60,6 +61,7 @@ Use the shell scripts from the repository root:
 ./scripts/bootstrap_macos.sh
 ./compile.sh
 ./compile.sh -b
+./compile.sh -r
 ./publish.sh
 ./test.sh
 ```
@@ -78,6 +80,7 @@ The build scripts share the same intent:
 - `-b` / `--blitz` rebuild BlitzForge itself
 - `-e` / `--skip-engine` skip the main RCCE engine build
 - `-t` / `--skip-tools` skip the editor/tool builds
+- `-r` / `--rust` also build the optional Rust client and server (requires Cargo), producing `bin/ClientRS` and `bin/ServerRS` (`.exe` on Windows)
 
 ## Run What You Built
 

--- a/src/Tests/Modules/ReadMeMacOSInstallTest.bb
+++ b/src/Tests/Modules/ReadMeMacOSInstallTest.bb
@@ -43,6 +43,22 @@ Test testSourceBuildOnboardingDoesNotAdvertiseTheMacOSBootstrapForLinux()
 	Assert(FileContains%("CONTRIBUTING.md", "macOS equivalent") = True)
 End Test
 
+Test testSourceBuildOnboardingDocumentsOptionalRustTargets()
+	Assert(FileContains%("ReadMe.md", "compile.bat -r") = True)
+	Assert(FileContains%("ReadMe.md", "bin\ClientRS.exe") = True)
+	Assert(FileContains%("ReadMe.md", "bin\ServerRS.exe") = True)
+	Assert(FileContains%("ReadMe.md", "optional Rust client and server") = True)
+	Assert(FileContains%("ReadMe.md", "Rust build is required") = False)
+	Assert(FileContains%("ReadMe.md", "only build the Rust server") = False)
+	Assert(FileContains%("docs/start.md", "compile.bat -r") = True)
+	Assert(FileContains%("docs/start.md", "./compile.sh -r") = True)
+	Assert(FileContains%("docs/start.md", "bin/ClientRS") = True)
+	Assert(FileContains%("docs/start.md", "bin/ServerRS") = True)
+	Assert(FileContains%("docs/start.md", "optional Rust client and server") = True)
+	Assert(FileContains%("docs/start.md", "Rust build is required") = False)
+	Assert(FileContains%("docs/start.md", "only build the Rust server") = False)
+End Test
+
 Test testContributorGeneratedDocsGuidanceMatchesCI()
 	Assert(FileContains%("CONTRIBUTING.md", "./scripts/gen_packet_index.sh") = True)
 	Assert(FileContains%("CONTRIBUTING.md", "./scripts/gen_bvm_reference.sh") = True)


### PR DESCRIPTION
## Outcome
Contributors can now discover the optional Rust client/server build route directly from both public source-build guides.

## Changes
- Documents compile.bat -r and compile.sh -r alongside existing source-build commands.
- States the Cargo prerequisite and both ClientRS/ServerRS outputs.
- Adds a focused source-contract regression for optional, dual-target guidance.

Fixes #802

## Acceptance evidence
- Both public guides name the optional Rust route and outputs: portable source contract GREEN 14/14.
- The regression rejects mandatory-Rust and server-only wording.
- Existing build commands and macOS alpha wording are unchanged in the reviewed diff.

## TDD and verification
- BASELINE: ./test.sh ReadMeMacOSInstallTest exited 1 before execution because compiler/BlitzForge/bin/blitzcc is absent.
- RED: portable probe exited 1 with RED_EXPECTED=public_docs_missing_rust_build_contract.
- GREEN: portable source contract printed SOURCE_CONTRACT_GREEN=14/14.
- Final: git diff --check, scripts/gen_packet_index.sh --check, and scripts/gen_bvm_reference.sh --check exited 0; the latter printed two pre-existing DEAD-API warnings.

## Compatibility and rollback
Documentation/test-only; no build behavior, artifact format, protocol, or platform support policy changes. Rollback is a normal revert of this one commit.

## Review
Fresh adversarial self-review: ACCEPT with no findings. A separate reviewer agent is unavailable in this run; final exact-head review will be repeated before merge.