### PR TITLE
fix(build): make Unix publish help non-destructive

### DIFF
--- a/publish.sh
+++ b/publish.sh
@@ -8,6 +8,15 @@ set -euo pipefail
 ROOTDIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 RELEASE_DIR="${ROOTDIR}/release"
 
+for arg in "$@"; do
+  case "$arg" in
+    -h|--help)
+      "${ROOTDIR}/compile.sh" "$arg"
+      exit 0
+      ;;
+  esac
+done
+
 "${ROOTDIR}/compile.sh" "$@"
 
 cd "${ROOTDIR}"

--- a/src/Tests/Modules/PublishShellHelpTest.bb
+++ b/src/Tests/Modules/PublishShellHelpTest.bb
@@ -35,10 +35,12 @@ Function HelpGuardPrecedesCleanup%(Path$)
 		ElseIf Stage = 1
 			If Instr(Line$, "-h|--help)") > 0 Then Stage = 2
 		ElseIf Stage = 2
-			If Instr(Line$, "exit 0") > 0 Then Stage = 3
+			If Instr(Line$, Chr$(34) + "${ROOTDIR}/compile.sh" + Chr$(34) + " " + Chr$(34) + "$arg" + Chr$(34)) > 0 Then Stage = 3
 		ElseIf Stage = 3
-			If Instr(Line$, Chr$(34) + "${ROOTDIR}/compile.sh" + Chr$(34) + " " + Chr$(34) + "$@" + Chr$(34)) > 0 Then Stage = 4
+			If Instr(Line$, "exit 0") > 0 Then Stage = 4
 		ElseIf Stage = 4
+			If Instr(Line$, Chr$(34) + "${ROOTDIR}/compile.sh" + Chr$(34) + " " + Chr$(34) + "$@" + Chr$(34)) > 0 Then Stage = 5
+		ElseIf Stage = 5
 			If Instr(Line$, "rm -rf " + Chr$(34) + "${RELEASE_DIR}" + Chr$(34)) > 0
 				CloseFile F
 				Return True

--- a/src/Tests/Modules/PublishShellHelpTest.bb
+++ b/src/Tests/Modules/PublishShellHelpTest.bb
@@ -1,0 +1,58 @@
+Strict
+EnableGC
+
+; Source-contract regression for the Unix release packager. A help request is
+; an inspection action and must return before release/ is replaced.
+
+Function FileContains%(Path$, Needle$)
+	Local F.BBStream = ReadFile(Path$)
+	Local Line$
+	If F = Null Then F = ReadFile("..\\" + Path$)
+	If F = Null Then F = ReadFile("..\\..\\" + Path$)
+	If F = Null Then Return False
+	While Not Eof(F)
+		Line$ = ReadLine$(F)
+		If Instr(Line$, Needle$) > 0
+			CloseFile F
+			Return True
+		EndIf
+	Wend
+	CloseFile F
+	Return False
+End Function
+
+Function HelpGuardPrecedesCleanup%(Path$)
+	Local F.BBStream = ReadFile(Path$)
+	Local Line$
+	Local Stage = 0
+	If F = Null Then F = ReadFile("..\\" + Path$)
+	If F = Null Then F = ReadFile("..\\..\\" + Path$)
+	If F = Null Then Return False
+	While Not Eof(F)
+		Line$ = ReadLine$(F)
+		If Stage = 0
+			If Instr(Line$, "for arg in " + Chr$(34) + "$@" + Chr$(34) + "; do") > 0 Then Stage = 1
+		ElseIf Stage = 1
+			If Instr(Line$, "-h|--help)") > 0 Then Stage = 2
+		ElseIf Stage = 2
+			If Instr(Line$, "exit 0") > 0 Then Stage = 3
+		ElseIf Stage = 3
+			If Instr(Line$, Chr$(34) + "${ROOTDIR}/compile.sh" + Chr$(34) + " " + Chr$(34) + "$@" + Chr$(34)) > 0 Then Stage = 4
+		ElseIf Stage = 4
+			If Instr(Line$, "rm -rf " + Chr$(34) + "${RELEASE_DIR}" + Chr$(34)) > 0
+				CloseFile F
+				Return True
+			EndIf
+		EndIf
+	Wend
+	CloseFile F
+	Return False
+End Function
+
+Test testPublishHelpExitsBeforeReleaseCleanup()
+	Assert(HelpGuardPrecedesCleanup%("publish.sh") = True)
+End Test
+
+Test testPublishRetainsNormalArgumentForwarding()
+	Assert(FileContains%("publish.sh", Chr$(34) + "${ROOTDIR}/compile.sh" + Chr$(34) + " " + Chr$(34) + "$@" + Chr$(34)) = True)
+End Test


### PR DESCRIPTION
## Outcome

Unix contributors can now ask `publish.sh` for help without replacing an existing `release/` package.

## Technical changes

- Scan publish arguments for `-h`/`--help` before release cleanup.
- Delegate that help request to `compile.sh` and exit successfully before packaging.
- Add a focused source-contract regression for ordered help delegation, exit, normal forwarding, and cleanup.

Fixes #857

## Acceptance evidence

- A help flag anywhere in the arguments delegates to `compile.sh`, exits 0, and cannot reach `rm -rf "${RELEASE_DIR}"`.
- Normal packaging retains the existing `compile.sh "$@"` forwarding.
- Sandboxed `publish.sh --help` and `publish.sh -t --help` printed `RCCE2 Compiler Script` while retaining a release sentinel.

## RED -> GREEN and final verification

- RED: portable ordered contract exited 1 with `PUBLISH_HELP_CONTRACT_RED` before implementation.
- GREEN: it exited 0 with `PUBLISH_HELP_CONTRACT_GREEN` after the guard.
- Review-strengthening mutant: removing the delegated `compile.sh "$arg"` call produced `PUBLISH_HELP_DELEGATION_MUTANT_RED` (exit 1); the exact source produced `PUBLISH_HELP_DELEGATION_CONTRACT_GREEN` (exit 0).
- Local static gates: packet-index, BVM-reference (two known DEAD-API warnings only), shell syntax, and diff checks passed.
- Local native `./test.sh PublishShellHelpTest` is unavailable because `compiler/BlitzForge/bin/blitzcc` is absent before execution.
- Exact-head CI `a66e0ffc`: Build and test passed (6m56s); Rust server (Linux) passed (4m41s); direct check runs are terminal success and legacy statuses are empty.

## Compatibility, risk, rollback, and deferred work

Normal package invocations retain forwarding and release contents. Only help requests become non-destructive. Rollback is reverting `9b03c835` and `a66e0ffc`. No release/deployment, Windows packager, compiler, or content changes are included.

## Independent review

Fresh exact-head review verdict: **ACCEPT**. The reviewer verified help invocation variants, ordered delegation before exit and cleanup, scope, safety, and the strengthened regression contract. No remaining findings.