### PR TITLE
fix(rc-rock): drain queued editor events safely

### DIFF
--- a/src/Tests/Modules/RCRockEditorEventIteratorTest.bb
+++ b/src/Tests/Modules/RCRockEditorEventIteratorTest.bb
@@ -1,0 +1,52 @@
+Strict
+EnableGC
+
+; The RC Rock Editor is renderer-heavy, so this bounded source contract keeps
+; BUTTONCHECK's F-UI event drain safe without loading the tool dependency graph.
+; Dialog handlers can consume queue entries, so the cursor must restart from
+; First Event after each delete instead of advancing a stale iterator.
+Function RCRockEditorEventDrainRestartsFromFirst%()
+	Local F.BBStream = ReadFile("Tools\\RC Rock Editor.bb")
+	Local InFunction%, Stage%
+	Local Line$
+	If F = Null Then F = ReadFile("..\\Tools\\RC Rock Editor.bb")
+	If F = Null Then F = ReadFile("..\\..\\Tools\\RC Rock Editor.bb")
+	If F = Null Then Return False
+
+	While Not Eof(F)
+		Line$ = ReadLine$(F)
+		If Instr(Line$, "Function BUTTONCHECK()") > 0 Then InFunction = True
+		If InFunction = True
+			If Instr(Line$, "For e.Event = Each event") > 0 Then
+				CloseFile F
+				Return False
+			EndIf
+			If Stage < 6 And Instr(Line$, "Delete E") > 0 Then
+				CloseFile F
+				Return False
+			EndIf
+			If Stage = 0 And Instr(Line$, "Local E.Event = First Event") > 0 Then Stage = 1
+			If Stage = 1 And Instr(Line$, "While E <> Null") > 0 Then Stage = 2
+			If Stage = 2 And Instr(Line$, "Select E\\EventId") > 0 Then Stage = 3
+			If Stage = 3 And Instr(Line$, "Case GUI_MENUFILE_Exit") > 0 Then Stage = 4
+			If Stage = 4 And Instr(Line$, "Case GUI_HELP_ABOUT") > 0 Then Stage = 5
+			If Stage = 5 And Instr(Line$, "Case GUI_RIGHTWIN_GENERATE") > 0 Then Stage = 6
+			If Stage = 6 And Instr(Line$, "Case GUI_MENUFILE_EXPORT") > 0 Then Stage = 7
+			If Stage = 7 And Instr(Line$, "Case gui_rightwin_changetexture") > 0 Then Stage = 8
+			If Stage = 8 And Instr(Line$, "Delete E") > 0 Then Stage = 9
+			If Stage = 9 And Instr(Line$, "E = First Event") > 0 Then Stage = 10
+			If Stage = 10 And Instr(Line$, "Wend") > 0 Then Stage = 11
+			If Instr(Line$, "End Function") > 0
+				CloseFile F
+				Return Stage = 11
+			EndIf
+		EndIf
+	Wend
+
+	CloseFile F
+	Return False
+End Function
+
+Test testRCRockEditorEventDrainRestartsFromFirstAfterDelete()
+	Assert(RCRockEditorEventDrainRestartsFromFirst%() = True)
+End Test

--- a/src/Tests/Modules/RCRockEditorEventIteratorTest.bb
+++ b/src/Tests/Modules/RCRockEditorEventIteratorTest.bb
@@ -27,7 +27,7 @@ Function RCRockEditorEventDrainRestartsFromFirst%()
 			EndIf
 			If Stage = 0 And Instr(Line$, "Local E.Event = First Event") > 0 Then Stage = 1
 			If Stage = 1 And Instr(Line$, "While E <> Null") > 0 Then Stage = 2
