### PR TITLE
fix(actors): harden stale slave-chain unlink

### DIFF
--- a/src/Modules/Actors.bb
+++ b/src/Modules/Actors.bb
@@ -719,16 +719,27 @@ Function SlaveUnlink(Slave.ActorInstance)
 	; Walk-to-find-predecessor splice on the leader's chain.
 	If Leader\FirstSlave = Slave
 		Leader\FirstSlave = Slave\NextSlave
+		Slave\NextSlave = Null
+		Slave\Leader = Null
+		Leader\NumberOfSlaves = Leader\NumberOfSlaves - 1
+		Return
 	Else
 		Local Prev.ActorInstance = Leader\FirstSlave
-		While Prev <> Null And Prev\NextSlave <> Slave
+		While Prev <> Null
+			If Prev\NextSlave = Slave
+				Prev\NextSlave = Slave\NextSlave
+				Slave\NextSlave = Null
+				Slave\Leader = Null
+				Leader\NumberOfSlaves = Leader\NumberOfSlaves - 1
+				Return
+			EndIf
 			Prev = Prev\NextSlave
 		Wend
-		If Prev <> Null Then Prev\NextSlave = Slave\NextSlave
 	EndIf
+	; A stale leader pointer can outlive its leader's membership chain. Clear
+	; only the detached slave state: do not alter a valid leader chain/count.
 	Slave\NextSlave = Null
 	Slave\Leader = Null
-	Leader\NumberOfSlaves = Leader\NumberOfSlaves - 1
 
 End Function
 

--- a/src/Tests/Modules/SlaveChainTest.bb
+++ b/src/Tests/Modules/SlaveChainTest.bb
@@ -50,16 +50,55 @@ Function MockSlaveUnlink(Slave.MockActor)
 	If Leader = Null Then Return
 	If Leader\FirstSlave = Slave
 		Leader\FirstSlave = Slave\NextSlave
+		Slave\NextSlave = Null
+		Slave\Leader = Null
+		Leader\NumberOfSlaves = Leader\NumberOfSlaves - 1
+		Return
 	Else
 		Local Prev.MockActor = Leader\FirstSlave
-		While Prev <> Null And Prev\NextSlave <> Slave
+		While Prev <> Null
+			If Prev\NextSlave = Slave
+				Prev\NextSlave = Slave\NextSlave
+				Slave\NextSlave = Null
+				Slave\Leader = Null
+				Leader\NumberOfSlaves = Leader\NumberOfSlaves - 1
+				Return
+			EndIf
 			Prev = Prev\NextSlave
 		Wend
-		If Prev <> Null Then Prev\NextSlave = Slave\NextSlave
 	EndIf
 	Slave\NextSlave = Null
 	Slave\Leader = Null
