### PR TITLE
ci(windows): smoke-test non-destructive publish help

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,6 +43,19 @@ jobs:
             exit 1
           }
 
+      # Exercise the release wrapper's non-destructive help path before any
+      # compiler build or packaging work. This catches CMD label/delegation
+      # regressions while proving that help cannot create release output.
+      - name: Smoke-test Windows publish help
+        shell: cmd
+        run: |
+          call publish.bat --help
+          if errorlevel 1 exit /b %errorlevel%
+          if exist release (
+            echo release directory created by publish.bat --help
+            exit /b 1
+          )
+
       # Cache the BlitzForge runtime binaries keyed on the submodule SHA.
       # rcce2 PRs rarely change the BlitzForge pointer, so the common-case
       # CI run avoids the ~3min MSBuild step entirely.

--- a/src/Tests/Modules/PublishBatchContractTest.bb
+++ b/src/Tests/Modules/PublishBatchContractTest.bb
@@ -150,3 +150,31 @@ Test testPublishKeepsRecentProjectStateOutOfTheRelease()
 	Assert(FileContains%("publish.bat", "if exist " + Chr$(34) + "%ROOTDIR%\release\res\Recent.dat" + Chr$(34) + " del " + Chr$(34) + "%ROOTDIR%\release\res\Recent.dat" + Chr$(34)) = True)
 	Assert(RecentCleanupFollowsRequiredCopies%("publish.bat") = True)
 End Test
+
+Function WindowsPublishHelpSmokePrecedesCompile%(Path$)
+	Local F.BBStream = ReadFile(Path$)
+	Local Line$
+	Local Stage% = 0
+	If F = Null Then F = ReadFile("..\" + Path$)
+	If F = Null Then F = ReadFile("..\..\" + Path$)
+	If F = Null Then Return False
+	While Not Eof(F)
+		Line$ = ReadLine$(F)
+		If Stage = 0 And Instr(Line$, "- name: Smoke-test Windows publish help") > 0 Then Stage = 1
+		If Stage = 1 And Instr(Line$, "shell: cmd") > 0 Then Stage = 2
+		If Stage = 2 And Instr(Line$, "call publish.bat --help") > 0 Then Stage = 3
+		If Stage = 3 And Instr(Line$, "if errorlevel 1 exit /b %errorlevel%") > 0 Then Stage = 4
+		If Stage = 4 And Instr(Line$, "if exist release (") > 0 Then Stage = 5
+		If Stage = 5 And Instr(Line$, "exit /b 1") > 0 Then Stage = 6
+		If Stage = 6 And Instr(Line$, "- name: Resolve BlitzForge submodule SHA") > 0
+			CloseFile F
+			Return True
+		EndIf
+	Wend
+	CloseFile F
+	Return False
+End Function
+
+Test testWindowsCiSmokesPublishHelpBeforeCompilation()
+	Assert(WindowsPublishHelpSmokePrecedesCompile%(".github\workflows\ci.yml") = True)
+End Test


### PR DESCRIPTION
## Outcome

Windows CI now exercises the release wrapper's safe help route before compiler or packaging work, so CMD label, delegation, and exit-status regressions fail in CI instead of during a release attempt.

## Technical changes

- Add a Windows `cmd` smoke step that runs `publish.bat --help`, propagates failure, and rejects a created `release/` directory.
- Add a focused source-contract test that requires that smoke and its failure/no-output checks before BlitzForge toolchain work.

Fixes #913

## Acceptance evidence

- The workflow calls `publish.bat --help` with `shell: cmd`.
- A non-zero wrapper result exits the CI step.
- A `release/` directory after help fails the CI step.
- The contract requires the smoke before `Resolve BlitzForge submodule SHA`, preventing later compiler/toolchain work from moving ahead of it.

## Verification

- BASELINE: `PUBLISH_WINDOWS_HELP_CI_CONTRACT_RED missing-windows-help-smoke`.
- RED refinement: `PUBLISH_WINDOWS_HELP_CI_CONTRACT_RED smoke-not-before-toolchain-work stage=6`.
- GREEN: `PUBLISH_WINDOWS_HELP_CI_CONTRACT_GREEN smoke-before-toolchain=1`.
- YAML parse, shell syntax, diff, packet-index, and BVM-reference checks exit 0; BVM reports only its established SETOWNER/SCENERYOWNER warnings.
- `./test.sh PublishBatchContractTest` is UNVERIFIED locally because `compiler/BlitzForge/bin/blitzcc` is absent before test compilation; the local CMD probe is unavailable because this WSL scheduler worktree cannot be accessed through the Windows share. Exact-head Windows CI is required.

## Compatibility, rollback, deferred work

`publish.bat`, release contents, Rust builds, and Linux CI are unchanged. A fresh checkout has no release output before this help invocation; rollback is reverting this PR. Full packaging behavior remains covered by the existing Windows Rust packaging step.

## Independent review

Fresh independent review: **ACCEPT** for `520754c2f403ea37738fc31ac6fce5c51124f002`. It found the exact scope, CMD guard sequence, contract coverage, and pre-toolchain order correct; exact-head CI remains pending.