### PR TITLE
fix(server): safely clean every ActorEffect

### DIFF
--- a/src/Modules/Actors.bb
+++ b/src/Modules/Actors.bb
@@ -1500,11 +1500,13 @@ End Function
 
 
 Function CleanActorEffects()
-	Local AE.ActorEffect
-	For AE = Each ActorEffect
+	Local AE.ActorEffect = First ActorEffect
+	Local AENext.ActorEffect = Null
+	While AE <> Null
+		AENext = After AE
 		DestroyActorEffect( AE )
-	Next
-	Delete Each ActorEffect
+		AE = AENext
+	Wend
 
 End Function
 

--- a/src/Tests/Modules/ActorEffectCleanupIteratorTest.bb
+++ b/src/Tests/Modules/ActorEffectCleanupIteratorTest.bb
@@ -1,0 +1,46 @@
+Strict
+EnableGC
+
+; CleanActorEffects delegates deletion to DestroyActorEffect. The production
+; function must capture After before that call, otherwise a For Each cursor can
+; advance through a freed ActorEffect and skip later cleanup records.
+Function CleanActorEffectsUsesAfterCursor%()
+	Local F.BBStream = ReadFile("Modules\\Actors.bb")
+	Local InFunction%, Stage%
+	Local Line$
+	If F = Null Then F = ReadFile("..\\Modules\\Actors.bb")
+	If F = Null Then F = ReadFile("..\\..\\Modules\\Actors.bb")
+	If F = Null Then Return False
+
+	While Not Eof(F)
+		Line$ = ReadLine$(F)
+		If InFunction = False And Instr(Line$, "Function CleanActorEffects()") > 0 Then InFunction = True
+		If InFunction = True
+			If Instr(Line$, "For AE = Each ActorEffect") > 0 Or Instr(Line$, "Delete Each ActorEffect") > 0
+				CloseFile F
+				Return False
+			EndIf
+			If Stage < 4 And Instr(Line$, "DestroyActorEffect( AE )") > 0
+				CloseFile F
+				Return False
+			EndIf
+			If Stage = 0 And Instr(Line$, "Local AE.ActorEffect = First ActorEffect") > 0 Then Stage = 1
+			If Stage = 1 And Instr(Line$, "Local AENext.ActorEffect = Null") > 0 Then Stage = 2
+			If Stage = 2 And Instr(Line$, "While AE <> Null") > 0 Then Stage = 3
+			If Stage = 3 And Instr(Line$, "AENext = After AE") > 0 Then Stage = 4
+			If Stage = 4 And Instr(Line$, "DestroyActorEffect( AE )") > 0 Then Stage = 5
+			If Stage = 5 And Instr(Line$, "AE = AENext") > 0 Then Stage = 6
+			If Instr(Line$, "End Function") > 0
+				CloseFile F
+				Return Stage = 6
+			EndIf
+		EndIf
+	Wend
+
+	CloseFile F
+	Return False
+End Function
+
+Test testCleanActorEffectsCapturesSuccessorBeforeDestroy()
+	Assert(CleanActorEffectsUsesAfterCursor%() = True)
+End Test


### PR DESCRIPTION
## Outcome

Server shutdown and reload cleanup now visits every ActorEffect instead of advancing a live iterator through a record the cleanup helper just freed.

## Technical changes

- Replace CleanActorEffects' deleting For Each traversal with an After-cursor walk.
- Remove the redundant bulk delete because DestroyActorEffect owns both the effect and its attribute table.
- Add a focused source-contract regression that binds first -> after -> destroy -> advance ordering and rejects the legacy forms.

Fixes #885

## Acceptance criteria and evidence

- Successor capture precedes DestroyActorEffect, and the captured cursor advances afterward: portable contract GREEN at stage 6.
- The legacy For Each traversal and Delete Each ActorEffect are rejected by the focused contract.
- Only src/Modules/Actors.bb and src/Tests/Modules/ActorEffectCleanupIteratorTest.bb changed.

## Baseline, RED, GREEN, and final verification

- Baseline: portable source probe exited 1 with BASELINE: 1 ActorEffect cleanup contract failure legacy=1 bulk=1 stage=0.
- RED: focused portable probe exited 1 with RED_EXPECTED: ACTOR_EFFECT_CLEANUP_CONTRACT_RED legacy=1 bulk=1 stage=0.
- GREEN: portable source contract printed GREEN: ACTOR_EFFECT_CLEANUP_CONTRACT_GREEN stage=6.
- Final local static verification: git diff --check, packet-index check, BVM-reference check, and shell syntax check exited 0. The BVM check emitted only established BVM_SETOWNER and BVM_SCENERYOWNER DEAD-API warnings.
- Native focused test is UNVERIFIED locally: ./test.sh ActorEffectCleanupIteratorTest exited 1 before execution because compiler/BlitzForge/bin/blitzcc is absent. Exact-head CI supplies compiler-backed proof.

## Compatibility, risk, rollback, and deferred work

DestroyActorEffect behavior, cleanup order, notifications, and attribute reversals are unchanged. The only behavior change is safe cursor ownership while removing all effects. Reverting this PR restores the old traversal. No packet, generated-document, UI, or broad iterator audit is included.

## Independent review

ACCEPT for exact head ecf87752bcb8534ccf3f0954d64cfe7f6bbdd155. The fresh reviewer found the after-cursor invariant, focused source contract, scope, repository fit, performance, concurrency isolation, and hidden-cost analysis acceptable. Exact-head CI remains required before merge.