### PR TITLE
fix(projectiles): reject incomplete template records

### DIFF
--- a/docs/modules/projectiles.md
+++ b/docs/modules/projectiles.md
@@ -79,7 +79,7 @@ Parameters:
 
 *   _Filename$_ — Path to the projectile data file (typically `Data\Server Data\Projectiles.dat`).
 
-Reads projectile templates from disk and registers each one in `ProjectileList`. Each record carries a 2-byte `ID` followed by the projectile's fields; an out-of-range `ID` or a malformed length-prefixed string aborts the load defensively rather than crashing the server. String fields go through `ReadBoundedString$` (see [Logging.bb](logging.md)) with a 256-byte cap.
+Reads projectile templates from disk and registers each one in `ProjectileList`. Each record carries a 2-byte `ID` followed by the projectile's fields; the loader verifies the complete bounded record layout before publishing any template, so an incomplete or malformed trailing record loads no partial/default projectile. An out-of-range `ID` or malformed length-prefixed string also aborts the load defensively rather than crashing the server. String fields go through `ReadBoundedString$` (see [Logging.bb](logging.md)) with a 256-byte cap; the on-disk format itself is unchanged.
 
   
 

--- a/src/Modules/Projectiles.bb
+++ b/src/Modules/Projectiles.bb
@@ -66,6 +66,35 @@ Function DuplicateProjectileTemplate(srcID)
 	Return Dst\ID
 End Function
 
+; Checks the complete variable-length Projectiles.dat layout before the
+; normal reader allocates or indexes any live Projectile. ReadShort and
+; ReadInt zero-fill at EOF, so an incomplete record must not become a
+; zero-default template in ProjectileList.
+Function ProjectileBoundedStringIsComplete%(F, FileBytes)
+	If FilePos(F) + 4 > FileBytes Then Return False
+	NameBytes = ReadInt(F)
+	If NameBytes < 0 Or NameBytes > 256 Then Return False
+	If FilePos(F) + NameBytes > FileBytes Then Return False
+	SeekFile F, FilePos(F) + NameBytes
+	Return True
+End Function
+
+Function ProjectileFileIsComplete%(F, FileBytes)
+	While Not Eof(F)
+		If FilePos(F) + 2 > FileBytes Then Return False
+		SeekFile F, FilePos(F) + 2
+		If ProjectileBoundedStringIsComplete(F, FileBytes) = False Then Return False
+		If FilePos(F) + 2 > FileBytes Then Return False
+		SeekFile F, FilePos(F) + 2
+		If ProjectileBoundedStringIsComplete(F, FileBytes) = False Then Return False
+		If ProjectileBoundedStringIsComplete(F, FileBytes) = False Then Return False
+		; Emitter texture IDs, homing, hit chance, damage, damage type, speed.
+		If FilePos(F) + 11 > FileBytes Then Return False
+		SeekFile F, FilePos(F) + 11
+	Wend
+	Return True
+End Function
+
 ; Loads all projectiles from a file and returns how many were loaded
 Function LoadProjectiles(Filename$)
 
@@ -73,6 +102,11 @@ Function LoadProjectiles(Filename$)
 
 	F = ReadFile(Filename$)
 	If F = 0 Then Return -1
+	If ProjectileFileIsComplete(F, FileSize(Filename$)) = False
+		CloseFile F
+		Return 0
+	EndIf
+	SeekFile F, 0
 
 		While Not Eof(F)
 			P.Projectile = New Projectile

--- a/src/Tests/Modules/ProjectilesCorrectnessTest.bb
+++ b/src/Tests/Modules/ProjectilesCorrectnessTest.bb
@@ -211,3 +211,28 @@ Test testLoadProjectilesRejectsTruncatedStringTailBeforePublish()
 	ClearProjectiles()
 	CleanupProjFile()
 End Test
+
+; The fixed scalar tail is also part of the record boundary. Stopping in the
+; two-byte Damage field must not publish the otherwise complete template.
+Test testLoadProjectilesRejectsTruncatedScalarTailBeforePublish()
+	ClearProjectiles()
+	CleanupProjFile()
+	Local F.BBStream = WriteFile(ProjTestFile$)
+	WriteShort F, 8
+	WriteString F, "Scalar tail"
+	WriteShort F, 12
+	WriteString F, "FirstEmitter.rpc"
+	WriteString F, "SecondEmitter.rpc"
+	WriteShort F, 1
+	WriteShort F, 2
+	WriteByte F, 1
+	WriteByte F, 85
+	WriteByte F, 7
+	CloseFile(F)
+
+	Assert(LoadProjectiles(ProjTestFile$) = 0)
+	Assert(ProjectileList(8) = Null)
+
+	ClearProjectiles()
+	CleanupProjFile()
+End Test

