### PR TITLE
fix(gue): safely drain save and area-name dialog events

### DIFF
--- a/src/GUE.bb
+++ b/src/GUE.bb
@@ -9793,8 +9793,11 @@ Function SaveDialog()
 	Result = -1
 	While Result < 0
 
-		For E.Event = Each Event
-			Select E\EventID
+		Local SaveEvent.Event = First Event
+		Local NextSaveEvent.Event = Null
+		While SaveEvent <> Null
+			NextSaveEvent = After SaveEvent
+			Select SaveEvent\EventID
 
 				; Window closed
 				Case W
@@ -9909,8 +9912,9 @@ Function SaveDialog()
 					EndIf
 					Result = True
 			End Select
-			Delete E
-		Next
+			Delete(SaveEvent)
+			SaveEvent = NextSaveEvent
+		Wend
 
 		FUI_Update()
 		Flip(0)
@@ -9944,8 +9948,11 @@ Function AreaNameDialog$()
 		EndIf
 
 		; Events
-		For E.Event = Each Event
-			Select E\EventID
+		Local AreaNameEvent.Event = First Event
+		Local NextAreaNameEvent.Event = Null
+		While AreaNameEvent <> Null
+			NextAreaNameEvent = After AreaNameEvent
+			Select AreaNameEvent\EventID
 				; OK clicked
 				Case BDone
 					Result$ = FUI_SendMessage(TAreaName, M_GETCAPTION)
@@ -9959,8 +9966,9 @@ Function AreaNameDialog$()
 					Next
 					If AlreadyExists = False Then Done = True
 			End Select
-			Delete E
-		Next
+			Delete(AreaNameEvent)
+			AreaNameEvent = NextAreaNameEvent
+		Wend
 
 		; Render
 		FUI_Update()

--- a/src/GUE.bb
+++ b/src/GUE.bb
@@ -9801,7 +9801,7 @@ Function SaveDialog()
 
 				; Window closed
 				Case W
-					If Lower$(E\EventData$) = "closed" Then Result = False
+					If Lower$(SaveEvent\EventData$) = "closed" Then Result = False
 				; Cancel hit
 				Case BCancel
 					Result = False

--- a/src/Tests/Modules/GUEEventIteratorTest.bb
+++ b/src/Tests/Modules/GUEEventIteratorTest.bb
@@ -19,6 +19,10 @@ Function GUEEventDrainUsesAfterCursor%(Path$, FunctionMarker$, LegacyFor$, First
 			CloseFile F
 			Return False
 		EndIf
+		If Stage > 0 And Instr(Line$, "E\\Event") > 0 Then
+			CloseFile F
+			Return False
+		EndIf
 		If Stage = 1 And Instr(Line$, FirstCursor$) > 0 Then Stage = 2
 		If Stage = 2 And Instr(Line$, NextDeclaration$) > 0 Then Stage = 3
 		If Stage = 3 And Instr(Line$, WhileCursor$) > 0 Then Stage = 4

--- a/src/Tests/Modules/GUEEventIteratorTest.bb
+++ b/src/Tests/Modules/GUEEventIteratorTest.bb
@@ -59,6 +59,14 @@ Test testFixedAttributeDialogCapturesNextEventBeforeDelete()
 	Assert(GUEEventDrainUsesAfterCursor%("GUE.bb", "Function FixedAttributeDialog()", "For E.Event = Each Event", "Local FixedAttributeEvent.Event = First Event", "Local NextFixedAttributeEvent.Event = Null", "While FixedAttributeEvent <> Null", "NextFixedAttributeEvent = After FixedAttributeEvent", "Delete(FixedAttributeEvent)", "FixedAttributeEvent = NextFixedAttributeEvent") = True)
 End Test
 
+Test testSaveDialogCapturesNextEventBeforeDelete()
+	Assert(GUEEventDrainUsesAfterCursor%("GUE.bb", "Function SaveDialog()", "For E.Event = Each Event", "Local SaveEvent.Event = First Event", "Local NextSaveEvent.Event = Null", "While SaveEvent <> Null", "NextSaveEvent = After SaveEvent", "Delete(SaveEvent)", "SaveEvent = NextSaveEvent") = True)
+End Test
+
+Test testAreaNameDialogCapturesNextEventBeforeDelete()
+	Assert(GUEEventDrainUsesAfterCursor%("GUE.bb", "Function AreaNameDialog$()", "For E.Event = Each Event", "Local AreaNameEvent.Event = First Event", "Local NextAreaNameEvent.Event = Null", "While AreaNameEvent <> Null", "NextAreaNameEvent = After AreaNameEvent", "Delete(AreaNameEvent)", "AreaNameEvent = NextAreaNameEvent") = True)
+End Test
+
 Test testMeshDialogCapturesNextEventBeforeDelete()
 	Assert(GUEEventDrainUsesAfterCursor%("GUE.bb", "Function MeshDialog()", "For E.Event = Each Event", "Local MeshEvent.Event = First Event", "Local NextMeshEvent.Event = Null", "While MeshEvent <> Null", "NextMeshEvent = After MeshEvent", "Delete MeshEvent", "MeshEvent = NextMeshEvent") = True)
 End Test


### PR DESCRIPTION
## Outcome
Queued GUE save-confirmation and zone-name events now drain safely instead of deleting the active iterator node.

## Technical changes
- Replace the deleting `For Each Event` loops in `SaveDialog` and `AreaNameDialog` with typed `First` -> `After` -> `Delete` -> advance drains.
- Add focused source-contract coverage for both dialogs.

Fixes #812

## Acceptance evidence
- Both target loops capture their successor before deletion and advance afterward.
- The contract rejects the legacy form and binds the full cursor ordering for both functions.
- Existing event branches, dialog result behavior, F-UI event IDs, and save/name semantics are unchanged by the focused diff.

## Baseline and RED -> GREEN
- BASELINE: portable probe reported `2 unsafe deleting For Each event drains: SaveDialog, AreaNameDialog` (exit 0); `git diff --check` and `scripts/gen_packet_index.sh --check` exited 0.
- RED: focused portable contract printed `GUE_SAVE_AREA_EVENT_DRAIN_RED: SaveDialog and AreaNameDialog retain deleting For Each loops` (exit 1).
- GREEN: the same contract printed `GUE_SAVE_AREA_EVENT_DRAIN_GREEN` (exit 0).

## Final verification
- `git diff --check origin/develop...HEAD`, `bash -n compile.sh test.sh`, `bash scripts/gen_packet_index.sh --check`, and `bash scripts/gen_bvm_reference.sh --check` exited 0; BVM generation emitted only the two known DEAD-API warnings.
- `./test.sh GUEEventIteratorTest` is UNVERIFIED locally: it exits 1 before compilation because `compiler/BlitzForge/bin/blitzcc` is absent. Exact-head Build and test CI is required.

## Compatibility, risk, rollback, and follow-up
No F-UI internals, event payloads, protocol, or other GUE dialog behavior changes. Rollback is reverting commit `20094f74`. No follow-up is included.

## Independent review
ACCEPT — fresh independent review of exact head `fed4cfb86d092b2ff0895d2c354d3dedd91f5eae`; it confirmed acceptance criteria, scope, corrected cursor reference, test coverage, repository fit, documentation, security/performance, concurrency isolation, and hidden costs. Exact-head CI remains pending.