### PR TITLE
fix(GUE): retain damage edits after save failure

### DIFF
--- a/src/GUE.bb
+++ b/src/GUE.bb
@@ -9904,7 +9904,8 @@ Function SaveDialog()
 						SaveInterfaceSettings("Data\Game Data\Interface.dat")
 						If ChatBar <> Null Then Delete ChatBar
 					EndIf
-					If ParticlesSaved = False Or DamageTypesSaved = False Then Result = False
+					If ParticlesSaved = False Then Result = False
+					If DamageTypesSaved = False Then Result = False
 					If ParticlesSaved = True And DamageTypesSaved = True Then Result = True
 			End Select
 			Delete(SaveEvent)

--- a/src/GUE.bb
+++ b/src/GUE.bb
@@ -6563,7 +6563,7 @@ Cls
 
 			; Save damage types
 			Case BDamageTypesSave
-				DamageTypesSaved = SaveDamageTypes()
+				DamageTypesSaved = SaveDamageTypes("Data\Server Data\Damage.dat")
 
 			Default
 				; Damage type names
@@ -9767,21 +9767,6 @@ Function SaveParticleEmitters%()
 
 End Function
 
-; Saves every damage type and keeps the GUE dirty state when its atomic
-; promotion cannot complete.
-Function SaveDamageTypes%()
-
-	Local DamageFinal$ = "Data\Server Data\Damage.dat"
-	Local DamageTemp$ = SafeWriteOpen(DamageFinal$)
-	F = WriteFile(DamageTemp$)
-	If F = 0 Then Return False
-	For i = 0 To 19
-		WriteString F, DamageTypes$(i)
-	Next
-	Return SafeWriteCommit(DamageTemp$, DamageFinal$, F)
-
-End Function
-
 ; Displays the saving dialog
 Function SaveDialog()
 
@@ -9850,7 +9835,7 @@ Function SaveDialog()
 						Case "Particles"
 							ParticlesSaved = SaveParticleEmitters()
 						Case "Damage types"
-							DamageTypesSaved = SaveDamageTypes()
+							DamageTypesSaved = SaveDamageTypes("Data\Server Data\Damage.dat")
 						Case "Days & seasons"
 							SaveEnvironment(True)
 							SaveSuns()
@@ -9895,7 +9880,7 @@ Function SaveDialog()
 						ParticlesSaved = SaveParticleEmitters()
 					EndIf
 					If DamageTypesSaved = False
-						DamageTypesSaved = SaveDamageTypes()
+						DamageTypesSaved = SaveDamageTypes("Data\Server Data\Damage.dat")
 					EndIf
 					If EnvironmentSaved = False
 						SaveEnvironment(True)
@@ -10715,7 +10700,7 @@ Function menuSaveAll()
 				ParticlesSaved = SaveParticleEmitters()
 				
 				; Save combat
-				DamageTypesSaved = SaveDamageTypes()
+				DamageTypesSaved = SaveDamageTypes("Data\Server Data\Damage.dat")
 				
 				; Save projectiles
 				SaveProjectiles("Data\Server Data\Projectiles.dat")

--- a/src/GUE.bb
+++ b/src/GUE.bb
@@ -6563,15 +6563,7 @@ Cls
 
 			; Save damage types
 			Case BDamageTypesSave
-				Local DamageFinal$ = "Data\Server Data\Damage.dat"
-				Local DamageTemp$ = SafeWriteOpen(DamageFinal$)
-				F = WriteFile(DamageTemp$)
-				If F = 0 Then RuntimeError("Could not open " + DamageTemp$ + " for write")
-					For i = 0 To 19
-						WriteString F, DamageTypes$(i)
-					Next
-				SafeWriteCommit(DamageTemp$, DamageFinal$, F)
-				DamageTypesSaved = True
+				DamageTypesSaved = SaveDamageTypes()
 
 			Default
 				; Damage type names
@@ -9775,6 +9767,21 @@ Function SaveParticleEmitters%()
 
 End Function
 
+; Saves every damage type and keeps the GUE dirty state when its atomic
+; promotion cannot complete.
+Function SaveDamageTypes%()
+
+	Local DamageFinal$ = "Data\Server Data\Damage.dat"
+	Local DamageTemp$ = SafeWriteOpen(DamageFinal$)
+	F = WriteFile(DamageTemp$)
+	If F = 0 Then Return False
+	For i = 0 To 19
+		WriteString F, DamageTypes$(i)
+	Next
+	Return SafeWriteCommit(DamageTemp$, DamageFinal$, F)
+
+End Function
+
 ; Displays the saving dialog
 Function SaveDialog()
 
