### PR TITLE
fix(GUE): retain particle changes after save failure

### DIFF
--- a/src/GUE.bb
+++ b/src/GUE.bb
@@ -2199,6 +2199,7 @@ CloseAllLogs()
 ; Event loop ------------------------------------------------------------------------------------------------------------------------
 
 DeltaTime = MilliSecs()
+.MainEventLoop
 Repeat
 
 Cls
@@ -6698,7 +6699,10 @@ Cls
 
 ;New Closing Protocol
 Until app\Quit = True
-	SaveDialog()
+	If SaveDialog() = False
+		app\Quit = False
+		Goto MainEventLoop
+	EndIf
 	FUI_Destroy()
 End
 

--- a/src/GUE.bb
+++ b/src/GUE.bb
@@ -6109,10 +6109,7 @@ Cls
 				EndIf
 			; Save emitters
 			Case BParticlesSave
-				For EmC.RP_EmitterConfig = Each RP_EmitterConfig
-					RP_SaveEmitterConfig(Handle(EmC), "Data\Emitter Configs\" + EmC\Name$ + ".rpc")
-				Next
-				ParticlesSaved = True
+				ParticlesSaved = SaveParticleEmitters()
 			; Delete emitter
 			Case BParticlesDelete
 				If ParticlesConfig <> 0
@@ -9762,6 +9759,18 @@ End Function
 ; shared zone loader can use it without depending on GUE.bb. Included near
 ; the top of this file; callers below resolve to it unchanged.
 
+; Saves every emitter configuration and retains the particle dirty state if any
+; independent atomic write fails.
+Function SaveParticleEmitters%()
+
+	Local SavedAll% = True
+	For EmC.RP_EmitterConfig = Each RP_EmitterConfig
+		If RP_SaveEmitterConfig(Handle(EmC), "Data\Emitter Configs\" + EmC\Name$ + ".rpc") = False Then SavedAll = False
+	Next
+	Return SavedAll
+
+End Function
+
 ; Displays the saving dialog
 Function SaveDialog()
 
@@ -9828,10 +9837,7 @@ Function SaveDialog()
 						Case "Attributes"
 							SaveAttributes("Data\Server Data\Attributes.dat") : StatsSaved = True
 						Case "Particles"
-							For EmC.RP_EmitterConfig = Each RP_EmitterConfig
-								RP_SaveEmitterConfig(Handle(EmC), "Data\Emitter Configs\" + EmC\Name$ + ".rpc")
-							Next
-							ParticlesSaved = True
+							ParticlesSaved = SaveParticleEmitters()
 						Case "Damage types"
 							DamageFinal$ = "Data\Server Data\Damage.dat"
 							DamageTemp$ = SafeWriteOpen(DamageFinal$)
@@ -9867,8 +9873,11 @@ Function SaveDialog()
 							If ChatBar <> Null Then Delete ChatBar
 							InterfaceSaved = True
 					End Select
-					FUI_SendMessage(List, M_DELETEINDEX, FUI_SendMessage(List, M_GETSELECTED))
-					FUI_SendMessage(List, M_SETINDEX, 1)
+					; Keep a failed particle save selectable so it can be retried.
+					If FUI_SendMessage(List, M_GETCAPTION) <> "Particles" Or ParticlesSaved = True
+						FUI_SendMessage(List, M_DELETEINDEX, FUI_SendMessage(List, M_GETSELECTED))
+						FUI_SendMessage(List, M_SETINDEX, 1)
+					EndIf
 				; Save all hit
 				Case BSaveAll
 					If ItemsSaved = False Then SaveItems("Data\Server Data\Items.dat")
@@ -9878,9 +9887,7 @@ Function SaveDialog()
 					If AnimsSaved = False Then SaveAnimSets("Data\Game Data\Animations.dat")
 					If StatsSaved = False Then SaveAttributes("Data\Server Data\Attributes.dat")
 					If ParticlesSaved = False
-						For EmC.RP_EmitterConfig = Each RP_EmitterConfig
-							RP_SaveEmitterConfig(Handle(EmC), "Data\Emitter Configs\" + EmC\Name$ + ".rpc")
-						Next
+						ParticlesSaved = SaveParticleEmitters()
 					EndIf
 					If DamageTypesSaved = False
 						DamageFinal$ = "Data\Server Data\Damage.dat"
@@ -9914,7 +9921,8 @@ Function SaveDialog()
 						SaveInterfaceSettings("Data\Game Data\Interface.dat")
 						If ChatBar <> Null Then Delete ChatBar
 					EndIf
-					Result = True
+					If ParticlesSaved = False Then Result = False
+					If ParticlesSaved = True Then Result = True
 			End Select
 			Delete(SaveEvent)
 			SaveEvent = NextSaveEvent
@@ -10706,10 +10714,7 @@ Function menuSaveAll()
 				FUI_CustomMessageBox( "Saving all data", "Save All", 0 )
 				
 				; Save emitters
-				For EmC.RP_EmitterConfig = Each RP_EmitterConfig
-					RP_SaveEmitterConfig(Handle(EmC), "Data\Emitter Configs\" + EmC\Name$ + ".rpc")
-				Next
-				ParticlesSaved = True
+				ParticlesSaved = SaveParticleEmitters()
 				
 				; Save combat
 				DamageFinal$ = "Data\Server Data\Damage.dat"

--- a/src/Tests/Modules/GUEParticleSaveOutcomeTest.bb
+++ b/src/Tests/Modules/GUEParticleSaveOutcomeTest.bb
@@ -73,6 +73,37 @@ Function HasParticleSaveAggregate%(Path$)
 	Return False
 End Function
 
+Function HasExitSaveFailureContainment%(Path$)
+	Local F.BBStream = ReadFile(Path$)
+	Local Line$
+	Local Stage% = 0
+	If F = Null Then F = ReadFile("..\\" + Path$)
+	If F = Null Then F = ReadFile("..\\..\\" + Path$)
+	If F = Null Then Return False
+
+	While Not Eof(F)
+		Line$ = Trim$(ReadLine$(F))
+		Select Stage
+			Case 0
+				If Line$ = ".MainEventLoop" Then Stage = 1
+			Case 1
+				If Line$ = "Until app\Quit = True" Then Stage = 2
+			Case 2
+				If Line$ = "If SaveDialog() = False" Then Stage = 3
+			Case 3
+				If Line$ = "app\Quit = False" Then Stage = 4
+			Case 4
+				If Line$ = "Goto MainEventLoop" Then
+					CloseFile F
+					Return True
+				EndIf
+		End Select
+	Wend
+
+	CloseFile F
+	Return False
+End Function
+
 Test testGUEParticleSavesAggregateEveryEmitterOutcome()
 	Assert(HasParticleSaveAggregate%("GUE.bb") = True)
 End Test
@@ -84,4 +115,5 @@ Test testGUEParticleSaveRoutesKeepDirtyStateOnFailure()
 	Assert(FileContains%(Source$, "If ParticlesSaved = False") = True)
 	Assert(FileContains%(Source$, "If ParticlesSaved = False Then Result = False") = True)
 	Assert(FileContains%(Source$, "If FUI_SendMessage(List, M_GETCAPTION) <> " + Chr$(34) + "Particles" + Chr$(34) + " Or ParticlesSaved = True") = True)
+	Assert(HasExitSaveFailureContainment%(Source$) = True)
 End Test

--- a/src/Tests/Modules/GUEParticleSaveOutcomeTest.bb
+++ b/src/Tests/Modules/GUEParticleSaveOutcomeTest.bb
@@ -1,0 +1,87 @@
+Strict
+EnableGC
+
+// GUE's full editor graph is not safe for the standalone test harness. These
+// bounded source contracts pin the save-outcome handoff instead.
+
+Function FileContains%(Path$, Needle$)
+	Local F.BBStream = ReadFile(Path$)
+	Local Line$
+	If F = Null Then F = ReadFile("..\\" + Path$)
+	If F = Null Then F = ReadFile("..\\..\\" + Path$)
+	If F = Null Then Return False
+
+	While Not Eof(F)
+		Line$ = ReadLine$(F)
+		If Instr(Line$, Needle$) > 0
+			CloseFile F
+			Return True
+		EndIf
+	Wend
+
+	CloseFile F
+	Return False
+End Function
+
+Function CountLinesContaining%(Path$, Needle$)
+	Local F.BBStream = ReadFile(Path$)
+	Local Line$
+	Local Count% = 0
+	If F = Null Then F = ReadFile("..\\" + Path$)
+	If F = Null Then F = ReadFile("..\\..\\" + Path$)
+	If F = Null Then Return 0
+
+	While Not Eof(F)
+		Line$ = ReadLine$(F)
+		If Instr(Line$, Needle$) > 0 Then Count = Count + 1
+	Wend
+
+	CloseFile F
+	Return Count
+End Function
+
+Function HasParticleSaveAggregate%(Path$)
+	Local F.BBStream = ReadFile(Path$)
+	Local Line$
+	Local Stage% = 0
+	If F = Null Then F = ReadFile("..\\" + Path$)
+	If F = Null Then F = ReadFile("..\\..\\" + Path$)
+	If F = Null Then Return False
+
+	While Not Eof(F)
+		Line$ = Trim$(ReadLine$(F))
+		Select Stage
+			Case 0
+				If Line$ = "Function SaveParticleEmitters%()" Then Stage = 1
+			Case 1
+				If Line$ = "Local SavedAll% = True" Then Stage = 2
+			Case 2
+				If Left$(Line$, Len("For EmC.RP_EmitterConfig = Each RP_EmitterConfig")) = "For EmC.RP_EmitterConfig = Each RP_EmitterConfig" Then Stage = 3
+			Case 3
+				If Instr(Line$, "If RP_SaveEmitterConfig") = 1 And Instr(Line$, "= False Then SavedAll = False") > 0 Then Stage = 4
+			Case 4
+				If Line$ = "Next" Then Stage = 5
+			Case 5
+				If Line$ = "Return SavedAll" Then
+					CloseFile F
+					Return True
+				EndIf
+		End Select
+	Wend
+
+	CloseFile F
+	Return False
+End Function
+
+Test testGUEParticleSavesAggregateEveryEmitterOutcome()
+	Assert(HasParticleSaveAggregate%("GUE.bb") = True)
+End Test
+
+Test testGUEParticleSaveRoutesKeepDirtyStateOnFailure()
+	Local Source$ = "GUE.bb"
+	Assert(CountLinesContaining%(Source$, "ParticlesSaved = SaveParticleEmitters()") = 4)
+	Assert(CountLinesContaining%(Source$, "RP_SaveEmitterConfig(Handle(EmC)") = 1)
+	Assert(FileContains%(Source$, "If ParticlesSaved = False") = True)
+	Assert(FileContains%(Source$, "If ParticlesSaved = False Then Result = False") = True)
+	Assert(FileContains%(Source$, "If FUI_SendMessage(List, M_GETCAPTION) <> " + Chr$(34) + "Particles" + Chr$(34) + " Or ParticlesSaved = True") = True)
+End Test


### PR DESCRIPTION
## Outcome

GUE now keeps particle edits marked unsaved whenever any emitter configuration cannot be atomically persisted, so its Save Dialog and exit flow no longer treat a failed write as durable.

## Technical changes

- Centralized all four GUE emitter-save routes behind one aggregate outcome helper.
- Kept failed particle entries selectable for retry and prevented Save All from returning success after a particle failure.
- Added a focused source-contract regression for aggregation, all call sites, dirty-state containment, and Save Dialog containment.

Fixes #893

## Acceptance evidence

- Aggregate helper attempts every emitter and returns failure when any `RP_SaveEmitterConfig` fails: focused contract GREEN.
- Four GUE save routes delegate to the helper; only the helper invokes `RP_SaveEmitterConfig`: focused contract GREEN (`routes=4 direct=1`).
- Save Dialog retains a failed particle selection and returns `False` rather than a successful exit: focused contract GREEN.

## TDD and verification

- Baseline: local native runner unavailable — `./test.sh GUEParticleSaveOutcomeTest` exits 1 because `compiler/BlitzForge/bin/blitzcc` is absent.
- RED: portable pre-fix contract printed `GUE_PARTICLE_SAVE_OUTCOME_CONTRACT_RED` (exit 1) because the aggregate helper and Save All failure gate were absent.
- GREEN: portable contract printed `GUE_PARTICLE_SAVE_OUTCOME_CONTRACT_GREEN helper=1 routes=4 direct=1` (exit 0).
- `git diff --check` and `bash scripts/gen_packet_index.sh --check` completed successfully (`PACKET_INDEX_CHECK_GREEN`).
- Exact-head CI and independent review: pending.

## Compatibility, risk, rollback

Successful `.rpc` writes and file format are unchanged. A failed write now remains visibly unsaved instead of allowing loss of in-memory edits. Roll back by reverting this PR. No deferred follow-up beyond the existing serializer and Loom work.

## Independent review

Pending fresh review of this exact head.
