### PR TITLE
fix(editors): atomically persist seasonal tree settings

### DIFF
--- a/docs/modules/rctrees.md
+++ b/docs/modules/rctrees.md
@@ -105,15 +105,15 @@ The freed-but-still-referenced texture/brush is the classic refcount edge — `F
 
 ### Season system
 
-`Tree_SetSeason(sn)` recolors every non-evergreen `Tree` and `RcGrass` to the season's RGB triple from `season_red(0..11)` / `season_green(0..11)` / `season_blue(0..11)`. The 12 seasons (the engine has more than 4) are loaded from `Data\Game Data\RCTE.dat` by `tree_setvalues` — or generated with random defaults and persisted if the file is missing.
+`Tree_SetSeason(sn)` recolors every non-evergreen `Tree` and `RcGrass` to the season's RGB triple from `season_red(0..11)` / `season_green(0..11)` / `season_blue(0..11)`. The 12 seasons (the engine has more than 4) are loaded from `Data\Game Data\RCTE.dat` by `tree_setvalues` — or generated with random defaults and persisted when the file is missing or malformed.
 
-Persistence shape: 12 × 3 × `Int = 144 bytes`. **Plain `WriteFile`, not `SafeWriteOpen` / `SafeWriteCommit`.** A crash during write leaves a truncated file; subsequent `ReadInt` past EOF zero-fills (Blitz3D doesn't error on past-EOF reads), so missing seasons get `0,0,0` (black). This is a SafeWrite migration candidate — same pattern as `RP_SaveEmitterConfig` in [`RottParticles.bb`](rottparticles.md).
+Persistence shape: 12 × 3 × `Int = 144 bytes`. `tree_setvalues` accepts only that exact size for reads; missing or malformed files are regenerated through `SafeWriteOpen` / `SafeWriteCommit`, so a failed promotion preserves the previous file rather than replacing it with a partial table.
 
 ## Conventions for new code touching this module
 
 - **Branch surfaces are identified by texture-name substring `"branch"`.** Authoring a tree mesh where branches don't have "branch" in the texture name collapses the whole tree into a trunk-only entity with no sway. This is undocumented in the source and a future content-pipeline rewrite should formalize the contract.
 - **`Tree\swingstyle` field stores `1` or `4`, NOT the input arg's value.** Input value space is `0..2` (the `Select Case` at line 275-282 picks `CenterMesh` / `HangMesh` / `StandMesh`). Don't compare `rt\swingstyle` against the input arg's range — they're different semantically.
-- **`tree_setvalues` writes `Data\Game Data\RCTE.dat` via plain `WriteFile`.** Atomic-write migration is a candidate; the file is small (144 bytes) and a corrupt write only loses the random defaults, so the impact is low.
+- **`tree_setvalues` treats `Data\Game Data\RCTE.dat` as exactly 144 bytes.** Missing or malformed files are regenerated atomically; do not bypass `SafeWriteOpen` / `SafeWriteCommit` when changing this fixed-size table.
 - **`updatetrees` reads engine globals `currentseason`, `currentweather`, `fogfarnow`** — added at module scope by the broader engine. Not declared in this file. If the engine ever stops setting them, `updatetrees` silently degrades (zero everywhere).
 - **`distance(e1, e2)` is XZ-only** (2D ground-plane distance, ignoring Y) — not Euclidean. Documented by the function body's `Sqr#((EntityX - EntityX)^2 + (EntityZ - EntityZ)^2)`. Aerial trees would compute "near" distances even when far above/below the camera.
 - **Maxbranches = 400 is a `Const` per-tree cap.** A tree with > 400 branch surfaces silently drops the overflow (the surface loop continues but `RT\Branchent[bcount]` indexes past the field's declared size 0..400, which Blitz3D doesn't bounds-check — writing past the field's `[400]` allocates more slots dynamically, but cap-aware code in `updatetrees` only loops `For bn = 1 To rt\maxbranches`).
@@ -129,7 +129,7 @@ Persistence shape: 12 × 3 × `Int = 144 bytes`. **Plain `WriteFile`, not `SafeW
 
 ## See also
 
-- CLAUDE.md → "Atomic writes" — `tree_setvalues`' `WriteFile` on `RCTE.dat` is a migration candidate.
+- CLAUDE.md → "Atomic writes" — `tree_setvalues` follows the repository safe-write convention for `RCTE.dat`.
 - CLAUDE.md → "Gotchas" → "Blitz3D array semantics" — `Dim X(N)` allocates `N+1` slots; relevant for `Dim weather_wind_swaymax#(7, 3)` (8 × 4 slots).
 - [`rottparticles.md`](rottparticles.md) — sibling-style "graphics subsystem with a non-atomic save format" with the same migration-candidate flag.
 

--- a/docs/modules/rctrees.md
+++ b/docs/modules/rctrees.md
@@ -41,7 +41,7 @@ Dim weather_wind_swayspeed#(7, 3)   ; per-weather × per-axis speed
 
 `Dim X(7, 3)` allocates `8 × 4` slots — but only `(0..5, 1..3)` are populated. The six used weather indices are the `W_Sun = 0` through `W_Wind = 5` `Const`s declared in [`Environment.bb:2-7`](../../src/Modules/Environment.bb#L2); slots 6 and 7 of the first dimension and slot 0 of the second dimension are unused (Blitz3D `Dim X(N)` is inclusive — see CLAUDE.md → "Gotchas" → "Blitz3D array semantics").
 
-`tree_setvalues()` ([RCTrees.bb:583-657](../../src/Modules/RCTrees.bb#L583)) populates the 2D table with hard-coded per-weather wind profiles. Some samples:
+`tree_setvalues()` ([RCTrees.bb:583-664](../../src/Modules/RCTrees.bb#L583)) populates the 2D table with hard-coded per-weather wind profiles. Some samples:
 
 | Weather | X sway max / speed | Y / speed | Z / speed |
 |---|---|---|---|
@@ -82,7 +82,7 @@ The `Tree\swingstyle` field stores either `1` or `4` (note: NOT the input `swing
 
 The spring oscillator state machine per axis: `swaydir` is 1 (positive) or 2 (negative); `swayvalue#` accumulates `±swaypower#` per frame; on hitting `±TreeSwayMax#`, `swaydir` flips. Output rotation is `(swayvalue / swingstyle) * tdelta`.
 
-`updategrass(Gdelta, Grasswind)` ([RCTrees.bb:811-820](../../src/Modules/RCTrees.bb#L811)) is much simpler: maintains a global `GrassPos` angle (mod 3600 = 10-degree resolution full revolution), looks up `lcos#(GrassPos) * .015 * 360` from the pre-computed cosine table, calls `TransTex` on every distinct grass texture to rotate it. No per-instance per-frame work — texture rotation is global.
+`updategrass(Gdelta, Grasswind)` ([RCTrees.bb:818-827](../../src/Modules/RCTrees.bb#L818)) is much simpler: maintains a global `GrassPos` angle (mod 3600 = 10-degree resolution full revolution), looks up `lcos#(GrassPos) * .015 * 360` from the pre-computed cosine table, calls `TransTex` on every distinct grass texture to rotate it. No per-instance per-frame work — texture rotation is global.
 
 ### Pre-computed trig LUTs
 
@@ -99,7 +99,7 @@ Next
 
 ### Grass deduplication: `clumpgrass`
 
-[RCTrees.bb:668-705](../../src/Modules/RCTrees.bb#L668). Walks every `RcGrass` and builds a `GrassTextures` cache keyed by texture name. After: every `RcGrass` whose texture name matches an existing cache entry shares the cache entry's `Brush` handle (via `PaintMesh rcg\ent, gt\brush`). Closes a real perf issue: pre-clump, a zone with 200 grass tufts using 10 unique textures would issue 200 brush-swap calls per frame; post-clump, 10.
+[RCTrees.bb:675-712](../../src/Modules/RCTrees.bb#L675). Walks every `RcGrass` and builds a `GrassTextures` cache keyed by texture name. After: every `RcGrass` whose texture name matches an existing cache entry shares the cache entry's `Brush` handle (via `PaintMesh rcg\ent, gt\brush`). Closes a real perf issue: pre-clump, a zone with 200 grass tufts using 10 unique textures would issue 200 brush-swap calls per frame; post-clump, 10.
 
 The freed-but-still-referenced texture/brush is the classic refcount edge — `FreeBrush rcg\brush` / `FreeTexture rcg\tex` on the per-grass handle is safe because the cached `gt\brush` / `gt\tex` is a fresh `GetBrushTexture` lookup, not an alias.
 
@@ -140,9 +140,9 @@ The legacy function-by-function reference for this module has not been generated
 The module exports 25 functions. Notable groups:
 
 - **Tree lifecycle:** `LoadTree` ([RCTrees.bb:128](../../src/Modules/RCTrees.bb#L128)), `Deletetree` ([:480](../../src/Modules/RCTrees.bb#L480)), `UnloadTrees` ([:490](../../src/Modules/RCTrees.bb#L490)), `Droptree` ([:441](../../src/Modules/RCTrees.bb#L441)) — drop-via-LinePick onto terrain.
-- **Per-frame:** `updatetrees` ([:301](../../src/Modules/RCTrees.bb#L301)), `updategrass` ([:811](../../src/Modules/RCTrees.bb#L811)).
+- **Per-frame:** `updatetrees` ([:301](../../src/Modules/RCTrees.bb#L301)), `updategrass` ([:818](../../src/Modules/RCTrees.bb#L818)).
 - **Anchor helpers:** `CenterMesh` ([:461](../../src/Modules/RCTrees.bb#L461)), `StandMesh` ([:465](../../src/Modules/RCTrees.bb#L465)), `HangMesh` ([:469](../../src/Modules/RCTrees.bb#L469)) — anchor a branch mesh's pivot.
-- **Season/weather:** `Tree_SetSeason` ([:512](../../src/Modules/RCTrees.bb#L512)), `Tree_Changeweather` ([:659](../../src/Modules/RCTrees.bb#L659)), `tree_setvalues` ([:583](../../src/Modules/RCTrees.bb#L583)).
-- **Grass:** `LoadGrass` ([:562](../../src/Modules/RCTrees.bb#L562)), `clumpgrass` ([:668](../../src/Modules/RCTrees.bb#L668)), `ColorGrass` ([:762](../../src/Modules/RCTrees.bb#L762)), `Lightmapgrass` ([:822](../../src/Modules/RCTrees.bb#L822)), `TransTex` ([:803](../../src/Modules/RCTrees.bb#L803)).
+- **Season/weather:** `Tree_SetSeason` ([:512](../../src/Modules/RCTrees.bb#L512)), `Tree_Changeweather` ([:666](../../src/Modules/RCTrees.bb#L666)), `tree_setvalues` ([:583](../../src/Modules/RCTrees.bb#L583)).
+- **Grass:** `LoadGrass` ([:562](../../src/Modules/RCTrees.bb#L562)), `clumpgrass` ([:675](../../src/Modules/RCTrees.bb#L675)), `ColorGrass` ([:769](../../src/Modules/RCTrees.bb#L769)), `Lightmapgrass` ([:829](../../src/Modules/RCTrees.bb#L829)), `TransTex` ([:810](../../src/Modules/RCTrees.bb#L810)).
 - **Visibility:** `SetTreePickmode`, `Tree_Hideall`, `Tree_Showall`, `tree_autofade`.
 - **Utility:** `CountTrees`, `fps`, `distance`, `xForm`.

--- a/src/Modules/RCTrees.bb
+++ b/src/Modules/RCTrees.bb
@@ -626,10 +626,12 @@ weather_wind_swaymax#(W_WIND,3)=7
 weather_wind_swayspeed#(W_WIND,3)=.2
 
 ;load season settings here
-If FileType(seasoncolor_file$)<>1 Then 
-;create the file, and input defualts
+If FileType(seasoncolor_file$)<>1 Or FileSize(seasoncolor_file$)<>144 Then
+;create or replace an invalid file with defaults
 
- cfile=WriteFile(seasoncolor_file$)
+ TempPath$=SafeWriteOpen$(seasoncolor_file$)
+ cfile=WriteFile(TempPath$)
+ If cfile=0 Then Return
 For i=0 To 11
   scr=(40+Rand(-40,40))
   scg=(150+Rand(-40,10))
@@ -641,7 +643,12 @@ For i=0 To 11
   season_green(i)=scg
   season_blue(i)=scb
  Next
-CloseFile cfile
+ CloseFile cfile
+ If FileSize(TempPath$)<>144
+  SafeWriteAbort(TempPath$)
+  Return
+ EndIf
+ If SafeWriteCommit(TempPath$,seasoncolor_file$,0)=False Then Return
 Else
  cfile=ReadFile(seasoncolor_file$)
   For i=0 To 11

--- a/src/Tests/Modules/RCTreesPersistenceTest.bb
+++ b/src/Tests/Modules/RCTreesPersistenceTest.bb
@@ -31,11 +31,13 @@ Function RCTreesSeasonSettingsUseAtomicPersistence%(Path$)
 			If Stage = 7 And Trimmed$ = "SafeWriteAbort(TempPath$)" Then Stage = 8
 			If Stage = 8 And Trimmed$ = "EndIf" Then Stage = 9
 			If Stage = 9 And Trimmed$ = "If SafeWriteCommit(TempPath$,seasoncolor_file$,0)=False Then Return" Then Stage = 10
-			If Stage = 10 And Trimmed$ = "Else"
+			If Stage = 10 And Trimmed$ = "Else" Then Stage = 11
+			If Stage = 11 And Trimmed$ = "cfile=ReadFile(seasoncolor_file$)" Then Stage = 12
+			If Stage = 12 And Trimmed$ = "EndIf" Then Stage = 13
+			If Stage = 13 And Trimmed$ = "End Function"
 				CloseFile F
 				Return True
 			EndIf
-			If Trimmed$ = "End Function" Then Exit
 		EndIf
 	Wend
 
@@ -66,6 +68,33 @@ Test testRCTreesPersistenceScannerRejectsDirectFinalWrite()
 		WriteLine F, "EndIf"
 		WriteLine F, "If SafeWriteCommit(TempPath$,seasoncolor_file$,0)=False Then Return"
 		WriteLine F, "Else"
+		WriteLine F, "EndIf"
+		WriteLine F, "End Function"
+		CloseFile F
+		Assert(RCTreesSeasonSettingsUseAtomicPersistence%(RCTreesPersistenceFixture$) = False)
+	EndIf
+	If FileType(RCTreesPersistenceFixture$) = 1 Then DeleteFile(RCTreesPersistenceFixture$)
+End Test
+
+Test testRCTreesPersistenceScannerRejectsFinalWriteInValidBranch()
+	If FileType(RCTreesPersistenceFixture$) = 1 Then DeleteFile(RCTreesPersistenceFixture$)
+	Local F.BBStream = WriteFile(RCTreesPersistenceFixture$)
+	Assert(F <> Null)
+	If F <> Null
+		WriteLine F, "Function tree_setvalues()"
+		WriteLine F, "If FileType(seasoncolor_file$)<>1 Or FileSize(seasoncolor_file$)<>144 Then"
+		WriteLine F, "TempPath$=SafeWriteOpen$(seasoncolor_file$)"
+		WriteLine F, "cfile=WriteFile(TempPath$)"
+		WriteLine F, "For i=0 To 11"
+		WriteLine F, "Next"
+		WriteLine F, "CloseFile cfile"
+		WriteLine F, "If FileSize(TempPath$)<>144"
+		WriteLine F, "SafeWriteAbort(TempPath$)"
+		WriteLine F, "EndIf"
+		WriteLine F, "If SafeWriteCommit(TempPath$,seasoncolor_file$,0)=False Then Return"
+		WriteLine F, "Else"
+		WriteLine F, "cfile=ReadFile(seasoncolor_file$)"
+		WriteLine F, "WriteFile(seasoncolor_file$)"
 		WriteLine F, "EndIf"
 		WriteLine F, "End Function"
 		CloseFile F

--- a/src/Tests/Modules/RCTreesPersistenceTest.bb
+++ b/src/Tests/Modules/RCTreesPersistenceTest.bb
@@ -1,0 +1,75 @@
+Strict
+EnableGC
+
+; RCTrees is a legacy editor module with a large rendering dependency graph.
+; Keep this regression focused on the RCTE.dat persistence boundary instead of
+; pulling the whole editor into a unit-test compile.
+Function RCTreesSeasonSettingsUseAtomicPersistence%(Path$)
+	Local F.BBStream = ReadFile(Path$)
+	Local InFunction%, Stage%
+	Local Line$, Trimmed$
+	If F = Null Then F = ReadFile("..\" + Path$)
+	If F = Null Then F = ReadFile("..\..\" + Path$)
+	If F = Null Then Return False
+
+	While Not Eof(F)
+		Line$ = ReadLine$(F)
+		Trimmed$ = Trim$(Line$)
+		If Instr(Line$, "Function tree_setvalues()") > 0 Then InFunction = True
+		If InFunction = True
+			If Instr(Line$, "WriteFile(seasoncolor_file$)") > 0
+				CloseFile F
+				Return False
+			EndIf
+			If Stage = 0 And Trimmed$ = "If FileType(seasoncolor_file$)<>1 Or FileSize(seasoncolor_file$)<>144 Then" Then Stage = 1
+			If Stage = 1 And Trimmed$ = "TempPath$=SafeWriteOpen$(seasoncolor_file$)" Then Stage = 2
+			If Stage = 2 And Trimmed$ = "cfile=WriteFile(TempPath$)" Then Stage = 3
+			If Stage = 3 And Trimmed$ = "For i=0 To 11" Then Stage = 4
+			If Stage = 4 And Trimmed$ = "Next" Then Stage = 5
+			If Stage = 5 And Trimmed$ = "CloseFile cfile" Then Stage = 6
+			If Stage = 6 And Trimmed$ = "If FileSize(TempPath$)<>144" Then Stage = 7
+			If Stage = 7 And Trimmed$ = "SafeWriteAbort(TempPath$)" Then Stage = 8
+			If Stage = 8 And Trimmed$ = "EndIf" Then Stage = 9
+			If Stage = 9 And Trimmed$ = "If SafeWriteCommit(TempPath$,seasoncolor_file$,0)=False Then Return" Then Stage = 10
+			If Stage = 10 And Trimmed$ = "Else"
+				CloseFile F
+				Return True
+			EndIf
+			If Trimmed$ = "End Function" Then Exit
+		EndIf
+	Wend
+
+	CloseFile F
+	Return False
+End Function
+
+Global RCTreesPersistenceFixture$ = CurrentDir$() + "rctrees_persistence_unsafe.tmp"
+
+Test testRCTreesSeasonSettingsUseAtomicPersistence()
+	Assert(RCTreesSeasonSettingsUseAtomicPersistence%("Modules\RCTrees.bb") = True)
+End Test
+
+Test testRCTreesPersistenceScannerRejectsDirectFinalWrite()
+	If FileType(RCTreesPersistenceFixture$) = 1 Then DeleteFile(RCTreesPersistenceFixture$)
+	Local F.BBStream = WriteFile(RCTreesPersistenceFixture$)
+	Assert(F <> Null)
+	If F <> Null
+		WriteLine F, "Function tree_setvalues()"
+		WriteLine F, "If FileType(seasoncolor_file$)<>1 Or FileSize(seasoncolor_file$)<>144 Then"
+		WriteLine F, "TempPath$=SafeWriteOpen$(seasoncolor_file$)"
+		WriteLine F, "cfile=WriteFile(seasoncolor_file$)"
+		WriteLine F, "For i=0 To 11"
+		WriteLine F, "Next"
+		WriteLine F, "CloseFile cfile"
+		WriteLine F, "If FileSize(TempPath$)<>144"
+		WriteLine F, "SafeWriteAbort(TempPath$)"
+		WriteLine F, "EndIf"
+		WriteLine F, "If SafeWriteCommit(TempPath$,seasoncolor_file$,0)=False Then Return"
+		WriteLine F, "Else"
+		WriteLine F, "EndIf"
+		WriteLine F, "End Function"
+		CloseFile F
+		Assert(RCTreesSeasonSettingsUseAtomicPersistence%(RCTreesPersistenceFixture$) = False)
+	EndIf
+	If FileType(RCTreesPersistenceFixture$) = 1 Then DeleteFile(RCTreesPersistenceFixture$)
+End Test


### PR DESCRIPTION
## Outcome

GUE and Loom no longer accept a truncated seasonal-tree settings table as valid data. A failed write leaves the prior file recoverable instead of promoting a partial replacement.

## Technical changes

- Treat `RCTE.dat` as an exact 144-byte (12 × 3 `Int`) contract.
- Regenerate missing or malformed data through `SafeWriteOpen` / `SafeWriteCommit`, including a post-close temp-size check and abort path.
- Add a focused source-contract regression and align the RCTrees module documentation.

Fixes #826

## Acceptance evidence

- Missing/malformed gate and safe-write ordering: portable RED `RCTREES_PERSISTENCE_CONTRACT_RED` (exit 1) then GREEN `RCTREES_PERSISTENCE_CONTRACT_GREEN` (exit 0).
- Direct final-path writes are rejected by `RCTreesPersistenceTest.bb`; the contract requires temp creation, 36-write loop, post-close 144-byte validation, abort, promotion, and a normal valid-file read before returning success.
- `git diff --check`, packet-index, and BVM-reference checks exit 0 (the latter has two known DEAD-API warnings).

## Baseline and local limits

Baseline source probe exited 1: `BASELINE: 1 failure: RCTE seasonal settings lack fixed-size atomic persistence`. `./test.sh RCTreesPersistenceTest` cannot compile locally because `compiler/BlitzForge/bin/blitzcc` is absent; exact-head Windows CI supplied native compiler proof.

## Compatibility, rollback, and deferred work

The format remains 36 `Int`s / 144 bytes. Revert this PR to restore the old behavior; SafeWrite retains recovery artifacts when promotion fails. Tree-editor UI, weather tuning, asset-format redesign, and Rock-export persistence remain deferred.

## Independent review

Fresh review cycle 2: **ACCEPT** for exact head `b820d7435ae67d33ae11eb9643333af3ca22cd16`. It confirmed the temp-only 144-byte write/recovery path, valid-file read path, full-function direct-write guard, refreshed documentation anchors, and bounded scope.

## Exact-head CI

CI run `29783672152`: Build and test passed (6m42s); Rust server (Linux) passed (4m03s).