### PR TITLE
fix(RC Rock): preserve encrypted exports on promotion failure

### DIFF
--- a/src/Tests/Modules/RockEditorEncryptPersistenceTest.bb
+++ b/src/Tests/Modules/RockEditorEncryptPersistenceTest.bb
@@ -22,7 +22,7 @@ Function EncryptB3DUsesVerifiedPromotion%()
 
 	While Not Eof(F)
 		Line$ = ReadLine$(F)
-		If Instr(Line$, "Function Encrypt_B3D$(") > 0 Then InEncrypt = True
+		If Instr(Line$, "Function") > 0 And Instr(Line$, "Encrypt_B3D$(") > 0 Then InEncrypt = True
 		If InEncrypt
 			If Stage = 0 And Instr(Line$, "TmpPath$ = fname$ + " + Chr$(34) + ".tmp" + Chr$(34)) > 0
 				Stage = 1
@@ -54,7 +54,7 @@ Function EncryptB3DContainsDirectPromotion%()
 
 	While Not Eof(F)
 		Line$ = ReadLine$(F)
-		If Instr(Line$, "Function Encrypt_B3D$(") > 0 Then InEncrypt = True
+		If Instr(Line$, "Function") > 0 And Instr(Line$, "Encrypt_B3D$(") > 0 Then InEncrypt = True
 		If InEncrypt
 			If Instr(Line$, "DeleteFile(fname$)") > 0 Or Instr(Line$, "CopyFile TmpPath$, fname$") > 0
 				CloseFile F

--- a/src/Tests/Modules/RockEditorEncryptPersistenceTest.bb
+++ b/src/Tests/Modules/RockEditorEncryptPersistenceTest.bb
@@ -1,0 +1,74 @@
+Strict
+EnableGC
+
+; RC Rock Editor is a full legacy tool, so keep this focused contract
+; standalone rather than pulling its UI and media dependency graph into a
+; Strict test. The contract binds the encrypted-export promotion order.
+
+Function OpenRockEditorSource.BBStream()
+	Local F.BBStream = ReadFile("Tools\RC Rock Editor.bb")
+	If F = Null Then F = ReadFile("..\Tools\RC Rock Editor.bb")
+	If F = Null Then F = ReadFile("..\..\Tools\RC Rock Editor.bb")
+	If F = Null Then F = ReadFile("src\Tools\RC Rock Editor.bb")
+	Return F
+End Function
+
+Function EncryptB3DUsesVerifiedPromotion%()
+	Local F.BBStream = OpenRockEditorSource()
+	Local Line$
+	Local Stage = 0
+	Local InEncrypt = False
+	If F = Null Then Return False
+
+	While Not Eof(F)
+		Line$ = ReadLine$(F)
+		If Instr(Line$, "Function Encrypt_B3D$(") > 0 Then InEncrypt = True
+		If InEncrypt
+			If Stage = 0 And Instr(Line$, "TmpPath$ = fname$ + " + Chr$(34) + ".tmp" + Chr$(34)) > 0
+				Stage = 1
+			ElseIf Stage = 1 And Instr(Line$, "If FileSize(TmpPath$) <> offset") > 0
+				Stage = 2
+			ElseIf Stage = 2 And Instr(Line$, "If SafeWriteCommit%(TmpPath$, fname$, 0) = False") > 0
+				Stage = 3
+			ElseIf Stage = 3 And Trim$(Line$) = "FreeBank thisbank"
+				Stage = 4
+			ElseIf Stage = 4 And Trim$(Line$) = "Return -1"
+				Stage = 5
+			ElseIf Stage = 5 And Trim$(Line$) = "Return newn$"
+				CloseFile F
+				Return True
+			EndIf
+			If Instr(Line$, "End Function") > 0 Then Exit
+		EndIf
+	Wend
+
+	CloseFile F
+	Return False
+End Function
+
+Function EncryptB3DContainsDirectPromotion%()
+	Local F.BBStream = OpenRockEditorSource()
+	Local Line$
+	Local InEncrypt = False
+	If F = Null Then Return False
+
+	While Not Eof(F)
+		Line$ = ReadLine$(F)
+		If Instr(Line$, "Function Encrypt_B3D$(") > 0 Then InEncrypt = True
+		If InEncrypt
+			If Instr(Line$, "DeleteFile(fname$)") > 0 Or Instr(Line$, "CopyFile TmpPath$, fname$") > 0
+				CloseFile F
+				Return True
+			EndIf
+			If Instr(Line$, "End Function") > 0 Then Exit
+		EndIf
+	Wend
+
+	CloseFile F
+	Return False
+End Function
+
+Test testEncryptB3DUsesRollbackSafePromotion()
+	Assert(EncryptB3DUsesVerifiedPromotion%() = True)
+	Assert(EncryptB3DContainsDirectPromotion%() = False)
+End Test

