### PR TITLE
fix(animations): reject incomplete records before publication

### DIFF
--- a/src/Modules/Animations.bb
+++ b/src/Modules/Animations.bb
@@ -114,6 +114,32 @@ Function CreateAnimSet()
 
 End Function
 
+; Checks a length-prefixed Animations.dat string without publishing any of
+; the surrounding record. LoadAnimSets uses this before allocation so a
+; truncated tail cannot become a default-valued AnimSet in AnimList.
+Function AnimSetBoundedStringIsComplete%(F, FileBytes, Limit)
+	If FilePos(F) + 4 > FileBytes Then Return False
+	NameBytes = ReadInt(F)
+	If NameBytes < 0 Or NameBytes > Limit Then Return False
+	If FilePos(F) + NameBytes > FileBytes Then Return False
+	SeekFile F, FilePos(F) + NameBytes
+	Return True
+End Function
+
+; Every animation-set record has an ID, a set name, and 150 clip entries.
+; Each clip stores a bounded name plus start/end shorts and a speed float.
+Function AnimSetRecordIsComplete%(F, FileBytes)
+	If FilePos(F) + 2 > FileBytes Then Return False
+	SeekFile F, FilePos(F) + 2
+	If AnimSetBoundedStringIsComplete(F, FileBytes, 256) = False Then Return False
+	For i = 0 To 149
+		If AnimSetBoundedStringIsComplete(F, FileBytes, 256) = False Then Return False
+		If FilePos(F) + 8 > FileBytes Then Return False
+		SeekFile F, FilePos(F) + 8
+	Next
+	Return True
+End Function
+
 ; Loads all animation sets
 Function LoadAnimSets(Filename$)
 
@@ -121,8 +147,12 @@ Function LoadAnimSets(Filename$)
 
 	F = ReadFile(Filename$)
 	If F = 0 Then Return -1
+	FileBytes = FileSize(Filename$)
 
 		While Not Eof(F)
+			RecordPos = FilePos(F)
+			If AnimSetRecordIsComplete(F, FileBytes) = False Then Exit
+			SeekFile F, RecordPos
 			A.AnimSet = New AnimSet
 			A\ID = ReadShort(F)
 			; AnimList is Dim'd 0..999. ReadShort is signed, so a malformed

--- a/src/Tests/Modules/AnimationsRecordCompletenessTest.bb
+++ b/src/Tests/Modules/AnimationsRecordCompletenessTest.bb
@@ -34,7 +34,7 @@ Function CleanupAnimationsRecordTestFile()
 	If FileType(AnimationsRecordTestFile$ + ".bak") = 1 Then DeleteFile(AnimationsRecordTestFile$ + ".bak")
 End Function
 
-Function WriteCompleteAnimSet(F, ID, Name$)
+Function WriteCompleteAnimSet(F.BBStream, ID, Name$)
 	WriteShort F, ID
 	WriteString F, Name$
 	For i = 0 To 149
@@ -50,6 +50,22 @@ Test testLoadAnimSetsRejectsIdOnlyRecordBeforePublish()
 	CleanupAnimationsRecordTestFile()
 	Local F.BBStream = WriteFile(AnimationsRecordTestFile$)
 	WriteShort F, 7
+	CloseFile F
+
+	Assert(LoadAnimSets(AnimationsRecordTestFile$) = 0)
+	Assert(AnimList(7) = Null)
+
+	ClearAnimSets()
+	CleanupAnimationsRecordTestFile()
+End Test
+
+Test testLoadAnimSetsRejectsTruncatedSetNameBeforePublish()
+	ClearAnimSets()
+	CleanupAnimationsRecordTestFile()
+	Local F.BBStream = WriteFile(AnimationsRecordTestFile$)
+	WriteShort F, 7
+	WriteInt F, 4
+	WriteByte F, Asc("x")
 	CloseFile F
 
 	Assert(LoadAnimSets(AnimationsRecordTestFile$) = 0)