@@ -9843,15 +9850,7 @@ Function SaveDialog()
 						Case "Particles"
 							ParticlesSaved = SaveParticleEmitters()
 						Case "Damage types"
-							DamageFinal$ = "Data\Server Data\Damage.dat"
-							DamageTemp$ = SafeWriteOpen(DamageFinal$)
-							F = WriteFile(DamageTemp$)
-							If F = 0 Then RuntimeError("Could not open " + DamageTemp$ + " for write")
-								For i = 0 To 19
-									WriteString F, DamageTypes$(i)
-								Next
-							SafeWriteCommit(DamageTemp$, DamageFinal$, F)
-							DamageTypesSaved = True
+							DamageTypesSaved = SaveDamageTypes()
 						Case "Days & seasons"
 							SaveEnvironment(True)
 							SaveSuns()
@@ -9877,10 +9876,12 @@ Function SaveDialog()
 							If ChatBar <> Null Then Delete ChatBar
 							InterfaceSaved = True
 					End Select
-					; Keep a failed particle save selectable so it can be retried.
+					; Keep failed particle and damage-type saves selectable so either can be retried.
 					If FUI_SendMessage(List, M_GETCAPTION) <> "Particles" Or ParticlesSaved = True
-						FUI_SendMessage(List, M_DELETEINDEX, FUI_SendMessage(List, M_GETSELECTED))
-						FUI_SendMessage(List, M_SETINDEX, 1)
+						If FUI_SendMessage(List, M_GETCAPTION) <> "Damage types" Or DamageTypesSaved = True
+							FUI_SendMessage(List, M_DELETEINDEX, FUI_SendMessage(List, M_GETSELECTED))
+							FUI_SendMessage(List, M_SETINDEX, 1)
+						EndIf
 					EndIf
 				; Save all hit
 				Case BSaveAll
@@ -9894,14 +9895,7 @@ Function SaveDialog()
 						ParticlesSaved = SaveParticleEmitters()
 					EndIf
 					If DamageTypesSaved = False
-						DamageFinal$ = "Data\Server Data\Damage.dat"
-						DamageTemp$ = SafeWriteOpen(DamageFinal$)
-						F = WriteFile(DamageTemp$)
-						If F = 0 Then RuntimeError("Could not open " + DamageTemp$ + " for write")
-							For i = 0 To 19
-								WriteString F, DamageTypes$(i)
-							Next
-						SafeWriteCommit(DamageTemp$, DamageFinal$, F)
+						DamageTypesSaved = SaveDamageTypes()
 					EndIf
 					If EnvironmentSaved = False
 						SaveEnvironment(True)
@@ -9925,8 +9919,8 @@ Function SaveDialog()
 						SaveInterfaceSettings("Data\Game Data\Interface.dat")
 						If ChatBar <> Null Then Delete ChatBar
 					EndIf
-					If ParticlesSaved = False Then Result = False
-					If ParticlesSaved = True Then Result = True
+					If ParticlesSaved = False Or DamageTypesSaved = False Then Result = False
+					If ParticlesSaved = True And DamageTypesSaved = True Then Result = True
 			End Select
 			Delete(SaveEvent)
 			SaveEvent = NextSaveEvent
@@ -10721,15 +10715,7 @@ Function menuSaveAll()
 				ParticlesSaved = SaveParticleEmitters()
 				
 				; Save combat
-				DamageFinal$ = "Data\Server Data\Damage.dat"
-				DamageTemp$ = SafeWriteOpen(DamageFinal$)
-				F = WriteFile(DamageTemp$)
-				If F = 0 Then RuntimeError("Could not open " + DamageTemp$ + " for write")
-					For i = 0 To 19
-						WriteString F, DamageTypes$(i)
-					Next
-				SafeWriteCommit(DamageTemp$, DamageFinal$, F)
-				DamageTypesSaved = True
+				DamageTypesSaved = SaveDamageTypes()
 				
 				; Save projectiles
 				SaveProjectiles("Data\Server Data\Projectiles.dat")

--- a/src/Tests/Modules/GUEDamageTypeSaveOutcomeTest.bb
+++ b/src/Tests/Modules/GUEDamageTypeSaveOutcomeTest.bb
@@ -78,14 +78,14 @@ Function HasDamageTypeSerializer%(Path$)
 End Function
 
 Test testGUEDamageTypeSaveUsesOneOutcomeHelper()