-			If Stage = 2 And Instr(Line$, "Select E\\EventId") > 0 Then Stage = 3
+			If Stage = 2 And Instr(Line$, "Select E\EventId") > 0 Then Stage = 3
 			If Stage = 3 And Instr(Line$, "Case GUI_MENUFILE_Exit") > 0 Then Stage = 4
 			If Stage = 4 And Instr(Line$, "Case GUI_HELP_ABOUT") > 0 Then Stage = 5
 			If Stage = 5 And Instr(Line$, "Case GUI_RIGHTWIN_GENERATE") > 0 Then Stage = 6

--- a/src/Tools/RC Rock Editor.bb
+++ b/src/Tools/RC Rock Editor.bb
@@ -662,9 +662,10 @@ End Function
 
 Function BUTTONCHECK()
 		MOUSEPRESSED1 = MouseHit(1)
-		
-For e.Event = Each event
-  Select e\EventId
+
+Local E.Event = First Event
+While E <> Null
+  Select E\EventId
    Case GUI_MENUFILE_Exit
    yn=Fui_confirm("Quit program","Yes","No")
    If yn=1 Then 
@@ -775,7 +776,8 @@ Case GUI_MENUFILE_EXPORT
      ChangeDir thispath$
   End Select
   Delete E
-Next
+  E = First Event
+Wend
 
 
 


### PR DESCRIPTION
## Outcome

RC Rock Editor now drains queued UI actions from a fresh event cursor after each action, so a multi-action frame cannot advance through a deleted F-UI event and lose its successor.

## Technical changes

- Replace the live `For Each Event` traversal in `BUTTONCHECK` with `First Event` / `While` / delete / reacquire-first control flow.
- Add a focused source-contract regression covering queue restart ordering and retained quit, help, generate, export, and texture actions.

Fixes #869

## Acceptance criteria mapped to evidence

- The legacy live cursor is absent; dispatch reaches `Delete E` only after all owned action cases, then reacquires `First Event`: `RCRock_EVENT_DRAIN_CONTRACT_GREEN`.
- The focused source contract encodes the required traversal and action ordering in `RCRockEditorEventIteratorTest.bb`.
- Scope is limited to the RC Rock editor event drain and its focused test.

## Baseline -> RED -> GREEN -> final verification

- Baseline: `git diff --check` and shell syntax checks were clean; portable probe printed `BASELINE_RCRock_EVENT_CURSOR_UNSAFE`.
- RED: focused portable contract printed `RCRock_EVENT_DRAIN_CONTRACT_RED stage=0 legacy=1`.
- GREEN: focused portable contract printed `RCRock_EVENT_DRAIN_CONTRACT_GREEN`.
- Final static proof: `git diff --check`, `bash -n compile.sh test.sh scripts/gen_packet_index.sh scripts/gen_bvm_reference.sh`, `bash scripts/gen_packet_index.sh --check`, and `bash scripts/gen_bvm_reference.sh --check` passed. The BVM check emitted only its established `BVM_SETOWNER` / `BVM_SCENERYOWNER` DEAD-API warnings.
- Local native limitation: `./test.sh RCRockEditorEventIteratorTest` cannot execute because `compiler/BlitzForge/bin/blitzcc` is absent. A bounded `./compile.sh -b -e` setup attempt exited 1 because Linux lacks the runtime/linker shared libraries required by `blitzcc`; exact-head Windows CI is required compiler-backed proof.

## Compatibility, risks, rollback, and deferred work

Existing actions retain their case order and behavior; only queue cursor ownership changes. Restarting from `First Event` is intentional because dialog handlers can affect queued events. Rollback is reverting `351b9bf2`. RC Terrain Editor, Rock export persistence, and the F-UI framework remain out of scope.

## Final independent review

ACCEPT — a fresh reviewer inspected exact head `5b832e35aa228119ba57569c87a70c3173ac8405`: the diff is confined to the event-drain loop and focused source contract; traversal, action ordering, and the one-backslash field reference match production. No correctness, compatibility, security, performance, concurrency-isolation, documentation, or hidden-cost concern was found. Exact-head CI is green.