### PR TITLE
fix(server): deduplicate deferred actor deaths

### DIFF
--- a/src/Modules/GameServer.bb
+++ b/src/Modules/GameServer.bb
@@ -122,6 +122,12 @@ End Type
 
 Function DeferKillActor(A.ActorInstance, Killer.ActorInstance)
 	If A = Null Then Return
+	; A can reach both underwater-death paths in one tick. Keep the first
+	; request (and therefore its killer) so ProcessPendingKills never repeats
+	; KillActor against an actor that the first queued death already freed.
+	For PK.PendingKill = Each PendingKill
+		If PK\Actor = A Then Return
+	Next
 	PK.PendingKill = New PendingKill
 	PK\Actor = A
 	PK\Killer = Killer

--- a/src/Tests/Modules/GameServerPendingKillDedupTest.bb
+++ b/src/Tests/Modules/GameServerPendingKillDedupTest.bb
@@ -1,0 +1,66 @@
+Strict
+EnableGC
+
+; Source-contract regression for GameServer's deferred death queue. The module
+; is server-graph heavy, so this test pins queue ordering without including it.
+
+Function FileSectionContainsSequence3%(Path$, StartNeedle$, EndNeedle$, FirstNeedle$, SecondNeedle$, ThirdNeedle$)
+	Local F.BBStream = ReadFile(Path$)
+	Local Line$
+	Local InSection = False
+	Local Stage = 0
+	If F = Null Then F = ReadFile("../" + Path$)
+	If F = Null Then F = ReadFile("../../" + Path$)
+	If F = Null Then F = ReadFile("..\" + Path$)
+	If F = Null Then F = ReadFile("..\..\" + Path$)
+	If F = Null Then Return False
+	While Not Eof(F)
+		Line$ = ReadLine$(F)
+		If InSection = False
+			If Instr(Line$, StartNeedle$) > 0 Then InSection = True
+		ElseIf Instr(Line$, EndNeedle$) > 0
+			Exit
+		ElseIf Stage = 0 And Instr(Line$, FirstNeedle$) > 0
+			Stage = 1
+		ElseIf Stage = 1 And Instr(Line$, SecondNeedle$) > 0
+			Stage = 2
+		ElseIf Stage = 2 And Instr(Line$, ThirdNeedle$) > 0
+			CloseFile F
+			Return True
+		EndIf
+	Wend
+	CloseFile F
+	Return False
+End Function
+
+Function FileSectionCount%(Path$, StartNeedle$, EndNeedle$, Needle$)
+	Local F.BBStream = ReadFile(Path$)
+	Local Line$
+	Local Count = 0
+	Local InSection = False
+	If F = Null Then F = ReadFile("../" + Path$)
+	If F = Null Then F = ReadFile("../../" + Path$)
+	If F = Null Then F = ReadFile("..\" + Path$)
+	If F = Null Then F = ReadFile("..\..\" + Path$)
+	If F = Null Then Return -1
+	While Not Eof(F)
+		Line$ = ReadLine$(F)
+		If InSection = False
+			If Instr(Line$, StartNeedle$) > 0 Then InSection = True
+		ElseIf Instr(Line$, EndNeedle$) > 0
+			Exit
+		ElseIf Instr(Line$, Needle$) > 0
+			Count = Count + 1
+		EndIf
+	Wend
+	CloseFile F
+	Return Count
+End Function
+
+Test testDeferredKillQueueRejectsDuplicateActorBeforeAllocation()
+	Assert(FileSectionContainsSequence3%("Modules\GameServer.bb", "Function DeferKillActor", "Function ProcessPendingKills", "For PK.PendingKill = Each PendingKill", "If PK\Actor = A Then Return", "PK.PendingKill = New PendingKill") = True)
+End Test
+
+Test testUnderwaterDeathsContinueUsingBothDeferredKillCallSites()
+	Assert(FileSectionCount%("Modules\GameServer.bb", "Function UpdateActorInstances", "; Fires a projectile from one actor at another", "DeferKillActor(AI, Null)") = 2)
+End Test


### PR DESCRIPTION
## Outcome

A single underwater death can no longer queue the same actor twice, preventing a second deferred `KillActor` from repeating cleanup against already-freed AI state.

## Technical changes

- Make `DeferKillActor` idempotent per actor until `ProcessPendingKills` drains the queue.
- Preserve the first queued killer.
- Add a focused GameServer source-contract regression.

Fixes #847

## Acceptance evidence

- Existing breath-loss and water-damage call sites remain deferred.
- The queue scans for the same actor and returns before `New PendingKill`.
- The portable contract reaches `PENDING_KILL_DEDUP_SOURCE_CONTRACT_GREEN stage=3`.

## RED -> GREEN and verification

- Baseline native focused test: `./test.sh GameServerPendingKillDedupTest` exited 1 before compilation because `compiler/BlitzForge/bin/blitzcc` is absent.
- RED: portable source-contract probe emitted `RED_EXPECTED: PENDING_KILL_DEDUP_GUARD_MISSING stage=2`.
- GREEN: portable source-contract probe emitted `GREEN: PENDING_KILL_DEDUP_SOURCE_CONTRACT_GREEN stage=3`.
- Final local checks: `git diff --check`, `bash scripts/gen_packet_index.sh --check`, and `bash -n compile.sh test.sh scripts/*.sh` exited 0. `bash scripts/gen_bvm_reference.sh --check` exited 0 with only the two known DEAD-API warnings.

## Compatibility, rollback, and deferred work

Valid death behavior remains one kill per actor; water-damage values and rules are unchanged. Revert this PR to restore prior queue behavior. Native local compilation is deferred to exact-head CI because the bundled compiler executable is unavailable.

## Independent review

Pending fresh review of exact head `1e7ac899d9f622472b97b7d6b36fdbf732cc8dc9`.

Fresh independent reviewer verdict: **ACCEPT** on exact head `1e7ac899d9f622472b97b7d6b36fdbf732cc8dc9`. It confirmed guard-before-allocation, retained first killer, both underwater call sites, after-loop drain, in-scope diff, and no documentation/security/performance/concurrency concern. Native local test remains unverified only because `compiler/BlitzForge/bin/blitzcc` is absent; exact-head CI is pending.