### PR TITLE
docs: surface Loom beta guide from the documentation landing

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -8,13 +8,14 @@ behavior, or finding module-level details.
 ## Start Here
 
 - [`start.md`](start.md) - contributor/source-build quick start
+- [`loom/README.md`](loom/README.md) - Loom (Beta) editor guide
 - [`reference.md`](reference.md) - module-by-module engine reference
 - [`formats.md`](formats.md) - on-disk data format notes
 - [`scripting/language.md`](scripting/language.md) - the RSL scripting language for content authors
 
 ## What These Docs Cover
 
-- `src/` application entrypoints such as Client, Server, GUE, and Project Manager
+- `src/` application entrypoints such as Client, Server, GUE, Loom (Beta), and Project Manager
 - `src/Modules/` engine and editor modules
 - file formats and scripting-adjacent data surfaces
 

--- a/src/Tests/Modules/ReadMeMacOSInstallTest.bb
+++ b/src/Tests/Modules/ReadMeMacOSInstallTest.bb
@@ -80,3 +80,9 @@ Test testPublicSourceBuildOnboardingListsLoomAsShippedBeta()
 	Assert(FileContains%("ReadMe.md", "Loom replacement for GUE") = False)
 	Assert(FileContains%("docs/start.md", "Loom replacement for GUE") = False)
 End Test
+
+Test testDocumentationLandingLinksLoomAsShippedBeta()
+	Assert(FileContains%("docs/index.md", "[`loom/README.md`](loom/README.md) - Loom (Beta) editor guide") = True)
+	Assert(FileContains%("docs/index.md", "Client, Server, GUE, Loom (Beta), and Project Manager") = True)
+	Assert(FileContains%("docs/index.md", "Loom replacement for GUE") = False)
+End Test


### PR DESCRIPTION
## Outcome

The RCCE documentation landing now points contributors to the shipped Loom (Beta) guide, so the editor is discoverable from the primary documentation navigation without overstating its scope.

## Technical changes

- Add a beta-framed `docs/loom/README.md` link under `docs/index.md` Start Here.
- Include Loom (Beta) in the landing page entrypoint list.
- Add a focused source contract that binds the guide link and beta wording and rejects a GUE-replacement claim.

Fixes #808

## Acceptance evidence

- Landing navigation link: portable contract observed the exact Loom guide link.
- Entrypoint coverage: portable contract observed Client, Server, GUE, Loom (Beta), and Project Manager.
- Product framing: portable contract confirms the landing contains no `Loom replacement for GUE` claim.
- Scope: `git diff --name-only` contains only `docs/index.md` and `src/Tests/Modules/ReadMeMacOSInstallTest.bb`.

## Baseline and RED → GREEN

- BASELINE: documentation landing omitted the Loom beta guide; `git diff --check` exited 0.
- Native baseline: `./test.sh ReadMeMacOSInstallTest` exited 1 before execution because `compiler/BlitzForge/bin/blitzcc` is absent in this worktree.
- RED: focused portable contract printed `LOOM_DOCS_INDEX_CONTRACT_RED` because both required landing strings were absent.
- GREEN: the same contract printed `LOOM_DOCS_INDEX_CONTRACT_GREEN`; `git diff --check`, `bash scripts/gen_packet_index.sh --check`, and `bash scripts/gen_bvm_reference.sh --check` exited 0. The BVM check emitted its two known DEAD-API warnings.

## Verification status

- Local compiler-backed test remains UNVERIFIED due to the missing BlitzForge binary; exact-head CI is required for compiled proof.
- Independent review: pending for this exact head.

## Compatibility, risk, rollback, and deferred work

No runtime behavior, build scripts, protocol documentation, or product claims inside Loom docs changed. The change only adds a beta-framed navigation route. Roll back by reverting `08906cb8`. Root README/start/reference navigation is intentionally deferred.

## Independent review

ACCEPT — fresh reviewer inspected exact head `08906cb8203e03c724953a21a302d095c64fe353`. It found the two-file diff meets the navigation/beta-framing criteria; the focused contract covers both required strings and rejects the scoped replacement claim. No correctness, security, performance, documentation-fit, or concurrency-isolation findings. The compiler-backed focused test remains unverified locally only because `compiler/BlitzForge/bin/blitzcc` is absent; exact-head CI is in progress.