### PR TITLE
fix(loom): clear back-stack entries with a safe cursor

### DIFF
--- a/src/Modules/Loom/Threads.bb
+++ b/src/Modules/Loom/Threads.bb
@@ -146,10 +146,13 @@ Type Threads
     // -------------------------------------------------------------------------
     Method clearStack()
         If self\backStack = Null Then Return
-        Local entry.LoomFocusEntry
-        For entry = Each LoomFocusEntry
+        Local entry.LoomFocusEntry = First LoomFocusEntry
+        Local nextEntry.LoomFocusEntry = Null
+        While entry <> Null
+            nextEntry = After entry
             Delete entry
-        Next
+            entry = nextEntry
+        Wend
         ListClear(self\backStack)
     End Method
 

--- a/src/Tests/Modules/LoomThreadsClearStackIteratorTest.bb
+++ b/src/Tests/Modules/LoomThreadsClearStackIteratorTest.bb
@@ -1,0 +1,59 @@
+Strict
+EnableGC
+
+; Source-contract regression for Loom thread-history cleanup. Deleting a
+; live Each cursor can skip or corrupt entries, so clearStack must capture
+; the successor before deleting the current LoomFocusEntry.
+
+Function ClearStackUsesAfterCursor%(Path$)
+    Local F.BBStream = ReadFile(Path$)
+    Local Line$, Trimmed$
+    Local InMethod%, Stage%, SawListClear%
+    If F = Null Then F = ReadFile("..\" + Path$)
+    If F = Null Then F = ReadFile("..\..\" + Path$)
+    If F = Null Then Return False
+
+    While Not Eof(F)
+        Line$ = ReadLine$(F)
+        Trimmed$ = Trim$(Line$)
+        If Trimmed$ = "Method clearStack()" Then InMethod = True
+        If InMethod = False Then Continue
+
+        If Trimmed$ = "For entry = Each LoomFocusEntry"
+            CloseFile F
+            Return False
+        EndIf
+        If Trimmed$ = "Delete entry" And Stage < 4
+            CloseFile F
+            Return False
+        EndIf
+
+        Select Stage
+            Case 0
+                If Trimmed$ = "Local entry.LoomFocusEntry = First LoomFocusEntry" Then Stage = 1
+            Case 1
+                If Trimmed$ = "Local nextEntry.LoomFocusEntry = Null" Then Stage = 2
+            Case 2
+                If Trimmed$ = "While entry <> Null" Then Stage = 3
+            Case 3
+                If Trimmed$ = "nextEntry = After entry" Then Stage = 4
+            Case 4
+                If Trimmed$ = "Delete entry" Then Stage = 5
+            Case 5
+                If Trimmed$ = "entry = nextEntry" Then Stage = 6
+        End Select
+
+        If Trimmed$ = "ListClear(self\backStack)" Then SawListClear = True
+        If Trimmed$ = "End Method"
+            CloseFile F
+            Return Stage = 6 And SawListClear
+        EndIf
+    Wend
+
+    CloseFile F
+    Return False
+End Function
+
+Test testLoomThreadsClearStackCapturesSuccessorBeforeDelete()
+    Assert(ClearStackUsesAfterCursor%("Modules\Loom\Threads.bb") = True)
+End Test


### PR DESCRIPTION
## Outcome

Loom now safely clears a multi-hop thread-navigation back stack when the user closes the Composer, preventing cursor corruption or stale history from leaking into the next browse session.

## Technical changes

- Replaced the live `For Each` deletion in `Threads::clearStack` with `First` → `After` → `Delete` → advance traversal.
- Added a focused source-contract regression that rejects the unsafe iterator and requires successor capture before deletion.

Fixes #859

## Acceptance criteria and evidence

| Criterion | Evidence |
| --- | --- |
| No live `For Each` deletion in `clearStack` | RED portable contract detected the old `For entry = Each LoomFocusEntry`; current source has the ordered after-cursor traversal. |
| Capture successor before delete and preserve final list clear | GREEN portable contract printed `GREEN: LoomThreadsClearStackIteratorTest portable contract passes: successor captured before delete`; source-contract test pins the same sequence. |
| Scope stays isolated | Two-file diff only: `Threads.bb` and `LoomThreadsClearStackIteratorTest.bb`; #839/PR #840 owns only Server event paths. |

## Baseline, RED, GREEN, and verification

- Baseline: `BASELINE: 1 unsafe iterator contract failure: Threads.clearStack uses For Each/Delete`.
- RED: `./test.sh LoomThreadsClearStackIteratorTest` could not start because `compiler/BlitzForge/bin/blitzcc` is absent; the portable source-contract mirror then printed `RED: LoomThreadsClearStackIteratorTest portable contract fails: unsafe Each/Delete remains`.
- GREEN: portable source-contract mirror printed `GREEN: LoomThreadsClearStackIteratorTest portable contract passes: successor captured before delete`.
- Static: `git diff --check origin/develop...HEAD` exited 0; `bash scripts/gen_packet_index.sh --check` exited 0.
- Native local proof is unverified because the initialized compiler submodule does not contain `bin/blitzcc`; exact-head CI remains required for compiler-backed proof.

## Compatibility, risk, rollback, and deferred work

This preserves `Threads::back` and the existing `ListClear(self\backStack)` behavior; it changes no persistence, protocol, GUE, or Composer semantics. Risk is limited to iterator mechanics. Roll back with a single revert of `7f9d956b`. No broader Loom navigation changes are included.

## Independent review

**ACCEPT** — a fresh reviewer inspected exact head `7f9d956baab08a46b2b4a02a39f0b9f54b78b0dd` against `origin/develop` and confirmed acceptance criteria, scope, correctness, test quality, repository fit, docs, security, performance, concurrency isolation, and hidden-cost review. Native local compiler proof remains unverified only because `compiler/BlitzForge/bin/blitzcc` is absent.