### PR TITLE
fix(mainmenu): drain update files with a safe cursor

### DIFF
--- a/src/Modules/MainMenu.bb
+++ b/src/Modules/MainMenu.bb
@@ -264,33 +264,33 @@ Function UpdateFiles()
 	; Go through each file to make sure that I have it
 	ThisFile = 0
 	GY_UpdateLabel(TStatus, LanguageString$(LS_CheckingFiles))
-	Local U.UpdateFile = First UpdateFile
-	Local UNext.UpdateFile = Null
-	While U <> Null
-		UNext = After U
+	Local CurrentUpdate.UpdateFile = First UpdateFile
+	Local NextUpdate.UpdateFile = Null
+	While CurrentUpdate <> Null
+		NextUpdate = After CurrentUpdate
 		; Skip entries the announcement path already rejected as unsafe.
-		If U\Name$ = "" Then NeedFile = False : Goto skipUpdateApply
+		If CurrentUpdate\Name$ = "" Then NeedFile = False : Goto skipUpdateApply
 
 		NeedFile = False
 		; I don't have it at all
-		If FileType(U\Name$) = 0
+		If FileType(CurrentUpdate\Name$) = 0
 			NeedFile = True
 		Else
 			; I have it but it's the wrong version
-			If U\Checksum <> CountChecksum(U\Name$) Then NeedFile = True
+			If CurrentUpdate\Checksum <> CountChecksum(CurrentUpdate\Name$) Then NeedFile = True
 		EndIf
 
 		; If it's music, and the skip music option is enabled, then skip it
 		If UpdateMusic = False
-			If Instr(Upper$(U\Name$), "DATA\MUSIC") Then NeedFile = False
+			If Instr(Upper$(CurrentUpdate\Name$), "DATA\MUSIC") Then NeedFile = False
 		EndIf
 
 		; If file is required
 		If NeedFile = True
-			GY_UpdateLabel(LFile, LanguageString$(LS_UpdateFile) + " " + U\Name$)
+			GY_UpdateLabel(LFile, LanguageString$(LS_UpdateFile) + " " + CurrentUpdate\Name$)
 
 			; Download it
