### PR TITLE
fix(loom): refresh ribbon after timeline reverts

### DIFF
--- a/src/Modules/Loom/Timeline.bb
+++ b/src/Modules/Loom/Timeline.bb
@@ -337,6 +337,8 @@ Type Timeline
         EndIf
         Composer::writeField(self\composer, e\Kind, e\RefID, e\FieldId, e\OldValue)
         Composer::markDirtyForKind(self\composer, e\Kind)
+        // Reverts mutate the same shared entity state as composer edits.
+        WorldCache_Invalidate()
         WriteLog(LoomLog, "Timeline: reverted " + e\Kind + "#" + Str(e\RefID) + "." + e\FieldId + " back to " + Chr(34) + e\OldValue + Chr(34))
     End Method
 

--- a/src/Tests/Modules/LoomTimelineCacheInvalidationTest.bb
+++ b/src/Tests/Modules/LoomTimelineCacheInvalidationTest.bb
@@ -1,0 +1,71 @@
+Strict
+EnableGC
+
+// Timeline.bb is part of Loom's renderer graph, so this source contract pins
+// the mutation sequence without loading the full editor. A revert must make
+// the same shared WorldCache invalidation promise as a normal composer edit.
+
+Function RevertInvalidatesWorldCache%(Path$)
+    Local F.BBStream = ReadFile(Path$)
+    Local Line$, Trimmed$
+    Local InMethod%, Stage%
+    If F = Null Then F = ReadFile("..\\" + Path$)
+    If F = Null Then F = ReadFile("..\\..\\" + Path$)
+    If F = Null Then Return False
+
+    While Not Eof(F)
+        Line$ = ReadLine$(F)
+        Trimmed$ = Trim$(Line$)
+        If Trimmed$ = "Method revertEntry(e.TimelineEntry)" Then InMethod = True
+        If InMethod = False Then Continue
+
+        Select Stage
+            Case 0
+                If Trimmed$ = "Composer::writeField(self\\composer, e\\Kind, e\\RefID, e\\FieldId, e\\OldValue)" Then Stage = 1
+            Case 1
+                If Trimmed$ = "Composer::markDirtyForKind(self\\composer, e\\Kind)" Then Stage = 2
+            Case 2
+                If Trimmed$ = "WorldCache_Invalidate()" Then Stage = 3
+        End Select
+
+        If Trimmed$ = "End Method"
+            CloseFile F
+            Return Stage = 3
+        EndIf
+    Wend
+
+    CloseFile F
+    Return False
+End Function
+
+Function WriteInvalidTimelineRevertFixture(Path$, EarlyInvalidation%)
+    Local F.BBStream = WriteFile(Path$)
+    If F = Null Then Return
+    WriteLine(F, "Method revertEntry(e.TimelineEntry)")
+    WriteLine(F, "Composer::writeField(self\\composer, e\\Kind, e\\RefID, e\\FieldId, e\\OldValue)")
+    If EarlyInvalidation = True Then WriteLine(F, "WorldCache_Invalidate()")
+    WriteLine(F, "Composer::markDirtyForKind(self\\composer, e\\Kind)")
+    WriteLine(F, "End Method")
+    CloseFile F
+End Function
+
+Function DeleteTimelineRevertFixture(Path$)
+    If FileType(Path$) = 1 Then DeleteFile(Path$)
+End Function
+
+Test testTimelineRevertInvalidatesWorldCacheAfterMutation()
+    Assert(RevertInvalidatesWorldCache%("Modules\\Loom\\Timeline.bb") = True)
+
+    Local MissingFixture$ = "loom_timeline_cache_missing.bb"
+    Local EarlyFixture$ = "loom_timeline_cache_early.bb"
+    DeleteTimelineRevertFixture(MissingFixture$)
+    DeleteTimelineRevertFixture(EarlyFixture$)
+
+    WriteInvalidTimelineRevertFixture(MissingFixture$, False)
+    Assert(RevertInvalidatesWorldCache%(MissingFixture$) = False)
+    WriteInvalidTimelineRevertFixture(EarlyFixture$, True)
+    Assert(RevertInvalidatesWorldCache%(EarlyFixture$) = False)
+
+    DeleteTimelineRevertFixture(MissingFixture$)
+    DeleteTimelineRevertFixture(EarlyFixture$)
+End Test

