### PR TITLE
fix(fui): guard projection updates against stale handles

### DIFF
--- a/src/Modules/F-UI.bb
+++ b/src/Modules/F-UI.bb
@@ -1339,7 +1339,13 @@ End Function
 ; Rebuild the GUI projection after any window size change so pointer picking
 ; and layout scaling stay aligned with the resized client area.
 Function FUI_UpdateProjection()
-	If app = Null Or app\Cam = Null Or app\Pivot = Null
+	If app = Null
+		Return
+	EndIf
+	If app\Cam = Null
+		Return
+	EndIf
+	If app\Pivot = Null
 		Return
 	EndIf
 	If app\W <= 0 Or app\H <= 0

--- a/src/Tests/Modules/FUIProjectionGuardTest.bb
+++ b/src/Tests/Modules/FUIProjectionGuardTest.bb
@@ -4,6 +4,12 @@ EnableGC
 ; BlitzForge evaluates Or operands eagerly. FUI_UpdateProjection must stage
 ; each handle guard before reading the next Application field or using it.
 
+Function FUIProjectionLineIsIgnorable%(Line$)
+    If Line$ = "" Then Return True
+    If Left$(Line$, 1) = ";" Then Return True
+    Return False
+End Function
+
 Function FUIProjectionGuardsAreStaged%(Path$)
     Local F.BBStream = ReadFile(Path$)
     Local InProjection%, Stage%
@@ -15,77 +21,152 @@ Function FUIProjectionGuardsAreStaged%(Path$)
     While Not Eof(F)
         Line$ = ReadLine$(F)
         Trimmed$ = Trim$(Line$)
-        If Instr(Line$, "Function FUI_UpdateProjection()") > 0 Then InProjection = True
-        If InProjection = True
-            If Stage = 0 And Trimmed$ = "If app = Null"
-                Stage = 1
-            ElseIf Stage = 1
-                If Trimmed$ = "Return"
-                    Stage = 2
-                ElseIf Trimmed$ <> "" And Left$(Trimmed$, 1) <> ";"
+        If Instr(Line$, "Function FUI_UpdateProjection()") > 0
+            InProjection = True
+        ElseIf InProjection = True
+            If Stage = 0
+                If Trimmed$ = "If app = Null"
+                    Stage = 1
+                ElseIf FUIProjectionLineIsIgnorable%(Trimmed$) = False
                     CloseFile F
                     Return False
                 EndIf
-            ElseIf Stage = 2 And Trimmed$ = "EndIf"
-                Stage = 3
+            ElseIf Stage = 1
+                If Trimmed$ = "Return"
+                    Stage = 2
+                ElseIf FUIProjectionLineIsIgnorable%(Trimmed$) = False
+                    CloseFile F
+                    Return False
+                EndIf
+            ElseIf Stage = 2
+                If Trimmed$ = "EndIf"
+                    Stage = 3
+                ElseIf FUIProjectionLineIsIgnorable%(Trimmed$) = False
+                    CloseFile F
+                    Return False
+                EndIf
             ElseIf Stage = 3
                 If Trimmed$ = "If app\Cam = Null"
                     Stage = 4
-                ElseIf Instr(Trimmed$, "app\Cam") > 0
+                ElseIf FUIProjectionLineIsIgnorable%(Trimmed$) = False
                     CloseFile F
                     Return False
                 EndIf
             ElseIf Stage = 4
                 If Trimmed$ = "Return"
                     Stage = 5
-                ElseIf Trimmed$ <> "" And Left$(Trimmed$, 1) <> ";"
+                ElseIf FUIProjectionLineIsIgnorable%(Trimmed$) = False
                     CloseFile F
                     Return False
                 EndIf
-            ElseIf Stage = 5 And Trimmed$ = "EndIf"
-                Stage = 6
+            ElseIf Stage = 5
+                If Trimmed$ = "EndIf"
+                    Stage = 6
+                ElseIf FUIProjectionLineIsIgnorable%(Trimmed$) = False
+                    CloseFile F
+                    Return False
+                EndIf
             ElseIf Stage = 6
                 If Trimmed$ = "If app\Pivot = Null"
                     Stage = 7
