### PR TITLE
docs: link Loom beta guide from top-level references

### DIFF
--- a/ReadMe.md
+++ b/ReadMe.md
@@ -134,6 +134,7 @@ rcce2/
 ## Documentation
 
 - **[Getting Started](docs/start.md)** — your first project
+- **[Loom (Beta) Editor Guide](docs/loom/README.md)** — shipped editor overview, capabilities, and beta boundaries
 - **[macOS Apple Silicon Notes](docs/macos-apple-silicon.md)** — source-build steps, release notes, and alpha caveats
 - **[Module Reference](docs/reference.md)** — engine APIs
 - **[Format Reference](docs/formats.md)** — file formats and conventions

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -4,8 +4,8 @@ This page is the reference landing map for the documented RCCE modules under
 [`docs/modules/`](modules/). Use it together with the live application
 entrypoints in [`src/Client.bb`](../src/Client.bb),
 [`src/Server.bb`](../src/Server.bb), [`src/GUE.bb`](../src/GUE.bb), and
-[`src/Project Manager.bb`](../src/Project%20Manager.bb) when you are tracing a
-runtime path through the current source tree.
+[`src/Loom.bb`](../src/Loom.bb), and [`src/Project Manager.bb`](../src/Project%20Manager.bb)
+when you are tracing a runtime path through the current source tree.
 
 Not every source module has a matching reference page yet. This index covers
 the modules that already have docs and calls out the largest undocumented
@@ -78,6 +78,12 @@ surfaces so the page reflects the real repository state.
 - Shared runtime plumbing:
   [`Language`](modules/language.md), [`RottNet`](modules/rottnet.md),
   [`Packets`](modules/packets.md), [`Logging`](modules/logging.md)
+
+### Loom (Beta)
+
+Loom is a shipped beta editor at [`src/Loom.bb`](../src/Loom.bb). Loom (Beta) runs alongside the established GUE workflow; see the
+[Loom (Beta) editor guide](loom/README.md) for its current capabilities,
+boundaries, and Project Manager launch flow.
 
 ### Project Manager
 

--- a/src/Tests/Modules/ReadMeMacOSInstallTest.bb
+++ b/src/Tests/Modules/ReadMeMacOSInstallTest.bb
@@ -86,3 +86,11 @@ Test testDocumentationLandingLinksLoomAsShippedBeta()
 	Assert(FileContains%("docs/index.md", "Client, Server, GUE, Loom (Beta), and Project Manager") = True)
 	Assert(FileContains%("docs/index.md", "Loom replacement for GUE") = False)
 End Test
+
+Test testTopLevelReferencesLinkLoomGuideAlongsideGUE()
+	Assert(FileContains%("ReadMe.md", "[Loom (Beta) Editor Guide](docs/loom/README.md)") = True)
+	Assert(FileContains%("docs/reference.md", "[`src/Loom.bb`](../src/Loom.bb)") = True)
+	Assert(FileContains%("docs/reference.md", "[Loom (Beta) editor guide](loom/README.md)") = True)
+	Assert(FileContains%("docs/reference.md", "Loom (Beta) runs alongside the established GUE workflow") = True)
+	Assert(FileContains%("docs/reference.md", "Loom replacement for GUE") = False)
+End Test


### PR DESCRIPTION
## Outcome
Top-level documentation now leads contributors to the shipped Loom (Beta) editor guide from both the root README and module-reference map, while explicitly keeping Loom alongside the established GUE workflow.

## Technical changes
- Add the Loom (Beta) guide to `ReadMe.md`.
- Add `src/Loom.bb`, beta framing, and the guide route to `docs/reference.md`.
- Extend the focused documentation source contract.

Fixes #816

## Acceptance evidence
- README guide route: portable contract GREEN.
- Module-reference entrypoint, guide route, and alongside-GUE framing: portable contract GREEN.
- Replacement claim is rejected by the focused source contract.
- `git diff --check`, packet-index check, and BVM-reference check passed locally.

## RED → GREEN
- Baseline: portable probe printed `BASELINE: Loom top-level guide routes absent`.
- RED: focused portable contract exited 1 with `LOOM_REFERENCE_CONTRACT_RED: top-level routes or framing missing`.
- GREEN: portable contract printed `LOOM_REFERENCE_CONTRACT_GREEN`.

## Verification
- `git diff --check` exited 0.
- `bash scripts/gen_packet_index.sh --check` exited 0.
- `bash scripts/gen_bvm_reference.sh --check` exited 0 with only the two known DEAD-API warnings.
- Local native `./test.sh ReadMeMacOSInstallTest` is UNVERIFIED: `compiler/BlitzForge/bin/blitzcc` is absent. Scoped submodule initialization timed out twice (55s and 20s); exact-head Build and test CI is required.

## Compatibility, risk, rollback, and deferred work
Documentation-only, no runtime or wire-contract change. Loom remains beta and alongside GUE. Rollback is reverting `1b966a62`. No deferred implementation work.

## Review
Adversarial self-review of the three-file diff found no issues; fresh independent review is pending exact head.

## Independent review
Fresh review of exact head `1b966a62` returned `ACCEPT` with no findings. It confirmed all acceptance criteria, three-file scope isolation, source-contract quality, and adequate disclosure of the unavailable local native test. CI was non-terminal during review; do not merge until exact-head checks complete successfully.