### PR TITLE
fix(client): reject malformed equipment visual payloads

### DIFF
--- a/src/Modules/ClientNet.bb
+++ b/src/Modules/ClientNet.bb
@@ -1457,9 +1457,9 @@ Function UpdateNetwork()
 						EndIf
 						RotateEntity(DItem\EN, 0.0, Rnd#(-180.0, 180.0), 0.0)
 						NameEntity(DItem\EN, Handle(DItem))
-					; Update for another actor
-					Case "O"
-						RuntimeID = RCE_IntFromStr(Mid$(M\MessageData$, 2, 2))
+					Case "O" : If Len(M\MessageData$) <> 17
+						WriteLog(MainLog, "P_InventoryUpdate O: bad payload length " + Len(M\MessageData$) + ", dropping")
+					Else : RuntimeID = RCE_IntFromStr(Mid$(M\MessageData$, 2, 2))
 						A.ActorInstance = RuntimeIDList(RuntimeID)
 						If A <> Null
 							WeaponID = RCE_IntFromStr(Mid$(M\MessageData$, 4, 2))
@@ -1485,7 +1485,7 @@ Function UpdateNetwork()
 									HideGubbin(A, i)
 								EndIf
 							Next
-						EndIf
+						EndIf : EndIf
 					; Given an item
 					Case "G"
 						ItemID = RCE_IntFromStr(Mid$(M\MessageData$, 6, 2))

--- a/src/Tests/Modules/ClientNetInventorySlotBoundsTest.bb
+++ b/src/Tests/Modules/ClientNetInventorySlotBoundsTest.bb
@@ -70,6 +70,16 @@ Function ButtonSlot$(SlotName$)
 	Return "BSlots" + Chr$(40) + SlotName$ + Chr$(41)
 End Function
 
+Const EquipmentVisualPayloadBytes% = 17
+
+Function EquipmentVisualPayloadExact%(PayloadLen%)
+	Return PayloadLen = EquipmentVisualPayloadBytes
+End Function
+
+Function EquipmentVisualLengthGuard$()
+	Return "If Len(M" + Chr$(92) + "MessageData$) <> " + EquipmentVisualPayloadBytes
+End Function
+
 Test testClientInventorySlotGuardRejectsMissingPlayerAndOutOfRangeSlots()
 	Local Source$ = ClientNetSource$()
 	Local Guard$ = Between$(Source$, "Function ClientInventorySlotUsable", "End Function")
@@ -103,4 +113,17 @@ Test testInventoryUpdateReceiveValidatesSlotBeforeDroppedItemMutation()
 	Local InventoryUpdate$ = Between$(ClientNetSource$(), "Case P_InventoryUpdate", "Case P_StandardUpdate")
 	Local Received$ = Between$(InventoryUpdate$, "Case " + Chr$(34) + "R" + Chr$(34), "Case " + Chr$(34) + "P" + Chr$(34))
 	Assert(ContainsInOrder%(Received$, PacketLengthGuard$(6), "i = RCE_IntFromStr", UsableSlotGuard$("i"), "For DItem.DroppedItem = Each DroppedItem") = True)
+End Test
+
+Test testEquipmentVisualPayloadRequiresExactly17Bytes()
+	Assert(EquipmentVisualPayloadExact%(0) = False)
+	Assert(EquipmentVisualPayloadExact%(16) = False)
+	Assert(EquipmentVisualPayloadExact%(17) = True)
+	Assert(EquipmentVisualPayloadExact%(18) = False)
+End Test
+
+Test testEquipmentVisualLengthGuardPrecedesParseAndVisualMutation()
+	Local InventoryUpdate$ = Between$(ClientNetSource$(), "Case P_InventoryUpdate", "Case P_StandardUpdate")
+	Local Equipment$ = Between$(InventoryUpdate$, "Case " + Chr$(34) + "O" + Chr$(34), "Case " + Chr$(34) + "G" + Chr$(34))
+	Assert(ContainsInOrder%(Equipment$, EquipmentVisualLengthGuard$(), "RuntimeID = RCE_IntFromStr", "FreeItemInstance(A" + Chr$(92) + "Inventory" + Chr$(92) + "Items[SlotI_Weapon])", "UpdateActorItems(A)") = True)
 End Test


### PR DESCRIPTION
## Outcome
Malformed server equipment-visual updates no longer silently clear or alter another actor’s rendered gear.

## Technical changes
- Require exactly 17 bytes for S→C `P_InventoryUpdate` `"O"` before parsing or mutating remote equipment.
- Log and drop other lengths.
- Add focused exact-length and guard-order source-contract coverage.
- Preserve `ClientNet.bb` line count, leaving generated protocol index output unchanged.

Fixes #814

## Acceptance evidence
- 0/16/18-byte rejection and 17-byte acceptance are modeled in `ClientNetInventorySlotBoundsTest`.
- The source contract requires the exact-length guard before RuntimeID parsing, the first `FreeItemInstance`, and `UpdateActorItems`.
- `bash scripts/gen_packet_index.sh --check` exits 0 with no `docs/protocol/index.md` edit.
- Server wire format, valid 17-byte behavior, Rust client, and Gubbin policy are unchanged.

## Baseline → RED → GREEN
- Baseline: `git diff --check` exited 0; a guard-absence probe printed `BASELINE_EQUIPMENT_VISUAL_LENGTH_GUARD_ABSENT`; focused native test exited 1 before execution because `compiler/BlitzForge/bin/blitzcc` is absent.
- RED: the new portable source contract exited 1 with `EQUIPMENT_VISUAL_LENGTH_CONTRACT_RED`.
- GREEN: the same contract printed `EQUIPMENT_VISUAL_LENGTH_CONTRACT_GREEN` and exited 0 after commit `9e6a57f3`.

## Final verification
- `git diff --check` — exit 0.
- `bash scripts/gen_packet_index.sh --check` — exit 0.
- `bash scripts/gen_bvm_reference.sh --check` — exit 0; only the two known DEAD-API warnings.
- `./test.sh ClientNetInventorySlotBoundsTest` — exit 1 before compilation; local native proof is unavailable because `blitzcc` is missing. Exact-head Build and test CI is required.

## Compatibility, risk, rollback, and deferred work
Valid payloads retain their existing parser and visual-refresh behavior. Invalid payloads now log/drop rather than partially decode. Rollback is reverting `9e6a57f3`. Broader client packet framing and protocol documentation are intentionally out of scope.

## Independent review
Pending fresh review of this exact head.

## Independent review
Fresh review of exact head `9e6a57f3d1603f7c55c892126aa988181a18ea20`: **ACCEPT**. It confirmed the two-file scope, 17-byte guard-before-parse/mutation behavior, preserved ClientNet line count and #799 isolation, unchanged valid path, focused 0/16/17/18 coverage, and no material performance/concurrency or documentation concern. Local native execution remains unavailable only because `blitzcc` is absent.