### PR TITLE
fix(server): reject blank flat-file account fields

### DIFF
--- a/docs/modules/accountsserver.md
+++ b/docs/modules/accountsserver.md
@@ -158,7 +158,7 @@ Parameters:
 *   _Email$_ - Email address for the new account
 
   
-This function creates a new Account object, sets its initial values, and adds it to the server's Accounts window. It then saves the complete account set through `SaveAccounts`' atomic v1 writer. It returns True only after that commit succeeds; on failure it removes the new account and its list/count changes so callers can report that registration did not persist.
+This function rejects an empty username, password hash, or email address before it creates an Account object or mutates the server Accounts window. For nonempty fields, it creates the object, sets its initial values, and adds it to the window. It then saves the complete account set through `SaveAccounts`' atomic v1 writer. It returns True only after that commit succeeds; validation or commit failure leaves no new account/list/count state so callers can report that registration did not persist.
 
   
   

--- a/docs/protocol/packets/P_CreateAccount.md
+++ b/docs/protocol/packets/P_CreateAccount.md
@@ -48,13 +48,13 @@ All server-side, since the packet is attacker-controlled. In sequence:
 4. **Password (MD5 hex) character set** ([:2439-2442](../../../src/Modules/ServerNet.bb#L2439)) — same alnum set plus `.` (46), `_` (95), or `>= 192`. (The client always sends 32 lowercase hex chars, which trivially pass; the check guards a hand-rolled packet.)
 5. **Email character set** ([:2444-2447](../../../src/Modules/ServerNet.bb#L2444)) — validated **after** `Encrypt$(..., 1)` de-obfuscation, so the check runs on the plaintext email. Allowed: alnum, `@` (64), `*` (42), `+` (43), `-` (45), `.` (46), `=` (61), `_` (95), or `>= 192`.
 6. **Length caps** ([:2448](../../../src/Modules/ServerNet.bb#L2448)) — `Len(Username$) > 50 Or Len(Password$) > 50 Or Len(Email$) > 200` -> `Valid = False`.
-7. On `Valid = True`, [`AddAccount(Username$, Password$, Email$)`](../../../src/Modules/AccountsServer.bb#L193) creates the record (storing the password as a salted SHA-256 v1 hash via [`HashPassword$`](../../../src/Modules/PasswordHash.bb#L209)) and commits the complete v1 account file atomically. It replies `"Y"` only when that commit succeeds; validation or persistence failure replies `"N"`.
+7. On `Valid = True`, the flat-file [`AddAccount(Username$, Password$, Email$)`](../../../src/Modules/AccountsServer.bb#L193) boundary rejects any empty field before it creates a record, then stores nonempty passwords as salted SHA-256 v1 hashes via [`HashPassword$`](../../../src/Modules/PasswordHash.bb#L209) and commits the complete v1 account file atomically. It replies `"Y"` only when that commit succeeds; validation or persistence failure replies `"N"`.
 
 ### Gaps in the validation (verified against source)
 
 These are **not** defended and are documented here honestly rather than implied:
 
-- **No minimum-length / non-empty check.** A zero-length username passes step 3 (the `For i = 1 To Len(Username$)` loop never runs, so `Valid` stays `True`). The client enforces `Len(Name$) >= 2` ([MainMenu.bb:1195](../../../src/Modules/MainMenu.bb#L1195)) and `Len(Pass$) >= 2` ([:1196](../../../src/Modules/MainMenu.bb#L1196)), but a hand-rolled packet bypasses that — the server will create an empty-username / empty-password account.
+- **No client-equivalent minimum-length check.** A zero-length username still passes step 3 because the character loop does not run. The flat-file `AddAccount` boundary rejects empty username, password, and email values before mutation, but it does not impose the client's two-character username/password minimum; the MySQL branch also remains outside that flat-file guard. The client enforces `Len(Name$) >= 2` ([MainMenu.bb:1195](../../../src/Modules/MainMenu.bb#L1195)) and `Len(Pass$) >= 2` ([:1196](../../../src/Modules/MainMenu.bb#L1196)).
 - **No `LoginAttemptOk` throttle.** Unlike [`P_VerifyAccount`](P_VerifyAccount.md), `P_StartGame`, `P_FetchCharacter`, `P_CreateCharacter`, and `P_DeleteCharacter` (all throttled by PR [#266](https://github.com/RydeTec/rcce2/pull/266) / [#268](https://github.com/RydeTec/rcce2/pull/268)), `P_CreateAccount` has no per-source rate limit. See Anti-cheat surface.
 
 ## Anti-cheat / abuse surface

--- a/src/Modules/AccountsServer.bb
+++ b/src/Modules/AccountsServer.bb
@@ -216,6 +216,11 @@ End Function
 ; not directly replayable on the wire.
 Function AddAccount%(User$, Pass$, Email$)
 
+	; Packet-level character checks accept empty strings because their loops do
+	; not execute. Reject them at the flat-file persistence boundary before any
+	; account, UI, count, hash, or atomic-save mutation.
+	If User$ = "" Or Pass$ = "" Or Email$ = "" Then Return False
+
 	; Create account
 	A.Account = New Account
 	A\User$ = User$

--- a/src/Tests/Modules/AccountsServerTest.bb
+++ b/src/Tests/Modules/AccountsServerTest.bb
@@ -158,7 +158,7 @@ Function AddAccountRejectsBlankFieldsBeforeMutation%(Path$)
 	While Not Eof(F)
 		Line$ = ReadLine$(F)
 		If Instr(Line$, "Function AddAccount%(User$, Pass$, Email$)") > 0 Then Stage = 1
-		If Stage = 1 And (Instr(Line$, "A.Account = New Account") > 0 Or Instr(Line$, "HashPassword$(Pass$)") > 0 Or Instr(Line$, "AddListBoxItem(") > 0 Or Instr(Line$, "SaveAccounts()") > 0)
+		If Stage = 1 And (Instr(Line$, "A.Account = New Account") > 0 Or Instr(Line$, "HashPassword$(Pass$)") > 0 Or Instr(Line$, "AddListBoxItem(") > 0 Or Instr(Line$, "Accounts\TotalAccounts =") > 0 Or Instr(Line$, "SetGadgetText(Accounts\AccountsLabel") > 0 Or Instr(Line$, "SaveAccounts()") > 0)
 			CloseFile F
 			Return False
 		EndIf

--- a/src/Tests/Modules/AccountsServerTest.bb
+++ b/src/Tests/Modules/AccountsServerTest.bb
@@ -144,6 +144,36 @@ Function AddAccountUsesAtomicSaveAndRollback%(Path$)
 	Return False
 End Function
 
+; Account-creation packet validation has maximum-length checks, but hand-built
+; packets can still supply zero-length fields. AddAccount is the flat-file
+; persistence boundary, so it must reject those values before any account, UI,
+; count, hash, or save mutation begins.
+Function AddAccountRejectsBlankFieldsBeforeMutation%(Path$)
+	Local F.BBStream = ReadFile(Path$)
+	Local Stage%
+	Local Line$
+	If F = Null Then F = ReadFile("..\" + Path$)
+	If F = Null Then Return False
+
+	While Not Eof(F)
+		Line$ = ReadLine$(F)
+		If Instr(Line$, "Function AddAccount%(User$, Pass$, Email$)") > 0 Then Stage = 1
+		If Stage = 1 And (Instr(Line$, "A.Account = New Account") > 0 Or Instr(Line$, "HashPassword$(Pass$)") > 0 Or Instr(Line$, "AddListBoxItem(") > 0 Or Instr(Line$, "SaveAccounts()") > 0)
+			CloseFile F
+			Return False
+		EndIf
+		If Stage = 1 And Instr(Line$, "If User$ = " + Chr$(34) + Chr$(34) + " Or Pass$ = " + Chr$(34) + Chr$(34) + " Or Email$ = " + Chr$(34) + Chr$(34) + " Then Return False") > 0 Then Stage = 2
+		If Stage = 2 And Instr(Line$, "A.Account = New Account") > 0
+			CloseFile F
+			Return True
+		EndIf
+		If Stage > 0 And Instr(Line$, "Function SaveAccounts()") > 0 Then Exit
+	Wend
+
+	CloseFile F
+	Return False
+End Function
+
 Function CreateAccountRepliesAfterAtomicSave%(Path$)
 	Local F.BBStream = ReadFile(Path$)
 	Local FailureReply%, GuardIndent%, InCase%, Stage%
@@ -281,6 +311,10 @@ End Test
 
 Test testAddAccountUsesAtomicSaveAndRollsBackOnFailure()
 	Assert(AddAccountUsesAtomicSaveAndRollback%("Modules\AccountsServer.bb") = True)
+End Test
+
+Test testAddAccountRejectsBlankFieldsBeforeMutation()
+	Assert(AddAccountRejectsBlankFieldsBeforeMutation%("Modules\AccountsServer.bb") = True)
 End Test
 
 Test testCreateAccountSendsFailureWhenAtomicSaveFails()


### PR DESCRIPTION
## Outcome
Flat-file account registration now rejects blank username, password-hash, or email fields before an unusable account record can reach the Accounts UI or Accounts.dat.

## Technical changes
- Add a pre-mutation blank-field guard at AddAccount.
- Add focused source-contract coverage for guard-before-mutation ordering.
- Align the account module and P_CreateAccount references with the flat-file invariant while preserving the separate MySQL/minimum-length/throttling gaps.

Fixes #804

## Acceptance criteria and evidence
- Empty User, Pass, and Email are guarded before New Account, HashPassword, UI, count, or SaveAccounts: ACCOUNT_BLANK_FIELD_CONTRACT_GREEN.
- Valid nonblank flow and existing atomic-save rollback remain structurally bound by the pre-existing AccountsServer source contract.
- Existing AddAccount false-to-P_CreateAccount N branch remains covered by the pre-existing focused source contract; ServerNet is unchanged.
- Documentation distinguishes the flat-file guard from deferred client-equivalent minimum lengths, MySQL validation, and throttling.

## RED -> GREEN
- RED: portable focused probe emitted ACCOUNT_BLANK_FIELD_CONTRACT_RED before implementation.
- GREEN: the same probe emitted ACCOUNT_BLANK_FIELD_CONTRACT_GREEN after the guard, regression contract, and docs update.

## Baseline and final verification
- BASELINE: ./test.sh AccountsServerTest exited 1 before test execution because compiler/BlitzForge/bin/blitzcc was absent.
- Final: git diff --check exited 0; bash scripts/gen_packet_index.sh --check exited 0; bash scripts/gen_bvm_reference.sh --check exited 0 with two known DEAD-API warnings.
- Native focused test remains unverified locally: two bounded git submodule update --init compiler/BlitzForge attempts did not yield blitzcc (first timed out cloning after 55s; retry reported missing current revision). Exact-head CI is required for native proof.

## Compatibility, risk, rollback, deferred work
- Valid flat-file registration and the Y/N packet format remain unchanged; only blank flat-file requests now receive the existing N failure reply.
- Rollback: revert 7b0726a1.
- Deferred: ServerNet validation changes, MySQL behavior, Rust parity, registration throttling, client two-character policy, and client wording.

## Independent review
ACCEPT — fresh reviewer inspected exact head ce5c4dd4, confirmed the guard precedes account allocation, hash, UI, count, and save mutations, confirmed the existing flat-file N reply, and found no material issues. Native focused execution remains locally unverified because blitzcc is absent.