### PR TITLE
fix(editors): make tree unloading cursor-safe

### DIFF
--- a/src/Modules/RCTrees.bb
+++ b/src/Modules/RCTrees.bb
@@ -488,22 +488,34 @@ Next
 End Function
 
 Function UnloadTrees(deltree=True)
- For Rt.Tree=Each tree
-  If deltree=True Then  FreeEntity RT\MainEnt
-   Delete rt
-   Next
+ Local Rt.Tree=First tree
+ Local RtNext.Tree=Null
+ While Rt<>Null
+  RtNext=After Rt
+  If deltree=True Then FreeEntity RT\MainEnt
+  Delete Rt
+  Rt=RtNext
+ Wend
 
-For RtG.RCGRASS=Each rcgrass
+Local RtG.RCGRASS=First rcgrass
+Local RtGNext.RCGRASS=Null
+While RtG<>Null
+  RtGNext=After RtG
   If deltree=True Then FreeEntity RTg\ent
-  Delete rtg
-  Next
+  Delete RtG
+  RtG=RtGNext
+Wend
 
-For gt.GrassTextures=Each grasstextures
+Local gt.GrassTextures=First grasstextures
+Local gtNext.GrassTextures=Null
+While gt<>Null
+  gtNext=After gt
 ;  FreeBrush gt\Brush
 ;  FreeTexture gt\tex
   DebugLog "freed a grasstexture"
   Delete gt
-Next
+  gt=gtNext
+Wend
 
 End Function
 

--- a/src/Tests/Modules/RCTreesUnloadIteratorTest.bb
+++ b/src/Tests/Modules/RCTreesUnloadIteratorTest.bb
@@ -1,0 +1,86 @@
+Strict
+EnableGC
+
+; UnloadTrees clears three Type lists during an area transition. Each direct
+; deletion must save the successor before it frees an entity or deletes its
+; current record, otherwise multi-record unloads can corrupt the cursor.
+Function UnloadTreesCursorContract%(LegacyFor$, FirstCursor$, NextCursor$, WhileCursor$, Capture$, OptionalFree$, DeleteNode$, Advance$)
+	Local F.BBStream = ReadFile("Modules\RCTrees.bb")
+	Local Stage%
+	Local Line$
+	If F = Null Then F = ReadFile("..\Modules\RCTrees.bb")
+	If F = Null Then F = ReadFile("..\..\Modules\RCTrees.bb")
+	If F = Null Then Return False
+
+	While Not Eof(F)
+		Line$ = ReadLine$(F)
+		If Instr(Line$, "Function UnloadTrees(deltree=True)") > 0 Then Exit
+	Wend
+	If Eof(F)
+		CloseFile F
+		Return False
+	EndIf
+
+	While Not Eof(F)
+		Line$ = ReadLine$(F)
+		If Instr(Line$, LegacyFor$) > 0
+			CloseFile F
+			Return False
+		EndIf
+		If Stage < 5
+			If Instr(Line$, DeleteNode$) > 0
+				CloseFile F
+				Return False
+			EndIf
+		EndIf
+		If Stage = 0
+			If Instr(Line$, FirstCursor$) > 0 Then Stage = 1
+		ElseIf Stage = 1
+			If Instr(Line$, NextCursor$) > 0 Then Stage = 2
+		ElseIf Stage = 2
+			If Instr(Line$, WhileCursor$) > 0 Then Stage = 3
+		ElseIf Stage = 3
+			If Instr(Line$, Capture$) > 0 Then Stage = 4
+		ElseIf Stage = 4
+			If OptionalFree$ = "" Then Stage = 5
+			If OptionalFree$ <> ""
+				If Instr(Line$, OptionalFree$) > 0 Then Stage = 5
+			EndIf
+		ElseIf Stage = 5
+			If Instr(Line$, DeleteNode$) > 0 Then Stage = 6
+		ElseIf Stage = 6
+			If Instr(Line$, Advance$) > 0 Then Stage = 7
+		EndIf
+		If Instr(Line$, "End Function") > 0
+			CloseFile F
+			Return Stage = 7
+		EndIf
+	Wend
+
+	CloseFile F
+	Return False
+End Function
+
+Function TreeUnloadUsesAfterCursor%()
+	Return UnloadTreesCursorContract%("For Rt.Tree=Each tree", "Local Rt.Tree=First tree", "Local RtNext.Tree=Null", "While Rt<>Null", "RtNext=After Rt", "FreeEntity RT\MainEnt", "Delete Rt", "Rt=RtNext")
+End Function
+
+Function GrassUnloadUsesAfterCursor%()
+	Return UnloadTreesCursorContract%("For RtG.RCGRASS=Each rcgrass", "Local RtG.RCGRASS=First rcgrass", "Local RtGNext.RCGRASS=Null", "While RtG<>Null", "RtGNext=After RtG", "FreeEntity RTg\ent", "Delete RtG", "RtG=RtGNext")
+End Function
+
+Function GrassTextureUnloadUsesAfterCursor%()
+	Return UnloadTreesCursorContract%("For gt.GrassTextures=Each grasstextures", "Local gt.GrassTextures=First grasstextures", "Local gtNext.GrassTextures=Null", "While gt<>Null", "gtNext=After gt", "", "Delete gt", "gt=gtNext")
+End Function
+
+Test testTreeUnloadCapturesNextBeforeEntityFreeAndDelete()
+	Assert(TreeUnloadUsesAfterCursor%() = True)
+End Test
+
+Test testGrassUnloadCapturesNextBeforeEntityFreeAndDelete()
+	Assert(GrassUnloadUsesAfterCursor%() = True)
+End Test
+
+Test testGrassTextureUnloadCapturesNextBeforeDelete()
+	Assert(GrassTextureUnloadUsesAfterCursor%() = True)
+End Test


