### PR TITLE
fix(server): bound area water records at load

### DIFF
--- a/src/Modules/ServerAreas.bb
+++ b/src/Modules/ServerAreas.bb
@@ -318,7 +318,9 @@ End Function
 ; Loads the server data for an area
 Function ServerLoadArea.Area(Name$)
 
-	F = ReadFile("Data\Server Data\Areas\" + Name$ + ".dat")
+	Local AreaWaterRecordBytes = 24
+	Local AreaPath$ = "Data\Server Data\Areas\" + Name$ + ".dat"
+	F = ReadFile(AreaPath$)
 	If F = 0 Then Return Null
 
 		A.Area = New Area
@@ -387,6 +389,7 @@ Function ServerLoadArea.Area(Name$)
 			A\SpawnRange#[i]       = ReadFloat#(F)
 		Next
 		Waters = ReadShort(F)
+		If Waters < 0 Or Waters > (FileSize(AreaPath$) - FilePos(F)) / AreaWaterRecordBytes Then Waters = 0
 		For i = 1 To Waters
 			W.ServerWater = New ServerWater
 			W\X# = ReadFloat#(F)

--- a/src/Tests/Modules/ServerAreasWaterCountTest.bb
+++ b/src/Tests/Modules/ServerAreasWaterCountTest.bb
@@ -26,14 +26,22 @@ Function ServerLoadAreaUsesBoundedWaterCount%(Path$)
 		If Line$ = "Function ServerLoadArea.Area(Name$)" Then InSection = True
 		If InSection = True
 			If Line$ = "End Function" Then Exit
-			If Stage = 0 And Line$ = "Local AreaWaterRecordBytes = 24" Then Stage = 1
-			ElseIf Stage = 1 And Instr(Line$, "Local AreaPath$ = ") = 1 Then Stage = 2
-			ElseIf Stage = 2 And Line$ = "F = ReadFile(AreaPath$)" Then Stage = 3
-			ElseIf Stage = 3 And Line$ = "Waters = ReadShort(F)" Then Stage = 4
-			ElseIf Stage = 4 And Line$ = "If Waters < 0 Or Waters > (FileSize(AreaPath$) - FilePos(F)) / AreaWaterRecordBytes Then Waters = 0" Then Stage = 5
-			ElseIf Stage = 5 And Line$ = "For i = 1 To Waters" Then Stage = 6
-			ElseIf Stage = 6 And Line$ = "W.ServerWater = New ServerWater" Then Stage = 7
-			ElseIf Stage = 7 And Line$ = "ServerWaterAttach(W, A)" Then Stage = 8
+			If Stage = 0
+				If Line$ = "Local AreaWaterRecordBytes = 24" Then Stage = 1
+			ElseIf Stage = 1
+				If Instr(Line$, "Local AreaPath$ = ") = 1 Then Stage = 2
+			ElseIf Stage = 2
+				If Line$ = "F = ReadFile(AreaPath$)" Then Stage = 3
+			ElseIf Stage = 3
+				If Line$ = "Waters = ReadShort(F)" Then Stage = 4
+			ElseIf Stage = 4
+				If Line$ = "If Waters < 0 Or Waters > (FileSize(AreaPath$) - FilePos(F)) / AreaWaterRecordBytes Then Waters = 0" Then Stage = 5
+			ElseIf Stage = 5
+				If Line$ = "For i = 1 To Waters" Then Stage = 6
+			ElseIf Stage = 6
+				If Line$ = "W.ServerWater = New ServerWater" Then Stage = 7
+			ElseIf Stage = 7
+				If Line$ = "ServerWaterAttach(W, A)" Then Stage = 8
 			EndIf
 		EndIf
 	Wend

--- a/src/Tests/Modules/ServerAreasWaterCountTest.bb
+++ b/src/Tests/Modules/ServerAreasWaterCountTest.bb
@@ -1,0 +1,60 @@
+Strict
+EnableGC
+
+; ServerLoadArea cannot be included in a focused test without its complete
+; world/server dependency graph. This contract therefore pins the persistence
+; boundary directly, while the small mirror below exercises the count math.
+
+Const WaterRecordBytes = 24
+
+Function WaterRecordCountFits%(Waters%, RemainingBytes%)
+	If Waters < 0 Then Return False
+	If Waters > RemainingBytes / WaterRecordBytes Then Return False
+	Return True
+End Function
+
+Function ServerLoadAreaUsesBoundedWaterCount%(Path$)
+	Local F.BBStream = ReadFile(Path$)
+	Local InSection%, Stage%
+	Local Line$
+
+	If F = Null Then F = ReadFile("..\\" + Path$)
+	If F = Null Then Return False
+
+	While Not Eof(F)
+		Line$ = Trim$(ReadLine$(F))
+		If Line$ = "Function ServerLoadArea.Area(Name$)" Then InSection = True
+		If InSection = True
+			If Line$ = "End Function" Then Exit
+			If Stage = 0 And Line$ = "Local AreaWaterRecordBytes = 24" Then Stage = 1
+			ElseIf Stage = 1 And Instr(Line$, "Local AreaPath$ = ") = 1 Then Stage = 2
+			ElseIf Stage = 2 And Line$ = "F = ReadFile(AreaPath$)" Then Stage = 3
+			ElseIf Stage = 3 And Line$ = "Waters = ReadShort(F)" Then Stage = 4
+			ElseIf Stage = 4 And Line$ = "If Waters < 0 Or Waters > (FileSize(AreaPath$) - FilePos(F)) / AreaWaterRecordBytes Then Waters = 0" Then Stage = 5
+			ElseIf Stage = 5 And Line$ = "For i = 1 To Waters" Then Stage = 6
+			ElseIf Stage = 6 And Line$ = "W.ServerWater = New ServerWater" Then Stage = 7
+			ElseIf Stage = 7 And Line$ = "ServerWaterAttach(W, A)" Then Stage = 8
+			EndIf
+		EndIf
+	Wend
+
+	CloseFile F
+	Return Stage = 8
+End Function
+
+Test testWaterRecordCountAllowsExactFixedWidthPayload()
+	Assert(WaterRecordCountFits%(0, 0) = True)
+	Assert(WaterRecordCountFits%(1, WaterRecordBytes) = True)
+	Assert(WaterRecordCountFits%(2, WaterRecordBytes * 2) = True)
+End Test
+
+Test testWaterRecordCountRejectsNegativeAndTruncatedPayloads()
+	Assert(WaterRecordCountFits%(-1, WaterRecordBytes) = False)
+	Assert(WaterRecordCountFits%(1, WaterRecordBytes - 1) = False)
+	Assert(WaterRecordCountFits%(2, WaterRecordBytes * 2 - 1) = False)
+	Assert(WaterRecordCountFits%(32767, 0) = False)
+End Test
+
+Test testServerLoadAreaGuardsWaterCountBeforeAllocation()
+	Assert(ServerLoadAreaUsesBoundedWaterCount%("Modules\\ServerAreas.bb") = True)
+End Test


### PR DESCRIPTION
## Outcome
Malformed or truncated area files can no longer make the server fabricate water records during startup. Valid water records load exactly as before.

## Technical changes
- Reuse the area path to calculate the trailing bytes remaining after the saved water count.
- Reject negative counts and counts that need more than the fixed 24-byte records remaining before `New ServerWater`.
- Add a bounded regression contract for count -> guard -> allocation -> attach ordering, plus exact-fit and malformed-count arithmetic.

Fixes #832

## Acceptance criteria and evidence
- Negative and oversized/truncated counts are set to zero before allocation: source contract binds the guard between `ReadShort(F)` and `New ServerWater`.
- Exact-fit records retain the existing decoder and `ServerWaterAttach` path: focused arithmetic checks zero, one, and two exact-width records.
- Area save format, GUE editing, packet protocol, movement behavior, generated docs, and Rust are unchanged: two-file diff only; packet-index check is clean.

## RED -> GREEN
- RED: portable source contract exited 1 with `RED_EXPECTED: SERVER_AREA_WATER_COUNT_GUARD_MISSING`.
- GREEN: the same bounded contract exited 0 with `GREEN: SERVER_AREA_WATER_COUNT_CONTRACT_GREEN`.

## Verification
- `git diff --check` -> exit 0.
- `bash scripts/gen_packet_index.sh --check` -> exit 0.
- `bash scripts/gen_bvm_reference.sh --check` -> exit 0; only the known `BVM_SETOWNER` and `BVM_SCENERYOWNER` DEAD-API warnings.
- `./test.sh ServerAreasWaterCountTest` -> exit 1 before compilation because `compiler/BlitzForge/bin/blitzcc` is unavailable in this Linux worktree; exact-head Windows CI is required for native execution.

## Compatibility, risk, rollback, and deferred work
The on-disk format remains unchanged. A malformed trailing water section now fails closed rather than yielding fabricated records. Revert `eb8a26d7` to roll back. Broader area-file truncation recovery and format versioning are deferred.

## Independent review
Pending fresh review of this exact head after CI is terminal.

## Final independent review
Fresh reviewer verdict: **ACCEPT** for exact head `3e1542276b8534ca8cf893507d8479413eeeebac`. It confirmed the negative/oversized count guard precedes allocation, 24-byte writer/loader compatibility, multiline exclusive test stages, focused scope, and clean static checks. Native local execution remains unverified because `blitzcc` is absent; exact-head CI is still required before merge.