--- a/src/Tests/Modules/ProjectilesCorrectnessTest.bb
+++ b/src/Tests/Modules/ProjectilesCorrectnessTest.bb
@@ -158,8 +158,56 @@ Test testLoadProjectilesRejectsOutOfRangeID()
 	CleanupProjFile()
 	Local F.BBStream = WriteFile(ProjTestFile$)
 	WriteShort F, 6000
+	WriteString F, "Out of range"
+	WriteShort F, 0
+	WriteString F, ""
+	WriteString F, ""
+	WriteShort F, 0
+	WriteShort F, 0
+	WriteByte F, 0
+	WriteByte F, 0
+	WriteShort F, 0
+	WriteShort F, 0
+	WriteByte F, 0
 	CloseFile(F)
 	Assert(LoadProjectiles(ProjTestFile$) = 0)
+	ClearProjectiles()
+	CleanupProjFile()
+End Test
+
+; An ID-only record must not be published as a default Projectile. The old
+; loader allocated and indexed P immediately after this two-byte read.
+Test testLoadProjectilesRejectsIdOnlyRecordBeforePublish()
+	ClearProjectiles()
+	CleanupProjFile()
+	Local F.BBStream = WriteFile(ProjTestFile$)
+	WriteShort F, 7
+	CloseFile(F)
+
+	Assert(LoadProjectiles(ProjTestFile$) = 0)
+	Assert(ProjectileList(7) = Null)
+
+	ClearProjectiles()
+	CleanupProjFile()
+End Test
+
+; A tail that ends partway through a length-prefixed string must also remain
+; unpublished rather than accepting EOF-zero-filled fields as a template.
+Test testLoadProjectilesRejectsTruncatedStringTailBeforePublish()
+	ClearProjectiles()
+	CleanupProjFile()
+	Local F.BBStream = WriteFile(ProjTestFile$)
+	WriteShort F, 7
+	WriteString F, "Partial"
+	WriteShort F, 12
+	WriteString F, "FirstEmitter.rpc"
+	WriteInt F, 4
+	WriteByte F, Asc("x")
+	CloseFile(F)
+
+	Assert(LoadProjectiles(ProjTestFile$) = 0)
+	Assert(ProjectileList(7) = Null)
+
 	ClearProjectiles()
 	CleanupProjFile()
 End Test


### PR DESCRIPTION
## Outcome

Incomplete `Projectiles.dat` records no longer become zero-default projectile templates. This prevents malformed editor-managed data from leaking into the server and GUE/Loom projectile catalogs.

## Technical changes

- Preflight the full bounded projectile-record layout before allocating or writing `ProjectileList`.
- Reject ID-only, truncated string-tail, and truncated fixed-scalar-tail records with zero published templates.
- Preserve complete-record behavior and the existing out-of-range-ID check.
- Document the defensive load contract without changing the file format.

Fixes #906

## Acceptance evidence

- Full preflight happens before the first loader `New Projectile` / `ProjectileList` write.
- Regressions cover ID-only, declared-string, and fixed-scalar-tail truncation; each expects zero records and a null slot.
- A complete out-of-range record still exercises the existing ID rejection.
- `docs/modules/projectiles.md` states the no-partial-publication contract and explicitly preserves the format.

## Baseline, RED, and GREEN

- Baseline: `git diff --check` exited 0; `./test.sh ProjectilesCorrectnessTest` exited 1 because `compiler/BlitzForge/bin/blitzcc` was absent.
- RED: portable completeness probe exited 1 with `PROJECTILE_INCOMPLETE_RECORD_RED regression_test=1 expects_no_publish=1 preflight_missing=1 preflight_not_called=1`.
- GREEN: `PROJECTILE_COMPLETENESS_REVIEW_GREEN preflight_before_publish=1 id_only=1 string_tail=1 scalar_tail=1 scalar_null=1 fixed_tail_guard=1` exited 0.

## Verification

- `git diff --check` -> exit 0.
- `bash scripts/gen_packet_index.sh --check` -> exit 0.
- `bash scripts/gen_bvm_reference.sh --check` -> exit 0; only established `BVM_SETOWNER` and `BVM_SCENERYOWNER` DEAD-API warnings.
- `bash -n compile.sh test.sh publish.sh scripts/*.sh` -> exit 0.
- Local `./test.sh ProjectilesCorrectnessTest` is unverified because `blitzcc` is absent; BlitzForge reports runnable Linux host builds are unsupported.
- Exact-head CI run `30020308681` passed: Build and test and Rust server (Linux), with no legacy status contexts.

## Compatibility, risk, rollback, and deferred work

Complete records retain their current format and loader behavior. Incomplete/corrupt catalogs now reject before exposing a partial template; revert this PR to restore the old loader behavior. Deferred: runtime projectile behavior, packets, and editor save UI.

## Independent review

Fresh review ACCEPTed exact head `75578de3b4770b08bbccf75c02da6c785576242f`: preflight ordering, all three malformed-record cases, preserved valid/OOB coverage, docs/scope, linear-pass cost, and concurrency isolation were accepted.