### PR TITLE
fix(spells): reject incomplete template records

### DIFF
--- a/docs/modules/spells.md
+++ b/docs/modules/spells.md
@@ -106,7 +106,7 @@ Parameters:
 
 *   _Filename$_ — Path to the spell data file (typically `Data\Server Data\Spells.dat`).
 
-Reads spell templates from disk into `SpellsList`. Each record carries a 2-byte `ID` followed by the spell's fields. An out-of-range `ID` aborts the load defensively (preserving any spells already parsed) rather than corrupt memory via a `Dim` out-of-range write. String fields go through `ReadBoundedString$` ([Logging.bb](logging.md)): 256 bytes for `Name$` / `ExclusiveRace$` / `ExclusiveClass$`, 1024 for `Description$` and 1024 for `Script$` / `SMethod$`.
+Reads spell templates from disk into `SpellsList`. Each record carries a 2-byte `ID` followed by the spell's fields. The loader verifies that each bounded record is complete before publishing it, so an incomplete trailing record cannot enter the catalog as a partial/default template; previously complete records remain loaded. An out-of-range `ID` aborts the load defensively (preserving any spells already parsed) rather than corrupt memory via a `Dim` out-of-range write. String fields go through `ReadBoundedString$` ([Logging.bb](logging.md)): 256 bytes for `Name$` / `ExclusiveRace$` / `ExclusiveClass$`, 1024 for `Description$` and 1024 for `Script$` / `SMethod$`. The on-disk format is unchanged.
 
   
 

--- a/src/Modules/Spells.bb
+++ b/src/Modules/Spells.bb
@@ -73,14 +73,47 @@ Function DuplicateSpellTemplate(srcID)
 	Return Dst\ID
 End Function
 
+; Checks one complete variable-length Spells.dat record before the normal
+; reader allocates or indexes a live Spell. ReadShort and ReadInt zero-fill at
+; EOF, so an incomplete record must not become a default template in
+; SpellsList.
+Function SpellBoundedStringIsComplete%(F, FileBytes, Limit)
+	If FilePos(F) + 4 > FileBytes Then Return False
+	NameBytes = ReadInt(F)
+	If NameBytes < 0 Or NameBytes > Limit Then Return False
+	If FilePos(F) + NameBytes > FileBytes Then Return False
+	SeekFile F, FilePos(F) + NameBytes
+	Return True
+End Function
+
+Function SpellRecordIsComplete%(F, FileBytes)
+	If FilePos(F) + 2 > FileBytes Then Return False
+	SeekFile F, FilePos(F) + 2
+	If SpellBoundedStringIsComplete(F, FileBytes, 256) = False Then Return False
+	If SpellBoundedStringIsComplete(F, FileBytes, 1024) = False Then Return False
+	If FilePos(F) + 2 > FileBytes Then Return False
+	SeekFile F, FilePos(F) + 2
+	If SpellBoundedStringIsComplete(F, FileBytes, 256) = False Then Return False
+	If SpellBoundedStringIsComplete(F, FileBytes, 256) = False Then Return False
+	If FilePos(F) + 4 > FileBytes Then Return False
+	SeekFile F, FilePos(F) + 4
+	If SpellBoundedStringIsComplete(F, FileBytes, 1024) = False Then Return False
+	If SpellBoundedStringIsComplete(F, FileBytes, 1024) = False Then Return False
+	Return True
+End Function
+
 ; Loads all spells from file
 Function LoadSpells(Filename$)
 
 	F = ReadFile(Filename$)
 	If F = 0 Then Return -1
+	FileBytes = FileSize(Filename$)
 
 		Local Number = 0
 		While Not Eof(F)
+			RecordPos = FilePos(F)
+			If SpellRecordIsComplete(F, FileBytes) = False Then Exit
+			SeekFile F, RecordPos
 			S.Spell = New Spell
 			S\ID = ReadShort(F)
 			; Same defensive bound as LoadItems: ReadShort is signed, the list is

--- a/src/Tests/Modules/SpellsCorrectnessTest.bb
+++ b/src/Tests/Modules/SpellsCorrectnessTest.bb
@@ -198,12 +198,21 @@ End Test
 ; so the `< 0` arm is unreachable. The `> 65534` arm is what actually
 ; rejects wrapped negatives, and only -1 (= 65535) is out of range; any
 ; other wrapped negative lands in a valid high slot. Pinned: the reject
-; works for the 65535 case.
+; works for the 65535 case. The record must otherwise be complete so this
+; reaches the ID guard rather than the incomplete-record guard.
 Test testLoadSpellsRejectsOutOfRangeID()
 	ClearSpells()
 	CleanupSpellsFile()
 	Local F.BBStream = WriteFile(SpellsTestFile$)
 	WriteShort F, 65535
+	WriteString F, "Out of range"
+	WriteString F, ""
+	WriteShort F, 0
+	WriteString F, ""
+	WriteString F, ""
+	WriteInt F, 0
+	WriteString F, ""
+	WriteString F, ""
 	CloseFile(F)
 	Assert(LoadSpells(SpellsTestFile$) = 0)
 	Assert(SpellsList(65534) = Null)

