### PR TITLE
fix(GUE): drain main events with an after cursor

### DIFF
--- a/src/GUE.bb
+++ b/src/GUE.bb
@@ -3169,8 +3169,11 @@ Cls
 	;Flip(0)
 
 	Local E.Event
+	Local ENext.Event
 	; Process events
-	For E.Event = Each Event
+	E = First Event
+	While E <> Null
+		ENext = After E
 		Select E\EventID
 
 			;- Tab switched ----------------------------------------------------------------------------------------------------------
@@ -6594,7 +6597,8 @@ Cls
 				Next
 		End Select
 		Delete E
-	Next
+		E = ENext
+	Wend
 	
 	;Flip(0) added here after events cysis145
 	RenderWorld

--- a/src/Tests/Modules/GUEEventIteratorTest.bb
+++ b/src/Tests/Modules/GUEEventIteratorTest.bb
@@ -7,6 +7,7 @@ EnableGC
 Function GUEEventDrainUsesAfterCursor%(Path$, FunctionMarker$, LegacyFor$, FirstCursor$, NextDeclaration$, WhileCursor$, Capture$, DeleteEvent$, Advance$)
 	Local F.BBStream = ReadFile(Path$)
 	Local Stage%
+	Local LoopDepth%
 	Local Line$
 	If F = Null Then F = ReadFile("..\\" + Path$)
 	If F = Null Then F = ReadFile("..\\..\\" + Path$)
@@ -60,26 +61,41 @@ Function GUEMainQueueUsesAfterCursor%(Path$)
 			CloseFile F
 			Return False
 		EndIf
-		If Stage > 0 And Stage < 5 And Instr(Line$, "Delete E") > 0
+		If Stage > 0 And Stage < 6 And Instr(Line$, "Delete E") > 0
 			CloseFile F
 			Return False
 		EndIf
+		If Stage >= 6 And Stage < 8
+			If Left$(Trim$(Line$), 6) = "While " Then LoopDepth = LoopDepth + 1
+			If Trim$(Line$) = "Wend"
+				LoopDepth = LoopDepth - 1
+				If LoopDepth = 0
+					CloseFile F
+					Return False
+				EndIf
+			EndIf
+		EndIf
 		If Stage = 0
-			If Instr(Line$, "; Process events") > 0 Then Stage = 1
+			If Instr(Line$, "Local E.Event") > 0 Then Stage = 1
 		ElseIf Stage = 1
-			If Instr(Line$, "Local E.Event") > 0 Then Stage = 2
+			If Instr(Line$, "Local ENext.Event") > 0 Then Stage = 2
 		ElseIf Stage = 2
-			If Instr(Line$, "Local ENext.Event") > 0 Then Stage = 3
+			If Instr(Line$, "; Process events") > 0 Then Stage = 3
 		ElseIf Stage = 3
 			If Instr(Line$, "E = First Event") > 0 Then Stage = 4
 		ElseIf Stage = 4
-			If Instr(Line$, "While E <> Null") > 0 Then Stage = 5
+			If Instr(Line$, "While E <> Null") > 0
+				LoopDepth = 1
+				Stage = 5
+			EndIf
 		ElseIf Stage = 5
 			If Instr(Line$, "ENext = After E") > 0 Then Stage = 6
 		ElseIf Stage = 6
 			If Instr(Line$, "Delete E") > 0 Then Stage = 7
 		ElseIf Stage = 7
-			If Instr(Line$, "E = ENext") > 0
+			If Instr(Line$, "E = ENext") > 0 Then Stage = 8
+		ElseIf Stage = 8
+			If Trim$(Line$) = "Wend" And LoopDepth = 1
 				CloseFile F
 				Return True
 			EndIf

--- a/src/Tests/Modules/GUEEventIteratorTest.bb
+++ b/src/Tests/Modules/GUEEventIteratorTest.bb
@@ -7,7 +7,6 @@ EnableGC
 Function GUEEventDrainUsesAfterCursor%(Path$, FunctionMarker$, LegacyFor$, FirstCursor$, NextDeclaration$, WhileCursor$, Capture$, DeleteEvent$, Advance$)
 	Local F.BBStream = ReadFile(Path$)
 	Local Stage%
-	Local LoopDepth%
 	Local Line$
 	If F = Null Then F = ReadFile("..\\" + Path$)
 	If F = Null Then F = ReadFile("..\\..\\" + Path$)
@@ -50,6 +49,7 @@ End Function
 Function GUEMainQueueUsesAfterCursor%(Path$)
 	Local F.BBStream = ReadFile(Path$)
 	Local Stage%
+	Local LoopDepth%
 	Local Line$
 	If F = Null Then F = ReadFile("..\\" + Path$)
 	If F = Null Then F = ReadFile("..\\..\\" + Path$)