-                ElseIf Instr(Trimmed$, "app\Pivot") > 0
+                ElseIf FUIProjectionLineIsIgnorable%(Trimmed$) = False
                     CloseFile F
                     Return False
                 EndIf
             ElseIf Stage = 7
                 If Trimmed$ = "Return"
                     Stage = 8
-                ElseIf Trimmed$ <> "" And Left$(Trimmed$, 1) <> ";"
+                ElseIf FUIProjectionLineIsIgnorable%(Trimmed$) = False
                     CloseFile F
                     Return False
                 EndIf
-            ElseIf Stage = 8 And Trimmed$ = "EndIf"
-                Stage = 9
-            ElseIf Stage = 9 And Trimmed$ = "If app\W <= 0 Or app\H <= 0"
-                Stage = 10
-            ElseIf Stage = 10 And Trimmed$ = "Return"
-                Stage = 11
-            ElseIf Stage = 11 And Trimmed$ = "EndIf"
-                Stage = 12
-            ElseIf Stage = 12 And Instr(Trimmed$, "app\Aspect = FUI_WindowAspect#") > 0
-                Stage = 13
-            ElseIf Stage = 13 And Instr(Trimmed$, "app\Scale = FUI_WindowScale#") > 0
-                Stage = 14
-            ElseIf Stage = 14 And Trimmed$ = "CameraViewport app\Cam, 0, 0, app\W, app\H"
-                Stage = 15
-            ElseIf Stage = 15 And Trimmed$ = "PositionEntity app\Pivot,-1.0, app\Aspect, 1.0"
-                Stage = 16
-            ElseIf Stage = 16 And Trimmed$ = "ScaleEntity app\Pivot, app\Scale,-app\Scale,-app\Scale"
-                CloseFile F
-                Return True
-            ElseIf Instr(Line$, "End Function") > 0
-                CloseFile F
-                Return False
+            ElseIf Stage = 8
+                If Trimmed$ = "EndIf"
+                    Stage = 9
+                ElseIf FUIProjectionLineIsIgnorable%(Trimmed$) = False
+                    CloseFile F
+                    Return False
+                EndIf
+            ElseIf Stage = 9
+                If Trimmed$ = "If app\W <= 0 Or app\H <= 0"
+                    Stage = 10
+                ElseIf FUIProjectionLineIsIgnorable%(Trimmed$) = False
+                    CloseFile F
+                    Return False
+                EndIf
+            ElseIf Stage = 10
+                If Trimmed$ = "Return"
+                    Stage = 11
+                ElseIf FUIProjectionLineIsIgnorable%(Trimmed$) = False
+                    CloseFile F
+                    Return False
+                EndIf
+            ElseIf Stage = 11
+                If Trimmed$ = "EndIf"
+                    Stage = 12
+                ElseIf FUIProjectionLineIsIgnorable%(Trimmed$) = False
+                    CloseFile F
+                    Return False
+                EndIf
+            ElseIf Stage = 12
+                If Instr(Trimmed$, "app\Aspect = FUI_WindowAspect#") > 0
+                    Stage = 13
+                ElseIf FUIProjectionLineIsIgnorable%(Trimmed$) = False
+                    CloseFile F
+                    Return False
+                EndIf
+            ElseIf Stage = 13
+                If Instr(Trimmed$, "app\Scale = FUI_WindowScale#") > 0
+                    Stage = 14
+                ElseIf FUIProjectionLineIsIgnorable%(Trimmed$) = False
+                    CloseFile F
+                    Return False
+                EndIf
+            ElseIf Stage = 14
+                If Trimmed$ = "CameraViewport app\Cam, 0, 0, app\W, app\H"
+                    Stage = 15
+                ElseIf FUIProjectionLineIsIgnorable%(Trimmed$) = False
+                    CloseFile F
+                    Return False
+                EndIf
+            ElseIf Stage = 15
+                If Trimmed$ = "PositionEntity app\Pivot,-1.0, app\Aspect, 1.0"
+                    Stage = 16
+                ElseIf FUIProjectionLineIsIgnorable%(Trimmed$) = False
+                    CloseFile F
+                    Return False
+                EndIf
+            ElseIf Stage = 16
+                If Trimmed$ = "ScaleEntity app\Pivot, app\Scale,-app\Scale,-app\Scale"
+                    CloseFile F
+                    Return True
+                ElseIf FUIProjectionLineIsIgnorable%(Trimmed$) = False
+                    CloseFile F
+                    Return False
+                EndIf
             EndIf
         EndIf
     Wend
 
     CloseFile F
     Return False
