### PR TITLE
fix(server): reject incomplete Accounts.dat metadata records

### DIFF
--- a/docs/modules/accountsserver.md
+++ b/docs/modules/accountsserver.md
@@ -182,7 +182,7 @@ Return value: Number of accounts loaded
   
 Parameters: None  
   
-This function loads all accounts and characters from the Accounts.dat file and returns the total number loaded. It also displays all the loaded accounts on the server's Accounts window.
+This function loads all complete accounts and characters from the Accounts.dat file and returns the total number loaded. It also displays all loaded accounts on the server's Accounts window. Before it allocates an account or changes the window counters, it verifies that the account metadata record (user, password hash, email, GM/ban flags, ignore list, and character count) is complete. A truncated final record is left unpublished, while earlier complete records and the existing per-character EOF tolerance remain intact.
 
   
   

--- a/src/Modules/AccountsServer.bb
+++ b/src/Modules/AccountsServer.bb
@@ -307,6 +307,30 @@ Function SaveAccounts()
 
 End Function
 
+; Checks the next account's metadata record before LoadAccounts allocates an
+; Account or publishes its counters/UI row. ReadInt and ReadByte zero-fill at
+; EOF, so every variable-length field and fixed tail needs this boundary.
+Function AccountBoundedStringIsComplete%(F, FileBytes, Limit)
+	If FilePos(F) + 4 > FileBytes Then Return False
+	StringBytes = ReadInt(F)
+	If StringBytes < 0 Or StringBytes > Limit Then Return False
+	If FilePos(F) + StringBytes > FileBytes Then Return False
+	SeekFile F, FilePos(F) + StringBytes
+	Return True
+End Function
+
+Function AccountRecordIsComplete%(F, FileBytes)
+	If AccountBoundedStringIsComplete(F, FileBytes, 256) = False Then Return False
+	If AccountBoundedStringIsComplete(F, FileBytes, 256) = False Then Return False
+	If AccountBoundedStringIsComplete(F, FileBytes, 256) = False Then Return False
+	If FilePos(F) + 2 > FileBytes Then Return False
+	SeekFile F, FilePos(F) + 2
+	If AccountBoundedStringIsComplete(F, FileBytes, 4096) = False Then Return False
+	If FilePos(F) + 1 > FileBytes Then Return False
+	SeekFile F, FilePos(F) + 1
+	Return True
+End Function
+
 ; Loads all game accounts and returns the number loaded
 Function LoadAccounts()
 
@@ -326,6 +350,7 @@ Function LoadAccounts()
 			SetGadgetText(Accounts\BannedLabel, "Banned accounts: 0")
 			Return 0
 		EndIf
+	FileBytes = FileSize("Data\Server Data\Accounts.dat")
 
 		; Detect format version by peeking the first 4 bytes for the
 		; magic header. If absent (pre-v1 file), seek back to 0 and
@@ -355,6 +380,9 @@ Function LoadAccounts()
 		;   QuestLog entry text: 1024 bytes
 		;   ActionBar slot text: 256 bytes
 		While Eof(F) = False
+			RecordPos = FilePos(F)
+			If AccountRecordIsComplete(F, FileBytes) = False Then Exit
+			SeekFile F, RecordPos
 			Accounts\TotalAccounts = Accounts\TotalAccounts + 1
 			A.Account = New Account
 			A\User$ = ReadBoundedString$(F, 256)

