### PR TITLE
fix(project-manager): drain queued events safely

### DIFF
--- a/src/Project Manager.bb
+++ b/src/Project Manager.bb
@@ -444,10 +444,12 @@ Repeat
 	FUI_Update()
 	Flip(0)
 	
-	;Activate Buttons
-	Local E.Event	
-	For E.Event = Each Event
-		Select E\EventID
+	; Activate queued buttons without deleting the active For Each cursor.
+	Local CurrentEvent.Event = First Event
+	Local NextEvent.Event = Null
+	While CurrentEvent <> Null
+		NextEvent = After CurrentEvent
+		Select CurrentEvent\EventID
 		
 	;Main Window
 		Case BMINI
@@ -597,8 +599,8 @@ Repeat
 			ExecFile(discFull$)
 		End Select
 
-		if E <> Null
-			local mi.MenuItem = Object.MenuItem(E\EventID)
+		if CurrentEvent <> Null
+			local mi.MenuItem = Object.MenuItem(CurrentEvent\EventID)
 			if mi <> Null
 				if Handle( mi\Parent ) = M_ProjectsRecent
 					ProjectManager::loadProject(pm, ProjectManager::getProject(pm, mi\caption$))
@@ -607,8 +609,9 @@ Repeat
 			EndIf
 		EndIf
 
-		Delete E
-	Next
+		Delete CurrentEvent
+		CurrentEvent = NextEvent
+	Wend
 Until app\Quit = True
 
 FUI_Destroy()

--- a/src/Tests/Modules/ProjectManagerEventIteratorTest.bb
+++ b/src/Tests/Modules/ProjectManagerEventIteratorTest.bb
@@ -1,0 +1,58 @@
+Strict
+EnableGC
+
+; Project Manager must preserve the successor before deleting a queued F-UI
+; Event. Deleting from a For Each traversal corrupts Blitz3D's iterator.
+
+Function ProjectManagerEventDrainUsesAfterCursor%(Path$)
+	Local F.BBStream = ReadFile(Path$)
+	Local Line$
+	Local Stage%
+	If F = Null Then F = ReadFile("..\\" + Path$)
+	If F = Null Then F = ReadFile("..\\..\\" + Path$)
+	If F = Null Then Return False
+
+	While Not Eof(F)
+		Line$ = ReadLine$(F)
+		If Stage > 0
+			If Instr(Line$, "For E.Event = Each Event") > 0
+				CloseFile F
+				Return False
+			EndIf
+			If Stage < 5
+				If Instr(Line$, "Delete CurrentEvent") > 0
+					CloseFile F
+					Return False
+				EndIf
+			EndIf
+		EndIf
+
+		If Stage = 0
+			If Instr(Line$, ";Start Loop") > 0 Then Stage = 1
+		Else If Stage = 1
+			If Instr(Line$, "Local CurrentEvent.Event = First Event") > 0 Then Stage = 2
+		Else If Stage = 2
+			If Instr(Line$, "Local NextEvent.Event = Null") > 0 Then Stage = 3
+		Else If Stage = 3
+			If Instr(Line$, "While CurrentEvent <> Null") > 0 Then Stage = 4
+		Else If Stage = 4
+			If Instr(Line$, "NextEvent = After CurrentEvent") > 0 Then Stage = 5
+		Else If Stage = 5
+			If Instr(Line$, "Delete CurrentEvent") > 0 Then Stage = 6
+		Else If Stage = 6
+			If Instr(Line$, "CurrentEvent = NextEvent") > 0
+				CloseFile F
+				Return True
+			EndIf
+		EndIf
+
+		If Stage > 0 And Instr(Line$, "Until app\\Quit = True") > 0 Then Exit
+	Wend
+
+	CloseFile F
+	Return False
+End Function
+
+Test testProjectManagerCapturesNextEventBeforeDelete()
+	Assert(ProjectManagerEventDrainUsesAfterCursor%("Project Manager.bb") = True)
+End Test


### PR DESCRIPTION
## Outcome
Project Manager now drains queued UI events without deleting the active iterator cursor, preserving burst input and launcher command dispatch.

## Technical changes
- Replace the main-loop For Each Event traversal with the established First -> After -> While cursor walk.
- Add ProjectManagerEventIteratorTest.bb, a focused source contract that rejects the legacy traversal and requires successor capture before deletion.

Fixes #820

## Acceptance evidence
- Legacy traversal detector: BASELINE: 1 failure: Project Manager deletes an Event inside For Each (exit 1).
- RED after adding the regression: RED: Project Manager Event cursor contract is absent (exit 1).
- GREEN after the repair: PROJECT_MANAGER_EVENT_CURSOR_CONTRACT_GREEN (exit 0).
- Diff hygiene: git diff --check (exit 0).

## Verification limitations
- ./test.sh ProjectManagerEventIteratorTest exited 1 before test execution because compiler/BlitzForge/bin/blitzcc is absent.
- A bounded git submodule update --init compiler/BlitzForge timed out cloning; the safe retry exited 128 with fatal: Unable to find current revision in submodule path compiler/BlitzForge. Exact-head CI is required for native compilation and test proof.

## Compatibility, risk, and rollback
No event IDs, dispatch branches, or F-UI internals change. The risk is confined to main-loop cursor semantics. Rollback is reverting commit 28f6261e.

## Deferred work
Other event drains and F-UI internals are intentionally out of scope.

## Independent review
ACCEPT — a fresh reviewer inspected exact head 28f6261e, confirmed the acceptance criteria and scoped two-file diff, independently observed PROJECT_MANAGER_EVENT_CURSOR_CONTRACT_GREEN, and found no correctness, security, performance, concurrency, documentation, or hidden-cost blocker. Native proof remains pending exact-head CI.