+End Function
+
+Function WriteFUIProjectionValidTail(F.BBStream)
+    WriteLine F, "If app\Cam = Null"
+    WriteLine F, "Return"
+    WriteLine F, "EndIf"
+    WriteLine F, "If app\Pivot = Null"
+    WriteLine F, "Return"
+    WriteLine F, "EndIf"
+    WriteLine F, "If app\W <= 0 Or app\H <= 0"
+    WriteLine F, "Return"
+    WriteLine F, "EndIf"
+    WriteLine F, "app\Aspect = FUI_WindowAspect#(app\W, app\H)"
+    WriteLine F, "app\Scale = FUI_WindowScale#(app\W)"
+    WriteLine F, "CameraViewport app\Cam, 0, 0, app\W, app\H"
+    WriteLine F, "PositionEntity app\Pivot,-1.0, app\Aspect, 1.0"
+    WriteLine F, "ScaleEntity app\Pivot, app\Scale,-app\Scale,-app\Scale"
 End Function
 
 Global FUIProjectionGuardTestPath$ = CurrentDir$() + "fui_projection_guard_same_line.tmp"
@@ -102,20 +183,24 @@ Test testFUIProjectionGuardScannerRejectsSameLineTransitions()
         WriteLine F, "Function FUI_UpdateProjection()"
         WriteLine F, "If app = Null Return"
         WriteLine F, "EndIf"
-        WriteLine F, "If app\Cam = Null"
+        WriteFUIProjectionValidTail(F)
+        CloseFile F
+        Assert(FUIProjectionGuardsAreStaged%(FUIProjectionGuardTestPath$) = False)
+    EndIf
+    If FileType(FUIProjectionGuardTestPath$) = 1 Then DeleteFile(FUIProjectionGuardTestPath$)
+End Test
+
+Test testFUIProjectionGuardScannerRejectsEarlyPivotRead()
+    If FileType(FUIProjectionGuardTestPath$) = 1 Then DeleteFile(FUIProjectionGuardTestPath$)
+    Local F.BBStream = WriteFile(FUIProjectionGuardTestPath$)
+    Assert(F <> Null)
+    If F <> Null
+        WriteLine F, "Function FUI_UpdateProjection()"
+        WriteLine F, "If app = Null"
         WriteLine F, "Return"
         WriteLine F, "EndIf"
-        WriteLine F, "If app\Pivot = Null"
-        WriteLine F, "Return"
-        WriteLine F, "EndIf"
-        WriteLine F, "If app\W <= 0 Or app\H <= 0"
-        WriteLine F, "Return"
-        WriteLine F, "EndIf"
-        WriteLine F, "app\Aspect = FUI_WindowAspect#(app\W, app\H)"
-        WriteLine F, "app\Scale = FUI_WindowScale#(app\W)"
-        WriteLine F, "CameraViewport app\Cam, 0, 0, app\W, app\H"
         WriteLine F, "PositionEntity app\Pivot,-1.0, app\Aspect, 1.0"
-        WriteLine F, "ScaleEntity app\Pivot, app\Scale,-app\Scale,-app\Scale"
+        WriteFUIProjectionValidTail(F)
         CloseFile F
         Assert(FUIProjectionGuardsAreStaged%(FUIProjectionGuardTestPath$) = False)
     EndIf