-	Assert(HasDamageTypeSerializer%("Modules\\Items.bb") = True)
+	Assert(HasDamageTypeSerializer%("Modules\Items.bb") = True)
 	Assert(CountLinesContaining%("GUE.bb", "SafeWriteCommit(DamageTemp$, DamageFinal$, F)") = 0)
 End Test
 
 Test testGUEDamageTypeSaveRoutesKeepDirtyStateOnFailure()
 	Local Source$ = "GUE.bb"
-	Assert(CountLinesContaining%(Source$, "DamageTypesSaved = SaveDamageTypes(" + Chr$(34) + "Data\\Server Data\\Damage.dat" + Chr$(34) + ")") = 4)
+	Assert(CountLinesContaining%(Source$, "DamageTypesSaved = SaveDamageTypes(" + Chr$(34) + "Data\Server Data\Damage.dat" + Chr$(34) + ")") = 4)
 	Assert(FileContains%(Source$, "If FUI_SendMessage(List, M_GETCAPTION) <> " + Chr$(34) + "Damage types" + Chr$(34) + " Or DamageTypesSaved = True") = True)
-	Assert(FileContains%(Source$, "If ParticlesSaved = False Or DamageTypesSaved = False Then Result = False") = True)
+	Assert(FileContains%(Source$, "If DamageTypesSaved = False Then Result = False") = True)
 	Assert(FileContains%(Source$, "If ParticlesSaved = True And DamageTypesSaved = True Then Result = True") = True)
 End Test

--- a/src/Tests/Modules/GUEDamageTypeSaveOutcomeTest.bb
+++ b/src/Tests/Modules/GUEDamageTypeSaveOutcomeTest.bb
@@ -40,7 +40,7 @@ Function CountLinesContaining%(Path$, Needle$)
 	Return Count
 End Function
 
-Function HasDamageSaveHelper%(Path$)
+Function HasDamageTypeSerializer%(Path$)
 	Local F.BBStream = ReadFile(Path$)
 	Local Line$
 	Local Stage% = 0
@@ -52,23 +52,21 @@ Function HasDamageSaveHelper%(Path$)
 		Line$ = Trim$(ReadLine$(F))
 		Select Stage
 			Case 0
-				If Line$ = "Function SaveDamageTypes%()" Then Stage = 1
+				If Line$ = "Function SaveDamageTypes(Filename$)" Then Stage = 1
 			Case 1
-				If Line$ = "Local DamageFinal$ = " + Chr$(34) + "Data\\Server Data\\Damage.dat" + Chr$(34) Then Stage = 2
+				If Line$ = "Local Temp$ = SafeWriteOpen$(Filename$)" Then Stage = 2
 			Case 2
-				If Line$ = "Local DamageTemp$ = SafeWriteOpen(DamageFinal$)" Then Stage = 3
+				If Line$ = "F = WriteFile(Temp$)" Then Stage = 3
 			Case 3
-				If Line$ = "F = WriteFile(DamageTemp$)" Then Stage = 4
+				If Line$ = "If F = 0 Then Return False" Then Stage = 4
 			Case 4
-				If Line$ = "If F = 0 Then Return False" Then Stage = 5
+				If Line$ = "For i = 0 To 19" Then Stage = 5
 			Case 5
-				If Line$ = "For i = 0 To 19" Then Stage = 6
+				If Line$ = "WriteString(F, DamageTypes$(i))" Then Stage = 6
 			Case 6
-				If Line$ = "WriteString F, DamageTypes$(i)" Then Stage = 7
+				If Line$ = "Next" Then Stage = 7
 			Case 7
-				If Line$ = "Next" Then Stage = 8
-			Case 8
-				If Line$ = "Return SafeWriteCommit(DamageTemp$, DamageFinal$, F)" Then
+				If Line$ = "Return SafeWriteCommit%(Temp$, Filename$, F)" Then
 					CloseFile F
 					Return True
 				EndIf
@@ -80,15 +78,13 @@ Function HasDamageSaveHelper%(Path$)
 End Function
 
 Test testGUEDamageTypeSaveUsesOneOutcomeHelper()
