### PR TITLE
ci: parse Unix publish wrapper before release packaging

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -208,7 +208,7 @@ jobs:
 
       - name: Validate Unix shell syntax
         shell: bash
-        run: bash -n compile.sh test.sh scripts/*.sh
+        run: bash -n compile.sh test.sh publish.sh scripts/*.sh
 
       - name: Set up Rust 1.85.0 (server)
         # dtolnay/rust-toolchain@1.85.0

--- a/src/Tests/Modules/UnixShellSyntaxGateTest.bb
+++ b/src/Tests/Modules/UnixShellSyntaxGateTest.bb
@@ -55,9 +55,10 @@ Function FileContainsOrderedNonComment%(Path$, StartNeedle$, FirstNeedle$, Secon
 End Function
 
 Test testLinuxCISyntaxGateCoversUnixEntrypoints()
-	Assert(FileContains%(".github/workflows/ci.yml", "bash -n compile.sh test.sh scripts/*.sh") = True)
+	Assert(FileContains%(".github/workflows/ci.yml", "bash -n compile.sh test.sh publish.sh scripts/*.sh") = True)
+	Assert(FileContains%(".github/workflows/ci.yml", "bash -n compile.sh test.sh scripts/*.sh") = False)
 End Test
 
 Test testLinuxCISyntaxGateRunsBeforeRustSetup()
-	Assert(FileContainsOrderedNonComment%(".github/workflows/ci.yml", "rust-server:", "- name: Validate Unix shell syntax", "bash -n compile.sh test.sh scripts/*.sh", "- name: Set up Rust 1.85.0 (server)") = True)
+	Assert(FileContainsOrderedNonComment%(".github/workflows/ci.yml", "rust-server:", "- name: Validate Unix shell syntax", "bash -n compile.sh test.sh publish.sh scripts/*.sh", "- name: Set up Rust 1.85.0 (server)") = True)
 End Test


### PR DESCRIPTION
## Outcome

Unix and macOS contributors now get a CI syntax failure before release packaging if the root `publish.sh` wrapper is malformed.

## Technical changes

- Extend the existing Linux parse-only syntax command to include `publish.sh`.
- Strengthen `UnixShellSyntaxGateTest` to require that four-entry-point command, reject the former narrower command, and retain ordering before Rust setup.

Fixes #899

## Acceptance evidence

- The `rust-server` syntax step now parses `compile.sh`, `test.sh`, `publish.sh`, and `scripts/*.sh`.
- The source contract requires the named Linux gate and its placement before Rust setup.
- Packaging remains unexecuted; the workflow only invokes `bash -n`.

## Baseline, RED, GREEN, and final verification

- Baseline: `bash -n compile.sh test.sh publish.sh scripts/*.sh` exited 0 while workflow coverage omitted `publish.sh` (`BASELINE: PUBLISH_SH_OMITTED_FROM_CI_PARSE_GATE`).
- RED: the portable contract exited 1 with `RED_EXPECTED: UNIX_SHELL_SYNTAX_GATE_CONTRACT_RED publish_omitted=1 old_command_present=1`.
- GREEN: the portable contract emitted `UNIX_SHELL_SYNTAX_GATE_CONTRACT_GREEN publish_included=1 ordered_before_rust_setup=1`; parsing emitted `SHELL_PARSE_GREEN entrypoints=6`.
- Final local checks: `git diff --check`, both generated-doc checks, and the six-entry-point `bash -n` command exited 0. BVM-reference check emitted only known `BVM_SETOWNER` / `BVM_SCENERYOWNER` dead-API warnings.
- Local native focused test is UNVERIFIED: `./test.sh UnixShellSyntaxGateTest` exited 1 because `compiler/BlitzForge/bin/blitzcc` is absent. Exact-head Build and test CI is required for compiler-backed proof.

## Compatibility, risks, rollback, and deferred work

This is parse coverage only: it does not execute or change `publish.sh`, release contents, Windows CI, or Rust toolchain policy. Rollback is reverting this PR. Runtime package behavior remains deferred.

## Independent review

Pending: a fresh reviewer will assess the exact PR head after CI completes.

## Independent review

ACCEPT: a fresh reviewer inspected exact head `8f24e9434ae17eb66d3e8bce65e6a84ca9ccb10e` against `e65e1ac7`, confirmed the two-file scope, parse-only behavior, full-command contract, old-command rejection, and pre-Rust ordering. Native focused execution remains unverified locally because `blitzcc` is absent; exact-head CI remains required.
