### PR TITLE
fix(server): preserve move frame for same-area warps

### DIFF
--- a/src/Modules/GameServer.bb
+++ b/src/Modules/GameServer.bb
@@ -1380,7 +1380,7 @@ Function SetArea(A.ActorInstance, Ar.Area, Instance, Waypoint = -1, Portal = 0, 
 		EndIf
 	; If he's warped to the same area he was already in, tell players he has changed position
 	Else
-		Pa$ = RCE_StrFromInt$(A\RuntimeID, 2) + RCE_StrFromFloat$(A\X#) + RCE_StrFromFloat$(A\Y#) + RCE_StrFromFloat$(A\Z#) + RCE_StrFromInt$(0, 1)
+		Pa$ = "M" + RCE_StrFromInt$(A\RuntimeID, 2) + RCE_StrFromFloat$(A\X#) + RCE_StrFromFloat$(A\Y#) + RCE_StrFromFloat$(A\Z#) + RCE_StrFromInt$(0, 1)
 		A2.ActorInstance = Ar\Instances[Instance]\FirstInZone
 		While A2 <> Null
 			If A2\RNID > 0

--- a/src/Tests/Modules/GameServerRepositionPacketTest.bb
+++ b/src/Tests/Modules/GameServerRepositionPacketTest.bb
@@ -30,7 +30,7 @@ Function FileSectionContains%(Path$, StartNeedle$, EndNeedle$, Needle$)
 	Return False
 End Function
 
-Function FileSectionContainsSequence%(Path$, StartNeedle$, EndNeedle$, FirstNeedle$, SecondNeedle$, ThirdNeedle$)
+Function FileSectionContainsSequence%(Path$, StartNeedle$, EndNeedle$, FirstNeedle$, SecondNeedle$)
 	Local F.BBStream = ReadFile(Path$)
 	Local Line$
 	Local InSection = False
@@ -49,8 +49,6 @@ Function FileSectionContainsSequence%(Path$, StartNeedle$, EndNeedle$, FirstNeed
 			If Stage = 0 And Instr(Line$, FirstNeedle$) > 0
 				Stage = 1
 			ElseIf Stage = 1 And Instr(Line$, SecondNeedle$) > 0
-				Stage = 2
-			ElseIf Stage = 2 And Instr(Line$, ThirdNeedle$) > 0
 				CloseFile F
 				Return True
 			EndIf
@@ -61,7 +59,7 @@ Function FileSectionContainsSequence%(Path$, StartNeedle$, EndNeedle$, FirstNeed
 End Function
 
 Test testSameAreaSetAreaUsesMoveFrame()
-	Assert(FileSectionContainsSequence%("Modules\GameServer.bb", "; If he's warped to the same area he was already in, tell players he has changed position", "; Removes an actor instance from a party", "Pa$ = " + Chr$(34) + "M" + Chr$(34) + " + RCE_StrFromInt$(A\RuntimeID, 2)", "RCE_StrFromFloat$(A\X#)", "RCE_Send(Host, A2\RNID, P_RepositionActor, Pa$, True)") = True)
+	Assert(FileSectionContainsSequence%("Modules\GameServer.bb", "; If he's warped to the same area he was already in, tell players he has changed position", "; Removes an actor instance from a party", "Pa$ = " + Chr$(34) + "M" + Chr$(34) + " + RCE_StrFromInt$(A\RuntimeID, 2) + RCE_StrFromFloat$(A\X#) + RCE_StrFromFloat$(A\Y#) + RCE_StrFromFloat$(A\Z#) + RCE_StrFromInt$(0, 1)", "RCE_Send(Host, A2\RNID, P_RepositionActor, Pa$, True)") = True)
 	Assert(FileSectionContains%("Modules\GameServer.bb", "; If he's warped to the same area he was already in, tell players he has changed position", "; Removes an actor instance from a party", "Pa$ = RCE_StrFromInt$(A\RuntimeID, 2)") = False)
 End Test
 

--- a/src/Tests/Modules/GameServerRepositionPacketTest.bb
+++ b/src/Tests/Modules/GameServerRepositionPacketTest.bb
@@ -61,11 +61,11 @@ Function FileSectionContainsSequence%(Path$, StartNeedle$, EndNeedle$, FirstNeed
 End Function
 
 Test testSameAreaSetAreaUsesMoveFrame()
-	Assert(FileSectionContainsSequence%("Modules\\GameServer.bb", "; If he's warped to the same area he was already in, tell players he has changed position", "; Removes an actor instance from a party", "Pa$ = \"M\" + RCE_StrFromInt$(A\\RuntimeID, 2)", "RCE_StrFromFloat$(A\\X#)", "RCE_Send(Host, A2\\RNID, P_RepositionActor, Pa$, True)") = True)
+	Assert(FileSectionContainsSequence%("Modules\\GameServer.bb", "; If he's warped to the same area he was already in, tell players he has changed position", "; Removes an actor instance from a party", "Pa$ = " + Chr$(34) + "M" + Chr$(34) + " + RCE_StrFromInt$(A\\RuntimeID, 2)", "RCE_StrFromFloat$(A\\X#)", "RCE_Send(Host, A2\\RNID, P_RepositionActor, Pa$, True)") = True)
 	Assert(FileSectionContains%("Modules\\GameServer.bb", "; If he's warped to the same area he was already in, tell players he has changed position", "; Removes an actor instance from a party", "Pa$ = RCE_StrFromInt$(A\\RuntimeID, 2)") = False)
 End Test
 
 Test testClientRepositionMoveDecoderRequiresMoveSubCode()
-	Assert(FileSectionContains%("Modules\\ClientNet.bb", "Case P_RepositionActor", "; Floating number", "If Left$(M\\MessageData$, 1) = \"M\"") = True)
+	Assert(FileSectionContains%("Modules\\ClientNet.bb", "Case P_RepositionActor", "; Floating number", "If Left$(M\\MessageData$, 1) = " + Chr$(34) + "M" + Chr$(34)) = True)
 	Assert(FileSectionContains%("Modules\\ClientNet.bb", "Case P_RepositionActor", "; Floating number", "RuntimeID = RCE_IntFromStr(Mid$(M\\MessageData$, 2, 2))") = True)
 End Test

--- a/src/Tests/Modules/GameServerRepositionPacketTest.bb
+++ b/src/Tests/Modules/GameServerRepositionPacketTest.bb
@@ -11,8 +11,8 @@ Function FileSectionContains%(Path$, StartNeedle$, EndNeedle$, Needle$)
 	Local InSection = False
 	If F = Null Then F = ReadFile("../" + Path$)
 	If F = Null Then F = ReadFile("../../" + Path$)
-	If F = Null Then F = ReadFile("..\\" + Path$)
-	If F = Null Then F = ReadFile("..\\..\\" + Path$)
+	If F = Null Then F = ReadFile("..\" + Path$)
+	If F = Null Then F = ReadFile("..\..\" + Path$)
 	If F = Null Then Return False
 	While Not Eof(F)
 		Line$ = ReadLine$(F)
@@ -37,8 +37,8 @@ Function FileSectionContainsSequence%(Path$, StartNeedle$, EndNeedle$, FirstNeed
 	Local Stage = 0
 	If F = Null Then F = ReadFile("../" + Path$)
 	If F = Null Then F = ReadFile("../../" + Path$)
-	If F = Null Then F = ReadFile("..\\" + Path$)
-	If F = Null Then F = ReadFile("..\\..\\" + Path$)
+	If F = Null Then F = ReadFile("..\" + Path$)
+	If F = Null Then F = ReadFile("..\..\" + Path$)
 	If F = Null Then Return False
 	While Not Eof(F)
 		Line$ = ReadLine$(F)
@@ -61,11 +61,11 @@ Function FileSectionContainsSequence%(Path$, StartNeedle$, EndNeedle$, FirstNeed
 End Function
 
 Test testSameAreaSetAreaUsesMoveFrame()
-	Assert(FileSectionContainsSequence%("Modules\\GameServer.bb", "; If he's warped to the same area he was already in, tell players he has changed position", "; Removes an actor instance from a party", "Pa$ = " + Chr$(34) + "M" + Chr$(34) + " + RCE_StrFromInt$(A\\RuntimeID, 2)", "RCE_StrFromFloat$(A\\X#)", "RCE_Send(Host, A2\\RNID, P_RepositionActor, Pa$, True)") = True)
-	Assert(FileSectionContains%("Modules\\GameServer.bb", "; If he's warped to the same area he was already in, tell players he has changed position", "; Removes an actor instance from a party", "Pa$ = RCE_StrFromInt$(A\\RuntimeID, 2)") = False)
+	Assert(FileSectionContainsSequence%("Modules\GameServer.bb", "; If he's warped to the same area he was already in, tell players he has changed position", "; Removes an actor instance from a party", "Pa$ = " + Chr$(34) + "M" + Chr$(34) + " + RCE_StrFromInt$(A\RuntimeID, 2)", "RCE_StrFromFloat$(A\X#)", "RCE_Send(Host, A2\RNID, P_RepositionActor, Pa$, True)") = True)
+	Assert(FileSectionContains%("Modules\GameServer.bb", "; If he's warped to the same area he was already in, tell players he has changed position", "; Removes an actor instance from a party", "Pa$ = RCE_StrFromInt$(A\RuntimeID, 2)") = False)
 End Test
 
 Test testClientRepositionMoveDecoderRequiresMoveSubCode()
-	Assert(FileSectionContains%("Modules\\ClientNet.bb", "Case P_RepositionActor", "; Floating number", "If Left$(M\\MessageData$, 1) = " + Chr$(34) + "M" + Chr$(34)) = True)
-	Assert(FileSectionContains%("Modules\\ClientNet.bb", "Case P_RepositionActor", "; Floating number", "RuntimeID = RCE_IntFromStr(Mid$(M\\MessageData$, 2, 2))") = True)
+	Assert(FileSectionContains%("Modules\ClientNet.bb", "Case P_RepositionActor", "; Floating number", "If Left$(M\MessageData$, 1) = " + Chr$(34) + "M" + Chr$(34)) = True)
+	Assert(FileSectionContains%("Modules\ClientNet.bb", "Case P_RepositionActor", "; Floating number", "RuntimeID = RCE_IntFromStr(Mid$(M\MessageData$, 2, 2))") = True)
 End Test

--- a/src/Tests/Modules/GameServerRepositionPacketTest.bb
+++ b/src/Tests/Modules/GameServerRepositionPacketTest.bb
@@ -1,0 +1,71 @@
+Strict
+EnableGC
+
+; Source-contract regression for the move-form P_RepositionActor frame that
+; SetArea broadcasts when an actor remains in the same area. This stays
+; standalone because the sender and decoder belong to the server/client graph.
+
+Function FileSectionContains%(Path$, StartNeedle$, EndNeedle$, Needle$)
+	Local F.BBStream = ReadFile(Path$)
+	Local Line$
+	Local InSection = False
+	If F = Null Then F = ReadFile("../" + Path$)
+	If F = Null Then F = ReadFile("../../" + Path$)
+	If F = Null Then F = ReadFile("..\\" + Path$)
+	If F = Null Then F = ReadFile("..\\..\\" + Path$)
+	If F = Null Then Return False
+	While Not Eof(F)
+		Line$ = ReadLine$(F)
+		If InSection = False
+			If Instr(Line$, StartNeedle$) > 0 Then InSection = True
+		Else
+			If Instr(Line$, EndNeedle$) > 0 Then Exit
+			If Instr(Line$, Needle$) > 0
+				CloseFile F
+				Return True
+			EndIf
+		EndIf
+	Wend
+	CloseFile F
+	Return False
+End Function
+
+Function FileSectionContainsSequence%(Path$, StartNeedle$, EndNeedle$, FirstNeedle$, SecondNeedle$, ThirdNeedle$)
+	Local F.BBStream = ReadFile(Path$)
+	Local Line$
+	Local InSection = False
+	Local Stage = 0
+	If F = Null Then F = ReadFile("../" + Path$)
+	If F = Null Then F = ReadFile("../../" + Path$)
+	If F = Null Then F = ReadFile("..\\" + Path$)
+	If F = Null Then F = ReadFile("..\\..\\" + Path$)
+	If F = Null Then Return False
+	While Not Eof(F)
+		Line$ = ReadLine$(F)
+		If InSection = False
+			If Instr(Line$, StartNeedle$) > 0 Then InSection = True
+		Else
+			If Instr(Line$, EndNeedle$) > 0 Then Exit
+			If Stage = 0 And Instr(Line$, FirstNeedle$) > 0
+				Stage = 1
+			ElseIf Stage = 1 And Instr(Line$, SecondNeedle$) > 0
+				Stage = 2
+			ElseIf Stage = 2 And Instr(Line$, ThirdNeedle$) > 0
+				CloseFile F
+				Return True
+			EndIf
+		EndIf
+	Wend
+	CloseFile F
+	Return False
+End Function
+
+Test testSameAreaSetAreaUsesMoveFrame()
+	Assert(FileSectionContainsSequence%("Modules\\GameServer.bb", "; If he's warped to the same area he was already in, tell players he has changed position", "; Removes an actor instance from a party", "Pa$ = \"M\" + RCE_StrFromInt$(A\\RuntimeID, 2)", "RCE_StrFromFloat$(A\\X#)", "RCE_Send(Host, A2\\RNID, P_RepositionActor, Pa$, True)") = True)
+	Assert(FileSectionContains%("Modules\\GameServer.bb", "; If he's warped to the same area he was already in, tell players he has changed position", "; Removes an actor instance from a party", "Pa$ = RCE_StrFromInt$(A\\RuntimeID, 2)") = False)
+End Test
+
+Test testClientRepositionMoveDecoderRequiresMoveSubCode()
+	Assert(FileSectionContains%("Modules\\ClientNet.bb", "Case P_RepositionActor", "; Floating number", "If Left$(M\\MessageData$, 1) = \"M\"") = True)
+	Assert(FileSectionContains%("Modules\\ClientNet.bb", "Case P_RepositionActor", "; Floating number", "RuntimeID = RCE_IntFromStr(Mid$(M\\MessageData$, 2, 2))") = True)
+End Test


### PR DESCRIPTION
## Outcome
Scripted and portal warps that keep an actor in the same area now render at the new position for nearby players; the focused regression test now correctly validates the intentionally single-line move-frame construction.

## Technical changes
- Preserve the existing same-area `SetArea` `P_RepositionActor` sender fix: it prefixes the payload with the established `M` move sub-code.
- Replace the test scanner with a two-stage combined-frame assertion: it matches the complete `M` + runtime ID + X/Y/Z + camera-byte assignment, then the later broadcast.

Fixes #818

## Acceptance evidence
- Same-area payload begins with `M` before the runtime ID and retains all three coordinate fields plus the camera byte: focused combined-frame source contract is GREEN.
- The broadcast remains after that frame in the bounded same-area `SetArea` section; the legacy unprefixed assignment remains rejected.
- The existing ClientNet consumer contract still requires `M` and reads the runtime ID from bytes 2-3.

## Baseline, RED, GREEN, and final verification
- Baseline exact-head CI run `29768215739`: Build and test compiled the project but reported `Ran 112 files: 111 passed, 1 failed` (`GameServerRepositionPacketTest.bb`); Rust server (Linux) succeeded.
- RED (portable reproduction): `RED_EXPECTED: legacy three-stage scanner stalls at stage=1` because the prefix/runtime ID and coordinate serialization share one source line.
- GREEN (portable source proof): `GREEN: combined-frame source contract reaches broadcast`.
- Final local checks: `git diff --check`, `bash scripts/gen_packet_index.sh --check`, `bash scripts/gen_bvm_reference.sh --check`, and `bash -n compile.sh test.sh` exited 0; the BVM check emitted only the known `BVM_SETOWNER` / `BVM_SCENERYOWNER` warnings.
- Local native test remains unavailable: `./test.sh GameServerRepositionPacketTest` exits 1 before compilation because `compiler/BlitzForge/bin/blitzcc` is absent. Exact-head CI is the required compiler/test proof.

## Compatibility, risk, rollback, and deferred work
- Compatible: the production payload continues to use the existing ClientNet move layout; no packet IDs, offsets, decoder code, ServerNet code, or generated protocol docs change.
- Risk: low and test-only in this resume; rollback is reverting `9517430a`.
- Deferred: generic source-contract scanner hardening remains separate work.

## Independent review
Pending a fresh review of exact head `9517430a3ae503e46b0414dd2cf462c43a94eaf8` after exact-head CI is terminal green.\n\n## Current-develop integration and final review
- Current origin/develop 4c340656ab426132dde2040649469d17dec38c9b was merged without conflicts; the effective PR diff remains the same one-line sender correction plus its focused regression test.
- Exact integration head ed7d5dbd3377fd1794103c520dbcb8110fe23f8f CI run 29803634450 passed: Build and test (6m46s) and Rust server (Linux) (3m56s), with completed/success check-runs and zero legacy status contexts.
- Fresh independent reviewer verdict: ACCEPT. It verified the M / 2-byte runtime ID / X-Y-Z / camera frame, nearby-player broadcast, ClientNet byte alignment, same-line contract behavior, scope, compatibility, and no documentation/security/performance/concurrency concerns.