--- a/src/Tools/RC Rock Editor.bb
+++ b/src/Tools/RC Rock Editor.bb
@@ -836,9 +836,10 @@ If FileSize(TmpPath$) <> offset
 	FreeBank thisbank
 	Return -1
 EndIf
-DeleteFile(fname$)
-CopyFile TmpPath$, fname$
-DeleteFile(TmpPath$)
+If SafeWriteCommit%(TmpPath$, fname$, 0) = False
+	FreeBank thisbank
+	Return -1
+EndIf
 
 ; WriteBytes thisbank,newf,0,ts
 ; CloseFile newf


### PR DESCRIPTION
## Outcome
RC Rock now preserves the previous encrypted export if promotion of a verified temporary file fails, rather than deleting the existing creator asset before an unchecked copy.

## Technical changes
- Replace the manual delete/copy/delete promotion in `Encrypt_B3D$` with checked `SafeWriteCommit%`.
- Return the existing failure sentinel when promotion fails, preserving the helper’s `.bak`/temporary recovery artifacts.
- Add a focused standalone source-contract test for the promotion order and removal of the unsafe direct sequence.

Fixes #835

## Acceptance evidence
- The portable contract observed `ROCK_EDITOR_ENCRYPT_PERSISTENCE_CONTRACT_GREEN` after the production edit.
- Existing temporary write and exact-size validation precede `SafeWriteCommit%`; the checked false branch frees the bank and returns `-1`.
- The old `DeleteFile(fname$)` / unchecked `CopyFile TmpPath$, fname$` path is absent from `Encrypt_B3D$`.

## RED → GREEN
- RED: portable contract printed `ROCK_EDITOR_ENCRYPT_PERSISTENCE_CONTRACT_RED safe=1 unsafe=0` and exited 1 before the production edit.
- GREEN: the same portable contract printed `ROCK_EDITOR_ENCRYPT_PERSISTENCE_CONTRACT_GREEN` and exited 0 after it.

## Verification
- Baseline: `git diff --check`, `bash scripts/gen_packet_index.sh --check`, and `bash scripts/gen_bvm_reference.sh --check` exited 0; the BVM check emitted only the known `BVM_SETOWNER` and `BVM_SCENERYOWNER` DEAD-API warnings.
- Final: those same static checks plus `bash -n compile.sh test.sh` exited 0.
- Local compiler-backed test is UNVERIFIED: `./test.sh RockEditorEncryptPersistenceTest` exited 1 before execution because `compiler/BlitzForge/bin/blitzcc` is absent. Exact-head CI is required for native compile/test proof.

## Compatibility, risk, rollback, deferred work
Valid encrypted exports retain their temp-write, payload, and return-name behavior; promotion now uses the existing repository recovery semantics. Rollback is reverting `bd504e60`. The separate `Rock_export.bb` direct B3D writer and database registration are intentionally deferred.

## Independent reviewer verdict
ACCEPT — fresh read-only review of exact head e7581cfa confirmed scope, recovery behavior, ordered contract, and no material compatibility, security, performance, or concurrency concern. Compiler-backed proof remains gated on exact-head CI.