### PR TITLE
fix(environment): atomically persist default saves

### DIFF
--- a/src/Modules/Environment.bb
+++ b/src/Modules/Environment.bb
@@ -158,63 +158,35 @@ Function LoadEnvironmentFromFile(Filename$, CreateMissing = False)
 
 End Function
 
-; Saves all environment settings.
-;
-; Two modes:
-;   FullSave=True  — rewrites the whole file (time fields + season/month
-;                    config tables). Atomic temp+rename to avoid partial
-;                    writes on crash.
-;   FullSave=False — updates only the time fields at the start of the
-;                    existing file (OpenFile, no truncate). Refuse this
-;                    path if the file doesn't already exist OR is too small
-;                    to hold the full config — otherwise LoadEnvironment
-;                    later reads past EOF for TimeFactor/Seasons/Months and
-;                    silently sets them to zero (TimeFactor=0 then triggers
-;                    divide-by-zero in UpdateEnvironment).
+; Saves all environment settings through the complete atomic writer. The
+; default time-save callers use the same promotion path so a stopped process
+; cannot leave Environment.dat with only a partially updated header.
 Function SaveEnvironment(FullSave = False)
 
 	Local FinalPath$ = "Data\Server Data\Environment.dat"
-
-	If FullSave = True
-		Local TempPath$ = SafeWriteOpen(FinalPath$)
-		F = WriteFile(TempPath$)
-		If F = 0
-			WriteLog(MainLog, "SaveEnvironment: cannot open " + TempPath$ + " for write")
-			Return False
-		EndIf
-		WriteInt F, Year
-		WriteInt F, Day
-		WriteInt F, TimeH
-		WriteInt F, TimeM
-		WriteInt F, TimeFactor
-		For i = 0 To 11
-			WriteString F, SeasonName$(i)
-			WriteInt F, SeasonStartDay(i)
-			WriteInt F, SeasonDuskH(i)
-			WriteInt F, SeasonDawnH(i)
-		Next
-		For i = 0 To 19
-			WriteString F, MonthName$(i)
-			WriteInt F, MonthStartDay(i)
-		Next
-		Return SafeWriteCommit(TempPath$, FinalPath$, F)
-	EndIf
-
-	; Mid-session time-only update path.
-	If FileType(FinalPath$) <> 1
-		; No full save has ever happened. Refuse to write a half file that
-		; LoadEnvironment would parse as TimeFactor=0 + zeroed Seasons/Months.
-		WriteLog(MainLog, "SaveEnvironment: refusing partial save before a FullSave has been committed")
+	If FullSave = False Then Return SaveEnvironment(True)
+	Local TempPath$ = SafeWriteOpen(FinalPath$)
+	F = WriteFile(TempPath$)
+	If F = 0
+		WriteLog(MainLog, "SaveEnvironment: cannot open " + TempPath$ + " for write")
 		Return False
 	EndIf
-	F = OpenFile(FinalPath$)
-	If F = 0 Then Return False
-		WriteInt F, Year
-		WriteInt F, Day
-		WriteInt F, TimeH
-		WriteInt F, TimeM
-	CloseFile(F)
-	Return True
+	WriteInt F, Year
+	WriteInt F, Day
+	WriteInt F, TimeH
+	WriteInt F, TimeM
+	WriteInt F, TimeFactor
+	For i = 0 To 11
+		WriteString F, SeasonName$(i)
+		WriteInt F, SeasonStartDay(i)
+		WriteInt F, SeasonDuskH(i)
+		WriteInt F, SeasonDawnH(i)
+	Next
+	For i = 0 To 19
+		WriteString F, MonthName$(i)
+		WriteInt F, MonthStartDay(i)
+	Next
+	Return SafeWriteCommit(TempPath$, FinalPath$, F)
 
 End Function
 

--- a/src/Tests/Modules/EnvironmentTest.bb
+++ b/src/Tests/Modules/EnvironmentTest.bb
@@ -66,6 +66,32 @@ Function WriteEnvironmentLoadTestFile%(IncludeMonths = True)
 	Return True
 End Function
 
