### PR TITLE
ci: parse gfxprobe PowerShell syntax before Windows builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,6 +29,19 @@ jobs:
           # compile/test so we skip recursive to keep the checkout fast.
           submodules: true
 
+      # This diagnostic is only needed for the intermittent graphics launch
+      # investigation, so parse it here without launching the probe or a game.
+      - name: Validate PowerShell syntax
+        shell: pwsh
+        run: |
+          $tokens = $null
+          $parseErrors = $null
+          [void][System.Management.Automation.Language.Parser]::ParseFile("scripts/gfxprobe_loop.ps1", [ref]$tokens, [ref]$parseErrors)
+          if ($parseErrors.Count -gt 0) {
+            $parseErrors | ForEach-Object { Write-Error $_ }
+            exit 1
+          }
+
       # Cache the BlitzForge runtime binaries keyed on the submodule SHA.
       # rcce2 PRs rarely change the BlitzForge pointer, so the common-case
       # CI run avoids the ~3min MSBuild step entirely.

--- a/src/Tests/Modules/PowerShellSyntaxGateTest.bb
+++ b/src/Tests/Modules/PowerShellSyntaxGateTest.bb
@@ -1,0 +1,72 @@
+Strict
+EnableGC
+
+; Source-contract regression for the Windows CI parse-only gate over the
+; contributor-facing graphics diagnostic. The workflow itself is not a Blitz
+; module, so keep this focused test independent by reading the YAML directly.
+
+Function FileContains%(Path$, Needle$)
+	Local F.BBStream = ReadFile(Path$)
+	Local Line$
+	If F = Null Then F = ReadFile("../" + Path$)
+	If F = Null Then F = ReadFile("../../" + Path$)
+	If F = Null Then F = ReadFile("..\\" + Path$)
+	If F = Null Then F = ReadFile("..\\..\\" + Path$)
+	If F = Null Then Return False
+	While Not Eof(F)
+		Line$ = ReadLine$(F)
+		If Instr(Line$, Needle$) > 0
+			CloseFile F
+			Return True
+		EndIf
+	Wend
+	CloseFile F
+	Return False
+End Function
+
+Function FileContainsOrderedNonComment%(Path$, StartNeedle$, FirstNeedle$, SecondNeedle$, ThirdNeedle$, FourthNeedle$)
+	Local F.BBStream = ReadFile(Path$)
+	Local Line$
+	Local Stage = 0
+	If F = Null Then F = ReadFile("../" + Path$)
+	If F = Null Then F = ReadFile("../../" + Path$)
+	If F = Null Then F = ReadFile("..\\" + Path$)
+	If F = Null Then F = ReadFile("..\\..\\" + Path$)
+	If F = Null Then Return False
+	While Not Eof(F)
+		Line$ = Trim$(ReadLine$(F))
+		If Left$(Line$, 1) <> "#"
+			If Stage = 0
+				If Instr(Line$, StartNeedle$) > 0 Then Stage = 1
+			ElseIf Stage = 1
+				If Instr(Line$, FirstNeedle$) > 0 Then Stage = 2
+			ElseIf Stage = 2
+				If Instr(Line$, SecondNeedle$) > 0 Then Stage = 3
+			ElseIf Stage = 3
+				If Instr(Line$, ThirdNeedle$) > 0 Then Stage = 4
+			ElseIf Stage = 4
+				If Instr(Line$, FourthNeedle$) > 0
+					CloseFile F
+					Return True
+				EndIf
+			EndIf
+		EndIf
+	Wend
+	CloseFile F
+	Return False
+End Function
+
+Test testWindowsCIParsesTheGfxProbeWithoutExecutingIt()
+	Local Workflow$ = ".github/workflows/ci.yml"
+	Assert(FileContains%(Workflow$, "- name: Validate PowerShell syntax") = True)
+	Assert(FileContains%(Workflow$, "shell: pwsh") = True)
+	Assert(FileContains%(Workflow$, "[System.Management.Automation.Language.Parser]::ParseFile") = True)
+	Assert(FileContains%(Workflow$, "scripts/gfxprobe_loop.ps1") = True)
+	Assert(FileContains%(Workflow$, "if ($parseErrors.Count -gt 0)") = True)
+	Assert(FileContains%(Workflow$, "exit 1") = True)
+	Assert(FileContains%(Workflow$, "Start-Process scripts/gfxprobe_loop.ps1") = False)
+End Test
+
+Test testWindowsCIParsesGfxProbeBeforeCompilingTheProject()
+	Assert(FileContainsOrderedNonComment%(".github/workflows/ci.yml", "build-and-test:", "- name: Validate PowerShell syntax", "shell: pwsh", "scripts/gfxprobe_loop.ps1", "- name: Compile project") = True)
+End Test


### PR DESCRIPTION
## Outcome

Windows CI now checks that the graphics-incident diagnostic script still parses before contributors need it, without launching the probe or any graphics binary.

## Technical changes

- Adds a pwsh AST parse-only step for scripts/gfxprobe_loop.ps1 before project compilation.
- Adds PowerShellSyntaxGateTest.bb to bind the step, parser API, target script, fail-on-errors behavior, non-execution contract, and placement.

Fixes #883

## Acceptance criteria and evidence

- Parse exactly the diagnostic script without execution: the workflow invokes Parser::ParseFile for scripts/gfxprobe_loop.ps1; the contract checks this.
- Parser errors fail CI: the workflow reports parse errors and exits 1; the contract checks this.
- Focused regression exists: PowerShellSyntaxGateTest.bb was added.
- No graphics/probe/test-runner/client behavior changed: the diff is confined to the workflow and source contract.

## RED to GREEN

- RED: portable contract probe returned POWERSHELL_SYNTAX_GATE_CONTRACT_RED missing=parse-only-ci-step (exit 1).
- GREEN: portable contract probe returned POWERSHELL_SYNTAX_GATE_CONTRACT_GREEN parse-only-step-before-compile (exit 0).

## Verification

- git diff --check: exit 0.
- bash -n compile.sh test.sh scripts/*.sh: exit 0.
- bash scripts/gen_packet_index.sh --check: exit 0.
- bash scripts/gen_bvm_reference.sh --check: exit 0, with only established BVM_SETOWNER and BVM_SCENERYOWNER DEAD-API warnings.
- ./test.sh PowerShellSyntaxGateTest: unavailable locally because compiler/BlitzForge/bin/blitzcc is absent; exact-head Windows CI remains the compiler and real PowerShell parser proof.

## Compatibility, risk, rollback, and follow-up

The step only parses the existing script; it does not execute it or change runtime behavior. Reverting this commit removes the gate and test. Executing the probe in CI and fixing #40 itself remain out of scope.

## Independent review

Fresh independent review: ACCEPT for exact head 2566cff1c06ea593c4e851a22b0de7558b631329. It confirmed the AST parser targets only scripts/gfxprobe_loop.ps1, reports errors before compilation, does not execute the diagnostic, and the focused contract covers the acceptance criteria. Exact-head CI remains required before merge.
