### PR TITLE
fix(editor): bound malformed visual-area terrain grids

### DIFF
--- a/src/Modules/AreaLoader.bb
+++ b/src/Modules/AreaLoader.bb
@@ -11,6 +11,7 @@
 
 ;Set Constants
 Const MaxFogFar# = 2000.0
+Const MaxTerrainGrid = 4096
 
 Global SkyEN, CloudEN, StarsEN
 Global SkyTexID = 65535, CloudTexID = 65535, StormCloudTexID = 65535, StarsTexID = 65535
@@ -634,6 +635,19 @@ Function LoadAreaData(Name$, CameraEN, DisplayItems = False, UpdateRottNet = Fal
 			T\DetailTexID = ReadShort(F)
 			; Terrain heights
 			GridSize = ReadInt(F)
+			; The grid comes directly from the visual-area file. Reject corrupt
+			; negative or implausibly large values before native allocation and
+			; the quadratic height loop can exhaust resources or stall the editor.
+			If GridSize < 0 Or GridSize > MaxTerrainGrid
+				WriteLog(MainLog, "LoadArea: invalid terrain grid " + GridSize + " (zone: " + Name$ + ")")
+				Delete T
+				CloseFile(F)
+				UnlockMeshes()
+				UnlockTextures()
+				AreaLoadEnd()
+				UnloadArea()
+				Return False
+			EndIf
 			T\EN = CreateTerrain(GridSize)
 			For X = 0 To TerrainSize(T\EN)
 				For Z = 0 To TerrainSize(T\EN)

--- a/src/Tests/Modules/AreaLoaderTerrainGridBoundsTest.bb
+++ b/src/Tests/Modules/AreaLoaderTerrainGridBoundsTest.bb
@@ -1,0 +1,49 @@
+Strict
+EnableGC
+
+; A visual-area terrain grid comes directly from disk. It must be bounded
+; before the native terrain allocation or any height reads, and a rejected
+; record must leave the loader in its normal failed-load state.
+Function AreaLoaderRejectsInvalidTerrainGridBeforeAllocation%()
+	Local F.BBStream = ReadFile("Modules\\AreaLoader.bb")
+	Local Line$
+	Local MaxGridBound%
+	Local Stage%
+
+	If F = Null Then F = ReadFile("..\\Modules\\AreaLoader.bb")
+	If F = Null Then F = ReadFile("..\\..\\Modules\\AreaLoader.bb")
+	If F = Null Then Return False
+
+	While Not Eof(F)
+		Line$ = ReadLine$(F)
+
+		If Instr(Line$, "Const MaxTerrainGrid = 4096") > 0 Then MaxGridBound = True
+		If Stage = 0 And Instr(Line$, "GridSize = ReadInt(F)") > 0 Then Stage = 1
+		If Stage = 1 And Instr(Line$, "T\\EN = CreateTerrain(GridSize)") > 0
+			CloseFile F
+			Return False
+		EndIf
+		If Stage = 1 And Instr(Line$, "ReadFloat#(F)") > 0
+			CloseFile F
+			Return False
+		EndIf
+		If Stage = 1 And Instr(Line$, "If GridSize < 0 Or GridSize > MaxTerrainGrid") > 0 Then Stage = 2
+		If Stage = 2 And Instr(Line$, "Delete T") > 0 Then Stage = 3
+		If Stage = 3 And Instr(Line$, "CloseFile(F)") > 0 Then Stage = 4
+		If Stage = 4 And Instr(Line$, "UnlockMeshes()") > 0 Then Stage = 5
+		If Stage = 5 And Instr(Line$, "UnlockTextures()") > 0 Then Stage = 6
+		If Stage = 6 And Instr(Line$, "AreaLoadEnd()") > 0 Then Stage = 7
+		If Stage = 7 And Instr(Line$, "UnloadArea()") > 0 Then Stage = 8
+		If Stage = 8 And Instr(Line$, "Return False") > 0
+			CloseFile F
+			Return MaxGridBound
+		EndIf
+	Wend
+
+	CloseFile F
+	Return False
+End Function
+
+Test testTerrainGridBoundsRejectBeforeAllocationAndCleanUp()
+	Assert(AreaLoaderRejectsInvalidTerrainGridBeforeAllocation%() = True)
+End Test


### PR DESCRIPTION
## Outcome

Malformed visual-area terrain records now fail cleanly before they can allocate an implausible native terrain in GUE or Loom.

## Technical changes

- Bound the signed `LoadAreaData` terrain grid to the existing compatible `0..=4096` range before terrain allocation or height reads.
- On rejection, delete the partial terrain record, close the file, release media locks, end the loading presentation, unload partial area objects, and return `False`.
- Added a focused source-contract regression test for the bound, ordering, and cleanup path.

Fixes #873

## Acceptance evidence

| Criterion | Evidence |
| --- | --- |
| Reject corrupt grids before terrain work | RED probe exited 1 on the prior allocation-before-guard sequence; final source contract exited 0. |
| Preserve the compatible ceiling | Regression test pins `Const MaxTerrainGrid = 4096` and the `< 0 Or > MaxTerrainGrid` predicate. |
| Restore loader state on rejection | Regression test requires delete, close, both unlocks, presentation end, unload, then `Return False` in order. |

## Verification

- Baseline static probe + `git diff --check` — exit 0; legacy guard absent.
- RED source contract — exit 1, expected allocation-before-validation finding.
- GREEN source contract, `git diff --check`, `bash scripts/gen_packet_index.sh --check`, `bash scripts/gen_bvm_reference.sh --check` — exit 0. The BVM check reported only its known `BVM_SETOWNER` / `BVM_SCENERYOWNER` dead-API warnings.
- `./test.sh AreaLoaderTerrainGridBoundsTest` — exit 1 because `compiler/BlitzForge/bin/blitzcc` is absent locally. Scoped submodule initialization was attempted but the worktree submodule gitdir is unavailable, so hosted CI is the compiler-backed test gate.

## Compatibility, risk, rollback

Valid terrain grids and the visual-area file format are unchanged. A corrupt grid now returns the loader’s existing failure result; GUE/Loom callers already handle failed loads. Roll back by reverting `200560f3`.

## Deferred

ClientAreas_FE/TE, `SaveArea`, the Rust reader, and broader malformed-file auditing are out of scope.

## Independent review

ACCEPT — fresh independent review of exact head `200560f3f24aa138aa3345d74c70e733c320543f` found the two-file scope, pre-allocation signed grid bound, cleanup ordering, compatibility ceiling, and regression contract correct. Local native execution remains unavailable; CI is still required.