### PR TITLE
fix(RC Rock): preserve unencrypted B3D exports on write failure

### DIFF
--- a/src/Modules/Rock_export.bb
+++ b/src/Modules/Rock_export.bb
@@ -29,7 +29,12 @@ End Function
 
 
 Function WriteBB3D( f_name$,mesh,tofolder$ )
-	file=WriteFile( f_name$ )
+	TempPath$ = SafeWriteOpen$(f_name$)
+	file = WriteFile(TempPath$)
+	If file = 0
+		SafeWriteAbort(TempPath$)
+		Return
+	EndIf
 	
 	b3dSetFile( file )
 	
@@ -103,7 +108,9 @@ Function WriteBB3D( f_name$,mesh,tofolder$ )
 	
 	b3dEndChunk();end of BB3D chunk
 	
-	CloseFile file
+	If SafeWriteCommit%(TempPath$, f_name$, file) = False
+		Return
+	EndIf
 End Function
 
 Function WriteMESH( mesh )

--- a/src/Tests/Modules/RockExportAtomicWriteTest.bb
+++ b/src/Tests/Modules/RockExportAtomicWriteTest.bb
@@ -1,0 +1,78 @@
+Strict
+EnableGC
+
+; RC Rock export is a legacy Tool path, so this standalone source contract
+; avoids pulling in its F-UI and 3D-media dependency graph. It binds the
+; BB3D file promotion boundary that protects an existing exported mesh.
+
+Function OpenRockExportSource.BBStream()
+	Local F.BBStream = ReadFile("Modules\\Rock_export.bb")
+	If F = Null Then F = ReadFile("..\\Modules\\Rock_export.bb")
+	If F = Null Then F = ReadFile("..\\..\\Modules\\Rock_export.bb")
+	If F = Null Then F = ReadFile("src\\Modules\\Rock_export.bb")
+	Return F
+End Function
+
+Function WriteBB3DUsesSafeWritePromotion%()
+	Local F.BBStream = OpenRockExportSource()
+	Local Line$
+	Local Stage = 0
+	Local InWrite = False
+	If F = Null Then Return False
+
+	While Not Eof(F)
+		Line$ = ReadLine$(F)
+		If Instr(Line$, "Function WriteBB3D(") > 0 Then InWrite = True
+		If InWrite
+			If Stage = 0 And Instr(Line$, "TempPath$ = SafeWriteOpen$(f_name$)") > 0
+				Stage = 1
+			ElseIf Stage = 1 And Instr(Line$, "file = WriteFile(TempPath$)") > 0
+				Stage = 2
+			ElseIf Stage = 2 And Trim$(Line$) = "If file = 0"
+				Stage = 3
+			ElseIf Stage = 3 And Instr(Line$, "SafeWriteAbort(TempPath$)") > 0
+				Stage = 4
+			ElseIf Stage = 4 And Trim$(Line$) = "Return"
+				Stage = 5
+			ElseIf Stage = 5 And Instr(Line$, "b3dSetFile( file )") > 0
+				Stage = 6
+			ElseIf Stage = 6 And Instr(Line$, "b3dEndChunk();end of BB3D chunk") > 0
+				Stage = 7
+			ElseIf Stage = 7 And Instr(Line$, "If SafeWriteCommit%(TempPath$, f_name$, file) = False") > 0
+				CloseFile F
+				Return True
+			EndIf
+			If Instr(Line$, "End Function") > 0 Then Exit
+		EndIf
+	Wend
+
+	CloseFile F
+	Return False
+End Function
+
+Function WriteBB3DContainsDirectFinalWrite%()
+	Local F.BBStream = OpenRockExportSource()
+	Local Line$
+	Local InWrite = False
+	If F = Null Then Return False
+
+	While Not Eof(F)
+		Line$ = ReadLine$(F)
+		If Instr(Line$, "Function WriteBB3D(") > 0 Then InWrite = True
+		If InWrite
+			If Instr(Line$, "WriteFile( f_name$ )") > 0 Or Instr(Line$, "CloseFile file") > 0
+				CloseFile F
+				Return True
+			EndIf
+			If Instr(Line$, "End Function") > 0 Then Exit
+		EndIf
+	Wend
+
+	CloseFile F
+	Return False
+End Function
+
+Test testWriteBB3DUsesSafeWritePromotion()
+	Assert(WriteBB3DUsesSafeWritePromotion%() = True)
+	Assert(WriteBB3DContainsDirectFinalWrite%() = False)
+End Test


