### PR TITLE
ci: validate Unix shell entry-point syntax

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -191,6 +191,10 @@ jobs:
         # actions/checkout@v4
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
 
+      - name: Validate Unix shell syntax
+        shell: bash
+        run: bash -n compile.sh test.sh scripts/*.sh
+
       - name: Set up Rust 1.85.0 (server)
         # dtolnay/rust-toolchain@1.85.0
         uses: dtolnay/rust-toolchain@98effd2fc0b766278e30ab86762dd5e9a8531399

--- a/src/Tests/Modules/UnixShellSyntaxGateTest.bb
+++ b/src/Tests/Modules/UnixShellSyntaxGateTest.bb
@@ -1,0 +1,61 @@
+Strict
+EnableGC
+
+; Source-contract regression for the Linux CI syntax check over the
+; contributor-facing Unix shell entry points. The workflow is not a Blitz
+; module, so this standalone test reads its YAML directly.
+
+Function FileContains%(Path$, Needle$)
+	Local F.BBStream = ReadFile(Path$)
+	Local Line$
+	If F = Null Then F = ReadFile("../" + Path$)
+	If F = Null Then F = ReadFile("../../" + Path$)
+	If F = Null Then F = ReadFile("..\\" + Path$)
+	If F = Null Then F = ReadFile("..\\..\\" + Path$)
+	If F = Null Then Return False
+	While Not Eof(F)
+		Line$ = ReadLine$(F)
+		If Instr(Line$, Needle$) > 0
+			CloseFile F
+			Return True
+		EndIf
+	Wend
+	CloseFile F
+	Return False
+End Function
+
+Function FileContainsOrderedNonComment%(Path$, FirstNeedle$, SecondNeedle$, ThirdNeedle$)
+	Local F.BBStream = ReadFile(Path$)
+	Local Line$
+	Local Stage = 0
+	If F = Null Then F = ReadFile("../" + Path$)
+	If F = Null Then F = ReadFile("../../" + Path$)
+	If F = Null Then F = ReadFile("..\\" + Path$)
+	If F = Null Then F = ReadFile("..\\..\\" + Path$)
+	If F = Null Then Return False
+	While Not Eof(F)
+		Line$ = Trim$(ReadLine$(F))
+		If Left$(Line$, 1) <> "#"
+			If Stage = 0
+				If Instr(Line$, FirstNeedle$) > 0 Then Stage = 1
+			ElseIf Stage = 1
+				If Instr(Line$, SecondNeedle$) > 0 Then Stage = 2
+			ElseIf Stage = 2
+				If Instr(Line$, ThirdNeedle$) > 0
+					CloseFile F
+					Return True
+				EndIf
+			EndIf
+		EndIf
+	Wend
+	CloseFile F
+	Return False
+End Function
+
+Test testLinuxCISyntaxGateCoversUnixEntrypoints()
+	Assert(FileContains%(".github/workflows/ci.yml", "bash -n compile.sh test.sh scripts/*.sh") = True)
+End Test
+
+Test testLinuxCISyntaxGateRunsBeforeRustSetup()
+	Assert(FileContainsOrderedNonComment%(".github/workflows/ci.yml", "- name: Validate Unix shell syntax", "bash -n compile.sh test.sh scripts/*.sh", "- name: Set up Rust 1.85.0 (server)") = True)
+End Test

--- a/src/Tests/Modules/UnixShellSyntaxGateTest.bb
+++ b/src/Tests/Modules/UnixShellSyntaxGateTest.bb
@@ -24,7 +24,7 @@ Function FileContains%(Path$, Needle$)
 	Return False
 End Function
 
-Function FileContainsOrderedNonComment%(Path$, FirstNeedle$, SecondNeedle$, ThirdNeedle$)
+Function FileContainsOrderedNonComment%(Path$, StartNeedle$, FirstNeedle$, SecondNeedle$, ThirdNeedle$)
 	Local F.BBStream = ReadFile(Path$)
 	Local Line$
 	Local Stage = 0
@@ -37,10 +37,12 @@ Function FileContainsOrderedNonComment%(Path$, FirstNeedle$, SecondNeedle$, Thir
 		Line$ = Trim$(ReadLine$(F))
 		If Left$(Line$, 1) <> "#"
 			If Stage = 0
-				If Instr(Line$, FirstNeedle$) > 0 Then Stage = 1
+				If Instr(Line$, StartNeedle$) > 0 Then Stage = 1
 			ElseIf Stage = 1
-				If Instr(Line$, SecondNeedle$) > 0 Then Stage = 2
+				If Instr(Line$, FirstNeedle$) > 0 Then Stage = 2
 			ElseIf Stage = 2
+				If Instr(Line$, SecondNeedle$) > 0 Then Stage = 3
+			ElseIf Stage = 3
 				If Instr(Line$, ThirdNeedle$) > 0
 					CloseFile F
 					Return True
@@ -57,5 +59,5 @@ Test testLinuxCISyntaxGateCoversUnixEntrypoints()
 End Test
 
 Test testLinuxCISyntaxGateRunsBeforeRustSetup()
-	Assert(FileContainsOrderedNonComment%(".github/workflows/ci.yml", "- name: Validate Unix shell syntax", "bash -n compile.sh test.sh scripts/*.sh", "- name: Set up Rust 1.85.0 (server)") = True)
+	Assert(FileContainsOrderedNonComment%(".github/workflows/ci.yml", "rust-server:", "- name: Validate Unix shell syntax", "bash -n compile.sh test.sh scripts/*.sh", "- name: Set up Rust 1.85.0 (server)") = True)
 End Test


### PR DESCRIPTION
## Outcome

macOS and Linux contributors now get an immediate CI failure if a repository-owned shell entry point contains invalid Bash syntax.

## Technical changes

- Add a named Linux CI step that runs bash -n over compile.sh, test.sh, and scripts/*.sh before Rust setup.
- Add a focused standalone source-contract test that pins coverage, rust-server ownership, and gate ordering.

Fixes #841

## Acceptance evidence

- The named syntax step covers all three owned shell surfaces.
- The source contract requires rust-server -> syntax step -> syntax command -> server Rust setup.
- Windows build/test and the existing Linux package, test, Docker, and Clippy steps are unchanged.

## Baseline, RED, GREEN, and final verification

- Baseline: Unix shell syntax CI gate absent; direct bash -n compile.sh test.sh scripts/*.sh exited 0.
- RED: portable contract exited 1 with UNIX_SHELL_SYNTAX_CONTRACT_RED: named Linux syntax gate missing or out of order.
- GREEN: portable contract exited 0 with UNIX_SHELL_SYNTAX_CONTRACT_GREEN; the reviewer-strengthened rust-server contract also exited 0 with UNIX_SHELL_SYNTAX_RUST_SERVER_CONTRACT_GREEN.
- Final: bash -n compile.sh test.sh scripts/*.sh, git diff --check, bash scripts/gen_packet_index.sh --check, and bash scripts/gen_bvm_reference.sh --check exited 0. The BVM check emitted only the two known DEAD-API warnings.
- Native focused test is UNVERIFIED locally: ./test.sh UnixShellSyntaxGateTest exited 1 because compiler/BlitzForge/bin/blitzcc is absent. Exact-head Build and test CI is required.

## Compatibility, rollback, and deferred work

The gate parses scripts only; it does not change their behavior, toolchains, or Windows CI. Rollback is reverting this PR. The separate BriskVM serialization finding was deferred because its maximum-length compatibility boundary needs dedicated investigation.

## Independent review

ACCEPT: a fresh reviewer inspected exact head a5cb8f68491b5f9e7fb3f5a699adfaa2576e2f71 and found the Linux job binding, scope, and verification evidence sufficient. No findings.