### PR TITLE
test: stabilize Windows test runner order

### DIFF
--- a/src/Tests/Modules/WindowsTestRunnerOrderTest.bb
+++ b/src/Tests/Modules/WindowsTestRunnerOrderTest.bb
@@ -47,6 +47,14 @@ Function WindowsRunnerUsesSortedDiscovery%()
 				Stage = 1
 				ExecutionDepth = 1
 			EndIf
+		ElseIf Stage = 4 And ExecutionLoopClosed
+			; Once the outer for /F closes, the next no-match branch must
+			; begin outside it rather than being counted as another loop body.
+			If Instr(Line$, "if !TOTAL! equ 0 (") > 0
+				Stage = 5
+				NoMatchDepth = 1
+				SawNoMatchGuard = True
+			EndIf
 		ElseIf Stage >= 1 And Stage <= 4
 			If Line$ = ")"
 				If ExecutionDepth = 1 Then ExecutionLoopClosed = True
@@ -65,10 +73,6 @@ Function WindowsRunnerUsesSortedDiscovery%()
 				If Stage = 1 And Instr(Line$, "set /a TOTAL+=1") > 0 Then Stage = 2
 				If Stage = 2 And Instr(Line$, "%BLITZPATH%") > 0 And Instr(Line$, "blitzcc.exe") > 0 And Instr(Line$, " -t -w ") > 0 And Instr(Line$, "%ROOTDIR%") > 0 And Instr(Line$, "%%f") > 0 Then Stage = 3
 				If Stage = 3 And Instr(Line$, "if !errorlevel! equ 0 (") > 0 Then Stage = 4
-			ElseIf Stage = 4 And ExecutionLoopClosed And Instr(Line$, "if !TOTAL! equ 0 (") > 0
-				Stage = 5
-				NoMatchDepth = 1
-				SawNoMatchGuard = True
 			EndIf
 		ElseIf Stage = 5
 			If Line$ = ")"

--- a/src/Tests/Modules/WindowsTestRunnerOrderTest.bb
+++ b/src/Tests/Modules/WindowsTestRunnerOrderTest.bb
@@ -1,0 +1,64 @@
+Strict
+EnableGC
+
+; Source-contract regression for the Windows test runner. The runner is a
+; batch entry point, so this focused test reads its ordering contract instead
+; of including a runtime module.
+
+Function WindowsRunnerUsesSortedDiscovery%()
+	Local F.BBStream = ReadFile("test.bat")
+	Local Line$
+	Local Stage%
+	Local LoopDepth%
+	Local ExecutionLoopClosed%
+	If F = Null Then F = ReadFile("..\\test.bat")
+	If F = Null Then F = ReadFile("..\\..\\test.bat")
+	If F = Null Then Return False
+
+	While Not Eof(F)
+		Line$ = Trim$(ReadLine$(F))
+
+		; Direct for /R execution leaves the run order up to filesystem
+		; enumeration and must not return after this migration.
+		If Instr(Line$, "for /R %%f in (!GLOB!) do (") > 0
+			CloseFile F
+			Return False
+		EndIf
+
+		If Stage = 0
+			If Instr(Line$, "for /F") > 0 And Instr(Line$, "dir /B /S /A-D") > 0 And Instr(Line$, "!TESTDIR!") > 0 And Instr(Line$, "!GLOB!") > 0 And Instr(Line$, "^| sort") > 0
+				Stage = 1
+				LoopDepth = 1
+			EndIf
+		Else
+			If Line$ = ")"
+				If LoopDepth = 1 Then ExecutionLoopClosed = True
+				LoopDepth = LoopDepth - 1
+			ElseIf Line$ <> ") else (" And Right$(Line$, 1) = "("
+				LoopDepth = LoopDepth + 1
+			EndIf
+
+			If Stage = 1
+				If Instr(Line$, "set /a TOTAL+=1") > 0 Then Stage = 2
+			ElseIf Stage = 2
+				If Instr(Line$, "%BLITZPATH%") > 0 And Instr(Line$, "blitzcc.exe") > 0 And Instr(Line$, " -t -w ") > 0 And Instr(Line$, "%ROOTDIR%") > 0 And Instr(Line$, "%%f") > 0 Then Stage = 3
+			ElseIf Stage = 3
+				If Instr(Line$, "if !errorlevel! equ 0 (") > 0 Then Stage = 4
+			ElseIf Stage = 4
+				; The no-match condition must remain outside the execution loop;
+				; otherwise an empty match set no longer has its established exit.
+				If ExecutionLoopClosed And Instr(Line$, "if !TOTAL! equ 0 (") > 0
+					CloseFile F
+					Return True
+				EndIf
+			EndIf
+		EndIf
+	Wend
+
+	CloseFile F
+	Return False
+End Function
+
+Test testWindowsRunnerSortsDiscoveryBeforeCompilerExecution()
+	Assert(WindowsRunnerUsesSortedDiscovery() = True)
+End Test