--- a/src/Tests/Modules/SpellsCorrectnessTest.bb
+++ b/src/Tests/Modules/SpellsCorrectnessTest.bb
@@ -210,3 +210,71 @@ Test testLoadSpellsRejectsOutOfRangeID()
 	ClearSpells()
 	CleanupSpellsFile()
 End Test
+
+; An ID-only tail must not be published as a zero-default Spell. The loader
+; used to allocate and index a Spell immediately after this two-byte read.
+Test testLoadSpellsRejectsIdOnlyRecordBeforePublish()
+	ClearSpells()
+	CleanupSpellsFile()
+	Local F.BBStream = WriteFile(SpellsTestFile$)
+	WriteShort F, 7
+	CloseFile(F)
+
+	Assert(LoadSpells(SpellsTestFile$) = 0)
+	Assert(SpellsList(7) = Null)
+
+	ClearSpells()
+	CleanupSpellsFile()
+End Test
+
+; A length prefix with fewer bytes than promised is an incomplete record and
+; must not publish the partial template.
+Test testLoadSpellsRejectsTruncatedStringTailBeforePublish()
+	ClearSpells()
+	CleanupSpellsFile()
+	Local F.BBStream = WriteFile(SpellsTestFile$)
+	WriteShort F, 7
+	WriteString F, "Partial"
+	WriteInt F, 4
+	WriteByte F, Asc("x")
+	CloseFile(F)
+
+	Assert(LoadSpells(SpellsTestFile$) = 0)
+	Assert(SpellsList(7) = Null)
+
+	ClearSpells()
+	CleanupSpellsFile()
+End Test
+
+; A complete record before a truncated scalar tail remains loaded, while the
+; incomplete second record is left unpublished.
+Test testLoadSpellsRetainsCompleteRecordBeforeTruncatedScalarTail()
+	ClearSpells()
+	CleanupSpellsFile()
+	Local F.BBStream = WriteFile(SpellsTestFile$)
+	WriteShort F, 3
+	WriteString F, "Complete"
+	WriteString F, ""
+	WriteShort F, 0
+	WriteString F, ""
+	WriteString F, ""
+	WriteInt F, 100
+	WriteString F, ""
+	WriteString F, ""
+	WriteShort F, 8
+	WriteString F, "Scalar tail"
+	WriteString F, ""
+	WriteShort F, 0
+	WriteString F, ""
+	WriteString F, ""
+	WriteShort F, 1
+	CloseFile(F)
+
+	Assert(LoadSpells(SpellsTestFile$) = 1)
+	Assert(SpellsList(3) <> Null)
+	Assert(SpellsList(3)\Name$ = "Complete")
+	Assert(SpellsList(8) = Null)
+
+	ClearSpells()
+	CleanupSpellsFile()
+End Test


### PR DESCRIPTION
## Outcome

Incomplete `Spells.dat` records no longer enter the spell catalog as partially read or zero-default templates; complete records before a damaged tail remain available.

## Technical changes

- Preflight one complete bounded spell record before allocation or `SpellsList` publication.
- Preserve the existing string caps and on-disk layout.
- Add ID-only, truncated-string, complete-then-truncated-scalar, and complete-invalid-ID regression coverage.
- Document the loader’s complete-record behavior.

Fixes #908

## Acceptance evidence

- The preflight runs before `New Spell` and `SpellsList` mutation.
- The new tests require incomplete ID/string/scalar records to stay unpublished; the scalar case retains its preceding valid record.
- The retained malformed-ID test now supplies a complete record, so it reaches the existing ID guard rather than the preflight guard.

## RED → GREEN

- RED: portable contract exited 1 with `SPELLS_COMPLETE_RECORD_CONTRACT_RED missing=Function SpellRecordIsComplete%,If SpellRecordIsComplete(F, FileBytes) = False Then,SeekFile F, RecordPos`.
- GREEN: portable contract exited 0 with `SPELLS_COMPLETE_RECORD_CONTRACT_GREEN tests=1 invalid_id=1 bounds=1 containment=1`.
- Native Blitz test is not locally executable: `./test.sh SpellsCorrectnessTest` exited 1 because `compiler/BlitzForge/bin/blitzcc` is absent. Exact-head CI supplied the compiler-backed result.

## Verification

- `git diff --check origin/develop...HEAD` -> exit 0.
- `bash scripts/gen_packet_index.sh --check` -> exit 0.
- `bash scripts/gen_bvm_reference.sh --check` -> exit 0; established BVM_SETOWNER and BVM_SCENERYOWNER warnings only.
- Exact head `d4d971a09b047d7d7ccb0386732463fc757a9b3a`: Build and test passed in 6m19s; Rust server (Linux) passed in 3m45s; no legacy status contexts.

## Compatibility, risk, rollback, and deferred work

The `Spells.dat` format and complete-record behavior are unchanged. Incomplete records now stop at the damaged record instead of publishing it. Rollback is reverting this PR. Deferred: spell runtime/packet behavior and editor save UX.

## Independent review

The first independent review requested a complete invalid-ID fixture; the correction is included in this head. A fresh independent review returned ACCEPT for exact head `d4d971a09b047d7d7ccb0386732463fc757a9b3a`.
