### PR TITLE
fix(loom): retain particle edits after save failure

### DIFF
--- a/src/Modules/Loom/Composer.bb
+++ b/src/Modules/Loom/Composer.bb
@@ -2160,8 +2160,8 @@ Type Composer
             // GUE's "Save emitters": write every config to its own .rpc under
             // Data\Emitter Configs\. Particles_SaveAll also refreshes the
             // projectile-picker roster (Emitters_Rebuild) after a full save.
-            Local okE% = Particles_SaveAll()
-            If okE = False
+            Local okParticleSave% = Particles_SaveAll()
+            If okParticleSave = False
                 ParticlesSaved = False
                 WriteLog(LoomLog, "Composer: Particles_SaveAll FAILED")
                 Toast_Show("Save emitter configs FAILED", "danger")

--- a/src/Modules/Loom/Composer.bb
+++ b/src/Modules/Loom/Composer.bb
@@ -2159,8 +2159,14 @@ Type Composer
         If kind = "particle"
             // GUE's "Save emitters": write every config to its own .rpc under
             // Data\Emitter Configs\. Particles_SaveAll also refreshes the
-            // projectile-picker roster (Emitters_Rebuild).
-            Particles_SaveAll()
+            // projectile-picker roster (Emitters_Rebuild) after a full save.
+            Local okE% = Particles_SaveAll()
+            If okE = False
+                ParticlesSaved = False
+                WriteLog(LoomLog, "Composer: Particles_SaveAll FAILED")
+                Toast_Show("Save emitter configs FAILED", "danger")
+                Return
+            EndIf
             ParticlesSaved = True
             WriteLog(LoomLog, "Composer: saved emitter configs (*.rpc)")
             Toast_Show("Saved emitter configs", "success")

--- a/src/Modules/Loom/ParticleEditor.bb
+++ b/src/Modules/Loom/ParticleEditor.bb
@@ -68,16 +68,16 @@ End Function
 
 // =============================================================================
 // Particles_SaveAll -- write every config to Data\Emitter Configs\<Name>.rpc.
-// Byte-identical to GUE's "Save emitters" button loop. RP_SaveEmitterConfig
-// soft-fails per file (returns False on a bad handle / unwritable path)
-// without aborting the loop, so this always returns True. After the write,
-// refresh the projectile-picker roster so a newly-created / renamed emitter
-// name resolves there.
+// Attempt every independent emitter save, but report a failed aggregate when
+// any write cannot be committed. Rebuild the projectile-picker roster only
+// after every emitter reached durable storage.
 // =============================================================================
 Function Particles_SaveAll%()
+    Local SavedAll% = True
     For C.RP_EmitterConfig = Each RP_EmitterConfig