-			SafeFileName$ = Replace$(U\Name$, "\", "!!")
+			SafeFileName$ = Replace$(CurrentUpdate\Name$, "\", "!!")
 			SafeFileName$ = Replace$(SafeFileName$, " ", "!!!")
 			Result = DownloadFile(UpdateHost$ + Upper$(SafeFileName$) + ".DAT", "Temp.dat", GDLBar)
 			If Result = 0 Then RuntimeError(LanguageString$(LS_CouldNotDownload) + " " + UpdateHost$)
@@ -305,16 +305,16 @@ Function UpdateFiles()
 			; pinned key + SHA-256. Until that lands, at least refuse to apply
 			; a bz2 that decompressed to something other than what the server
 			; said it would. See docs/UPDATE-CHANNEL-HARDENING.md.
-			If CountChecksum("Temp2.dat") <> U\Checksum
+			If CountChecksum("Temp2.dat") <> CurrentUpdate\Checksum
 				DeleteFile("Temp2.dat")
-				WriteLog(MainLog, "Update for " + U\Name$ + " failed post-download checksum; refusing to apply.")
+				WriteLog(MainLog, "Update for " + CurrentUpdate\Name$ + " failed post-download checksum; refusing to apply.")
 				Goto skipUpdateApply
 			EndIf
 
 			; Ensure that the folder tree for the file actually exists
-			For i = 2 To Len(U\Name$)
-				If Mid$(U\Name$, i, 1) = "\"
-					Folder$ = Left$(U\Name$, i - 1)
+			For i = 2 To Len(CurrentUpdate\Name$)
+				If Mid$(CurrentUpdate\Name$, i, 1) = "\"
+					Folder$ = Left$(CurrentUpdate\Name$, i - 1)
 					; Belt-and-braces: never create a directory whose path
 					; contains a `..` segment, regardless of how the file
 					; name reached this point.
@@ -323,20 +323,20 @@ Function UpdateFiles()
 			Next
 ;---------------------------------------------
 			; Special case for client executable as it is currently running!
-			If Upper$(U\Name$) = Upper$(GameName$) + ".EXE"
+			If Upper$(CurrentUpdate\Name$) = Upper$(GameName$) + ".EXE"
 				DeInitExt
 				;multithreading ???
 				;FreeThread(Thread1)
 				EndGraphics()
 				ExecFile("Data\Patch.exe " + GameName$)
 				End
-			; Copy file to overwrite old version. (U\Name without the
+			; Copy file to overwrite old version. (CurrentUpdate\Name without the
 			; sigil resolved to a different/zero handle field; both calls
 			; here used to mis-target their path on the first apply cycle
 			; until subsequent Mid$ access populated the field.)
 			Else
-				If FileType(U\Name$) = 1 Then DeleteFile(U\Name$)
-				CopyFile("Temp2.dat", U\Name$)
+				If FileType(CurrentUpdate\Name$) = 1 Then DeleteFile(CurrentUpdate\Name$)
+				CopyFile("Temp2.dat", CurrentUpdate\Name$)
 				Delay(40)
 				DeleteFile("Temp2.dat")
 			EndIf
@@ -345,14 +345,14 @@ Function UpdateFiles()
 		EndIf
 		.skipUpdateApply
 
-		Delete(U)
+		Delete(CurrentUpdate)
 		ThisFile = ThisFile + 1
 		GY_UpdateProgressBar(GOverall, Int((Float#(ThisFile) / Float#(CreatedFiles)) * 100.0))
 		GY_Update()
 		RenderWorld()
 		Flip()
 		If KeyHit(1) Then End
-		U = UNext
+		CurrentUpdate = NextUpdate
 	Wend
 
 	FreeEntity(Background)

--- a/src/Modules/MainMenu.bb
+++ b/src/Modules/MainMenu.bb
@@ -264,7 +264,10 @@ Function UpdateFiles()
 	; Go through each file to make sure that I have it
 	ThisFile = 0
 	GY_UpdateLabel(TStatus, LanguageString$(LS_CheckingFiles))
-	For U.UpdateFile = Each UpdateFile
+	Local U.UpdateFile = First UpdateFile
+	Local UNext.UpdateFile = Null
+	While U <> Null
+		UNext = After U
 		; Skip entries the announcement path already rejected as unsafe.
 		If U\Name$ = "" Then NeedFile = False : Goto skipUpdateApply
 
@@ -349,7 +352,8 @@ Function UpdateFiles()
 		RenderWorld()
 		Flip()
 		If KeyHit(1) Then End
-	Next
+		U = UNext
+	Wend
 
 	FreeEntity(Background)
 	GY_FreeGadget(TStatus) : GY_FreeGadget(LFileProg) : GY_FreeGadget(LFile)

--- a/src/Tests/Modules/MainMenuUpdateFileIteratorTest.bb
+++ b/src/Tests/Modules/MainMenuUpdateFileIteratorTest.bb
@@ -18,17 +18,17 @@ Function UpdateFileApplyUsesAfterCursor%()
 			CloseFile F
 			Return False
 		EndIf
-		If Stage = 0 And Instr(Line$, "U.UpdateFile = First UpdateFile") > 0 Then Stage = 1
-		If Stage = 1 And Instr(Line$, "UNext.UpdateFile = Null") > 0 Then Stage = 2
-		If Stage = 2 And Instr(Line$, "While U <> Null") > 0 Then Stage = 3
-		If Stage = 3 And Instr(Line$, "UNext = After U") > 0 Then Stage = 4
-		If Stage < 4 And Instr(Line$, "Delete(U)") > 0
+		If Stage = 0 And Instr(Line$, "CurrentUpdate.UpdateFile = First UpdateFile") > 0 Then Stage = 1
+		If Stage = 1 And Instr(Line$, "NextUpdate.UpdateFile = Null") > 0 Then Stage = 2
+		If Stage = 2 And Instr(Line$, "While CurrentUpdate <> Null") > 0 Then Stage = 3
+		If Stage = 3 And Instr(Line$, "NextUpdate = After CurrentUpdate") > 0 Then Stage = 4
+		If Stage < 4 And Instr(Line$, "Delete(CurrentUpdate)") > 0
 			CloseFile F
 			Return False
 		EndIf
 		If Stage = 4 And Instr(Line$, "DownloadFile(") > 0 Then Stage = 5
-		If Stage = 5 And Instr(Line$, "Delete(U)") > 0 Then Stage = 6
-		If Stage = 6 And Instr(Line$, "U = UNext") > 0
+		If Stage = 5 And Instr(Line$, "Delete(CurrentUpdate)") > 0 Then Stage = 6
+		If Stage = 6 And Instr(Line$, "CurrentUpdate = NextUpdate") > 0
 			CloseFile F
 			Return True
 		EndIf

--- a/src/Tests/Modules/MainMenuUpdateFileIteratorTest.bb
+++ b/src/Tests/Modules/MainMenuUpdateFileIteratorTest.bb
@@ -1,0 +1,43 @@
+Strict
+EnableGC
+
+; The updater removes each announced UpdateFile after applying or skipping it.
+; A live For Each cursor advances through the deleted object, so a multi-file
+; update can lose its successor. Keep the cursor order explicit in source.
+Function UpdateFileApplyUsesAfterCursor%()
+	Local F.BBStream = ReadFile("Modules\\MainMenu.bb")
+	Local Line$
+	Local Stage%
+	If F = Null Then F = ReadFile("..\\Modules\\MainMenu.bb")
+	If F = Null Then F = ReadFile("..\\..\\Modules\\MainMenu.bb")
+	If F = Null Then Return False
+
+	While Not Eof(F)
+		Line$ = ReadLine$(F)
+		If Stage = 0 And Instr(Line$, "For U.UpdateFile = Each UpdateFile") > 0
+			CloseFile F
+			Return False
+		EndIf
+		If Stage = 0 And Instr(Line$, "U.UpdateFile = First UpdateFile") > 0 Then Stage = 1
+		If Stage = 1 And Instr(Line$, "UNext.UpdateFile = Null") > 0 Then Stage = 2
+		If Stage = 2 And Instr(Line$, "While U <> Null") > 0 Then Stage = 3
+		If Stage = 3 And Instr(Line$, "UNext = After U") > 0 Then Stage = 4
+		If Stage < 4 And Instr(Line$, "Delete(U)") > 0
+			CloseFile F
+			Return False
+		EndIf
+		If Stage = 4 And Instr(Line$, "DownloadFile(") > 0 Then Stage = 5
+		If Stage = 5 And Instr(Line$, "Delete(U)") > 0 Then Stage = 6
+		If Stage = 6 And Instr(Line$, "U = UNext") > 0
+			CloseFile F
+			Return True
+		EndIf
+	Wend
+
+	CloseFile F
+	Return False
+End Function
+
+Test testUpdateFileApplyCapturesSuccessorBeforeDelete()
+	Assert(UpdateFileApplyUsesAfterCursor%() = True)
+End Test


### PR DESCRIPTION
## Outcome

The client auto-updater now processes every announced update file without advancing through a freed record, so multi-file updates do not lose later entries.

## Technical changes

- Replace the `UpdateFile` apply-loop live `For Each` traversal with a `First` / `After` / `While` cursor using dedicated `CurrentUpdate` / `NextUpdate` handles.
- Add a focused source-contract regression for successor capture, existing download handling, deletion, and advancement order.

Fixes #861

## Acceptance evidence

- `NextUpdate = After CurrentUpdate` precedes the existing apply logic and `Delete(CurrentUpdate)`.
- The apply body keeps the existing unsafe-name skip, download, checksum, progress, and abort paths.
- The focused contract rejects the legacy live cursor and requires capture-before-delete-before-advance.

## RED -> GREEN and verification

- Baseline native focused test: `./test.sh MainMenuUpdateFileIteratorTest` exited 1 because `compiler/BlitzForge/bin/blitzcc` is absent; a narrow `git submodule update --init compiler/BlitzForge` clone attempt left no compiler binary.
- RED: portable probe exited 1 with `MAINMENU_UPDATE_FILE_CURSOR_CONTRACT_RED: apply loop still uses live For Each cursor`.
- GREEN: portable probe exited 0 with `MAINMENU_UPDATE_FILE_CURSOR_CONTRACT_GREEN stage=7`.
- The first CI head exposed `Duplicate variable name` for a reused legacy `U` handle; the follow-up uses distinct cursor handles.
- Final local gates: `git diff --check`, `bash scripts/gen_packet_index.sh --check`, `bash scripts/gen_bvm_reference.sh --check`, and shell syntax checks exited 0. The BVM generator emitted only the two known DEAD-API warnings.
- Exact-head CI: `Build and test` and `Rust server (Linux)` both completed successfully on run `29861734209`.

## Compatibility, rollback, and deferred work

Update-file order and patch-application behavior are unchanged; only the iteration cursor changes. Revert this PR to restore the former loop. Native local compiler proof is unavailable in this worktree, but the exact-head Windows compile/test CI passed.

## Independent review

Fresh review of exact head `4fde49eacec04283ef2fcb4af94c49062f0b0c44`: **ACCEPT**. It confirmed no cursor-name collision and that every skip path reaches delete then captured-successor advancement.