+; SaveEnvironment's default is used by server lock, shutdown, and BVM save
+; state. Keep that path on the complete atomic writer: a direct header update
+; can leave Environment.dat only partly updated if the process stops mid-save.
+Function EnvironmentDefaultSaveUsesAtomicFullWriter%()
+	Local F.BBStream = ReadFile("Modules\\Environment.bb")
+	Local Line$
+	Local Stage = 0
+	Local DirectOpen = False
+	If F = Null Then F = ReadFile("..\\Modules\\Environment.bb")
+	If F = Null Then F = ReadFile("..\\..\\Modules\\Environment.bb")
+	If F = Null Then Return False
+
+	While Not Eof(F)
+		Line$ = Trim$(ReadLine$(F))
+		If Instr(Line$, "Function SaveEnvironment(FullSave = False)") > 0 Then Stage = 1
+		If Stage = 1 And Line$ = "If FullSave = False Then Return SaveEnvironment(True)" Then Stage = 2
+		If Stage = 2 And Instr(Line$, "Local TempPath$ = SafeWriteOpen(FinalPath$)") > 0 Then Stage = 4
+		If Stage = 4 And Instr(Line$, "Return SafeWriteCommit(TempPath$, FinalPath$, F)") > 0 Then Stage = 5
+		If Instr(Line$, "F = OpenFile(FinalPath$)") > 0 Then DirectOpen = True
+		If Instr(Line$, "End Function") > 0 And Stage > 0 Then Exit
+	Wend
+
+	CloseFile(F)
+	Return Stage = 5 And DirectOpen = False
+End Function
+
 Function ClearSunLoadTestState()
 	If FileType(SunLoadTestFile$) = 1 Then DeleteFile(SunLoadTestFile$)
 	Local S.Sun = First Sun
@@ -219,4 +245,8 @@ Test testLoadEnvironmentFromFileRejectsTruncatedRequiredRecords()
 	Assert(WriteEnvironmentLoadTestFile(False) = True)
 	Assert(LoadEnvironmentFromFile(EnvironmentLoadTestFile$) = False)
 	ClearEnvironmentLoadTestState()
+End Test
+
+Test testDefaultSaveEnvironmentUsesCompleteAtomicWriter()
+	Assert(EnvironmentDefaultSaveUsesAtomicFullWriter() = True)
 End Test


### PR DESCRIPTION
## Outcome
Server lock, shutdown, and privileged save-state operations now atomically replace the complete environment configuration instead of rewriting only its live header.

## Technical changes
- Route default `SaveEnvironment()` calls to the existing full `SafeWriteOpen` / `SafeWriteCommit` writer.
- Preserve the existing Environment.dat field order and Boolean result.
- Add a focused bounded source contract that requires default delegation and rejects the retired direct `OpenFile` write path.

Fixes #929

## Acceptance evidence
- Default route delegates to complete atomic writer: `ENVIRONMENT_DEFAULT_ATOMIC_CONTRACT_GREEN stage=5 direct_open=0`.
- Existing source checks: `git diff --check`, packet index, and BVM reference all exit 0.

## RED and GREEN
- RED: `ENVIRONMENT_DEFAULT_ATOMIC_CONTRACT_RED stage=1 direct_open=1` (exit 1).
- GREEN: portable source contract reports `stage=5 direct_open=0` (exit 0).

## Verification and caveats
- Baseline/final `./test.sh EnvironmentTest` exit 1 before running because `compiler/BlitzForge/bin/blitzcc` is absent locally; exact-head CI is required for compiler-backed proof.
- Compatibility: same serialized schema and caller signature; each ordinary save now performs the established full atomic promotion. Rollback is reverting this commit.
- Deferred: no simulation, schema, Suns.dat, or editor changes.

## Independent review
Pending fresh review of this exact head.

## Independent review
Fresh reviewer verdict: **ACCEPT** for exact head `8ab3c49e294354166538c2446e10e8f336ad1ae0`. The reviewer confirmed default delegation, retained serialization order, scoped source contract coverage, disjoint scope, and no documentation gap; native local execution remains unverified pending CI.