### PR TITLE
ci: cap GitHub Actions job duration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,7 @@ jobs:
   build-and-test:
     name: Build and test
     runs-on: windows-latest
+    timeout-minutes: 30
 
     steps:
       - name: Check out repository
@@ -199,6 +200,7 @@ jobs:
   rust-server:
     name: Rust server (Linux)
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Check out repository
         # actions/checkout@v4

--- a/src/Tests/Modules/GitHubActionsPinTest.bb
+++ b/src/Tests/Modules/GitHubActionsPinTest.bb
@@ -36,6 +36,34 @@ Function FileOccurrenceCount%(Path$, Needle$)
 	Return Count
 End Function
 
+Function JobHasImmediateTimeout%(Path$, Job$, Runner$, Timeout$)
+	Local F.BBStream = ReadFile(Path$)
+	Local Line$
+	If F = Null Then F = ReadFile("..\" + Path$)
+	If F = Null Then F = ReadFile("..\..\" + Path$)
+	If F = Null Then Return False
+	While Not Eof(F)
+		Line$ = ReadLine$(F)
+		If Line$ = "  " + Job$ + ":"
+			While Not Eof(F)
+				Line$ = ReadLine$(F)
+				If Line$ = "    " + Runner$
+					If Eof(F)
+						CloseFile F
+						Return False
+					EndIf
+					Line$ = ReadLine$(F)
+					CloseFile F
+					Return Line$ = "    " + Timeout$
+				EndIf
+				If Left$(Line$, 2) = "  " And Left$(Line$, 4) <> "    " Then Exit
+			Wend
+		EndIf
+	Wend
+	CloseFile F
+	Return False
+End Function
+
 Test testCIActionReferencesUseReviewedImmutablePins()
 	Assert(FileOccurrenceCount%(".github\workflows\ci.yml", "uses:") = 8)
 	Assert(FileOccurrenceCount%(".github\workflows\ci.yml", "uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5") = 2)
@@ -46,4 +74,10 @@ Test testCIActionReferencesUseReviewedImmutablePins()
 	Assert(FileContains%(".github\workflows\ci.yml", "uses: actions/cache@v4") = False)
 	Assert(FileContains%(".github\workflows\ci.yml", "uses: microsoft/setup-msbuild@v2") = False)
 	Assert(FileContains%(".github\workflows\ci.yml", "uses: dtolnay/rust-toolchain@1.85.0") = False)
+End Test
+
+Test testCIJobsCapDurationImmediatelyAfterRunner()
+	Assert(FileOccurrenceCount%(".github\workflows\ci.yml", "timeout-minutes: 30") = 2)
+	Assert(JobHasImmediateTimeout%(".github\workflows\ci.yml", "build-and-test", "runs-on: windows-latest", "timeout-minutes: 30"))
+	Assert(JobHasImmediateTimeout%(".github\workflows\ci.yml", "rust-server", "runs-on: ubuntu-latest", "timeout-minutes: 30"))
 End Test

--- a/src/Tests/Modules/GitHubActionsPinTest.bb
+++ b/src/Tests/Modules/GitHubActionsPinTest.bb
@@ -77,7 +77,7 @@ Test testCIActionReferencesUseReviewedImmutablePins()
 End Test
 
 Test testCIJobsCapDurationImmediatelyAfterRunner()
-	Assert(FileOccurrenceCount%(".github\workflows\ci.yml", "timeout-minutes: 30") = 2)
+	Assert(FileOccurrenceCount%(".github\workflows\ci.yml", "timeout-minutes:") = 2)
 	Assert(JobHasImmediateTimeout%(".github\workflows\ci.yml", "build-and-test", "runs-on: windows-latest", "timeout-minutes: 30"))
 	Assert(JobHasImmediateTimeout%(".github\workflows\ci.yml", "rust-server", "runs-on: ubuntu-latest", "timeout-minutes: 30"))
 End Test


### PR DESCRIPTION
## Outcome

CI now stops a stalled Windows or Linux job after 30 minutes, while retaining more than four times the recent normal run duration.

## Technical changes

- Add `timeout-minutes: 30` directly after `runs-on` for `build-and-test` and `rust-server`.
- Extend `GitHubActionsPinTest` with an ordered, job-scoped source contract and an exact two-cap assertion that counts every `timeout-minutes:` key.

Fixes #891

## Acceptance evidence

- Both named job blocks have one immediate 30-minute cap: `CI_TIMEOUT_CAP_CONTRACT_GREEN`; total timeout-key count: `2`.
- RED: the initial ordered contract exited `1` with each named job missing a cap. The review-driven mutation probe added a third, 15-minute cap in the stream and produced `RED extra-timeout-minutes count=3` / exit `1`.
- GREEN/static: `bash -n compile.sh test.sh scripts/*.sh`, packet-index `--check`, BVM-reference `--check`, and `git diff --check` exited `0`; BVM reference printed only the known `BVM_SETOWNER` / `BVM_SCENERYOWNER` dead-API warnings.
- Local native limitation: `./test.sh GitHubActionsPinTest` could not execute because `compiler/BlitzForge/bin/blitzcc` is absent. Exact-head Build and test CI is required for executable proof.

## Compatibility, risk, rollback

Workflow triggers, actions, and test semantics are unchanged. The cap is well above the recent 3–7 minute successful jobs. Rollback is reverting this two-file commit series.

## Deferred work

This does not redesign CI concurrency, test discovery, or individual test behavior.

## Independent review

Fresh exact-head review verdict: **ACCEPT**. The first review identified an extra-timeout-key coverage gap; commit `b4ade6aa` added the all-key assertion, and a different fresh reviewer accepted the corrected head.