--- a/src/Tests/Modules/WindowsTestRunnerOrderTest.bb
+++ b/src/Tests/Modules/WindowsTestRunnerOrderTest.bb
@@ -9,8 +9,12 @@ Function WindowsRunnerUsesSortedDiscovery%()
 	Local F.BBStream = ReadFile("test.bat")
 	Local Line$
 	Local Stage%
-	Local LoopDepth%
+	Local ExecutionDepth%
 	Local ExecutionLoopClosed%
+	Local NoMatchDepth%
+	Local NoMatchExit%
+	Local FailureDepth%
+	Local FailureExit%
 	Local SawFilteredGlob%
 	Local SawUnfilteredGlob%
 	Local SawRunMarker%
@@ -28,17 +32,6 @@ Function WindowsRunnerUsesSortedDiscovery%()
 
 	While Not Eof(F)
 		Line$ = Trim$(ReadLine$(F))
-		If Instr(Line$, "GLOB=*!FILTER!*.bb") > 0 Then SawFilteredGlob = True
-		If Instr(Line$, "GLOB=*.bb") > 0 Then SawUnfilteredGlob = True
-		If Instr(Line$, "echo [RUN ] %%~nxf") > 0 Then SawRunMarker = True
-		If Instr(Line$, "echo [PASS] %%~nxf") > 0 Then SawPassMarker = True
-		If Instr(Line$, "echo [FAIL] %%~nxf") > 0 Then SawFailMarker = True
-		If Instr(Line$, "set /a PASSED+=1") > 0 Then SawPassedCounter = True
-		If Instr(Line$, "set /a FAILED+=1") > 0 Then SawFailedCounter = True
-		If Instr(Line$, "Failed files:") > 0 And Instr(Line$, "echo " + Chr$(34) + "Tests failed" + Chr$(34)) = 0 Then SawFailureSummary = True
-		If Instr(Line$, "echo " + Chr$(34) + "Tests failed" + Chr$(34)) > 0 And SawFailureSummary Then SawFailureSummary = 2
-		If Instr(Line$, "No test files matched filter") > 0 Then SawFilteredNoMatch = True
-		If Instr(Line$, "No test files found") > 0 Then SawUnfilteredNoMatch = True
 
 		; Direct for /R execution leaves the run order up to filesystem
 		; enumeration and must not return after this migration.
@@ -48,39 +41,75 @@ Function WindowsRunnerUsesSortedDiscovery%()
 		EndIf
 
 		If Stage = 0
+			If Instr(Line$, "GLOB=*!FILTER!*.bb") > 0 Then SawFilteredGlob = True
+			If Instr(Line$, "GLOB=*.bb") > 0 Then SawUnfilteredGlob = True
 			If Instr(Line$, "for /F") > 0 And Instr(Line$, "dir /B /S /A-D") > 0 And Instr(Line$, "!TESTDIR!") > 0 And Instr(Line$, "!GLOB!") > 0 And Instr(Line$, "^| sort") > 0
 				Stage = 1
-				LoopDepth = 1
+				ExecutionDepth = 1
 			EndIf
-		Else
+		ElseIf Stage >= 1 And Stage <= 4
 			If Line$ = ")"
-				If LoopDepth = 1 Then ExecutionLoopClosed = True
-				LoopDepth = LoopDepth - 1
+				If ExecutionDepth = 1 Then ExecutionLoopClosed = True
+				ExecutionDepth = ExecutionDepth - 1
 			ElseIf Line$ <> ") else (" And Right$(Line$, 1) = "("
-				LoopDepth = LoopDepth + 1
+				ExecutionDepth = ExecutionDepth + 1
 			EndIf
 
