### PR TITLE
fix(client): guard cycle target with no actors loaded

### DIFF
--- a/src/Modules/Interface3D.bb
+++ b/src/Modules/Interface3D.bb
@@ -418,7 +418,11 @@ Function UpdateInterface()
 	; Cycle target
 	If ControlHit(Key_CycleTarget)
 		StartAI.ActorInstance = Object.ActorInstance(PlayerTarget)
-		If StartAI = Null Then StartAI = First ActorInstance
+		If StartAI = Null
+			PlayerTarget = 0
+			StartAI = First ActorInstance
+			If StartAI = Null Then Return
+		EndIf
 		AI.ActorInstance = StartAI
 		Repeat
 			AI = After AI

--- a/src/Tests/Modules/Interface3DCycleTargetGuardTest.bb
+++ b/src/Tests/Modules/Interface3DCycleTargetGuardTest.bb
@@ -1,0 +1,48 @@
+Strict
+EnableGC
+
+; UpdateInterface needs the interactive graphics runtime, so protect the
+; empty actor-list boundary with a bounded source contract instead.
+
+Function HasCycleTargetEmptyListGuard%(Path$)
+	Local F.BBStream = ReadFile(Path$)
+	Local Line$
+	Local Stage = 0
+	If F = Null Then F = ReadFile("..\" + Path$)
+	If F = Null Then F = ReadFile("..\..\" + Path$)
+	If F = Null Then Return False
+	While Not Eof(F)
+		Line$ = Trim$(ReadLine$(F))
+		Select Stage
+			Case 0
+				If Line$ = "If ControlHit(Key_CycleTarget)" Then Stage = 1
+			Case 1
+				If Line$ = "StartAI.ActorInstance = Object.ActorInstance(PlayerTarget)" Then Stage = 2
+			Case 2
+				If Line$ = "If StartAI = Null" Then Stage = 3
+			Case 3
+				If Line$ = "PlayerTarget = 0" Then Stage = 4
+			Case 4
+				If Line$ = "StartAI = First ActorInstance" Then Stage = 5
+			Case 5
+				If Line$ = "If StartAI = Null Then Return" Then Stage = 6
+			Case 6
+				If Line$ = "AI.ActorInstance = StartAI" Then Stage = 7
+			Case 7
+				If Line$ = "AI = After AI" Then
+					CloseFile F
+					Return True
+				EndIf
+		End Select
+		If Stage < 7 And (Line$ = "AI = After AI" Or Instr(Line$, "AI\Actor\Aggressiveness") > 0)
+			CloseFile F
+			Return False
+		EndIf
+	Wend
+	CloseFile F
+	Return False
+End Function
+
+Test testCycleTargetClearsStaleTargetBeforeEmptyActorTraversal()
+	Assert(HasCycleTargetEmptyListGuard%("src\Modules\Interface3D.bb") = True)
+End Test


### PR DESCRIPTION
## Outcome

Pressing cycle target during an empty-world transition now safely clears an invalid target instead of dereferencing a missing actor and crashing the client.

## Technical changes

- Guard the `UpdateInterface` cycle-target fallback after `First ActorInstance`.
- Clear stale `PlayerTarget` and return before actor traversal when no actors are loaded.
- Add a focused standalone source-contract regression test.

Fixes #837

## Acceptance criteria and evidence

- Stale target clears before the empty-list return: source contract and `Interface3D.bb` ordering.
- Return precedes `After AI` and `AI\Actor\Aggressiveness`: `CYCLE_TARGET_EMPTY_LIST_CONTRACT_GREEN` (exit 0).
- Existing non-empty traversal remains unchanged after `AI.ActorInstance = StartAI`: bounded diff review.

## TDD and verification

- Baseline: `git diff --check`, packet-index check, and BVM-reference check exited 0; `./test.sh Interface3DWaterHandleTest` exited 1 before compilation because `compiler/BlitzForge/bin/blitzcc` is absent.
- RED: focused portable probe exited 1 with `RED_EXPECTED: CYCLE_TARGET_EMPTY_LIST_GUARD_MISSING stage=2`.
- GREEN/final: portable contract printed `CYCLE_TARGET_EMPTY_LIST_CONTRACT_GREEN`; `git diff --check`, `bash scripts/gen_packet_index.sh --check`, `bash scripts/gen_bvm_reference.sh --check` (two known DEAD-API warnings), and `bash -n compile.sh test.sh scripts/gen_packet_index.sh scripts/gen_bvm_reference.sh` all exited 0.
- Native local runner: `./test.sh Interface3DCycleTargetGuardTest` exits 1 before test execution for the same missing compiler; exact-head CI is required for native proof.

## Compatibility, rollback, and follow-up

No packet, data, API, or valid target-cycling behavior changes. Revert commit `14a014ad` to restore the prior path. No documentation change is needed because this only handles an invalid empty-list state. Independent review: ACCEPT (fresh read-only review of exact head `14a014ad`); exact-head CI: Build and test PASS (6m40s) and Rust server (Linux) PASS (3m47s); direct exact-head check runs are completed/success with no legacy status contexts.