### PR DESCRIPTION
## Outcome

RC Rock Editor now keeps an existing unencrypted `.b3d` export recoverable if the replacement cannot be staged or promoted.

## Technical changes

- Stage `WriteBB3D` output through `SafeWriteOpen$` instead of opening the final mesh path.
- Abort before B3D serialization when the temp file cannot open.
- Commit only after the final BB3D chunk through `SafeWriteCommit%`, which closes the handle, verifies the staged payload, and preserves recovery artifacts.
- Add a standalone focused source-contract regression for the legacy Tool export path.

Fixes #851

## Acceptance criteria and evidence

- Temp-path staging instead of direct `WriteFile(f_name$)`: `ROCK_EXPORT_ATOMIC_WRITE_CONTRACT_GREEN stage=8`.
- Failed temp open aborts before `b3dSetFile`: ordered source contract requires `If file = 0` -> `SafeWriteAbort` -> `Return` before B3D writes.
- Commit follows final BB3D chunk: contract requires `b3dEndChunk` before `SafeWriteCommit%`.
- Legacy direct final write/direct close rejected: `ROCK_EXPORT_ATOMIC_WRITE_CONTRACT_GREEN stage=8`.
- Payload structure, texture copies, encrypted promotion, registration, and other tools are untouched by the two-file diff.

## Baseline, RED, GREEN, and final verification

- Baseline: `git diff --check`, packet-index check, and BVM-reference check exited 0 (the BVM check printed only known `BVM_SETOWNER` / `BVM_SCENERYOWNER` DEAD-API warnings).
- Baseline native runner: `./test.sh RockExportAtomicWriteTest` exited 1 before execution because `compiler/BlitzForge/bin/blitzcc` is absent.
- RED: portable contract exited 1 with `ROCK_EXPORT_ATOMIC_WRITE_CONTRACT_RED stage=0 direct_final_write=1`.
- GREEN: portable contract exited 0 with `ROCK_EXPORT_ATOMIC_WRITE_CONTRACT_GREEN stage=8`.
- Final: `git diff --check`, `bash scripts/gen_packet_index.sh --check`, `bash scripts/gen_bvm_reference.sh --check`, and `bash -n compile.sh test.sh scripts/gen_packet_index.sh scripts/gen_bvm_reference.sh` exited 0; BVM output retained only the two known warnings.
- Compiler-backed local test is UNVERIFIED because the vendored `blitzcc` binary is unavailable; exact-head CI is required for compiled proof.

## Compatibility, risk, rollback, and deferred work

Valid BB3D serialization and texture-copy behavior retain their order; only the output promotion boundary changes. `SafeWriteCommit%` retains `.bak`/`.tmp` recovery artifacts on failures. Roll back by reverting commit `8b1391a2`. Encrypted `.eb3d` promotion, texture-copy atomicity, database registration, other editor writers, packets, Rust, and CI policy remain out of scope.

## Independent review

Pending fresh review of this exact head.

## Independent review

ACCEPT — a fresh reviewer inspected exact head `8b1391a20ec4490826b74db025b8fd06d4ad384d` against `721c634c` and confirmed the ordered SafeWrite boundary, two-file scope, compatibility, security, performance, concurrency isolation, test quality, and documentation fit. Local compiler-backed execution remains unavailable only because `compiler/BlitzForge/bin/blitzcc` is absent; exact-head CI is the remaining gate.