-	Leader\NumberOfSlaves = Leader\NumberOfSlaves - 1
+End Function
+
+; Actors.bb cannot be included by this focused test because it pulls in the
+; server/world graph. Keep the behavioral model above, and also bind the
+; production helper's stale-chain guard shape below.
+Function ProductionSlaveUnlinkGuardsStaleChains%(Path$)
+	Local F.BBStream = ReadFile(Path$)
+	Local Line$
+	Local InUnlink%, SawMemberCheck%, SawSplice%, SawConditionalDecrement%
+	If F = Null Then F = ReadFile("..\" + Path$)
+	If F = Null Then F = ReadFile("..\..\" + Path$)
+	If F = Null Then Return False
+
+	While Not Eof(F)
+		Line$ = ReadLine$(F)
+		If Instr(Line$, "Function SlaveUnlink(Slave.ActorInstance)") > 0 Then InUnlink = True
+		If InUnlink = True
+			If Instr(Line$, "While Prev <> Null And Prev\NextSlave <> Slave") > 0
+				CloseFile F
+				Return False
+			EndIf
+			If Instr(Line$, "If Prev\NextSlave = Slave") > 0 Then SawMemberCheck = True
+			If SawMemberCheck = True And Instr(Line$, "Prev\NextSlave = Slave\NextSlave") > 0 Then SawSplice = True
+			If SawMemberCheck = True And Instr(Line$, "Leader\NumberOfSlaves = Leader\NumberOfSlaves - 1") > 0 Then SawConditionalDecrement = True
+			If Instr(Line$, "End Function") > 0 Then Exit
+		EndIf
+	Wend
+
+	CloseFile F
+	Return SawMemberCheck And SawSplice And SawConditionalDecrement
 End Function
 
 Function ChainLen%(L.MockActor)
@@ -250,6 +289,41 @@ Test testUnlinkNullIsNoOp()
 	ResetPool()
 	MockSlaveUnlink(Null)
 	; No crash, no error.
+End Test
+
+Test testUnlinkStaleSlaveWithEmptyLeaderChainPreservesCount()
+	ResetPool()
+	Local L.MockActor = New MockActor() : L\Name = "L"
+	Local S.MockActor = New MockActor() : S\Name = "S"
+	S\Leader = L
+	S\NextSlave = New MockActor()
+	MockSlaveUnlink(S)
+	Assert(L\FirstSlave = Null)
+	Assert(L\NumberOfSlaves = 0)
+	Assert(S\Leader = Null)
+	Assert(S\NextSlave = Null)
+End Test
+
+Test testUnlinkStaleNonMemberPreservesValidLeaderChain()
+	ResetPool()
+	Local L.MockActor = New MockActor() : L\Name = "L"
+	Local Member.MockActor = New MockActor() : Member\Name = "Member"
+	Local Stale.MockActor = New MockActor() : Stale\Name = "Stale"
+	Member\Leader = L
+	L\FirstSlave = Member
+	L\NumberOfSlaves = 1
+	Stale\Leader = L
+	Stale\NextSlave = Member
+	MockSlaveUnlink(Stale)
+	Assert(L\FirstSlave = Member)
+	Assert(Member\NextSlave = Null)
+	Assert(L\NumberOfSlaves = 1)
+	Assert(Stale\Leader = Null)
+	Assert(Stale\NextSlave = Null)
+End Test
+
+Test testProductionSlaveUnlinkGuardsStaleChains()
+	Assert(ProductionSlaveUnlinkGuardsStaleChains%("Modules\Actors.bb") = True)
 End Test
 
 ; ====================================================================


### PR DESCRIPTION
## Outcome

Actor teardown and pet relinking no longer crash or corrupt a leader's valid slave chain when a stale slave points at a leader but is absent from that leader's chain.

## Technical changes

- Make `SlaveUnlink` walk predecessor links with a nested null-safe membership check.
- Decrement `NumberOfSlaves` only after a confirmed head or predecessor unlink.
- Clear detached stale slave links without mutating the leader's valid chain.
- Extend `SlaveChainTest` with empty-chain and non-member regressions plus a production-bound source contract.

Fixes #806

## Acceptance criteria and evidence

- Null/no-leader paths remain no-ops; valid head/middle/tail behavior remains modeled by the existing focused suite.
- New stale empty-chain and non-member cases assert local-link cleanup while preserving leader count/chain.
- The production-bound source contract rejects the eager `Prev <> Null And Prev\NextSlave` form and requires a confirmed predecessor membership check before splice/decrement.

## Baseline, RED, and final verification

- BASELINE: `./test.sh SlaveChainTest` exited 1 before execution because `compiler/BlitzForge/bin/blitzcc` is absent.
- RED: portable source contract exited 1 with `RED_EXPECTED=production_slave_unlink_still_uses_eager_predecessor_and_unconditional_decrement`.
- GREEN: portable source contract exited 0 with `SOURCE_CONTRACT_GREEN=stale_slave_unlink_guards_and_single_backslash_test_markers_present`.
- Final: `git diff --ignore-submodules=all --check origin/develop...HEAD`, `bash scripts/gen_packet_index.sh --check`, and `bash scripts/gen_bvm_reference.sh --check` all exited 0. The latter emitted only the two known DEAD-API warnings.
- Local native test remains unverified: narrow `git submodule update --init compiler/BlitzForge` timed out after 55 seconds and still supplied no `blitzcc`; exact-head Windows CI is required compiled proof.

## Compatibility, risks, rollback, and deferrals

No protocol, persistence format, AI behavior, or public API changes. Correct chains retain their existing order and count semantics. Roll back with one revert commit if a regression is found. No data migration or repair of already-corrupt saved ownership state is included.

## Independent reviewer verdict

ACCEPT — fresh independent review of exact head `4431397155cf15ba722e32bb214783ad24118c43`; no findings across acceptance criteria, scope, correctness, test quality, repository fit, security, performance, concurrency isolation, or hidden costs. Local native proof remains unverified pending CI because `blitzcc` is unavailable.