### PR TITLE
fix(client): reject malformed trade update frames

### DIFF
--- a/src/Modules/ClientNet.bb
+++ b/src/Modules/ClientNet.bb
@@ -570,11 +570,11 @@ Function UpdateNetwork()
 
 			; Trading updated
 			Case P_UpdateTrading
-				If TradingVisible = True
+				If TradingVisible = True And (Len(M\MessageData$) = 3 Or Len(M\MessageData$) = 86)
 					Slot = RCE_IntFromStr(Mid$(M\MessageData$, 1, 1))
 					Amount = RCE_IntFromStr(Mid$(M\MessageData$, 2, 2))
 					; Remove item
-					If Amount = 0
+					If Amount = 0 And Len(M\MessageData$) = 3
 						For i = 0 To 31
 							If ServerTradeIDs(i) = Slot
 								ServerTradeIDs(i) = 0
@@ -587,22 +587,22 @@ Function UpdateNetwork()
 								Exit
 							EndIf
 						Next
-					; Add item
-					Else
-						For i = 0 To 31
+					ElseIf Amount > 0 And Len(M\MessageData$) = 86
+							For i = 0 To 31
 							If TradeItems(i) = Null
-								ServerTradeIDs(i) = Slot
-								TradeAmounts(i) = Amount
-								TradeItems(i) = ItemInstanceFromString(Mid$(M\MessageData$, 4))
-								GYG.GY_Gadget = Object.GY_Gadget(BSlotsHis(i))
-								GYB.GY_Button = Object.GY_Button(GYG\TypeHandle)
-								EntityTexture GYB\Gadget\EN, GetTexture(TradeItems(i)\Item\ThumbnailTexID)
-								If TradeAmounts(i) > 1
-									GY_SetButtonLabel(BSlotsHis(i), TradeAmounts(i), 100, 255, 0, True)
-								Else
-									GY_SetButtonLabel(BSlotsHis(i), "")
-								EndIf
-								Exit
+								II.ItemInstance = ItemInstanceFromString(Mid$(M\MessageData$, 4))
+								If II <> Null
+									TradeItems(i) = II : ServerTradeIDs(i) = Slot
+									TradeAmounts(i) = Amount
+									GYG.GY_Gadget = Object.GY_Gadget(BSlotsHis(i))
+									GYB.GY_Button = Object.GY_Button(GYG\TypeHandle)
+									EntityTexture GYB\Gadget\EN, GetTexture(TradeItems(i)\Item\ThumbnailTexID)
+									If TradeAmounts(i) > 1
+										GY_SetButtonLabel(BSlotsHis(i), TradeAmounts(i), 100, 255, 0, True)
+									Else
+										GY_SetButtonLabel(BSlotsHis(i), "")
+									EndIf
+									Exit : EndIf
 							EndIf
 						Next
 					EndIf

