### PR TITLE
fix(client): reject malformed give-item offer frames

### DIFF
--- a/src/Modules/ClientNet.bb
+++ b/src/Modules/ClientNet.bb
@@ -1487,8 +1487,8 @@ Function UpdateNetwork()
 							Next
 						EndIf : EndIf
 					; Given an item
-					Case "G"
-						ItemID = RCE_IntFromStr(Mid$(M\MessageData$, 6, 2))
+					Case "G" : If Len(M\MessageData$) <> 9 : WriteLog(MainLog, "P_InventoryUpdate G: bad payload length " + Len(M\MessageData$) + ", dropping")
+					Else : ItemID = RCE_IntFromStr(Mid$(M\MessageData$, 6, 2))
 						Amount = RCE_IntFromStr(Mid$(M\MessageData$, 8, 2))
 						; ItemList is Dim'd 65534. A wire ItemID outside
 						; 0..65534 or pointing at a Null slot would crash
@@ -1535,9 +1535,9 @@ Function UpdateNetwork()
 						If Found = False
 							FreeItemInstance(II)
 							RCE_Send(Connection, PeerToHost, P_InventoryUpdate, "GN" + Mid$(M\MessageData$, 2, 4), True)
-						EndIf
-						EndIf
-				End Select
+							EndIf
+						EndIf : EndIf
+					End Select
 
 			; A standard update for an actor instance
 			Case P_StandardUpdate

--- a/src/Tests/Modules/ClientNetInventorySlotBoundsTest.bb
+++ b/src/Tests/Modules/ClientNetInventorySlotBoundsTest.bb
@@ -71,6 +71,7 @@ Function ButtonSlot$(SlotName$)
 End Function
 
 Const EquipmentVisualPayloadBytes% = 17
+Const GiveItemOfferPayloadBytes% = 9
 
 Function EquipmentVisualPayloadExact%(PayloadLen%)
 	Return PayloadLen = EquipmentVisualPayloadBytes
@@ -78,6 +79,14 @@ End Function
 
 Function EquipmentVisualLengthGuard$()
 	Return "If Len(M" + Chr$(92) + "MessageData$) <> " + EquipmentVisualPayloadBytes
+End Function
+
+Function GiveItemOfferPayloadExact%(PayloadLen%)
+	Return PayloadLen = GiveItemOfferPayloadBytes
+End Function
+
+Function GiveItemOfferLengthGuard$()
+	Return "If Len(M" + Chr$(92) + "MessageData$) <> " + GiveItemOfferPayloadBytes
 End Function
 
 Test testClientInventorySlotGuardRejectsMissingPlayerAndOutOfRangeSlots()
@@ -126,4 +135,17 @@ Test testEquipmentVisualLengthGuardPrecedesParseAndVisualMutation()
 	Local InventoryUpdate$ = Between$(ClientNetSource$(), "Case P_InventoryUpdate", "Case P_StandardUpdate")
 	Local Equipment$ = Between$(InventoryUpdate$, "Case " + Chr$(34) + "O" + Chr$(34), "Case " + Chr$(34) + "G" + Chr$(34))
 	Assert(ContainsInOrder%(Equipment$, EquipmentVisualLengthGuard$(), "RuntimeID = RCE_IntFromStr", "FreeItemInstance(A" + Chr$(92) + "Inventory" + Chr$(92) + "Items[SlotI_Weapon])", "UpdateActorItems(A)") = True)
+End Test
+
+Test testGiveItemOfferPayloadRequiresExactlyNineBytes()
+	Assert(GiveItemOfferPayloadExact%(8) = False)
+	Assert(GiveItemOfferPayloadExact%(9) = True)
+	Assert(GiveItemOfferPayloadExact%(10) = False)
+End Test
+
+Test testGiveItemOfferLengthGuardPrecedesInventoryMutation()
+	Local InventoryUpdate$ = Between$(ClientNetSource$(), "Case P_InventoryUpdate", "Case P_StandardUpdate")
+	Local Given$ = Between$(InventoryUpdate$, "Case " + Chr$(34) + "G" + Chr$(34), "End Select")
+	Local BadPayloadLog$ = "WriteLog(MainLog, " + Chr$(34) + "P_InventoryUpdate G: bad payload length "
+	Assert(ContainsInOrder%(Given$, GiveItemOfferLengthGuard$(), BadPayloadLog$, "ItemID = RCE_IntFromStr", "II.ItemInstance = CreateItemInstance") = True)
 End Test


### PR DESCRIPTION
## Outcome

Malformed give-item offers are now rejected before they can be decoded as zero-valued inventory data or mutate the client inventory/UI.

## Technical changes

- Require the existing fixed 9-byte S-to-C `P_InventoryUpdate "G"` offer frame before parsing.
- Log and drop invalid lengths before `ItemID` decode, item allocation, inventory/UI mutation, or reply.
- Extend the existing ClientNet inventory source-contract test with 8/9/10 boundaries and ordering assertions.

Fixes #830

## Acceptance criteria and evidence

- Valid 9-byte frame preserved: the guard rejects only `Len(...) <> 9`; source-contract boundary assertion pins 9 accepted.
- Invalid 8- and 10-byte frames rejected before parse/allocation: portable GREEN observed guard/log before decode/allocation; focused regression test asserts the same order.
- No format/server change: only ClientNet receiver plus its focused test changed.
- Generated protocol index remains unchanged: `bash scripts/gen_packet_index.sh --check` exited 0.

## RED -> GREEN

- RED: portable source contract exited 1 with `GIVE_ITEM_OFFER_SOURCE_CONTRACT_RED: fixed 9-byte guard is absent before ItemID decode`.
- GREEN: portable source contract reported `GIVE_ITEM_OFFER_SOURCE_CONTRACT_GREEN` with guard/log before decode/allocation.

## Verification

- Baseline and final focused native command: `./test.sh ClientNetInventorySlotBoundsTest` exited 1 before compilation because `compiler/BlitzForge/bin/blitzcc` is absent; a scoped submodule init made no progress and was interrupted after a bounded wait.
- `git diff --check -- src/Modules/ClientNet.bb src/Tests/Modules/ClientNetInventorySlotBoundsTest.bb` exited 0.
- `bash scripts/gen_packet_index.sh --check` exited 0.
- `bash scripts/gen_bvm_reference.sh --check` exited 0 (two known DEAD-API warnings for `BVM_SETOWNER` and `BVM_SCENERYOWNER`).
- `bash -n test.sh scripts/gen_packet_index.sh scripts/gen_bvm_reference.sh` exited 0.

## Compatibility, risk, rollback, deferred

No wire layout changes. Compatibility is fail-closed for frames that never satisfied the documented fixed layout. Roll back by reverting commit `44fc85d7`. Native local compiler proof is deferred to exact-head CI.

## Independent review

ACCEPT — fresh reviewer inspected exact head `44fc85d7` against merge base `ee097740`: the new length guard encloses all decode/allocation/mutation/reply work; the sender and protocol document the same 1+4+2+2 layout; the focused test pins boundaries and ordering. No scope, compatibility, security, performance, or hidden-cost findings. CI was still in progress at verdict time.