### PR TITLE
fix(GUE): retain days-and-seasons edits when save fails

### DIFF
--- a/src/GUE.bb
+++ b/src/GUE.bb
@@ -3885,9 +3885,7 @@ Cls
 				EndIf
 			; Save clicked
 			Case BSeasonSave
-				SaveEnvironment(True)
-				SaveSuns()
-				EnvironmentSaved = True
+				EnvironmentSaved = SaveEnvironmentAndSuns()
 
 			; Projectiles tab events ------------------------------------------------------------------------------------------------
 
@@ -9767,6 +9765,17 @@ Function SaveParticleEmitters%()
 
 End Function
 
+; Saves the paired days-and-seasons files and retains the dirty state if either
+; independent atomic write fails.
+Function SaveEnvironmentAndSuns%()
+
+	Local SavedAll% = True
+	If SaveEnvironment(True) = False Then SavedAll = False
+	If SaveSuns() = False Then SavedAll = False
+	Return SavedAll
+
+End Function
+
 ; Displays the saving dialog
 Function SaveDialog()
 
@@ -9837,9 +9846,7 @@ Function SaveDialog()
 						Case "Damage types"
 							DamageTypesSaved = SaveDamageTypes("Data\Server Data\Damage.dat")
 						Case "Days & seasons"
-							SaveEnvironment(True)
-							SaveSuns()
-							EnvironmentSaved = True
+							EnvironmentSaved = SaveEnvironmentAndSuns()
 						Case "Current zone"
 							ZoneSave()
 						Case "Abilities"
@@ -9861,11 +9868,13 @@ Function SaveDialog()
 							If ChatBar <> Null Then Delete ChatBar
 							InterfaceSaved = True
 					End Select
-					; Keep failed particle and damage-type saves selectable so either can be retried.
+					; Keep failed persistence saves selectable so each can be retried.
 					If FUI_SendMessage(List, M_GETCAPTION) <> "Particles" Or ParticlesSaved = True
 						If FUI_SendMessage(List, M_GETCAPTION) <> "Damage types" Or DamageTypesSaved = True
-							FUI_SendMessage(List, M_DELETEINDEX, FUI_SendMessage(List, M_GETSELECTED))
-							FUI_SendMessage(List, M_SETINDEX, 1)
+							If FUI_SendMessage(List, M_GETCAPTION) <> "Days & seasons" Or EnvironmentSaved = True
+								FUI_SendMessage(List, M_DELETEINDEX, FUI_SendMessage(List, M_GETSELECTED))
+								FUI_SendMessage(List, M_SETINDEX, 1)
+							EndIf
 						EndIf
 					EndIf
 				; Save all hit
@@ -9883,8 +9892,7 @@ Function SaveDialog()
 						DamageTypesSaved = SaveDamageTypes("Data\Server Data\Damage.dat")
 					EndIf
 					If EnvironmentSaved = False
-						SaveEnvironment(True)
-						SaveSuns()
+						EnvironmentSaved = SaveEnvironmentAndSuns()
 					EndIf
 					If ZoneSaved = False Then ZoneSave()
 					If SpellsSaved = False Then SaveSpells("Data\Server Data\Spells.dat")
@@ -9906,7 +9914,8 @@ Function SaveDialog()
 					EndIf
 					If ParticlesSaved = False Then Result = False
 					If DamageTypesSaved = False Then Result = False
-					If ParticlesSaved = True And DamageTypesSaved = True Then Result = True
+					If EnvironmentSaved = False Then Result = False
+					If ParticlesSaved = True And DamageTypesSaved = True And EnvironmentSaved = True Then Result = True
 			End Select
 			Delete(SaveEvent)
 			SaveEvent = NextSaveEvent
@@ -10729,9 +10738,7 @@ Function menuSaveAll()
 				ItemsSaved = True
 				
 				; Save environment
-				SaveEnvironment(True)
-				SaveSuns()
-				EnvironmentSaved = True
+				EnvironmentSaved = SaveEnvironmentAndSuns()
 				
 				; Save zone
 				ZoneSave()

