### PR TITLE
fix(project-manager): reject incomplete project roots

### DIFF
--- a/src/Modules/Framework/Project/Project.bb
+++ b/src/Modules/Framework/Project/Project.bb
@@ -26,6 +26,7 @@ Type Project
 
     Method verify()
         if (NOT Filesystem::dirExists(Null, self\rootDir + "Data")) return false
+        if (NOT Filesystem::fileExists(Null, self\rootDir + "Data\Game Data\Misc.dat")) return false
         return true
     End Method
 

--- a/src/Tests/Modules/ProjectVerificationTest.bb
+++ b/src/Tests/Modules/ProjectVerificationTest.bb
@@ -7,6 +7,7 @@ EnableGC
 Function ProjectVerificationRequiresMiscSettingsFile%()
     Local F.BBStream = ReadFile("Modules\Framework\Project\Project.bb")
     Local Line$
+    Local Quote$ = Chr$(34)
     Local Stage%
 
     If F = Null Then F = ReadFile("..\Modules\Framework\Project\Project.bb")
@@ -19,9 +20,9 @@ Function ProjectVerificationRequiresMiscSettingsFile%()
             Case 0
                 If Line$ = "Method verify()" Then Stage = 1
             Case 1
-                If Line$ = "if (NOT Filesystem::dirExists(Null, self\rootDir + \"Data\")) return false" Then Stage = 2
+                If Line$ = "if (NOT Filesystem::dirExists(Null, self\rootDir + " + Quote$ + "Data" + Quote$ + ")) return false" Then Stage = 2
             Case 2
-                If Line$ = "if (NOT Filesystem::fileExists(Null, self\rootDir + \"Data\Game Data\Misc.dat\")) return false" Then Stage = 3
+                If Line$ = "if (NOT Filesystem::fileExists(Null, self\rootDir + " + Quote$ + "Data\Game Data\Misc.dat" + Quote$ + ")) return false" Then Stage = 3
                 If Line$ = "return true"
                     CloseFile F
                     Return False

--- a/src/Tests/Modules/ProjectVerificationTest.bb
+++ b/src/Tests/Modules/ProjectVerificationTest.bb
@@ -1,0 +1,43 @@
+Strict
+EnableGC
+
+// Project Manager guards every project-entry path with Project::verify before
+// calling Project::load. A Data directory alone is not enough: load reads the
+// required Data\Game Data\Misc.dat settings file immediately.
+Function ProjectVerificationRequiresMiscSettingsFile%()
+    Local F.BBStream = ReadFile("Modules\Framework\Project\Project.bb")
+    Local Line$
+    Local Stage%
+
+    If F = Null Then F = ReadFile("..\Modules\Framework\Project\Project.bb")
+    If F = Null Then F = ReadFile("..\..\Modules\Framework\Project\Project.bb")
+    If F = Null Then Return False
+
+    While Not Eof(F)
+        Line$ = Trim$(ReadLine$(F))
+        Select Stage
+            Case 0
+                If Line$ = "Method verify()" Then Stage = 1
+            Case 1
+                If Line$ = "if (NOT Filesystem::dirExists(Null, self\rootDir + \"Data\")) return false" Then Stage = 2
+            Case 2
+                If Line$ = "if (NOT Filesystem::fileExists(Null, self\rootDir + \"Data\Game Data\Misc.dat\")) return false" Then Stage = 3
+                If Line$ = "return true"
+                    CloseFile F
+                    Return False
+                EndIf
+            Case 3
+                If Line$ = "return true"
+                    CloseFile F
+                    Return True
+                EndIf
+        End Select
+    Wend
+
+    CloseFile F
+    Return False
+End Function
+
+Test testProjectVerificationRequiresDataAndMiscSettings()
+    Assert(ProjectVerificationRequiresMiscSettingsFile%() = True)
+End Test


### PR DESCRIPTION
## Outcome

Project Manager now rejects incomplete project roots before it tries to read their required game settings. Selecting a folder that only contains `Data\` receives the existing invalid-project path instead of reaching an invalid `Misc.dat` read.

## Technical changes

- Require both `Data\` and `Data\Game Data\Misc.dat` in `Project::verify`.
- Add a focused source-contract regression that requires the Data check, then the Misc.dat check, before acceptance.
- Construct quoted source needles with `Chr$(34)`, matching the repository's BlitzForge test pattern.

Fixes #897

## Acceptance criteria and evidence

- Data-only root rejected before acceptance: the verifier has the required `Filesystem::fileExists` guard before `return true`; portable contract printed `GREEN: PROJECT_VERIFICATION_MISC_GUARD_CONTRACT_GREEN data_and_misc_before_accept=1`.
- Complete root remains accepted: the existing Data-directory guard and final acceptance are retained in sequence.
- Existing Project Manager ingress remains gated: inspected `src/Project Manager.bb:146-162` and `:186-195`; this PR changes only the shared predicate.
- Focused regression added: `src/Tests/Modules/ProjectVerificationTest.bb` rejects the Data-only predicate by requiring the Misc.dat guard before acceptance.

## Baseline, RED, and final verification

- Baseline: portable probe printed `BASELINE: project_verify_data_only=1 misc_guard=0`.
- RED: portable regression mirror printed `RED_EXPECTED: PROJECT_VERIFICATION_MISC_GUARD_MISSING`.
- GREEN: portable contract printed `GREEN: PROJECT_VERIFICATION_MISC_GUARD_CONTRACT_GREEN data_and_misc_before_accept=1`.
- Initial exact-head CI identified the test-literal compile error; follow-up `7101c35` replaced those literals with `Chr$(34)`. Portable correction proof printed `GREEN: PROJECT_VERIFICATION_TEST_LITERAL_CONTRACT_GREEN chr34=1 quoted_guards=2`.
- `git diff --check` -> exit 0.
- `bash scripts/gen_packet_index.sh --check` -> exit 0.
- `bash scripts/gen_bvm_reference.sh --check` -> exit 0; only established `BVM_SETOWNER` and `BVM_SCENERYOWNER` DEAD-API warnings.
- `./test.sh ProjectVerificationTest` and `./compile.sh -t` could not start because `compiler/BlitzForge/bin/blitzcc` is absent; exact-head CI remains the native-proof gate.

## Compatibility, risks, rollback, and deferred work

Valid project roots retain the same format and loading behavior. Incomplete roots that would have failed during load are now rejected earlier. Roll back by reverting `aabc7bef` and `7101c35`. Parsing/creating Misc.dat, project-format changes, and recent-project ordering are intentionally deferred.

## Independent review

Fresh reviewer verdict: **ACCEPT** for exact head `7101c35cf4a295f1c2d136d334b7c5555685ecf7`. It confirmed the two-file scope, directory/file distinction, existing ingress gates, source-contract ordering, and `Chr$(34)` pattern. Exact-head CI is still required before merge.