--- a/src/Tests/Modules/FUIProjectionGuardTest.bb
+++ b/src/Tests/Modules/FUIProjectionGuardTest.bb
@@ -7,40 +7,80 @@ EnableGC
 Function FUIProjectionGuardsAreStaged%(Path$)
     Local F.BBStream = ReadFile(Path$)
     Local InProjection%, Stage%
-    Local Line$
+    Local Line$, Trimmed$
     If F = Null Then F = ReadFile("..\" + Path$)
     If F = Null Then F = ReadFile("..\..\" + Path$)
     If F = Null Then Return False
 
     While Not Eof(F)
         Line$ = ReadLine$(F)
+        Trimmed$ = Trim$(Line$)
         If Instr(Line$, "Function FUI_UpdateProjection()") > 0 Then InProjection = True
         If InProjection = True
-            If Instr(Line$, "If app = Null Or") > 0
-                CloseFile F
-                Return False
-            EndIf
-            If Instr(Line$, "If app\Cam = Null Or") > 0
-                CloseFile F
-                Return False
-            EndIf
-            If Instr(Line$, "If app\Pivot = Null Or") > 0
-                CloseFile F
-                Return False
-            EndIf
-            If Stage = 0 And Instr(Line$, "If app = Null") > 0 Then Stage = 1
-            If Stage = 1 And Instr(Line$, "Return") > 0 Then Stage = 2
-            If Stage = 2 And Instr(Line$, "If app\Cam = Null") > 0 Then Stage = 3
-            If Stage = 3 And Instr(Line$, "Return") > 0 Then Stage = 4
-            If Stage = 4 And Instr(Line$, "If app\Pivot = Null") > 0 Then Stage = 5
-            If Stage = 5 And Instr(Line$, "Return") > 0 Then Stage = 6
-            If Stage = 6 And Instr(Line$, "CameraViewport app\Cam") > 0 Then Stage = 7
-            If Stage = 7 And Instr(Line$, "PositionEntity app\Pivot") > 0 Then Stage = 8
-            If Stage = 8 And Instr(Line$, "ScaleEntity app\Pivot") > 0 Then
+            If Stage = 0 And Trimmed$ = "If app = Null"
+                Stage = 1
+            ElseIf Stage = 1
+                If Trimmed$ = "Return"
+                    Stage = 2
+                ElseIf Trimmed$ <> "" And Left$(Trimmed$, 1) <> ";"
+                    CloseFile F
+                    Return False
+                EndIf
+            ElseIf Stage = 2 And Trimmed$ = "EndIf"
+                Stage = 3
+            ElseIf Stage = 3
+                If Trimmed$ = "If app\Cam = Null"
+                    Stage = 4
+                ElseIf Instr(Trimmed$, "app\Cam") > 0
+                    CloseFile F
+                    Return False
+                EndIf
+            ElseIf Stage = 4
+                If Trimmed$ = "Return"
+                    Stage = 5
+                ElseIf Trimmed$ <> "" And Left$(Trimmed$, 1) <> ";"
+                    CloseFile F
+                    Return False
+                EndIf
+            ElseIf Stage = 5 And Trimmed$ = "EndIf"
+                Stage = 6
+            ElseIf Stage = 6
+                If Trimmed$ = "If app\Pivot = Null"
+                    Stage = 7
+                ElseIf Instr(Trimmed$, "app\Pivot") > 0
+                    CloseFile F
+                    Return False
+                EndIf
+            ElseIf Stage = 7
+                If Trimmed$ = "Return"
+                    Stage = 8
+                ElseIf Trimmed$ <> "" And Left$(Trimmed$, 1) <> ";"
+                    CloseFile F
+                    Return False
+                EndIf
+            ElseIf Stage = 8 And Trimmed$ = "EndIf"
+                Stage = 9
+            ElseIf Stage = 9 And Trimmed$ = "If app\W <= 0 Or app\H <= 0"
+                Stage = 10
+            ElseIf Stage = 10 And Trimmed$ = "Return"
+                Stage = 11
+            ElseIf Stage = 11 And Trimmed$ = "EndIf"
+                Stage = 12
+            ElseIf Stage = 12 And Instr(Trimmed$, "app\Aspect = FUI_WindowAspect#") > 0
+                Stage = 13
+            ElseIf Stage = 13 And Instr(Trimmed$, "app\Scale = FUI_WindowScale#") > 0
+                Stage = 14
+            ElseIf Stage = 14 And Trimmed$ = "CameraViewport app\Cam, 0, 0, app\W, app\H"
+                Stage = 15
+            ElseIf Stage = 15 And Trimmed$ = "PositionEntity app\Pivot,-1.0, app\Aspect, 1.0"
+                Stage = 16
+            ElseIf Stage = 16 And Trimmed$ = "ScaleEntity app\Pivot, app\Scale,-app\Scale,-app\Scale"
                 CloseFile F
                 Return True
+            ElseIf Instr(Line$, "End Function") > 0
+                CloseFile F
+                Return False
             EndIf
-            If Instr(Line$, "End Function") > 0 Then Exit
         EndIf
     Wend
 
@@ -48,6 +88,36 @@ Function FUIProjectionGuardsAreStaged%(Path$)
     Return False
 End Function
 
+Global FUIProjectionGuardTestPath$ = CurrentDir$() + "fui_projection_guard_same_line.tmp"
+
 Test testFUIProjectionStagesGuardsBeforeProjectionCalls()
     Assert(FUIProjectionGuardsAreStaged%("Modules\F-UI.bb") = True)
+End Test
+
+Test testFUIProjectionGuardScannerRejectsSameLineTransitions()
+    If FileType(FUIProjectionGuardTestPath$) = 1 Then DeleteFile(FUIProjectionGuardTestPath$)
+    Local F.BBStream = WriteFile(FUIProjectionGuardTestPath$)
+    Assert(F <> Null)
+    If F <> Null
+        WriteLine F, "Function FUI_UpdateProjection()"
+        WriteLine F, "If app = Null Return"
+        WriteLine F, "EndIf"
+        WriteLine F, "If app\Cam = Null"
+        WriteLine F, "Return"
+        WriteLine F, "EndIf"
+        WriteLine F, "If app\Pivot = Null"
+        WriteLine F, "Return"
+        WriteLine F, "EndIf"
+        WriteLine F, "If app\W <= 0 Or app\H <= 0"
+        WriteLine F, "Return"
+        WriteLine F, "EndIf"
+        WriteLine F, "app\Aspect = FUI_WindowAspect#(app\W, app\H)"
+        WriteLine F, "app\Scale = FUI_WindowScale#(app\W)"
+        WriteLine F, "CameraViewport app\Cam, 0, 0, app\W, app\H"
+        WriteLine F, "PositionEntity app\Pivot,-1.0, app\Aspect, 1.0"
+        WriteLine F, "ScaleEntity app\Pivot, app\Scale,-app\Scale,-app\Scale"
+        CloseFile F
+        Assert(FUIProjectionGuardsAreStaged%(FUIProjectionGuardTestPath$) = False)
+    EndIf
+    If FileType(FUIProjectionGuardTestPath$) = 1 Then DeleteFile(FUIProjectionGuardTestPath$)
 End Test

--- a/src/Tests/Modules/FUIProjectionGuardTest.bb
+++ b/src/Tests/Modules/FUIProjectionGuardTest.bb
@@ -1,0 +1,53 @@
+Strict
+EnableGC
+
+; BlitzForge evaluates Or operands eagerly. FUI_UpdateProjection must stage
+; each handle guard before reading the next Application field or using it.
+
+Function FUIProjectionGuardsAreStaged%(Path$)
+    Local F.BBStream = ReadFile(Path$)
+    Local InProjection%, Stage%
+    Local Line$
+    If F = Null Then F = ReadFile("..\" + Path$)
+    If F = Null Then F = ReadFile("..\..\" + Path$)
+    If F = Null Then Return False
+
+    While Not Eof(F)
+        Line$ = ReadLine$(F)
+        If Instr(Line$, "Function FUI_UpdateProjection()") > 0 Then InProjection = True
+        If InProjection = True
+            If Instr(Line$, "If app = Null Or") > 0
+                CloseFile F
+                Return False
+            EndIf
+            If Instr(Line$, "If app\Cam = Null Or") > 0
+                CloseFile F
+                Return False
+            EndIf
+            If Instr(Line$, "If app\Pivot = Null Or") > 0
+                CloseFile F
+                Return False
+            EndIf
+            If Stage = 0 And Instr(Line$, "If app = Null") > 0 Then Stage = 1
+            If Stage = 1 And Instr(Line$, "Return") > 0 Then Stage = 2
+            If Stage = 2 And Instr(Line$, "If app\Cam = Null") > 0 Then Stage = 3
+            If Stage = 3 And Instr(Line$, "Return") > 0 Then Stage = 4
+            If Stage = 4 And Instr(Line$, "If app\Pivot = Null") > 0 Then Stage = 5
+            If Stage = 5 And Instr(Line$, "Return") > 0 Then Stage = 6
+            If Stage = 6 And Instr(Line$, "CameraViewport app\Cam") > 0 Then Stage = 7
+            If Stage = 7 And Instr(Line$, "PositionEntity app\Pivot") > 0 Then Stage = 8
+            If Stage = 8 And Instr(Line$, "ScaleEntity app\Pivot") > 0 Then
+                CloseFile F
+                Return True
+            EndIf
+            If Instr(Line$, "End Function") > 0 Then Exit
+        EndIf
+    Wend
+
+    CloseFile F
+    Return False
+End Function
+
+Test testFUIProjectionStagesGuardsBeforeProjectionCalls()
+    Assert(FUIProjectionGuardsAreStaged%("Modules\F-UI.bb") = True)
+End Test


### PR DESCRIPTION
## Outcome

F-UI now drops resize/projection refreshes safely when teardown has left the application, camera, or pivot handle unavailable, avoiding an editor/launcher crash path.

## Technical changes

- Split the eager combined null condition in `FUI_UpdateProjection` into ordered guards for `app`, `app\Cam`, and `app\Pivot`.
- Added `FUIProjectionGuardTest` to reject eager forms and bind guard-to-projection-call ordering.

Fixes #824

## Acceptance evidence

| Criterion | Evidence |
| --- | --- |
| Null application cannot reach a field read | ordered `If app = Null` → `Return` source contract |
| Missing camera/pivot cannot reach projection calls | ordered `Cam`/`Pivot` guards precede `CameraViewport`/`PositionEntity`/`ScaleEntity` |
| Valid projection path is retained | source contract reaches the unchanged three projection calls after all guards |
| Regression coverage exists | `src/Tests/Modules/FUIProjectionGuardTest.bb` |

## RED → GREEN

- RED: portable bounded probe exited 1 with `FUI_PROJECTION_GUARD_RED: eager combined null guard remains`.
- GREEN: the same probe exited 0 with `FUI_PROJECTION_GUARD_GREEN`.
- Native focused test command: `./test.sh FUIProjectionGuardTest` exits 1 in this Linux worktree before execution because `compiler/BlitzForge/bin/blitzcc` is absent; exact-head CI is required for compiled proof.

## Baseline and final verification

- Baseline: focused native runner exit 1 (missing local compiler); `git diff --check`, `bash scripts/gen_packet_index.sh --check`, and `bash scripts/gen_bvm_reference.sh --check` each exited 0 (the BVM check emitted its two known DEAD-API warnings).
- Final: portable guard contract exit 0; cached `git diff --check` exit 0; both generator checks exit 0 with the same known BVM warnings.

## Compatibility, risk, rollback

Valid F-UI projection math and API behavior are unchanged. Invalid-handle paths now return instead of evaluating stale fields. Roll back by reverting commit `8e0051fee458c2c3d9782090655a939511e3926a`.

## Independent review

Pending fresh review of this exact head; this section will be updated with the verdict before merge.

## Deferred

General F-UI teardown and unrelated Gooey/ServerNet work are intentionally out of scope.