--- a/src/Tests/Modules/GUEEventIteratorTest.bb
+++ b/src/Tests/Modules/GUEEventIteratorTest.bb
@@ -43,6 +43,54 @@ Function GUEEventDrainUsesAfterCursor%(Path$, FunctionMarker$, LegacyFor$, First
 	Return False
 End Function
 
+; The editor's top-level queue spans the main loop rather than a bounded modal
+; function. Keep its current Event cursor, but require its successor to be
+; captured before the dispatch can delete the current object.
+Function GUEMainQueueUsesAfterCursor%(Path$)
+	Local F.BBStream = ReadFile(Path$)
+	Local Stage%
+	Local Line$
+	If F = Null Then F = ReadFile("..\\" + Path$)
+	If F = Null Then F = ReadFile("..\\..\\" + Path$)
+	If F = Null Then Return False
+
+	While Not Eof(F)
+		Line$ = ReadLine$(F)
+		If Stage > 0 And Instr(Line$, "For E.Event = Each Event") > 0
+			CloseFile F
+			Return False
+		EndIf
+		If Stage > 0 And Stage < 5 And Instr(Line$, "Delete E") > 0
+			CloseFile F
+			Return False
+		EndIf
+		If Stage = 0
+			If Instr(Line$, "; Process events") > 0 Then Stage = 1
+		ElseIf Stage = 1
+			If Instr(Line$, "Local E.Event") > 0 Then Stage = 2
+		ElseIf Stage = 2
+			If Instr(Line$, "Local ENext.Event") > 0 Then Stage = 3
+		ElseIf Stage = 3
+			If Instr(Line$, "E = First Event") > 0 Then Stage = 4
+		ElseIf Stage = 4
+			If Instr(Line$, "While E <> Null") > 0 Then Stage = 5
+		ElseIf Stage = 5
+			If Instr(Line$, "ENext = After E") > 0 Then Stage = 6
+		ElseIf Stage = 6
+			If Instr(Line$, "Delete E") > 0 Then Stage = 7
+		ElseIf Stage = 7
+			If Instr(Line$, "E = ENext") > 0
+				CloseFile F
+				Return True
+			EndIf
+		EndIf
+		If Stage > 0 And Instr(Line$, "RenderWorld") > 0 Then Exit
+	Wend
+
+	CloseFile F
+	Return False
+End Function
+
 Test testScaleEntireZoneDialogCapturesNextEventBeforeDelete()
 	Assert(GUEEventDrainUsesAfterCursor%("GUE.bb", "Function ScaleEntireZoneDialog()", "For E.Event = Each Event", "Local ScaleEvent.Event = First Event", "Local NextScaleEvent.Event = Null", "While ScaleEvent <> Null", "NextScaleEvent = After ScaleEvent", "Delete(ScaleEvent)", "ScaleEvent = NextScaleEvent") = True)
 End Test
@@ -81,4 +129,8 @@ End Test
 
 Test testSoundDialogCapturesNextEventBeforeDelete()
 	Assert(GUEEventDrainUsesAfterCursor%("GUE.bb", "Function SoundDialog()", "For E.Event = Each Event", "Local SoundEvent.Event = First Event", "Local NextSoundEvent.Event = Null", "While SoundEvent <> Null", "NextSoundEvent = After SoundEvent", "Delete SoundEvent", "SoundEvent = NextSoundEvent") = True)
+End Test
+
+Test testMainQueueCapturesNextEventBeforeDelete()
+	Assert(GUEMainQueueUsesAfterCursor%("GUE.bb") = True)
 End Test


### PR DESCRIPTION
## Outcome
GUE now drains each queued main-loop UI event without following a deleted iterator cursor, preventing skipped or unsafe editor actions during bursts of queued events.

## Technical changes
- Replace only the top-level GUE `For E.Event = Each Event` loop with the established `First` → `After` → dispatch/delete → advance cursor sequence.
- Keep the existing `E` dispatch body and event order intact.
- Add a focused source-contract test for the main queue.

Fixes #828

## Acceptance evidence
- Successor capture precedes deletion and advancement follows deletion: portable contract prints `GUE_MAIN_EVENT_CURSOR_GREEN`.
- Legacy main live-cursor form is rejected: RED printed `GUE_MAIN_EVENT_CURSOR_RED expected after-cursor contract absent` before the production edit.
- Dispatch behavior remains scoped: the diff changes only loop setup/tail plus `GUEEventIteratorTest`.

## Baseline and final verification
- Baseline: portable detector printed `BASELINE: 1 failure: GUE main loop deletes Event inside For Each`; `git diff --check`, packet-index and BVM-reference checks, and shell syntax checks exited 0.
- RED: focused portable contract exited 1 with the expected missing after-cursor behavior.
- GREEN: focused portable contract exited 0 with `GUE_MAIN_EVENT_CURSOR_GREEN`.
- Final: `git diff --check`, `bash scripts/gen_packet_index.sh --check`, `bash scripts/gen_bvm_reference.sh --check`, and `bash -n compile.sh test.sh scripts/gen_packet_index.sh scripts/gen_bvm_reference.sh` exited 0. The BVM generator emitted only its known `BVM_SETOWNER` and `BVM_SCENERYOWNER` DEAD-API warnings.
- Local native focused test is UNVERIFIED: `./test.sh GUEEventIteratorTest` exited 1 before compilation because `compiler/BlitzForge/bin/blitzcc` is unavailable. Exact-head CI is required for native proof.

## Compatibility, risk, rollback, and deferred work
Event IDs, dispatch cases, and event order are unchanged. Risk is limited to cursor ownership; rollback is reverting `bcbdf2fd`. Modal drains already repaired, dispatch redesign, and unrelated UI/network work remain deferred.

## Independent review
ACCEPT — fresh independent review of exact head `3076b2658e20b8f905a2719be3ac564197a5f820` confirmed cursor ordering, scope, loop-containment coverage, and exact-head CI success.