### PR TITLE
docs(loom): align beta guide with parallel editor positioning

### DIFF
--- a/docs/loom/README.md
+++ b/docs/loom/README.md
@@ -31,7 +31,7 @@ The shipped beta implements **five of these directly** (threads, conscience ribb
 
 ## What Loom is today (beta)
 
-A full-featured GUE replacement with thread navigation, search, and a custom-drawn aesthetic. Specifically:
+A parallel beta editor with thread navigation, search, and a custom-drawn aesthetic, with editing parity for primary GUE workflows. GUE remains the established editor. Specifically:
 
 - **Browser** with 18 categories: Actors / Items / Spells / Projectiles / Particles / Zones / Factions / Animation Sets / Tools / Scripts / Textures / Meshes / Sounds / Music / Stats / Days & Seasons / Interface / Settings. Content and asset categories use clickable card grids; Tools launches companion editors, while Stats, Days & Seasons, Interface, and Settings expose project-level surfaces. Arrow keys + Enter navigate; card grids have live filter input.
 - **Composer** panel for the focused entity — ~40 editable fields across every kind; Save / Discard / Delete buttons (arm-confirm on the destructive ones); per-field range clamps so typos can't poison data.

--- a/src/Tests/Modules/LoomBetaLabelTest.bb
+++ b/src/Tests/Modules/LoomBetaLabelTest.bb
@@ -49,6 +49,11 @@ Test testLoomGuidanceMatchesTheBetaLauncher()
 	Assert(FileContains%("CLAUDE.md", "## Loom (beta redesigned editor)") = True)
 End Test
 
+Test testLoomGuidePositionsTheBetaAsParallelToGUE()
+	Assert(FileContains%("docs\\loom\\README.md", "A parallel beta editor with thread navigation, search, and a custom-drawn aesthetic, with editing parity for primary GUE workflows. GUE remains the established editor.") = True)
+	Assert(FileContains%("docs\\loom\\README.md", "A full-featured GUE replacement with thread navigation, search, and a custom-drawn aesthetic.") = False)
+End Test
+
 Test testCurrentFacingGuidanceCannotRegressToAlpha()
 	Assert(FileContains%("Project Manager.bb", "Loom (Alpha)") = False)
 	Assert(FileContains%("Loom.bb", "AppTitle(" + Chr$(34) + "Loom -- World Editor (Alpha) -- Realm Crafter ") = False)


### PR DESCRIPTION
## Outcome

The Loom contributor guide now accurately presents the shipped editor as a parallel beta with primary GUE workflow parity, rather than promising a full GUE replacement.

## Changes

- Corrected the stale Loom beta positioning sentence.
- Added a focused source-contract test requiring the accurate wording and rejecting the replacement claim.

Fixes #887

## Acceptance evidence

- Guide contains the parallel-beta/workflow-parity wording and no longer contains the stale replacement sentence: `LOOM_PARALLEL_BETA_CONTRACT_GREEN guide-and-test-bound`.
- Focused contract RED before the guide correction: `LOOM_PARALLEL_BETA_CONTRACT_RED missing=guide-wording stale-replacement-present`.
- `git diff --check`, `bash scripts/gen_packet_index.sh --check`, `bash scripts/gen_bvm_reference.sh --check` (only known `BVM_SETOWNER`/`BVM_SCENERYOWNER` warnings), and `bash -n compile.sh test.sh scripts/*.sh` exited 0.
- `./test.sh LoomBetaLabelTest` exits 1 locally only because `compiler/BlitzForge/bin/blitzcc` is absent; exact-head CI is required for compiler-backed test execution.

## Compatibility, risk, rollback, deferred work

Documentation and its source contract only; no runtime, wire, file-format, or editor behavior change. Revert this two-file commit to roll back. Runtime/editor work, Project Manager behavior, prototype mapping, GUE, client-rs, and protocol docs remain out of scope.

## Independent review

Fresh independent review: **ACCEPT** for exact head `49351794187e5033ee6582ab4f71e70d9b7d66a5`. The reviewer confirmed the two-file scope, acceptance criteria, source-contract quality, repository fit, documentation consistency, and absence of security, performance, concurrency, or hidden-cost blockers. Local native test remains unverified only because the local compiler is absent; CI is still required.