--- a/src/Tests/Modules/LoadAccountsRecordCompletenessTest.bb
+++ b/src/Tests/Modules/LoadAccountsRecordCompletenessTest.bb
@@ -1,0 +1,79 @@
+Strict
+EnableGC
+
+; LoadAccounts opens a fixed server-data path and depends on account-window
+; globals, so this focused source contract pins the record boundary without
+; creating a fragile nested Data\Server Data fixture in every test runner.
+
+Function AccountMetadataPreflightPrecedesPublish%(Path$)
+	Local F.BBStream = ReadFile(Path$)
+	Local Stage%
+	Local Line$
+	If F = Null Then F = ReadFile("..\" + Path$)
+	If F = Null Then Return False
+
+	While Not Eof(F)
+		Line$ = ReadLine$(F)
+		If Stage = 0 And Instr(Line$, "Function LoadAccounts()") > 0 Then Stage = 1
+		If Stage = 1 And (Instr(Line$, "Accounts\TotalAccounts =") > 0 Or Instr(Line$, "A.Account = New Account") > 0 Or Instr(Line$, "AddListBoxItem Accounts\List") > 0)
+			CloseFile F
+			Return False
+		EndIf
+		Select Stage
+			Case 1
+				If Instr(Line$, "RecordPos = FilePos(F)") > 0 Then Stage = 2
+			Case 2
+				If Instr(Line$, "If AccountRecordIsComplete(F, FileBytes) = False Then Exit") > 0 Then Stage = 3
+			Case 3
+				If Instr(Line$, "SeekFile F, RecordPos") > 0 Then Stage = 4
+			Case 4
+				If Instr(Line$, "Accounts\TotalAccounts = Accounts\TotalAccounts + 1") > 0 Then Stage = 5
+			Case 5
+				If Instr(Line$, "A.Account = New Account") > 0 Then Stage = 6
+			Case 6
+				If Instr(Line$, "AddListBoxItem Accounts\List") > 0
+					CloseFile F
+					Return True
+				EndIf
+		End Select
+	Wend
+
+	CloseFile F
+	Return False
+
+End Function
+
+Function AccountMetadataPreflightCoversEveryField%(Path$)
+
+	Local F.BBStream = ReadFile(Path$)
+	Local BoundedStrings%, HasFlags%, HasChars%, InHelper%
+	Local Line$
+	If F = Null Then F = ReadFile("..\" + Path$)
+	If F = Null Then Return False
+
+	While Not Eof(F)
+		Line$ = ReadLine$(F)
+		If Instr(Line$, "Function AccountRecordIsComplete%(F, FileBytes)") > 0 Then InHelper = True
+		If InHelper
+			If Instr(Line$, "If AccountBoundedStringIsComplete(F, FileBytes,") > 0 Then BoundedStrings = BoundedStrings + 1
+			If Instr(Line$, "If FilePos(F) + 2 > FileBytes Then Return False") > 0 Then HasFlags = True
+			If Instr(Line$, "If FilePos(F) + 1 > FileBytes Then Return False") > 0 Then HasChars = True
+			If Trim$(Line$) = "End Function"
+				CloseFile F
+				Return BoundedStrings = 4 And HasFlags And HasChars
+			EndIf
+		EndIf
+	Wend
+
+	CloseFile F
+	Return False
+
+End Function
+
+Test testLoadAccountsPreflightsMetadataBeforePublishingAccountState()
+	Assert(AccountMetadataPreflightPrecedesPublish%("Modules\AccountsServer.bb") = True)
+End Test
+
+Test testLoadAccountsPreflightCoversAllMetadataFields()
+	Assert(AccountMetadataPreflightCoversEveryField%("Modules\AccountsServer.bb") = True)
+End Test

--- a/src/Tests/Modules/LoadAccountsRecordCompletenessTest.bb
+++ b/src/Tests/Modules/LoadAccountsRecordCompletenessTest.bb
@@ -15,22 +15,23 @@ Function AccountMetadataPreflightPrecedesPublish%(Path$)
 	While Not Eof(F)
 		Line$ = ReadLine$(F)
 		If Stage = 0 And Instr(Line$, "Function LoadAccounts()") > 0 Then Stage = 1
-		If Stage = 1 And (Instr(Line$, "Accounts\TotalAccounts =") > 0 Or Instr(Line$, "A.Account = New Account") > 0 Or Instr(Line$, "AddListBoxItem Accounts\List") > 0)
+		If Stage = 1 And Instr(Line$, "While Eof(F) = False") > 0 Then Stage = 2
+		If Stage = 2 And (Instr(Line$, "Accounts\TotalAccounts =") > 0 Or Instr(Line$, "A.Account = New Account") > 0 Or Instr(Line$, "AddListBoxItem Accounts\List") > 0)
 			CloseFile F
 			Return False
 		EndIf
 		Select Stage
-			Case 1
-				If Instr(Line$, "RecordPos = FilePos(F)") > 0 Then Stage = 2
 			Case 2
-				If Instr(Line$, "If AccountRecordIsComplete(F, FileBytes) = False Then Exit") > 0 Then Stage = 3
+				If Instr(Line$, "RecordPos = FilePos(F)") > 0 Then Stage = 3
 			Case 3
-				If Instr(Line$, "SeekFile F, RecordPos") > 0 Then Stage = 4
+				If Instr(Line$, "If AccountRecordIsComplete(F, FileBytes) = False Then Exit") > 0 Then Stage = 4
 			Case 4
-				If Instr(Line$, "Accounts\TotalAccounts = Accounts\TotalAccounts + 1") > 0 Then Stage = 5
+				If Instr(Line$, "SeekFile F, RecordPos") > 0 Then Stage = 5
 			Case 5
-				If Instr(Line$, "A.Account = New Account") > 0 Then Stage = 6
+				If Instr(Line$, "Accounts\TotalAccounts = Accounts\TotalAccounts + 1") > 0 Then Stage = 6
 			Case 6
+				If Instr(Line$, "A.Account = New Account") > 0 Then Stage = 7
+			Case 7
 				If Instr(Line$, "AddListBoxItem Accounts\List") > 0
 					CloseFile F
 					Return True


### PR DESCRIPTION
## Outcome

Server startup now ignores an incomplete final `Accounts.dat` metadata record instead of showing a partial account in the administrator window.

## Technical changes

- Preflight all account metadata fields before allocation, counters, or UI publication.
- Preserve v0/v1 headers, valid empty fields, zero-character accounts, and existing per-character EOF tolerance.
- Add a focused source-contract regression test and update the Accounts module reference.

Fixes #915

## Acceptance criteria and evidence

1. Preflight is before counter/allocation publication: `ACCOUNTS_METADATA_RECORD_FINAL_GREEN preflight_before_publish=1`.
2. All metadata fields are checked: `strings=4 flags=1 chars=1`.
3. Existing character-tail behavior is unchanged by scope; the diff only adds the metadata preflight.
4. Docs describe the exact containment behavior in `docs/modules/accountsserver.md`.

## Baseline, RED, GREEN, and final verification

- Baseline: `./test.sh AccountsServerTest` exited 1 before test execution because `compiler/BlitzForge/bin/blitzcc` is absent locally.
- RED: portable contract printed `ACCOUNTS_METADATA_RECORD_RED missing-metadata-preflight-before-publish` (exit 1).
- GREEN: portable contract printed `ACCOUNTS_METADATA_RECORD_FINAL_GREEN preflight_before_publish=1 strings=4 flags=1 chars=1`.
- Review-cycle repair: the initial exact-head Windows CI compiled but rejected the scanner because it included missing-file initialization. Commit `cf1a0ec1` scopes the scanner to `While Eof(F) = False`; portable check printed `ACCOUNTS_METADATA_TEST_SCOPE_GREEN account_loop_only=1`.
- Final static gates: `git diff --check`, both generated-doc checks, and `bash -n compile.sh test.sh publish.sh scripts/*.sh` exited 0. The BVM generator emitted only its existing SETOWNER/SCENERYOWNER warnings.
- Native focused test remains unverified locally: `./test.sh LoadAccountsRecordCompletenessTest` exits 1 before execution because `blitzcc` is absent; exact-head CI is required.

## Compatibility, risk, rollback, and deferred work

No file format or write-path changes. The preflight accepts complete legacy/current records and stops only before publishing an incomplete metadata tail. Rollback is reverting commits `8e7be54d` and `cf1a0ec1`. Deferred: full runtime fixture coverage needs the compiler-backed CI environment; character payload semantics, MySQL, and auth are intentionally out of scope.

## Independent reviewer verdict

Cycle 1: `REQUEST_CHANGES` found the scanner incorrectly covered missing-file initialization; no production defect was found. Cycle 2: fresh independent review `ACCEPT` for exact head `cf1a0ec19b346074f06082cb31f37fbc84578072`, confirming the record-loop-only scanner, complete metadata boundary, compatibility, scope, docs, and static evidence. Terminal exact-head CI remains required before merge.