### PR TITLE
fix(environment): reject incomplete configuration loads

### DIFF
--- a/src/Modules/Environment.bb
+++ b/src/Modules/Environment.bb
@@ -6,6 +6,7 @@ Const W_Fog   = 3
 Const W_Storm = 4
 Const W_Wind  = 5
 Const SunRecordBytes = 78
+Const EnvironmentHeaderBytes = 20
 
 Dim SeasonName$(11)
 Dim SeasonStartDay(11)
@@ -84,9 +85,46 @@ End Function
 ;   * TimeH / TimeM bounded to wall-clock ranges; Year / Day clamped to
 ;     non-negative.
 Function LoadEnvironment()
+	Return LoadEnvironmentFromFile("Data\Server Data\Environment.dat", True)
+End Function
 
-	F = ReadFile("Data\Server Data\Environment.dat")
-	If F = 0 Then Return CreateEnvironment()
+; Verifies the variable-length Environment.dat layout before load mutates the
+; live time, season, and month globals. ReadInt silently zero-fills past EOF,
+; so a truncated file must be rejected before the normal reader starts.
+Function EnvironmentFileIsComplete%(F, FileBytes)
+	If FileBytes < EnvironmentHeaderBytes Then Return False
+	SeekFile F, EnvironmentHeaderBytes
+	For i = 0 To 11
+		If FilePos(F) + 4 > FileBytes Then Return False
+		NameBytes = ReadInt(F)
+		If NameBytes < 0 Or NameBytes > 256 Then Return False
+		If FilePos(F) + NameBytes + 12 > FileBytes Then Return False
+		SeekFile F, FilePos(F) + NameBytes + 12
+	Next
+	For i = 0 To 19
+		If FilePos(F) + 4 > FileBytes Then Return False
+		NameBytes = ReadInt(F)
+		If NameBytes < 0 Or NameBytes > 256 Then Return False
+		If FilePos(F) + NameBytes + 4 > FileBytes Then Return False
+		SeekFile F, FilePos(F) + NameBytes + 4
+	Next
+	Return True
+End Function
+
+; The optional CreateMissing flag retains LoadEnvironment's original default
+; creation behavior while allowing focused callers/tests to reject absence.
+Function LoadEnvironmentFromFile(Filename$, CreateMissing = False)
+
+	F = ReadFile(Filename$)
+	If F = 0
+		If CreateMissing = True Then Return CreateEnvironment()
+		Return False
+	EndIf
+	If EnvironmentFileIsComplete(F, FileSize(Filename$)) = False
+		CloseFile(F)
+		Return False
+	EndIf
+	SeekFile F, 0
 	Year = ReadInt(F)
 	Day = ReadInt(F)
 	TimeH = ReadInt(F)

--- a/src/Tests/Modules/EnvironmentTest.bb
+++ b/src/Tests/Modules/EnvironmentTest.bb
@@ -20,8 +20,8 @@ End Function
 Function SafeWriteAbort(TempPath$, F)
 End Function
 
-Function ReadBoundedString$(F, MaxLen)
-	If F = 0 Then Return ""
+Function ReadBoundedString$(F.BBStream, MaxLen)
+	If F = Null Then Return ""
 	Local Length = ReadInt(F)
 	If Length < 0 Or Length > MaxLen Then Return ""
 	Local Value$ = ""

--- a/src/Tests/Modules/EnvironmentTest.bb
+++ b/src/Tests/Modules/EnvironmentTest.bb
@@ -20,18 +20,51 @@ End Function
 Function SafeWriteAbort(TempPath$, F)
 End Function
 
-; LoadEnvironment now reads SeasonName / MonthName via ReadBoundedString$
-; (added to harden against corrupted Environment.dat). The real helper
-; lives in Logging.bb; this test doesn't exercise the load path -- only
-; TimeDelta is the unit under test below -- so a no-op stub is enough
-; to let Environment.bb compile under Strict.
 Function ReadBoundedString$(F, MaxLen)
-	Return ""
+	If F = 0 Then Return ""
+	Local Length = ReadInt(F)
+	If Length < 0 Or Length > MaxLen Then Return ""
+	Local Value$ = ""
+	For i = 1 To Length
+		If Eof(F) Then Exit
+		Value$ = Value$ + Chr$(ReadByte(F))
+	Next
+	Return Value$
 End Function
 
 Include "Modules\Environment.bb"
 
 Global SunLoadTestFile$ = CurrentDir$() + "environment_suns_test.dat"