--- a/src/Tests/Modules/AnimationsRecordCompletenessTest.bb
+++ b/src/Tests/Modules/AnimationsRecordCompletenessTest.bb
@@ -1,0 +1,80 @@
+Strict
+EnableGC
+
+; Regression coverage for LoadAnimSets: only complete Animations.dat records
+; may be published into AnimList. Keep the production module standalone by
+; stubbing the actor shapes used only by PlayAnimation.
+
+Type Actor
+	Field MAnimationSet, FAnimationSet
+End Type
+
+Type ActorInstance
+	Field Gender
+	Field Actor.Actor
+	Field EN
+	Field AnimSeqs[149]
+End Type
+
+Global LogMode = 0
+Global MainLog = 0
+
+Include "Modules\\Logging.bb"
+Include "Modules\\Animations.bb"
+
+Global AnimationsRecordTestFile$ = CurrentDir$() + "animations_record_completeness_test.dat"
+
+Function ClearAnimSets()
+	Delete Each AnimSet
+End Function
+
+Function CleanupAnimationsRecordTestFile()
+	If FileType(AnimationsRecordTestFile$) = 1 Then DeleteFile(AnimationsRecordTestFile$)
+	If FileType(AnimationsRecordTestFile$ + ".tmp") = 1 Then DeleteFile(AnimationsRecordTestFile$ + ".tmp")
+	If FileType(AnimationsRecordTestFile$ + ".bak") = 1 Then DeleteFile(AnimationsRecordTestFile$ + ".bak")
+End Function
+
+Function WriteCompleteAnimSet(F, ID, Name$)
+	WriteShort F, ID
+	WriteString F, Name$
+	For i = 0 To 149
+		WriteString F, "Clip " + i
+		WriteShort F, i
+		WriteShort F, i + 10
+		WriteFloat F, 1.0
+	Next
+End Function
+
+Test testLoadAnimSetsRejectsIdOnlyRecordBeforePublish()
+	ClearAnimSets()
+	CleanupAnimationsRecordTestFile()
+	Local F.BBStream = WriteFile(AnimationsRecordTestFile$)
+	WriteShort F, 7
+	CloseFile F
+
+	Assert(LoadAnimSets(AnimationsRecordTestFile$) = 0)
+	Assert(AnimList(7) = Null)
+
+	ClearAnimSets()
+	CleanupAnimationsRecordTestFile()
+End Test
+
+Test testLoadAnimSetsRetainsCompleteRecordBeforeTruncatedClipTail()
+	ClearAnimSets()
+	CleanupAnimationsRecordTestFile()
+	Local F.BBStream = WriteFile(AnimationsRecordTestFile$)
+	WriteCompleteAnimSet(F, 3, "Complete")
+	WriteShort F, 8
+	WriteString F, "Partial"
+	WriteString F, "Broken clip"
+	WriteShort F, 1
+	CloseFile F
+
+	Assert(LoadAnimSets(AnimationsRecordTestFile$) = 1)
+	Assert(AnimList(3) <> Null)
+	Assert(AnimList(3)\Name$ = "Complete")
+	Assert(AnimList(8) = Null)
+
+	ClearAnimSets()
+	CleanupAnimationsRecordTestFile()
+End Test


### PR DESCRIPTION
## Outcome

Malformed trailing `Animations.dat` records no longer become default animation templates during client, GUE, or Gubbin Tool startup.

## Technical changes

- Preflight each animation record before allocating or assigning `AnimList`.
- Bound the set/clip strings and require all 150 clip name/start/end/speed entries.
- Add a Strict regression test for an ID-only tail and valid-prefix retention before a truncated clip tail.

Fixes #921

## Acceptance evidence

- ID-only and truncated clip tails are rejected before `AnimList` publication by `AnimSetRecordIsComplete%`.
- The regression test asserts a complete preceding record remains available and the partial successor remains absent.
- Valid on-disk format and playback behavior are unchanged.

## RED → GREEN and verification

- Baseline: `./test.sh AnimationsRecordCompletenessTest` exited 1 because `compiler/BlitzForge/bin/blitzcc` is absent in this isolated worktree.
- RED: portable source contract printed `ANIMATIONS_RECORD_COMPLETENESS_CONTRACT_RED missing=AnimSetRecordIsComplete`.
- GREEN: portable source contract printed `ANIMATIONS_RECORD_COMPLETENESS_CONTRACT_GREEN preflight_line=131 publish_line=156 tests=2`.
- Final local: `git diff --check` passed; `bash scripts/gen_packet_index.sh --check` and `bash scripts/gen_bvm_reference.sh --check` both exited 0 (the latter emitted only the two existing SETOWNER/SCENERYOWNER notices).
- Native test/build proof is pending exact-head CI because the local compiler binary is unavailable.

## Compatibility, risk, rollback, deferred

The `Animations.dat` layout and valid-record behavior are unchanged. The only new behavior is withholding incomplete trailing records. Risk is low; rollback is a normal revert. Deferred, intentionally out of scope: format changes, animation playback, protocol work, Loom, Rust editor, and unrelated loaders.

## Independent review

Pending fresh review of this exact head.

## Independent review

Fresh source review of exact head `7755b16d45d05fe54e35ba6b2965b8355a60ec19`: **ACCEPT**. It found no critical, important, or minor findings, confirmed the ID-only, truncated-name, and truncated-clip-tail cases plus valid-prefix behavior, and noted CI remained pending at review time. The prior review-cycle compile error was corrected by typing the test helper as `F.BBStream`.