-	Local Source$ = "GUE.bb"
-	Assert(HasDamageSaveHelper%(Source$) = True)
-	Assert(CountLinesContaining%(Source$, "WriteString F, DamageTypes$(i)") = 1)
-	Assert(CountLinesContaining%(Source$, "SafeWriteCommit(DamageTemp$, DamageFinal$, F)") = 1)
+	Assert(HasDamageTypeSerializer%("Modules\\Items.bb") = True)
+	Assert(CountLinesContaining%("GUE.bb", "SafeWriteCommit(DamageTemp$, DamageFinal$, F)") = 0)
 End Test
 
 Test testGUEDamageTypeSaveRoutesKeepDirtyStateOnFailure()
 	Local Source$ = "GUE.bb"
-	Assert(CountLinesContaining%(Source$, "DamageTypesSaved = SaveDamageTypes()") = 4)
+	Assert(CountLinesContaining%(Source$, "DamageTypesSaved = SaveDamageTypes(" + Chr$(34) + "Data\\Server Data\\Damage.dat" + Chr$(34) + ")") = 4)
 	Assert(FileContains%(Source$, "If FUI_SendMessage(List, M_GETCAPTION) <> " + Chr$(34) + "Damage types" + Chr$(34) + " Or DamageTypesSaved = True") = True)
 	Assert(FileContains%(Source$, "If ParticlesSaved = False Or DamageTypesSaved = False Then Result = False") = True)
 	Assert(FileContains%(Source$, "If ParticlesSaved = True And DamageTypesSaved = True Then Result = True") = True)

--- a/src/Tests/Modules/GUEDamageTypeSaveOutcomeTest.bb
+++ b/src/Tests/Modules/GUEDamageTypeSaveOutcomeTest.bb
@@ -1,0 +1,95 @@
+Strict
+EnableGC
+
+// GUE's full editor graph is not safe for the standalone test harness. These
+// bounded source contracts pin the Damage.dat save-outcome handoff instead.
+
+Function FileContains%(Path$, Needle$)
+	Local F.BBStream = ReadFile(Path$)
+	Local Line$
+	If F = Null Then F = ReadFile("..\\" + Path$)
+	If F = Null Then F = ReadFile("..\\..\\" + Path$)
+	If F = Null Then Return False
+
+	While Not Eof(F)
+		Line$ = ReadLine$(F)
+		If Instr(Line$, Needle$) > 0
+			CloseFile F
+			Return True
+		EndIf
+	Wend
+
+	CloseFile F
+	Return False
+End Function
+
+Function CountLinesContaining%(Path$, Needle$)
+	Local F.BBStream = ReadFile(Path$)
+	Local Line$
+	Local Count% = 0
+	If F = Null Then F = ReadFile("..\\" + Path$)
+	If F = Null Then F = ReadFile("..\\..\\" + Path$)
+	If F = Null Then Return 0
+
+	While Not Eof(F)
+		Line$ = ReadLine$(F)
+		If Instr(Line$, Needle$) > 0 Then Count = Count + 1
+	Wend
+
+	CloseFile F
+	Return Count
+End Function
+
+Function HasDamageSaveHelper%(Path$)
+	Local F.BBStream = ReadFile(Path$)
+	Local Line$
+	Local Stage% = 0
+	If F = Null Then F = ReadFile("..\\" + Path$)
+	If F = Null Then F = ReadFile("..\\..\\" + Path$)
+	If F = Null Then Return False
+
+	While Not Eof(F)
+		Line$ = Trim$(ReadLine$(F))
+		Select Stage
+			Case 0
+				If Line$ = "Function SaveDamageTypes%()" Then Stage = 1
+			Case 1
+				If Line$ = "Local DamageFinal$ = " + Chr$(34) + "Data\\Server Data\\Damage.dat" + Chr$(34) Then Stage = 2
+			Case 2
+				If Line$ = "Local DamageTemp$ = SafeWriteOpen(DamageFinal$)" Then Stage = 3
+			Case 3
+				If Line$ = "F = WriteFile(DamageTemp$)" Then Stage = 4
+			Case 4
+				If Line$ = "If F = 0 Then Return False" Then Stage = 5
+			Case 5
+				If Line$ = "For i = 0 To 19" Then Stage = 6
+			Case 6
+				If Line$ = "WriteString F, DamageTypes$(i)" Then Stage = 7
+			Case 7
+				If Line$ = "Next" Then Stage = 8
+			Case 8
+				If Line$ = "Return SafeWriteCommit(DamageTemp$, DamageFinal$, F)" Then
+					CloseFile F
+					Return True
+				EndIf
+		End Select
+	Wend
+
+	CloseFile F
+	Return False
+End Function
+
+Test testGUEDamageTypeSaveUsesOneOutcomeHelper()
+	Local Source$ = "GUE.bb"
+	Assert(HasDamageSaveHelper%(Source$) = True)
+	Assert(CountLinesContaining%(Source$, "WriteString F, DamageTypes$(i)") = 1)
+	Assert(CountLinesContaining%(Source$, "SafeWriteCommit(DamageTemp$, DamageFinal$, F)") = 1)
+End Test
+
+Test testGUEDamageTypeSaveRoutesKeepDirtyStateOnFailure()
+	Local Source$ = "GUE.bb"
+	Assert(CountLinesContaining%(Source$, "DamageTypesSaved = SaveDamageTypes()") = 4)
+	Assert(FileContains%(Source$, "If FUI_SendMessage(List, M_GETCAPTION) <> " + Chr$(34) + "Damage types" + Chr$(34) + " Or DamageTypesSaved = True") = True)
+	Assert(FileContains%(Source$, "If ParticlesSaved = False Or DamageTypesSaved = False Then Result = False") = True)
+	Assert(FileContains%(Source$, "If ParticlesSaved = True And DamageTypesSaved = True Then Result = True") = True)
+End Test


