### PR TITLE
fix(client): reject malformed progress-bar create payloads

### DIFF
--- a/src/Modules/ClientNet.bb
+++ b/src/Modules/ClientNet.bb
@@ -160,7 +160,7 @@ Function UpdateNetwork()
 			; Scripted progress bar
 			Case P_ProgressBar ; :)
 				; Create new
-				If Left$(M\MessageData$, 1) = "C"
+				If Left$(M\MessageData$, 1) = "C" And Len(M\MessageData$) >= 28
 					Red = RCE_IntFromStr(Mid$(M\MessageData$, 2, 1))
 					Green = RCE_IntFromStr(Mid$(M\MessageData$, 3, 1))
 					Blue = RCE_IntFromStr(Mid$(M\MessageData$, 4, 1))

--- a/src/Tests/Modules/ClientNetProgressBarPacketTest.bb
+++ b/src/Tests/Modules/ClientNetProgressBarPacketTest.bb
@@ -1,0 +1,42 @@
+Strict
+EnableGC
+
+; ClientNet includes the renderer and network graph, so this source-contract
+; regression binds the P_ProgressBar create-frame boundary without pulling the
+; live client into the standalone test harness.
+
+Function ProgressBarCreateGuardPrecedesMutation%(Path$)
+	Local F.BBStream = ReadFile(Path$)
+	Local InCase%, Stage%
+	Local Line$
+	If F = Null Then F = ReadFile("..\" + Path$)
+	If F = Null Then Return False
+
+	While Not Eof(F)
+		Line$ = ReadLine$(F)
+		If Instr(Line$, "Case P_ProgressBar") > 0 Then InCase = True
+		If InCase = True And Instr(Line$, "Case P_RepositionActor") > 0 Then Exit
+		If InCase = True
+			If Stage = 0 And Instr(Line$, "If Left$(M\MessageData$, 1) = " + Chr$(34) + "C" + Chr$(34) + " And Len(M\MessageData$) >= 28") > 0 Then Stage = 1
+			If Instr(Line$, "RCE_IntFromStr(Mid$(M\MessageData$") > 0 Or Instr(Line$, "RCE_FloatFromStr#(Mid$(M\MessageData$") > 0
+				If Stage <> 1
+					CloseFile F
+					Return False
+				EndIf
+			EndIf
+			If Stage = 1 And Instr(Line$, "GY_CreateProgressBar(0, X#, Y#, W#, H#, Value, Max, Red, Green, Blue)") > 0 Then Stage = 2
+			If Stage = 2 And Instr(Line$, "0.015 / H#") > 0 Then Stage = 3
+			If Stage = 3 And Instr(Line$, "RCE_Send(Connection, PeerToHost, P_ProgressBar, " + Chr$(34) + "C" + Chr$(34)) > 0
+				CloseFile F
+				Return True
+			EndIf
+		EndIf
+	Wend
+
+	CloseFile F
+	Return False
+End Function
+
+Test testProgressBarCreateFrameNeedsTwentyEightBytesBeforeDecode()
+	Assert(ProgressBarCreateGuardPrecedesMutation%("Modules\ClientNet.bb") = True)
+End Test


### PR DESCRIPTION
## Outcome
Malformed scripted progress-bar create frames are now dropped before they can zero-fill the height, create UI, divide by that height, or acknowledge a bogus bar. Valid 28-byte-or-longer frames retain the existing flow.

## Technical changes
- Require `P_ProgressBar` `C` frames to contain the fixed 28-byte header before ClientNet decodes them.
- Add a focused source-contract regression for guard-before-decode, UI creation, height division, and acknowledgement ordering.

Fixes #822

## Acceptance criteria and evidence
- 0–27-byte create frames cannot reach parsing or UI mutation: `PROGRESS_BAR_SOURCE_CONTRACT_GREEN` (exit 0).
- 28-byte create frames retain the existing parse/ack path: the guard is `Len(M\MessageData$) >= 28`, matching the sender's 1 + 3 + 16 + 4 + 2 + 2 fixed bytes.
- Contract pins guard-before-`RCE_*` decoding, `GY_CreateProgressBar`, `0.015 / H#`, and acknowledgement.
- Generated protocol index unchanged: `bash scripts/gen_packet_index.sh --check` (exit 0).

## RED → GREEN
- RED: portable source probe printed `PROGRESS_BAR_SOURCE_CONTRACT_RED` (exit 1) before production change.
- GREEN: the same probe printed `PROGRESS_BAR_SOURCE_CONTRACT_GREEN` (exit 0) after the one-line guard.

## Baseline and final verification
- Baseline: `bash scripts/gen_packet_index.sh --check` and `git diff --check` each exited 0.
- Final: `git diff --check`, `bash scripts/gen_packet_index.sh --check`, `bash scripts/gen_bvm_reference.sh --check`, and `bash -n compile.sh test.sh scripts/gen_packet_index.sh scripts/gen_bvm_reference.sh` each exited 0. The BVM check emitted only its known `BVM_SETOWNER` / `BVM_SCENERYOWNER` DEAD-API warnings.
- Local native test is unverified: `./test.sh ClientNetProgressBarPacketTest` exits 1 before compilation because `compiler/BlitzForge/bin/blitzcc` is absent in this isolated worktree. Exact-head Windows CI is required compiled proof.

## Compatibility, risk, rollback, deferred work
No wire layout or valid-frame behavior changes. A malformed server frame now safely drops instead of partially decoding. Roll back by reverting `dab0656b`. A valid frame with an explicitly zero height is outside this truncation-only increment and remains deferred.

## Review
Independent review pending.

## Independent review
ACCEPT — fresh reviewer inspected exact head `dab0656b049148c299a0949412f15b57cd9484bc` against `develop` `20afacc9c7da6c658683fa0ec7b0027fc857e02c`. It confirmed the 28-byte sender layout, guard-before-decode/UI/division/ack ordering, focused scope, and clean generated-doc/static checks. Native local compilation remains unavailable; merge waits for exact-head CI.