### PR TITLE
fix(build): create Windows Rust output directory

### DIFF
--- a/compile.bat
+++ b/compile.bat
@@ -130,6 +130,7 @@ if errorlevel 1 (
     exit /b 1
 )
 rem Rust client (client-rs) -> bin\ClientRS.exe
+if not exist "%ROOTDIR%\bin" mkdir "%ROOTDIR%\bin"
 cd /d "%ROOTDIR%\client-rs"
 cargo build --release --locked -p rcce-client --bin client-window || (cd /d "%ROOTDIR%" & endlocal & exit /b 1)
 copy /Y "%ROOTDIR%\client-rs\target\release\client-window.exe" "%ROOTDIR%\bin\ClientRS.exe" >nul || (cd /d "%ROOTDIR%" & endlocal & exit /b 1)

--- a/src/Tests/Modules/RustToolchainPolicyTest.bb
+++ b/src/Tests/Modules/RustToolchainPolicyTest.bb
@@ -149,6 +149,12 @@ Test testWindowsCIExercisesRustReleasePackaging()
 	Assert(FileContains%(".github\workflows\ci.yml", "if not exist bin\ServerRS.exe (") = True)
 End Test
 
+Test testWindowsRustOnlyBuildCreatesOutputDirectoryBeforeCopies()
+	Local BinDirectory$ = "if not exist " + Chr$(34) + "%ROOTDIR%\bin" + Chr$(34) + " mkdir " + Chr$(34) + "%ROOTDIR%\bin" + Chr$(34)
+	Assert(FileContainsSequenceBefore%("compile.bat", "if not %BUILD_RUST%==1 goto skip_rust", BinDirectory$, "copy /Y " + Chr$(34) + "%ROOTDIR%\client-rs\target\release\client-window.exe" + Chr$(34), ":skip_rust") = True)
+	Assert(FileContainsSequenceBefore%("compile.bat", "if not %BUILD_RUST%==1 goto skip_rust", BinDirectory$, "copy /Y " + Chr$(34) + "%ROOTDIR%\server-rs\target\release\rcce-server.exe" + Chr$(34), ":skip_rust") = True)
+End Test
+
 Test testLinuxCIExercisesRustReleasePackaging()
 	Assert(FileContainsOrderedSequence10%(".github\workflows\ci.yml", "- name: Install Linux audio build dependency", "sudo apt-get install --yes libasound2-dev", "- name: Package Rust apps for Linux", "./compile.sh -e -t -r", "test -x bin/ClientRS", "test -x bin/ServerRS", "- name: Build + test (server workspace, locked)", "- name: Build Rust server Docker image", "- name: Smoke-test Rust server Docker startup", "- name: Clippy (server workspace, -D warnings)") = True)
 End Test


### PR DESCRIPTION
## Outcome

The documented Windows Rust-only build now creates its `bin` output directory before copying either shipped executable, so it no longer relies on a prior legacy-engine build.

## Technical changes

- Add a guarded `bin` directory creation inside the opt-in Rust branch of `compile.bat`.
- Add focused ordered source-contract coverage for both ClientRS and ServerRS copies.

Fixes #910

## Acceptance evidence

- Directory setup is inside the Rust branch and precedes both artifact copies: portable contract `RUST_BIN_DIRECTORY_CONTRACT_GREEN=both-copies-contained`.
- Baseline/RED: `BASELINE_PORTABLE=fail-missing-rust-bin-directory`; then `RUST_BIN_DIRECTORY_CONTRACT_RED=missing-directory-setup-before-first-copy`.
- Static verification: `git diff --check`, both generator checks, and shell syntax check exited 0. The BVM generator emitted only its established SETOWNER/SCENERYOWNER warnings.
- Local native test is unavailable: `./test.sh RustToolchainPolicyTest` exited 1 before execution because `compiler/BlitzForge/bin/blitzcc` is absent. Exact-head CI passed Build and test in 6m33s and Rust server (Linux) in 4m03s; no legacy status contexts existed.

## Compatibility, risk, rollback

Rust commands, output names, and non-Rust modes are unchanged. The previous `bin` directory is not an API surface; the only changed behavior is making its implicit prerequisite explicit. Roll back by reverting this commit.

## Deferred

No Rust source, CI workflow, Linux wrapper, release/deployment setting, or artifact-upload policy changes.

## Independent review

Fresh independent reviewer verdict: **ACCEPT** for exact head `cc5b9f27458895a45b4f3982837057117e14e12e`. It confirmed the guard is inside the Rust-only path, precedes both copies, preserves locked Cargo commands/destinations, and has focused coverage.