+Global EnvironmentLoadTestFile$ = CurrentDir$() + "environment_load_test.dat"
+
+Function ClearEnvironmentLoadTestState()
+	If FileType(EnvironmentLoadTestFile$) = 1 Then DeleteFile(EnvironmentLoadTestFile$)
+End Function
+
+Function WriteEnvironmentLoadTestFile%(IncludeMonths = True)
+	Local F.BBStream = WriteFile(EnvironmentLoadTestFile$)
+	Local i
+	If F = Null Then Return False
+	WriteInt F, 7
+	WriteInt F, 42
+	WriteInt F, 14
+	WriteInt F, 30
+	WriteInt F, 10
+	For i = 0 To 11
+		WriteString F, "Season " + i
+		WriteInt F, i * 28
+		WriteInt F, 18
+		WriteInt F, 6
+	Next
+	If IncludeMonths = True
+		For i = 0 To 19
+			WriteString F, "Month " + i
+			WriteInt F, i * 28
+		Next
+	EndIf
+	CloseFile F
+	Return True
+End Function
 
 Function ClearSunLoadTestState()
 	If FileType(SunLoadTestFile$) = 1 Then DeleteFile(SunLoadTestFile$)
@@ -165,4 +198,25 @@ Test testLoadSunsLoadsTheExactDeclaredRecordCount()
 	Assert(LoadSunsFromFile(SunLoadTestFile$) = True)
 	Assert(SunLoadTestCount() = 1)
 	ClearSunLoadTestState()
+End Test
+
+Test testLoadEnvironmentFromFileAcceptsCompleteRequiredRecords()
+	ClearEnvironmentLoadTestState()
+	Assert(WriteEnvironmentLoadTestFile(True) = True)
+	Assert(LoadEnvironmentFromFile(EnvironmentLoadTestFile$) = True)
+	Assert(Year = 7)
+	Assert(Day = 42)
+	Assert(TimeH = 14)
+	Assert(TimeM = 30)
+	Assert(TimeFactor = 10)
+	Assert(SeasonName$(0) = "Season 0")
+	Assert(MonthName$(19) = "Month 19")
+	ClearEnvironmentLoadTestState()
+End Test
+
+Test testLoadEnvironmentFromFileRejectsTruncatedRequiredRecords()
+	ClearEnvironmentLoadTestState()
+	Assert(WriteEnvironmentLoadTestFile(False) = True)
+	Assert(LoadEnvironmentFromFile(EnvironmentLoadTestFile$) = False)
+	ClearEnvironmentLoadTestState()
 End Test


### PR DESCRIPTION
## Outcome

Corrupted or incomplete environment configuration files now fail load instead of being silently read as zero-filled time, season, or month values during Server/GUE startup.

## Changes

- Preflight the complete variable-length `Environment.dat` layout before any live globals are mutated.
- Preserve default creation when the normal configuration file is missing.
- Add focused complete-file and truncated-file regression coverage.

Fixes #901

## Acceptance evidence

- Missing default file path still calls the existing creation path via `LoadEnvironmentFromFile(..., True)`.
- Complete season/month records are accepted by `testLoadEnvironmentFromFileAcceptsCompleteRequiredRecords`.
- A file truncated before required month records is rejected by `testLoadEnvironmentFromFileRejectsTruncatedRequiredRecords`.

## RED -> GREEN and verification

- RED: source contract exited 1 with `ENVIRONMENT_LOAD_CONTAINMENT_RED missing-loader-or-completeness-guard`.
- GREEN: source contract printed `ENVIRONMENT_LOAD_CONTAINMENT_GREEN complete-guard=1 valid-test=1 truncated-test=1`.
- `git diff --check` exited 0.
- Packet-index and BVM-reference checks exited 0; the latter emitted only the known `BVM_SETOWNER` / `BVM_SCENERYOWNER` warnings.
- Local native `./test.sh EnvironmentTest` is UNVERIFIED because `compiler/BlitzForge/bin/blitzcc` is absent after a bounded submodule-init attempt; exact-head CI is required for compiler-backed proof.

## Compatibility, rollback, and follow-up

The file format and valid-file path are unchanged. Malformed files now return `False`, matching existing Server/GUE failure handling. Rollback is reverting this PR. No deferred scope expansion.

## Independent review

Fresh review of exact head `8affccec4e95e1aa5fe5f467ae1c6695d444f76e`: **ACCEPT**. Review cycle 1 found the test stub Strict `BBStream` typing defect; commit `8affccec` corrected it and a fresh review accepted the new head. Exact-head CI remains required before merge.