--- a/src/Tests/Modules/GUEDamageTypeSaveOutcomeTest.bb
+++ b/src/Tests/Modules/GUEDamageTypeSaveOutcomeTest.bb
@@ -87,5 +87,5 @@ Test testGUEDamageTypeSaveRoutesKeepDirtyStateOnFailure()
 	Assert(CountLinesContaining%(Source$, "DamageTypesSaved = SaveDamageTypes(" + Chr$(34) + "Data\Server Data\Damage.dat" + Chr$(34) + ")") = 4)
 	Assert(FileContains%(Source$, "If FUI_SendMessage(List, M_GETCAPTION) <> " + Chr$(34) + "Damage types" + Chr$(34) + " Or DamageTypesSaved = True") = True)
 	Assert(FileContains%(Source$, "If DamageTypesSaved = False Then Result = False") = True)
-	Assert(FileContains%(Source$, "If ParticlesSaved = True And DamageTypesSaved = True Then Result = True") = True)
+	Assert(FileContains%(Source$, "If ParticlesSaved = True And DamageTypesSaved = True And EnvironmentSaved = True Then Result = True") = True)
 End Test

--- a/src/Tests/Modules/GUEEnvironmentSaveOutcomeTest.bb
+++ b/src/Tests/Modules/GUEEnvironmentSaveOutcomeTest.bb
@@ -1,0 +1,56 @@
+Strict
+EnableGC
+
+// GUE's full editor graph is not safe for the standalone test harness. These
+// bounded source contracts pin the Days & seasons save-outcome handoff instead.
+
+Function FileContains%(Path$, Needle$)
+	Local F.BBStream = ReadFile(Path$)
+	Local Line$
+	If F = Null Then F = ReadFile("..\\" + Path$)
+	If F = Null Then F = ReadFile("..\\..\\" + Path$)
+	If F = Null Then Return False
+
+	While Not Eof(F)
+		Line$ = ReadLine$(F)
+		If Instr(Line$, Needle$) > 0
+			CloseFile F
+			Return True
+		EndIf
+	Wend
+
+	CloseFile F
+	Return False
+End Function
+
+Function CountLinesContaining%(Path$, Needle$)
+	Local F.BBStream = ReadFile(Path$)
+	Local Line$
+	Local Count% = 0
+	If F = Null Then F = ReadFile("..\\" + Path$)
+	If F = Null Then F = ReadFile("..\\..\\" + Path$)
+	If F = Null Then Return 0
+
+	While Not Eof(F)
+		Line$ = ReadLine$(F)
+		If Instr(Line$, Needle$) > 0 Then Count = Count + 1
+	Wend
+
+	CloseFile F
+	Return Count
+End Function
+
+Test testGUEEnvironmentSaveRequiresBothAtomicWrites()
+	Local Source$ = "GUE.bb"
+	Assert(FileContains%(Source$, "Function SaveEnvironmentAndSuns%()") = True)
+	Assert(FileContains%(Source$, "If SaveEnvironment(True) = False Then SavedAll = False") = True)
+	Assert(FileContains%(Source$, "If SaveSuns() = False Then SavedAll = False") = True)
+End Test
+
+Test testGUEEnvironmentSaveRoutesKeepDirtyStateOnFailure()
+	Local Source$ = "GUE.bb"
+	Assert(CountLinesContaining%(Source$, "EnvironmentSaved = SaveEnvironmentAndSuns()") = 4)
+	Assert(FileContains%(Source$, "If FUI_SendMessage(List, M_GETCAPTION) <> " + Chr$(34) + "Days & seasons" + Chr$(34) + " Or EnvironmentSaved = True") = True)
+	Assert(FileContains%(Source$, "If EnvironmentSaved = False Then Result = False") = True)
+	Assert(FileContains%(Source$, "If ParticlesSaved = True And DamageTypesSaved = True And EnvironmentSaved = True Then Result = True") = True)
+End Test

--- a/src/Tests/Modules/GUEEnvironmentSaveOutcomeTest.bb
+++ b/src/Tests/Modules/GUEEnvironmentSaveOutcomeTest.bb
@@ -40,11 +40,40 @@ Function CountLinesContaining%(Path$, Needle$)
 	Return Count
 End Function
 