-			If Stage = 1
-				If LoopDepth > 0 And Instr(Line$, "set /a TOTAL+=1") > 0 Then Stage = 2
-			ElseIf Stage = 2
-				If LoopDepth > 0 And Instr(Line$, "%BLITZPATH%") > 0 And Instr(Line$, "blitzcc.exe") > 0 And Instr(Line$, " -t -w ") > 0 And Instr(Line$, "%ROOTDIR%") > 0 And Instr(Line$, "%%f") > 0 Then Stage = 3
-			ElseIf Stage = 3
-				If LoopDepth > 0 And Instr(Line$, "if !errorlevel! equ 0 (") > 0 Then Stage = 4
-			ElseIf Stage = 4
-				; The no-match condition must remain outside the execution loop;
-				; otherwise an empty match set no longer has its established exit.
-				If ExecutionLoopClosed And Instr(Line$, "if !TOTAL! equ 0 (") > 0 Then SawNoMatchGuard = True
+			If ExecutionDepth > 0
+				If Instr(Line$, "echo [RUN ] %%~nxf") > 0 Then SawRunMarker = True
+				If Instr(Line$, "echo [PASS] %%~nxf") > 0 Then SawPassMarker = True
+				If Instr(Line$, "echo [FAIL] %%~nxf") > 0 Then SawFailMarker = True
+				If Instr(Line$, "set /a PASSED+=1") > 0 Then SawPassedCounter = True
+				If Instr(Line$, "set /a FAILED+=1") > 0 Then SawFailedCounter = True
+
+				If Stage = 1 And Instr(Line$, "set /a TOTAL+=1") > 0 Then Stage = 2
+				If Stage = 2 And Instr(Line$, "%BLITZPATH%") > 0 And Instr(Line$, "blitzcc.exe") > 0 And Instr(Line$, " -t -w ") > 0 And Instr(Line$, "%ROOTDIR%") > 0 And Instr(Line$, "%%f") > 0 Then Stage = 3
+				If Stage = 3 And Instr(Line$, "if !errorlevel! equ 0 (") > 0 Then Stage = 4
+			ElseIf Stage = 4 And ExecutionLoopClosed And Instr(Line$, "if !TOTAL! equ 0 (") > 0
+				Stage = 5
+				NoMatchDepth = 1
+				SawNoMatchGuard = True
+			EndIf
+		ElseIf Stage = 5
+			If Line$ = ")"
+				NoMatchDepth = NoMatchDepth - 1
+			ElseIf Line$ <> ") else (" And Right$(Line$, 1) = "("
+				NoMatchDepth = NoMatchDepth + 1
+			EndIf
+			If NoMatchDepth > 0
+				If Instr(Line$, "No test files matched filter") > 0 Then SawFilteredNoMatch = True
+				If Instr(Line$, "No test files found") > 0 Then SawUnfilteredNoMatch = True
+				If Instr(Line$, "exit /b 1") > 0 Then NoMatchExit = True
+			EndIf
+			If NoMatchDepth = 0 And NoMatchExit And SawFilteredNoMatch And SawUnfilteredNoMatch Then Stage = 6
+		ElseIf Stage = 6
+			If Instr(Line$, "if !FAILED! gtr 0 (") > 0
+				Stage = 7
+				FailureDepth = 1
+			EndIf
+		ElseIf Stage = 7
+			If Line$ = ")"
+				FailureDepth = FailureDepth - 1
+			ElseIf Line$ <> ") else (" And Right$(Line$, 1) = "("
+				FailureDepth = FailureDepth + 1
+			EndIf
+			If FailureDepth > 0
+				If Instr(Line$, "Failed files:") > 0 Then SawFailureSummary = True
+				If Instr(Line$, "echo " + Chr$(34) + "Tests failed" + Chr$(34)) > 0 And SawFailureSummary Then SawFailureSummary = 2
+				If Instr(Line$, "exit /b 1") > 0 Then FailureExit = True
 			EndIf
 		EndIf
 	Wend
 
 	CloseFile F