-        RP_SaveEmitterConfig(Handle(C), "Data\Emitter Configs\" + C\Name$ + ".rpc")
+        If RP_SaveEmitterConfig(Handle(C), "Data\Emitter Configs\" + C\Name$ + ".rpc") = False Then SavedAll = False
     Next
+    If SavedAll = False Then Return False
     Emitters_Rebuild()
     Return True
 End Function

--- a/src/Tests/Modules/LoomSaveOutcomeTest.bb
+++ b/src/Tests/Modules/LoomSaveOutcomeTest.bb
@@ -64,6 +64,53 @@ Function HasZoneSaveFailureGuard%(Path$)
 	Return False
 End Function
 
+Function HasParticleSaveFailureGuard%(Path$)
+	Local F.BBStream = ReadFile(Path$)
+	Local Line$
+	Local Stage% = 0
+	If F = Null Then F = ReadFile("..\" + Path$)
+	If F = Null Then F = ReadFile("..\..\" + Path$)
+	If F = Null Then Return False
+
+	While Not Eof(F)
+		Line$ = Trim$(ReadLine$(F))
+		Select Stage
+			Case 0
+				If Line$ = "If kind = " + Chr$(34) + "particle" + Chr$(34) Then Stage = 1
+			Case 1
+				If Line$ = "Local okE% = Particles_SaveAll()" Then Stage = 2
+			Case 2
+				If Line$ = "If okE = False" Then Stage = 3
+			Case 3
+				If Line$ = "ParticlesSaved = True" Then
+					CloseFile F
+					Return False
+				EndIf
+				If Line$ = "ParticlesSaved = False" Then Stage = 4
+			Case 4
+				If Line$ = "ParticlesSaved = True" Then
+					CloseFile F
+					Return False
+				EndIf
+				If Line$ = "Return" Then Stage = 5
+			Case 5
+				If Line$ = "ParticlesSaved = True" Then
+					CloseFile F
+					Return False
+				EndIf
+				If Line$ = "EndIf" Then Stage = 6
+			Case 6
+				If Line$ = "ParticlesSaved = True" Then
+					CloseFile F
+					Return True
+				EndIf
+		End Select
+	Wend
+
+	CloseFile F
+	Return False
+End Function
+
 Function HasExitSaveFailureGuard%(Path$)
 	Local F.BBStream = ReadFile(Path$)
 	Local Line$
@@ -97,6 +144,15 @@ Test testZoneSaveFailureKeepsTheZoneDirty()
 	Local Source$ = "Modules\Loom\Composer.bb"
 	Assert(HasZoneSaveFailureGuard%(Source$) = True)
 	Assert(FileContains%(Source$, "Save Zone FAILED") = True)
+End Test
+
+Test testParticleSaveFailureKeepsParticlesDirty()
+	Local EditorSource$ = "Modules\Loom\ParticleEditor.bb"
+	Local ComposerSource$ = "Modules\Loom\Composer.bb"
+	Assert(FileContains%(EditorSource$, "Local SavedAll% = True") = True)
+	Assert(FileContains%(EditorSource$, "If SavedAll = False Then Return False") = True)
+	Assert(HasParticleSaveFailureGuard%(ComposerSource$) = True)
+	Assert(FileContains%(ComposerSource$, "Save emitter configs FAILED") = True)
 End Test
 
 Test testSaveAllCountsOnlyConfirmedSaves()

--- a/src/Tests/Modules/LoomSaveOutcomeTest.bb
+++ b/src/Tests/Modules/LoomSaveOutcomeTest.bb
@@ -64,6 +64,47 @@ Function HasZoneSaveFailureGuard%(Path$)
 	Return False
 End Function
 
+Function HasParticleSaveAggregateContract%(Path$)
+	Local F.BBStream = ReadFile(Path$)
+	Local Line$
+	Local Stage% = 0
+	If F = Null Then F = ReadFile("..\" + Path$)
+	If F = Null Then F = ReadFile("..\..\" + Path$)
+	If F = Null Then Return False
+
+	While Not Eof(F)
+		Line$ = Trim$(ReadLine$(F))
+		Select Stage
+			Case 0
+				If Line$ = "Function Particles_SaveAll%()" Then Stage = 1
+			Case 1
+				If Line$ = "Local SavedAll% = True" Then Stage = 2
+			Case 2
+				If Left$(Line$, Len("For C.RP_EmitterConfig = Each RP_EmitterConfig")) = "For C.RP_EmitterConfig = Each RP_EmitterConfig" Then Stage = 3
+			Case 3
+				If Line$ = "Return True" Or Line$ = "Return False" Then
+					CloseFile F
+					Return False
+				EndIf
+				If Instr(Line$, "If RP_SaveEmitterConfig") = 1 And Instr(Line$, "= False Then SavedAll = False") > 0 Then Stage = 4
+			Case 4
+				If Line$ = "Next" Then Stage = 5
+			Case 5
+				If Line$ = "If SavedAll = False Then Return False" Then Stage = 6
+			Case 6
+				If Line$ = "Emitters_Rebuild()" Then Stage = 7
+			Case 7
+				If Line$ = "Return True" Then
+					CloseFile F
+					Return True
+				EndIf
+		End Select
+	Wend
+
+	CloseFile F
+	Return False
+End Function
+
 Function HasParticleSaveFailureGuard%(Path$)
 	Local F.BBStream = ReadFile(Path$)
 	Local Line$
@@ -78,9 +119,9 @@ Function HasParticleSaveFailureGuard%(Path$)
 			Case 0
 				If Line$ = "If kind = " + Chr$(34) + "particle" + Chr$(34) Then Stage = 1
 			Case 1
-				If Line$ = "Local okE% = Particles_SaveAll()" Then Stage = 2
+				If Line$ = "Local okParticleSave% = Particles_SaveAll()" Then Stage = 2
 			Case 2
-				If Line$ = "If okE = False" Then Stage = 3
+				If Line$ = "If okParticleSave = False" Then Stage = 3
 			Case 3
 				If Line$ = "ParticlesSaved = True" Then
 					CloseFile F
@@ -151,6 +192,7 @@ Test testParticleSaveFailureKeepsParticlesDirty()
 	Local ComposerSource$ = "Modules\Loom\Composer.bb"
 	Assert(FileContains%(EditorSource$, "Local SavedAll% = True") = True)
 	Assert(FileContains%(EditorSource$, "If SavedAll = False Then Return False") = True)
+	Assert(HasParticleSaveAggregateContract%(EditorSource$) = True)
 	Assert(HasParticleSaveFailureGuard%(ComposerSource$) = True)
 	Assert(FileContains%(ComposerSource$, "Save emitter configs FAILED") = True)
 End Test


### PR DESCRIPTION
## Outcome

Loom now keeps particle edits marked unsaved if any emitter configuration cannot be committed, preventing Save All or exit from falsely accepting lost in-memory edits.

## Technical changes

- Aggregate `RP_SaveEmitterConfig` outcomes across all emitter configurations while attempting every independent save.
- Rebuild the emitter roster only after every write succeeds.
- Preserve `ParticlesSaved = False` and display a failure toast when any save fails.
- Extend the focused Loom source contract to prove save loop -> aggregate guard -> rebuild -> success ordering.

Fixes #889

## Acceptance evidence

- Any emitter save failure returns an aggregate false outcome only after the per-emitter loop completes.
- A false outcome retains the particle dirty state, logs the failure, shows a danger toast, and returns before success feedback.
- The roster rebuild and saved flag occur only after the aggregate guard; successful saves retain their prior feedback.

## RED -> GREEN

- Baseline: `git diff --check`, packet-index check, BVM-reference check (only established `BVM_SETOWNER` and `BVM_SCENERYOWNER` warnings), and shell syntax all exited 0. `./test.sh LoomSaveOutcomeTest` exited 1 because `compiler/BlitzForge/bin/blitzcc` is unavailable locally.
- RED: `LOOM_PARTICLE_SAVE_OUTCOME_CONTRACT_RED missing=4`.
- GREEN: `LOOM_PARTICLE_SAVE_OUTCOME_CONTRACT_GREEN aggregate=1 composer-guard=1`; the ordered source probe confirmed save loop -> next -> guard -> rebuild -> success.

## Verification

- `git diff --check` -> exit 0.
- `bash scripts/gen_packet_index.sh --check` -> exit 0.
- `bash scripts/gen_bvm_reference.sh --check` -> exit 0, with only the known DEAD-API warnings.
- `bash -n compile.sh test.sh scripts/*.sh` -> exit 0.
- Local compiler-backed test remains unavailable because the vendored compiler binary is absent. Exact-head CI is still running; wait for all check contexts before merge.

## Compatibility, rollback, and deferred work

Particle file bytes, rendering, and successful save behavior are unchanged. Failed saves now remain unsaved. Roll back by reverting the two commits. GUE parity and particle serialization changes are intentionally deferred.

## Independent review

Fresh exact-head review: ACCEPT for `c5c35b4216bfe3a5d7c70f34e73b08c880791045`; it found no critical, important, or minor concerns and confirmed the corrected local name plus ordered source contract.

## Final exact-head CI

c5c35b4216bfe3a5d7c70f34e73b08c880791045 passed Build and test (7m27s) and Rust server (Linux) (3m53s). Legacy status contexts: 0.