+Function SaveEnvironmentAndSunsContract%(Path$)
+	Local F.BBStream = ReadFile(Path$)
+	Local Line$
+	Local InHelper% = False
+	Local SavedEnvironment% = False
+	Local SavedSuns% = False
+	Local ReturnsAggregate% = False
+	If F = Null Then F = ReadFile("..\\" + Path$)
+	If F = Null Then F = ReadFile("..\\..\\" + Path$)
+	If F = Null Then Return False
+
+	While Not Eof(F)
+		Line$ = ReadLine$(F)
+		If Instr(Line$, "Function SaveEnvironmentAndSuns%()") > 0 Then InHelper = True
+		If InHelper = True
+			If Instr(Line$, "If SaveEnvironment(True) = False Then SavedAll = False") > 0 Then SavedEnvironment = True
+			If Instr(Line$, "If SaveSuns() = False Then SavedAll = False") > 0 Then SavedSuns = True
+			If SavedEnvironment = True And SavedSuns = True
+				If Instr(Line$, "Return SavedAll") > 0 Then ReturnsAggregate = True
+			EndIf
+			If Instr(Line$, "End Function") > 0
+				CloseFile F
+				Return ReturnsAggregate
+			EndIf
+		EndIf
+	Wend
+
+	CloseFile F
+	Return False
+End Function
+
 Test testGUEEnvironmentSaveRequiresBothAtomicWrites()
 	Local Source$ = "GUE.bb"
-	Assert(FileContains%(Source$, "Function SaveEnvironmentAndSuns%()") = True)
-	Assert(FileContains%(Source$, "If SaveEnvironment(True) = False Then SavedAll = False") = True)
-	Assert(FileContains%(Source$, "If SaveSuns() = False Then SavedAll = False") = True)
+	Assert(SaveEnvironmentAndSunsContract%(Source$) = True)
 End Test
 
 Test testGUEEnvironmentSaveRoutesKeepDirtyStateOnFailure()


### PR DESCRIPTION
## Outcome

GUE now keeps Days & seasons edits retryable when either the environment or sun atomic save fails, rather than treating the paired save as successful.

## Technical changes

- Add `SaveEnvironmentAndSuns()` to attempt both atomic writes and aggregate their outcomes.
- Route the tab save, Save Dialog selected save, Save Dialog Save All, and menu Save All through that helper.
- Keep failed Days & seasons entries selectable and prevent the Save Dialog success/exit path until the pair succeeds.
- Add a bounded helper contract, and update the existing shared Save Dialog outcome contract to require the environment result.

Fixes #905

## Acceptance evidence

- The bounded helper contract verifies both writes occur and `Return SavedAll` carries their aggregate result.
- The final portable contract reports four GUE routes, retained retry state, exit blocking, and all-success gating.
- The existing damage-save integration contract now requires `EnvironmentSaved=True` before shared Save Dialog success, matching the expanded outcome condition.
- No persistence format or serializer behavior changes.

## Verification

- Baseline: `git diff --check`, `bash scripts/gen_packet_index.sh --check`, `bash scripts/gen_bvm_reference.sh --check`, and `bash -n compile.sh test.sh scripts/*.sh` each exited 0; BVM emitted only its established two DEAD-API warnings.
- RED: portable source contract exited 1 with `GUE_ENVIRONMENT_SAVE_OUTCOME_CONTRACT_RED helper=0 env=0 suns=0 routes=0 retry=0 exit=0 success=0`.
- GREEN: the final portable contract exited 0 with `GUE_ENVIRONMENT_SAVE_OUTCOME_FINAL_GREEN helper=1 env=1 suns=1 aggregate=1 routes=4 retry=1 exit=1 success=1`; the affected integration assertion reports `GUE_DAMAGE_SAVE_DIALOG_INTEGRATION_CONTRACT_GREEN updated=1 stale=0`.
- First exact-head CI compiled the project but failed 145/146 because `GUEDamageTypeSaveOutcomeTest.bb` asserted the obsolete two-condition success gate. The one-line test correction is in head `4d3a375bd69a8bdbeb7dcfd5b6ac89e941b1bf0b`; replacement exact-head CI is pending.
- Local native gate is unavailable: `./test.sh GUEEnvironmentSaveOutcomeTest` exited 1 because `compiler/BlitzForge/bin/blitzcc` is absent.

## Compatibility, rollback, deferred work

Successful saves retain their existing data output; only failed paired saves remain visible and retryable. Rollback is reverting this PR. Environment/Suns serializers, other GUE persistence paths, and UI redesign remain out of scope.

## Independent review

Fresh independent reviewer verdict: **ACCEPT** for exact head `4d3a375bd69a8bdbeb7dcfd5b6ac89e941b1bf0b`. The reviewer confirmed the sequential aggregate helper, all four routes, retry/exit containment, and updated shared outcome assertion. Native proof remains CI-supplied.