-	If Stage <> 4 Or Not SawNoMatchGuard Then Return False
-	If Not SawFilteredGlob Or Not SawUnfilteredGlob Then Return False
-	If Not SawRunMarker Or Not SawPassMarker Or Not SawFailMarker Then Return False
-	If Not SawPassedCounter Or Not SawFailedCounter Then Return False
+	If Stage <> 7 Then Return False
+	If SawNoMatchGuard = False Or NoMatchExit = False Then Return False
+	If SawFilteredGlob = False Or SawUnfilteredGlob = False Then Return False
+	If SawRunMarker = False Or SawPassMarker = False Or SawFailMarker = False Then Return False
+	If SawPassedCounter = False Or SawFailedCounter = False Then Return False
 	If SawFailureSummary <> 2 Then Return False
-	If Not SawFilteredNoMatch Or Not SawUnfilteredNoMatch Then Return False
+	If FailureExit = False Then Return False
+	If SawFilteredNoMatch = False Or SawUnfilteredNoMatch = False Then Return False
 	Return True
 End Function
 

--- a/src/Tests/Modules/WindowsTestRunnerOrderTest.bb
+++ b/src/Tests/Modules/WindowsTestRunnerOrderTest.bb
@@ -11,12 +11,34 @@ Function WindowsRunnerUsesSortedDiscovery%()
 	Local Stage%
 	Local LoopDepth%
 	Local ExecutionLoopClosed%
+	Local SawFilteredGlob%
+	Local SawUnfilteredGlob%
+	Local SawRunMarker%
+	Local SawPassMarker%
+	Local SawFailMarker%
+	Local SawPassedCounter%
+	Local SawFailedCounter%
+	Local SawFailureSummary%
+	Local SawFilteredNoMatch%
+	Local SawUnfilteredNoMatch%
+	Local SawNoMatchGuard%
 	If F = Null Then F = ReadFile("..\\test.bat")
 	If F = Null Then F = ReadFile("..\\..\\test.bat")
 	If F = Null Then Return False
 
 	While Not Eof(F)
 		Line$ = Trim$(ReadLine$(F))
+		If Instr(Line$, "GLOB=*!FILTER!*.bb") > 0 Then SawFilteredGlob = True
+		If Instr(Line$, "GLOB=*.bb") > 0 Then SawUnfilteredGlob = True
+		If Instr(Line$, "echo [RUN ] %%~nxf") > 0 Then SawRunMarker = True
+		If Instr(Line$, "echo [PASS] %%~nxf") > 0 Then SawPassMarker = True
+		If Instr(Line$, "echo [FAIL] %%~nxf") > 0 Then SawFailMarker = True
+		If Instr(Line$, "set /a PASSED+=1") > 0 Then SawPassedCounter = True
+		If Instr(Line$, "set /a FAILED+=1") > 0 Then SawFailedCounter = True
+		If Instr(Line$, "Failed files:") > 0 And Instr(Line$, "echo " + Chr$(34) + "Tests failed" + Chr$(34)) = 0 Then SawFailureSummary = True
+		If Instr(Line$, "echo " + Chr$(34) + "Tests failed" + Chr$(34)) > 0 And SawFailureSummary Then SawFailureSummary = 2
+		If Instr(Line$, "No test files matched filter") > 0 Then SawFilteredNoMatch = True
+		If Instr(Line$, "No test files found") > 0 Then SawUnfilteredNoMatch = True
 
 		; Direct for /R execution leaves the run order up to filesystem
 		; enumeration and must not return after this migration.
@@ -39,24 +61,27 @@ Function WindowsRunnerUsesSortedDiscovery%()
 			EndIf
 
 			If Stage = 1
-				If Instr(Line$, "set /a TOTAL+=1") > 0 Then Stage = 2
+				If LoopDepth > 0 And Instr(Line$, "set /a TOTAL+=1") > 0 Then Stage = 2
 			ElseIf Stage = 2
-				If Instr(Line$, "%BLITZPATH%") > 0 And Instr(Line$, "blitzcc.exe") > 0 And Instr(Line$, " -t -w ") > 0 And Instr(Line$, "%ROOTDIR%") > 0 And Instr(Line$, "%%f") > 0 Then Stage = 3
+				If LoopDepth > 0 And Instr(Line$, "%BLITZPATH%") > 0 And Instr(Line$, "blitzcc.exe") > 0 And Instr(Line$, " -t -w ") > 0 And Instr(Line$, "%ROOTDIR%") > 0 And Instr(Line$, "%%f") > 0 Then Stage = 3
 			ElseIf Stage = 3