### PR DESCRIPTION
## Outcome

GUE now keeps unsaved Damage.dat edits retryable if an atomic save fails, instead of marking them saved or letting Save All exit successfully.

## Technical changes

- Routes every GUE Damage.dat save through the existing `Items.bb` `SaveDamageTypes(Filename$)` atomic serializer.
- Propagates its boolean result through the Damage Types tab, selected Save Dialog action, Save All, and menu Save All.
- Keeps a failed damage-type selection in the dialog and requires both particle and damage-type persistence to succeed before Save All reports success.

Fixes #903

## Acceptance evidence

- The focused contract proves the shared serializer's 20-string atomic write and that GUE no longer contains a direct Damage.dat commit.
- All four GUE routes assign the existing serializer result to `DamageTypesSaved`.
- The contract checks failed-selection retention, an explicit particle failure guard, a damage failure guard, and combined success containment.

## Baseline, RED, GREEN, and final verification

- Baseline: `git diff --check`, `bash scripts/gen_packet_index.sh --check`, and `bash scripts/gen_bvm_reference.sh --check` exited 0. The pre-change inventory was 4 direct Damage.dat commits, 0 outcome-aware routes, and 0 damage failure exit guards.
- RED: the current contract evaluated against `origin/develop` exited 1 with `GUE_DAMAGE_TYPE_SAVE_OUTCOME_CONTRACT_RED missing=no_direct_gue_commit,routes,retry,exit_false,exit_true`.
- GREEN: the same contract on this head printed `GUE_DAMAGE_TYPE_SAVE_OUTCOME_CONTRACT_GREEN serializer=1 routes=4 direct=0 retry=1 particle=1 damage=1 dialog=1`.
- Final local checks: `git diff --check`, `bash scripts/gen_packet_index.sh --check`, `bash scripts/gen_bvm_reference.sh --check`, and `bash -n compile.sh test.sh publish.sh scripts/*.sh` exited 0; the BVM check emitted only known `BVM_SETOWNER` / `BVM_SCENERYOWNER` warnings.
- Native local `./test.sh GUEDamageTypeSaveOutcomeTest` exited 1 because `compiler/BlitzForge/bin/blitzcc` is absent after bounded submodule initialization. Exact head `a88209de` passed CI run `29946700135`: Build and test (6m35s) and Rust server (Linux) (3m52s).

## Compatibility, risk, rollback, and deferred work

Successful Damage.dat serialization and the file format are unchanged. Failed initial writes and failed atomic promotions now retain dirty state for retry. Roll back by reverting this PR. Particle persistence, other GUE save paths, Loom, protocol handling, and Rust work are intentionally out of scope.

## Independent review

- Review cycle 1: REQUEST_CHANGES; CI found a duplicate local serializer name. Corrected by reusing the existing Items serializer.
- Review cycle 2: REQUEST_CHANGES; exact-head test run found two source-contract regressions. Corrected by byte-identical path matching and preserving the particle failure guard.
- Review cycle 3: ACCEPT for exact head `a88209de96a189b82be9706eb75f1379861f38e4`; scope, outcome containment, test coverage, fit, and hidden costs reviewed. 