### PR DESCRIPTION
## Outcome

Area unload now clears every loaded tree, grass, and grass-texture record without deleting through a live iterator, avoiding incomplete editor/area cleanup after multi-record loads.

## Technical changes

- Replace the three UnloadTrees For Each plus Delete loops with First, After, While cursor walks.
- Preserve deltree=False behavior and the existing optional FreeEntity calls.
- Add a focused RCTrees unload source contract for traversal ordering and legacy-loop rejection.

Fixes #919

## Acceptance evidence

- Each list captures its successor before optional entity cleanup and Delete: portable contract GREEN.
- Each list advances only after Delete: portable contract GREEN.
- Legacy loop forms are absent: portable contract GREEN.

## Baseline, RED, and final verification

- BASELINE: 3 unsafe direct cleanup loops.
- RED: RCTREES_UNLOAD_ITERATOR_CONTRACT_RED legacy=3 missing_safe_starts=3, exit 1.
- GREEN: RCTREES_UNLOAD_ITERATOR_CONTRACT_GREEN tree=7 grass=7 texture=6 legacy=0, exit 0.
- git diff --check, bash scripts/gen_packet_index.sh --check, and bash scripts/gen_bvm_reference.sh --check each exit 0. The BVM generator emitted only its known BVM_SETOWNER and BVM_SCENERYOWNER notices.
- Native local test: ./test.sh RCTreesUnloadIteratorTest exits 1 because compiler/BlitzForge/bin/blitzcc is absent; exact-head CI is required for compiler-backed proof.

## Compatibility, risk, rollback, and follow-up

No wire, persistence-format, rendering, or editor-workflow semantics change. The risk is limited to cursor traversal and rollback is reverting this PR. No deferred follow-up is required.

## Independent review

ACCEPT: a fresh reviewer inspected exact head 58c5af6fb67355124a8fb9a18569e9cf659a5766. It confirmed capture before optional FreeEntity/Delete and post-delete advancement for all three lists, valid source-contract paths/order, scope fit, and no compatibility or performance concern. Exact-head CI is still required before merge.