### PR TITLE
fix(loom): keep ribbon issue chips safe before finder wiring

### DIFF
--- a/src/Modules/Loom/Ribbon.bb
+++ b/src/Modules/Loom/Ribbon.bb
@@ -154,9 +154,11 @@ Type Ribbon
                 LoomTextCentered(sw / 2, 6, brokenLabel, LOOM_DANGER_R, LOOM_DANGER_G, LOOM_DANGER_B)
             EndIf
 
-            If brkHover And clicked And self\brokenRefs <> Null
-                BrokenRefs::openModal(self\brokenRefs)
-                consumed = True
+            If brkHover And clicked
+                If self\brokenRefs <> Null
+                    BrokenRefs::openModal(self\brokenRefs)
+                    consumed = True
+                EndIf
             EndIf
         Else
             // No broken refs but warning/info issues may still be in the
@@ -170,9 +172,11 @@ Type Ribbon
             Else
                 LoomTextCentered(sw / 2, 6, emptyLabel, LOOM_STONE_300_R, LOOM_STONE_300_G, LOOM_STONE_300_B)
             EndIf
-            If emptyHover And clicked And self\brokenRefs <> Null
-                BrokenRefs::openModal(self\brokenRefs)
-                consumed = True
+            If emptyHover And clicked
+                If self\brokenRefs <> Null
+                    BrokenRefs::openModal(self\brokenRefs)
+                    consumed = True
+                EndIf
             EndIf
         EndIf
 

--- a/src/Tests/Modules/LoomRibbonNullGuardTest.bb
+++ b/src/Tests/Modules/LoomRibbonNullGuardTest.bb
@@ -1,0 +1,69 @@
+Strict
+EnableGC
+
+// Ribbon depends on the optional BrokenRefs finder. The full Loom UI graph is
+// not suitable for the standalone harness, so this bounded source contract
+// pins the sequential guard that must contain each modal dispatch.
+
+Function HasSequentialFinderGuard%(Path$, ClickNeedle$)
+    Local F.BBStream = ReadFile(Path$)
+    Local Line$
+    Local Stage% = 0
+    If F = Null Then F = ReadFile("..\" + Path$)
+    If F = Null Then F = ReadFile("..\..\" + Path$)
+    If F = Null Then Return False
+
+    While Not Eof(F)
+        Line$ = Trim$(ReadLine$(F))
+        Select Stage
+            Case 0
+                If Instr(Line$, ClickNeedle$) > 0 Then Stage = 1
+            Case 1
+                If Line$ <> "If self\brokenRefs <> Null"
+                    CloseFile F
+                    Return False
+                EndIf
+                Stage = 2
+            Case 2
+                If Line$ <> "BrokenRefs::openModal(self\brokenRefs)"
+                    CloseFile F
+                    Return False
+                EndIf
+                Stage = 3
+            Case 3
+                If Line$ = "EndIf"
+                    CloseFile F
+                    Return True
+                EndIf
+        End Select
+    Wend
+
+    CloseFile F
+    Return False
+End Function
+
+Function FileContains%(Path$, Needle$)
+    Local F.BBStream = ReadFile(Path$)
+    Local Line$
+    If F = Null Then F = ReadFile("..\" + Path$)
+    If F = Null Then F = ReadFile("..\..\" + Path$)
+    If F = Null Then Return False
+
+    While Not Eof(F)
+        Line$ = ReadLine$(F)
+        If Instr(Line$, Needle$) > 0
+            CloseFile F
+            Return True
+        EndIf
+    Wend
+
+    CloseFile F
+    Return False
+End Function
+
+Test testBrokenReferenceChipWaitsForFinderAttachment()
+    Local Source$ = "Modules\Loom\Ribbon.bb"
+    Assert(HasSequentialFinderGuard%(Source$, "If brkHover And clicked") = True)
+    Assert(HasSequentialFinderGuard%(Source$, "If emptyHover And clicked") = True)
+    Assert(FileContains%(Source$, "self\brokenRefs <> Null And") = False)
+End Test


### PR DESCRIPTION
## Outcome

Loom no longer tries to open the optional issue finder before it has been attached. An unwired ribbon click safely does nothing; attached-finder behavior is unchanged.

## Technical changes

- Replace the two eager `And self\brokenRefs <> Null` click guards with sequential null containment.
- Add a focused source-contract test for both broken-reference and no-broken-reference issue chips.

Fixes #895

## Acceptance evidence

- Each `BrokenRefs::openModal` call now occurs only inside `If self\brokenRefs <> Null`.
- The contract rejects the eager form and confirms both guarded dispatches.
- The normal wired modal dispatch remains the same call and success path.

## Baseline, RED, and GREEN

- Baseline: `git diff --check`, `bash scripts/gen_packet_index.sh --check`, and `bash scripts/gen_bvm_reference.sh --check` exited 0; the BVM generator emitted only its known `BVM_SETOWNER` / `BVM_SCENERYOWNER` warnings.
- RED: focused portable contract exited 1 with `LOOM_RIBBON_NULL_GUARD_CONTRACT_RED click=If brkHover And clicked guard=BrokenRefs::openModal(self\brokenRefs) call=consumed = True`.
- GREEN: the same contract exited 0 with `LOOM_RIBBON_NULL_GUARD_CONTRACT_GREEN guards=2`.
- Final local: `git diff --check`, packet-index check, BVM-reference check, and `bash -n compile.sh test.sh scripts/*.sh` exited 0.
- Native local test: `./test.sh LoomRibbonNullGuardTest` exited 1 because `compiler/BlitzForge/bin/blitzcc` is absent in this worktree. Exact-head CI is required for compiler-backed proof.

## Compatibility, risk, rollback

No wire, persistence, or file-format change. Before attachment, click events become safe no-ops; after attachment, the existing modal behavior remains. Roll back by reverting `e5b55557`.

## Deferred work

Other Loom optional dependencies and broader UI lifecycle work remain outside this narrow fix.

## Independent reviewer verdict

ACCEPT — fresh read-only review of exact head `e5b5555728f1d7f20ca00cb6a17614c7b1dc77af` found the two-file diff fully scoped, both modal calls sequentially contained, attached behavior unchanged, and the source contract adequate. The reviewer ran `git diff --check`, both generator checks, and an independent static scan (`LOOM_RIBBON_REVIEW_STATIC clicks=2 calls=2 unguarded=0 eager=0`). Compiler-backed local execution remains unavailable; exact-head CI is still the merge gate.