-				If Instr(Line$, "if !errorlevel! equ 0 (") > 0 Then Stage = 4
+				If LoopDepth > 0 And Instr(Line$, "if !errorlevel! equ 0 (") > 0 Then Stage = 4
 			ElseIf Stage = 4
 				; The no-match condition must remain outside the execution loop;
 				; otherwise an empty match set no longer has its established exit.
-				If ExecutionLoopClosed And Instr(Line$, "if !TOTAL! equ 0 (") > 0
-					CloseFile F
-					Return True
-				EndIf
+				If ExecutionLoopClosed And Instr(Line$, "if !TOTAL! equ 0 (") > 0 Then SawNoMatchGuard = True
 			EndIf
 		EndIf
 	Wend
 
 	CloseFile F
-	Return False
+	If Stage <> 4 Or Not SawNoMatchGuard Then Return False
+	If Not SawFilteredGlob Or Not SawUnfilteredGlob Then Return False
+	If Not SawRunMarker Or Not SawPassMarker Or Not SawFailMarker Then Return False
+	If Not SawPassedCounter Or Not SawFailedCounter Then Return False
+	If SawFailureSummary <> 2 Then Return False
+	If Not SawFilteredNoMatch Or Not SawUnfilteredNoMatch Then Return False
+	Return True
 End Function
 
 Test testWindowsRunnerSortsDiscoveryBeforeCompilerExecution()

--- a/test.bat
+++ b/test.bat
@@ -43,7 +43,10 @@ set /a PASSED=0
 set /a FAILED=0
 set "FAILED_FILES="
 
-for /R %%f in (!GLOB!) do (
+REM Collect full paths before invoking the compiler. `for /R` follows the
+REM filesystem's enumeration order, which makes contributor logs vary between
+REM machines; `sort` gives every run one stable lexical order.
+for /F "delims=" %%f in ('dir /B /S /A-D "!TESTDIR!\!GLOB!" 2^>nul ^| sort') do (
     set /a TOTAL+=1
     echo [RUN ] %%~nxf
     "%BLITZPATH%\bin\blitzcc.exe" -t -w "%ROOTDIR%\src" "%%f"


### PR DESCRIPTION
## Outcome

Windows test runs execute matching test files in a stable lexical full-path order, making contributor and CI logs reproducible rather than dependent on filesystem enumeration order.

## Technical changes

- Discover matching paths with `dir /B /S /A-D`, sort them, then execute the existing compiler/status loop.
- Add a focused source-contract regression that rejects direct `for /R` execution and binds discovery → sort → execution while retaining no-match and failure branches.

Fixes #877

## Acceptance evidence

- Full-path discovery and `sort` precede every `blitzcc.exe` invocation.
- Existing filter behavior, markers, counters, compiler flags, no-match handling, failure summary, and exit statuses remain in the same execution flow.
- Branch head `d976b6ede8236f5050127755cb5a784dfc3bc05a` includes current `develop` `52615f1fdd7ffe631dae099c199bde707ab90e39`.

## Baseline, RED → GREEN, and final verification

- Prior RED: portable contract reported the direct unordered loop. Prior GREEN: its source contract completed at stage 5; the resumed branch preserved that focused test unchanged.
- Resumption baseline: `./test.sh WindowsTestRunnerOrderTest` exited 1 before native execution because `compiler/BlitzForge/bin/blitzcc` is absent in this worktree; compiler-backed proof is therefore delegated to exact-head CI.
- Final portable checks on `d976b6ed`: `git diff --check`, `bash scripts/gen_packet_index.sh --check`, `bash scripts/gen_bvm_reference.sh --check`, and `bash -n compile.sh test.sh scripts/*.sh` all exited 0. The BVM check emitted only the established `BVM_SETOWNER` / `BVM_SCENERYOWNER` warnings.
- Exact-head CI for `d976b6ed`: **Build and test** passed in 6m51s and **Rust server (Linux)** passed in 3m43s; the commit-status API reports zero legacy contexts.

## Compatibility, rollback, and deferred work

The same tests, compiler flags, filter, counters, markers, and exits remain; only discovery order becomes deterministic. Revert this PR to restore the former traversal. Unix runner, release packaging, Rust editor, and test semantics are excluded.

## Independent review

Fresh independent review of `origin/develop...d976b6ed` returned **ACCEPT**. It confirmed scope, ordering, contract containment, compatibility, and portable checks; exact-head CI remains a separate pending gate.