--- a/src/Tests/Modules/ClientNetTradingPayloadTest.bb
+++ b/src/Tests/Modules/ClientNetTradingPayloadTest.bb
@@ -1,0 +1,80 @@
+Strict
+EnableGC
+
+; Source-contract regression for ClientNet's server-to-client trade updates.
+; The full network/UI graph is not standalone-testable, so bind the receive
+; frame lengths and ordering before item/UI mutation.
+
+Function ClientNetTradingSource$()
+	Local Paths$[2]
+	Paths[0] = "Modules\\ClientNet.bb"
+	Paths[1] = "..\\Modules\\ClientNet.bb"
+	Local i
+	For i = 0 To 1
+		Local F.BBStream = ReadFile(Paths[i])
+		If F <> Null
+			Local Source$ = ""
+			While Not Eof(F)
+				Source$ = Source$ + ReadLine$(F) + Chr$(10)
+			Wend
+			CloseFile F
+			Return Source$
+		EndIf
+	Next
+	Return ""
+End Function
+
+Function Between$(Source$, StartNeedle$, EndNeedle$)
+	Local Start = Instr(Source$, StartNeedle$)
+	If Start = 0 Then Return ""
+	Local EndAt = Instr(Mid$(Source$, Start + Len(StartNeedle$)), EndNeedle$)
+	If EndAt = 0 Then Return Mid$(Source$, Start)
+	Return Mid$(Source$, Start, Len(StartNeedle$) + EndAt - 1)
+End Function
+
+Function AppearsAfter%(Source$, FirstNeedle$, SecondNeedle$)
+	Local At = Instr(Source$, FirstNeedle$)
+	If At = 0 Then Return False
+	At = At + Len(FirstNeedle$)
+	Return Instr(Mid$(Source$, At), SecondNeedle$) > 0
+End Function
+
+Function TradeFrameIsUsable%(PayloadLen, Amount)
+	If PayloadLen = 3 And Amount = 0 Then Return True
+	If PayloadLen = 86 And Amount > 0 Then Return True
+	Return False
+End Function
+
+Function PacketLength$()
+	Return "Len(M" + Chr$(92) + "MessageData$)"
+End Function
+
+Test testTradeUpdateFrameBoundaries()
+	Assert(TradeFrameIsUsable%(0, 0) = False)
+	Assert(TradeFrameIsUsable%(2, 0) = False)
+	Assert(TradeFrameIsUsable%(3, 0) = True)
+	Assert(TradeFrameIsUsable%(4, 0) = False)
+	Assert(TradeFrameIsUsable%(85, 1) = False)
+	Assert(TradeFrameIsUsable%(86, 1) = True)
+	Assert(TradeFrameIsUsable%(87, 1) = False)
+	Assert(TradeFrameIsUsable%(86, 0) = False)
+End Test
+
+Test testTradeUpdateValidatesLengthBeforeDecodingOrUiMutation()
+	Local Section$ = Between$(ClientNetTradingSource$(), "Case P_UpdateTrading", "Case P_CloseTrading")
+	Local OuterGuard$ = "If TradingVisible = True And (" + PacketLength$() + " = 3 Or " + PacketLength$() + " = 86)"
+	Local RemovalGuard$ = "If Amount = 0 And " + PacketLength$() + " = 3"
+	Local AddGuard$ = "ElseIf Amount > 0 And " + PacketLength$() + " = 86"
+	Local Decode$ = "II.ItemInstance = ItemInstanceFromString(Mid$(M" + Chr$(92) + "MessageData$, 4))"
+	Local ParsedItemGuard$ = "If II <> Null"
+	Local SlotMutation$ = "TradeItems(i) = II"
+	Local UiMutation$ = "EntityTexture GYB" + Chr$(92) + "Gadget" + Chr$(92) + "EN, GetTexture(TradeItems(i)" + Chr$(92) + "Item" + Chr$(92) + "ThumbnailTexID)"
+	Assert(AppearsAfter%(Section$, OuterGuard$, "Slot = RCE_IntFromStr") = True)
+	Assert(AppearsAfter%(Section$, "Slot = RCE_IntFromStr", "Amount = RCE_IntFromStr") = True)
+	Assert(AppearsAfter%(Section$, "Amount = RCE_IntFromStr", RemovalGuard$) = True)
+	Assert(AppearsAfter%(Section$, RemovalGuard$, AddGuard$) = True)
+	Assert(AppearsAfter%(Section$, AddGuard$, Decode$) = True)
+	Assert(AppearsAfter%(Section$, Decode$, ParsedItemGuard$) = True)
+	Assert(AppearsAfter%(Section$, ParsedItemGuard$, SlotMutation$) = True)
+	Assert(AppearsAfter%(Section$, SlotMutation$, UiMutation$) = True)
+End Test


### PR DESCRIPTION
## Outcome

Trade windows ignore malformed server updates instead of rendering a missing item and crashing the client.

## Technical changes

- Accept only 3-byte removal or 86-byte positive-item `P_UpdateTrading` frames.
- Require a decoded item before trade-slot/UI mutation.
- Add a focused source contract; ClientNet handler line count is unchanged.

Fixes #853

## Evidence

- RED: `TRADE_FRAME_CONTRACT_RED: source lacks 3-byte removal and 86-byte positive-frame gates`.
- GREEN: `TRADE_FRAME_CONTRACT_GREEN: valid lengths and decoded items are gated before trade-slot/UI mutation`.
- Static gates exited 0: `git diff --check`, packet/BVM generator checks, and shell syntax checks (two known BVM DEAD-API warnings only).
- Local `./test.sh ClientNetTradingPayloadTest` exits 1 before execution because `compiler/BlitzForge/bin/blitzcc` is unavailable; exact-head CI is the compiled proof.

## Compatibility and rollback

ServerNet already emits only the accepted 3/86-byte forms. Revert this PR to restore the old permissive client behavior. ServerNet, protocol layout, Rust parity, and trade redesign are deferred.

## Independent review

`ACCEPT` — a fresh reviewer inspected exact head `c81cec2893bf153e689bd4558b9173b2a0c51089`, the issue contract, the null/length guards, test ordering, scope, and line-count invariant; no code changes requested. CI remains the final gate.