--- a/src/Tests/Modules/LoomTimelineCacheInvalidationTest.bb
+++ b/src/Tests/Modules/LoomTimelineCacheInvalidationTest.bb
@@ -9,8 +9,8 @@ Function RevertInvalidatesWorldCache%(Path$)
     Local F.BBStream = ReadFile(Path$)
     Local Line$, Trimmed$
     Local InMethod%, Stage%
-    If F = Null Then F = ReadFile("..\\" + Path$)
-    If F = Null Then F = ReadFile("..\\..\\" + Path$)
+    If F = Null Then F = ReadFile("..\" + Path$)
+    If F = Null Then F = ReadFile("..\..\" + Path$)
     If F = Null Then Return False
 
     While Not Eof(F)
@@ -21,9 +21,9 @@ Function RevertInvalidatesWorldCache%(Path$)
 
         Select Stage
             Case 0
-                If Trimmed$ = "Composer::writeField(self\\composer, e\\Kind, e\\RefID, e\\FieldId, e\\OldValue)" Then Stage = 1
+                If Trimmed$ = "Composer::writeField(self\composer, e\Kind, e\RefID, e\FieldId, e\OldValue)" Then Stage = 1
             Case 1
-                If Trimmed$ = "Composer::markDirtyForKind(self\\composer, e\\Kind)" Then Stage = 2
+                If Trimmed$ = "Composer::markDirtyForKind(self\composer, e\Kind)" Then Stage = 2
             Case 2
                 If Trimmed$ = "WorldCache_Invalidate()" Then Stage = 3
         End Select
@@ -42,9 +42,9 @@ Function WriteInvalidTimelineRevertFixture(Path$, EarlyInvalidation%)
     Local F.BBStream = WriteFile(Path$)
     If F = Null Then Return
     WriteLine(F, "Method revertEntry(e.TimelineEntry)")
-    WriteLine(F, "Composer::writeField(self\\composer, e\\Kind, e\\RefID, e\\FieldId, e\\OldValue)")
+    WriteLine(F, "Composer::writeField(self\composer, e\Kind, e\RefID, e\FieldId, e\OldValue)")
     If EarlyInvalidation = True Then WriteLine(F, "WorldCache_Invalidate()")
-    WriteLine(F, "Composer::markDirtyForKind(self\\composer, e\\Kind)")
+    WriteLine(F, "Composer::markDirtyForKind(self\composer, e\Kind)")
     WriteLine(F, "End Method")
     CloseFile F
 End Function
@@ -54,7 +54,7 @@ Function DeleteTimelineRevertFixture(Path$)
 End Function
 
 Test testTimelineRevertInvalidatesWorldCacheAfterMutation()
-    Assert(RevertInvalidatesWorldCache%("Modules\\Loom\\Timeline.bb") = True)
+    Assert(RevertInvalidatesWorldCache%("Modules\Loom\Timeline.bb") = True)
 
     Local MissingFixture$ = "loom_timeline_cache_missing.bb"
     Local EarlyFixture$ = "loom_timeline_cache_early.bb"


### PR DESCRIPTION
## Outcome

Timeline reverts now refresh Loom's Validation Conscience Ribbon on the next paint, so its world-health snapshot reflects the reverted world immediately.

## Technical changes

- Call `WorldCache_Invalidate()` after the existing timeline revert write and dirty-state update.
- Add a focused source-contract test for write → dirty → invalidate, including missing/early invalidation fixtures.

Fixes #917

## Acceptance and verification

- Baseline: invalidation absent; RED: stage 2/3; GREEN: `LOOM_TIMELINE_CACHE_CONTRACT_GREEN main=3/3 missing=2/3 early=2/3`.
- `git diff --check` and `bash scripts/gen_packet_index.sh --check` exited 0.
- Local Blitz compilation is unavailable because the initialized submodule has no `bin/blitzcc`.
- Exact-head CI run 30052816022: Build and test passed (6m21s); Rust server (Linux) passed (3m53s); zero legacy status contexts.

## Compatibility, risk, rollback, deferred

No persistence format, protocol, or cross-editor behavior changes. This marks an existing cache stale after an in-memory revert; rollback is reverting this PR. Timeline-history, GUE, ClientNet, and protocol-index work are excluded.

## Independent review

Fresh review cycle 2: **ACCEPT** for exact head `f5ba92269443269893de9f46e425a0f8c9983c32`. The prior review found an escaped-backslash mismatch in the matcher; `f5ba9226` corrected it and received fresh acceptance.